### PR TITLE
Stabilize cross-file usage accounting and verification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,10 @@ name = "ccstats"
 version = "0.2.61"
 edition = "2024"
 rust-version = "1.85"
-description = "Fast Claude Code token usage statistics CLI"
+description = "Fast token and cost usage statistics CLI for Claude Code and OpenAI Codex"
 license = "MIT"
 repository = "https://github.com/majiayu000/ccstats"
-keywords = ["claude", "anthropic", "token", "usage", "cli"]
+keywords = ["claude", "codex", "openai", "token", "usage"]
 categories = ["command-line-utilities"]
 
 [package.metadata.binstall]

--- a/README.md
+++ b/README.md
@@ -194,7 +194,12 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for:
 - Adding new data sources
 - Data flow and processing pipeline
 - Caching mechanism
-- Deduplication algorithm
+- Architecture and module boundaries
+
+See [docs/algorithm/authoritative-token-accounting.md](docs/algorithm/authoritative-token-accounting.md) for:
+- Token accounting rules
+- Source-specific normalization
+- Deduplication semantics
 
 ## License
 

--- a/docs/algorithm/authoritative-token-accounting.md
+++ b/docs/algorithm/authoritative-token-accounting.md
@@ -83,11 +83,13 @@ Anthropic 的字段天然互不重叠，parser 直接映射即可。
 
 Claude Code 的流式响应会为同一个 `message.id` 写入多条日志（每个 chunk 都可能更新 usage）。去重规则：
 
-1. 以 `message.id` 为全局去重键（跨主文件和 subagent 文件）
-2. 同一 `message.id` 的多条记录，选择规则：
-   - 优先选有 `stop_reason` 的（表示完成），取最早的一条
+1. 以“源日志文件 + `message.id`”作为去重键
+2. 同一去重键的多条记录，选择规则：
+   - 优先选有 `stop_reason` 的（表示完成），取最新的一条
    - 若都没有 `stop_reason`，取最晚的一条（最佳近似）
 3. 没有 `message.id` 的条目：仅当有 `stop_reason` 时才计入
+
+这样可以避免不同日志文件中碰巧复用同一 `message.id` 时发生误去重，同时仍然保留同一文件内流式 chunk 的合并行为。
 
 ### 模型名归一化
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -41,7 +41,10 @@ pub(crate) enum CostMode {
 
 #[derive(Parser)]
 #[command(name = "ccstats")]
-#[command(about = "Fast Claude Code token usage statistics", version)]
+#[command(
+    about = "Fast token and cost usage statistics for Claude Code and OpenAI Codex",
+    version
+)]
 #[allow(clippy::struct_excessive_bools)]
 pub(crate) struct Cli {
     #[command(subcommand)]

--- a/src/core/aggregator.rs
+++ b/src/core/aggregator.rs
@@ -23,6 +23,8 @@ pub(crate) fn aggregate_daily(entries: Vec<RawEntry>) -> HashMap<String, DayStat
 /// Session accumulator for building session stats
 #[derive(Debug, Default)]
 struct SessionAccumulator {
+    session_key: String,
+    session_id: String,
     project_path: String,
     first_timestamp: String,
     last_timestamp: String,
@@ -33,8 +35,16 @@ struct SessionAccumulator {
 }
 
 impl SessionAccumulator {
-    fn new(project_path: String, timestamp: &str, timestamp_ms: i64) -> Self {
+    fn new(
+        session_key: String,
+        session_id: String,
+        project_path: String,
+        timestamp: &str,
+        timestamp_ms: i64,
+    ) -> Self {
         SessionAccumulator {
+            session_key,
+            session_id,
             project_path,
             first_timestamp: timestamp.to_string(),
             last_timestamp: timestamp.to_string(),
@@ -86,29 +96,39 @@ impl SessionAccumulator {
             self.last_timestamp_ms = timestamp_ms;
         }
     }
+
+    fn into_session_stats(self) -> SessionStats {
+        SessionStats {
+            session_key: self.session_key,
+            session_id: self.session_id,
+            project_path: self.project_path,
+            first_timestamp: self.first_timestamp,
+            last_timestamp: self.last_timestamp,
+            stats: self.stats,
+            models: self.models,
+        }
+    }
 }
 
 /// Aggregate entries by session (consumes entries to avoid cloning)
 pub(crate) fn aggregate_sessions(entries: Vec<RawEntry>) -> Vec<SessionStats> {
-    let session_map = aggregate_sessions_map(entries);
-    session_map
-        .into_iter()
-        .map(|(session_id, mut session)| {
-            session.session_id = session_id;
-            session
-        })
-        .collect()
+    aggregate_sessions_map(entries).into_values().collect()
 }
 
-/// Aggregate entries by session into a map keyed by session ID.
-/// Values intentionally omit `session_id` to avoid duplicate storage.
+/// Aggregate entries by session into a map keyed by stable internal session key.
 pub(crate) fn aggregate_sessions_map(entries: Vec<RawEntry>) -> HashMap<String, SessionStats> {
     let mut sessions: HashMap<String, SessionAccumulator> = HashMap::with_capacity(entries.len());
 
-    for mut entry in entries {
-        let session_id = std::mem::take(&mut entry.session_id);
-        let session = sessions.entry(session_id).or_insert_with(|| {
+    for entry in entries {
+        let session_key = if entry.session_key.is_empty() {
+            entry.session_id.clone()
+        } else {
+            entry.session_key.clone()
+        };
+        let session = sessions.entry(session_key.clone()).or_insert_with(|| {
             SessionAccumulator::new(
+                session_key,
+                entry.session_id.clone(),
                 entry.project_path.clone(),
                 &entry.timestamp,
                 entry.timestamp_ms,
@@ -119,19 +139,7 @@ pub(crate) fn aggregate_sessions_map(entries: Vec<RawEntry>) -> HashMap<String, 
 
     sessions
         .into_iter()
-        .map(|(session_id, acc)| {
-            (
-                session_id,
-                SessionStats {
-                    session_id: String::new(),
-                    project_path: acc.project_path,
-                    first_timestamp: acc.first_timestamp,
-                    last_timestamp: acc.last_timestamp,
-                    stats: acc.stats,
-                    models: acc.models,
-                },
-            )
-        })
+        .map(|(session_key, acc)| (session_key, acc.into_session_stats()))
         .collect()
 }
 
@@ -243,6 +251,7 @@ mod tests {
             timestamp_ms: ts_ms,
             date_str: date.to_string(),
             message_id: None,
+            session_key: session.to_string(),
             session_id: session.to_string(),
             project_path: project.to_string(),
             model: model.to_string(),
@@ -396,6 +405,7 @@ mod tests {
                 timestamp_ms: 5000,
                 date_str: "2025-01-01".to_string(),
                 message_id: None,
+                session_key: "s1".to_string(),
                 session_id: "s1".to_string(),
                 project_path: "p1".to_string(),
                 model: "claude".to_string(),
@@ -411,6 +421,7 @@ mod tests {
                 timestamp_ms: 1000,
                 date_str: "2025-01-01".to_string(),
                 message_id: None,
+                session_key: "s1".to_string(),
                 session_id: "s1".to_string(),
                 project_path: "p1".to_string(),
                 model: "claude".to_string(),
@@ -426,6 +437,7 @@ mod tests {
                 timestamp_ms: 9000,
                 date_str: "2025-01-01".to_string(),
                 message_id: None,
+                session_key: "s1".to_string(),
                 session_id: "s1".to_string(),
                 project_path: "p1".to_string(),
                 model: "claude".to_string(),
@@ -475,6 +487,7 @@ mod tests {
     #[test]
     fn aggregate_projects_single_project() {
         let sessions = vec![SessionStats {
+            session_key: "s1".to_string(),
             session_id: "s1".to_string(),
             project_path: "/Users/john/myapp".to_string(),
             first_timestamp: "t1".to_string(),

--- a/src/core/dedup.rs
+++ b/src/core/dedup.rs
@@ -11,6 +11,9 @@ pub(crate) trait Deduplicatable {
     fn timestamp_ms(&self) -> i64;
     fn has_stop_reason(&self) -> bool;
     fn message_id(&self) -> Option<&str>;
+    fn dedup_scope(&self) -> Option<&str> {
+        None
+    }
 }
 
 impl Deduplicatable for RawEntry {
@@ -24,6 +27,10 @@ impl Deduplicatable for RawEntry {
 
     fn message_id(&self) -> Option<&str> {
         self.message_id.as_deref()
+    }
+
+    fn dedup_scope(&self) -> Option<&str> {
+        Some(&self.session_key)
     }
 }
 
@@ -114,7 +121,7 @@ impl<T: Deduplicatable> CandidateState<T> {
 /// Incremental dedup accumulator for chunked/parallel loading.
 #[derive(Debug)]
 pub(crate) struct DedupAccumulator<T: Deduplicatable> {
-    message_map: HashMap<String, CandidateState<T>>,
+    message_map: HashMap<(String, String), CandidateState<T>>,
     no_id_entries: Vec<T>,
     total_with_id: i64,
 }
@@ -137,11 +144,14 @@ impl<T: Deduplicatable> DedupAccumulator<T> {
     pub(crate) fn push(&mut self, entry: T) {
         if let Some(id) = entry.message_id() {
             self.total_with_id += 1;
-            match self.message_map.get_mut(id) {
+            let key = (
+                entry.dedup_scope().unwrap_or_default().to_string(),
+                id.to_string(),
+            );
+            match self.message_map.get_mut(&key) {
                 Some(state) => state.update(entry),
                 None => {
-                    self.message_map
-                        .insert(id.to_string(), CandidateState::new(entry));
+                    self.message_map.insert(key, CandidateState::new(entry));
                 }
             }
         } else if entry.has_stop_reason() {
@@ -162,11 +172,11 @@ impl<T: Deduplicatable> DedupAccumulator<T> {
         self.total_with_id += other.total_with_id;
         self.no_id_entries.extend(other.no_id_entries);
 
-        for (id, state) in other.message_map {
-            match self.message_map.get_mut(&id) {
+        for (key, state) in other.message_map {
+            match self.message_map.get_mut(&key) {
                 Some(existing) => existing.merge(state),
                 None => {
-                    self.message_map.insert(id, state);
+                    self.message_map.insert(key, state);
                 }
             }
         }

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -56,6 +56,7 @@ impl DayStats {
 /// Session statistics
 #[derive(Debug, Default, Clone)]
 pub(crate) struct SessionStats {
+    pub(crate) session_key: String,
     pub(crate) session_id: String,
     pub(crate) project_path: String,
     pub(crate) first_timestamp: String,
@@ -95,6 +96,9 @@ pub(crate) struct RawEntry {
     pub(crate) date_str: String,
     /// Message ID for deduplication (optional)
     pub(crate) message_id: Option<String>,
+    /// Stable internal session identity used for aggregation/deduplication.
+    #[serde(skip_serializing, skip_deserializing, default)]
+    pub(crate) session_key: String,
     /// Session ID
     pub(crate) session_id: String,
     /// Project path (may be empty for some sources)
@@ -296,6 +300,7 @@ mod tests {
             timestamp_ms: 0,
             date_str: String::new(),
             message_id: None,
+            session_key: String::new(),
             session_id: String::new(),
             project_path: String::new(),
             model: String::new(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,11 +198,21 @@ fn main() {
     // Initialize currency converter if requested
     let currency_converter = if show_cost {
         cli.currency.as_ref().map(|code| {
-            let Some(conv) = CurrencyConverter::load(code, cli.offline) else {
-                eprintln!("Error: failed to load exchange rate for '{code}'");
-                std::process::exit(1);
+            let conv = if let Some(conv) = CurrencyConverter::load(code, cli.offline) {
+                conv
+            } else {
+                if !is_statusline {
+                    eprintln!(
+                        "Warning: failed to load exchange rate for '{code}', showing USD costs."
+                    );
+                }
+                let Some(conv) = CurrencyConverter::load("USD", true) else {
+                    eprintln!("Error: failed to initialize USD currency converter");
+                    std::process::exit(1);
+                };
+                conv
             };
-            if !is_statusline {
+            if !is_statusline && conv.currency_code() != "USD" {
                 eprintln!(
                     "Converting costs to {} (rate: displayed as {})",
                     conv.currency_code(),

--- a/src/output/csv.rs
+++ b/src/output/csv.rs
@@ -462,6 +462,7 @@ mod tests {
     #[test]
     fn session_csv_structure() {
         let sessions = vec![SessionStats {
+            session_key: "abc-123".to_string(),
             session_id: "abc-123".to_string(),
             project_path: "/home/user/project".to_string(),
             first_timestamp: "2025-01-01T00:00:00Z".to_string(),
@@ -489,6 +490,7 @@ mod tests {
     #[test]
     fn session_csv_includes_reasoning_and_cache_tokens() {
         let sessions = vec![SessionStats {
+            session_key: "reasoning".to_string(),
             session_id: "reasoning".to_string(),
             project_path: String::new(),
             first_timestamp: "2025-01-01T00:00:00Z".to_string(),

--- a/src/output/session.rs
+++ b/src/output/session.rs
@@ -440,6 +440,7 @@ mod tests {
 
     fn make_session(id: &str, last_ts: &str, input: i64, output: i64) -> SessionStats {
         SessionStats {
+            session_key: id.to_string(),
             session_id: id.to_string(),
             project_path: "/home/user/project".to_string(),
             first_timestamp: "2026-02-12T08:00:00Z".to_string(),
@@ -515,6 +516,7 @@ mod tests {
         models.insert("haiku".to_string(), Stats::default());
 
         let sessions = vec![SessionStats {
+            session_key: "s1".to_string(),
             session_id: "s1".to_string(),
             models,
             ..Default::default()

--- a/src/output/tools.rs
+++ b/src/output/tools.rs
@@ -1,7 +1,8 @@
 //! Output formatters for tool usage statistics
 
-use comfy_table::CellAlignment;
 use std::fmt::Write;
+
+use comfy_table::CellAlignment;
 
 use crate::core::ToolSummary;
 

--- a/src/pricing/resolver.rs
+++ b/src/pricing/resolver.rs
@@ -143,6 +143,12 @@ pub(super) fn fallback_pricing(model: &str) -> ModelPricing {
             cache_create: 1e-6,
             cache_read: 0.08e-6,
         }
+    } else if model_lower.contains("gpt-5.4-mini") {
+        openai_pricing(0.75e-6, 4.5e-6, 0.075e-6)
+    } else if model_lower.contains("gpt-5.4-nano") {
+        openai_pricing(0.2e-6, 1.25e-6, 0.02e-6)
+    } else if model_lower.contains("gpt-5.4") {
+        openai_pricing(2.5e-6, 15e-6, 0.25e-6)
     } else if model_lower.contains("gpt-5.1-codex-mini") {
         openai_pricing(0.25e-6, 2e-6, 0.025e-6)
     } else if model_lower.contains("gpt-5.2-codex") || model_lower.contains("gpt-5.3-codex") {
@@ -387,6 +393,14 @@ mod tests {
         assert_eq!(p.input, 0.25e-6);
         assert_eq!(p.output, 2e-6);
         assert_eq!(p.cache_read, 0.025e-6);
+    }
+
+    #[test]
+    fn test_fallback_gpt5_4_mini() {
+        let p = fallback_pricing("gpt-5.4-mini");
+        assert_eq!(p.input, 0.75e-6);
+        assert_eq!(p.output, 4.5e-6);
+        assert_eq!(p.cache_read, 0.075e-6);
     }
 
     #[test]

--- a/src/source/claude/parser.rs
+++ b/src/source/claude/parser.rs
@@ -356,6 +356,18 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_derive_project_path_uses_project_segment_for_subagent_logs() {
+        let path = Path::new("/tmp/.claude/projects/myproject/subagents/agent-a.jsonl");
+        assert_eq!(derive_project_path(path), "myproject");
+    }
+
+    #[test]
+    fn test_derive_project_path_falls_back_to_immediate_parent() {
+        let path = Path::new("/tmp/custom/session-a.jsonl");
+        assert_eq!(derive_project_path(path), "custom");
+    }
+
     // ========================================================================
     // parse_entry
     // ========================================================================

--- a/src/source/claude/parser.rs
+++ b/src/source/claude/parser.rs
@@ -96,23 +96,37 @@ fn normalize_model_name(model: &str) -> String {
     name.to_string()
 }
 
+fn derive_project_path(path: &Path) -> String {
+    let mut components = path.parent().into_iter().flat_map(Path::components);
+    while let Some(component) = components.next() {
+        if component.as_os_str() == "projects" {
+            if let Some(project) = components.next() {
+                return project.as_os_str().to_string_lossy().into_owned();
+            }
+            break;
+        }
+    }
+
+    path.parent()
+        .and_then(|p| p.file_name())
+        .and_then(|s| s.to_str())
+        .unwrap_or(UNKNOWN)
+        .to_string()
+}
+
 pub(super) fn parse_claude_file_with_debug(
     path: &Path,
     timezone: Timezone,
     debug: bool,
 ) -> ParseOutput {
+    let session_key = path.display().to_string();
     let session_id = path
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or(UNKNOWN)
         .to_string();
 
-    let project_path = path
-        .parent()
-        .and_then(|p| p.file_name())
-        .and_then(|s| s.to_str())
-        .unwrap_or(UNKNOWN)
-        .to_string();
+    let project_path = derive_project_path(path);
 
     let file = match File::open(path) {
         Ok(f) => f,
@@ -176,6 +190,7 @@ pub(super) fn parse_claude_file_with_debug(
         if let Some(entry) = parse_entry_with_debug(
             entry,
             path,
+            &session_key,
             &session_id,
             &project_path,
             timezone,
@@ -196,6 +211,7 @@ pub(super) fn parse_claude_file_with_debug(
 fn parse_entry(
     entry: UsageEntry,
     path: &Path,
+    session_key: &str,
     session_id: &str,
     project_path: &str,
     timezone: Timezone,
@@ -205,6 +221,7 @@ fn parse_entry(
     parse_entry_with_debug(
         entry,
         path,
+        session_key,
         session_id,
         project_path,
         timezone,
@@ -218,6 +235,7 @@ fn parse_entry(
 fn parse_entry_with_debug(
     entry: UsageEntry,
     path: &Path,
+    session_key: &str,
     session_id: &str,
     project_path: &str,
     timezone: Timezone,
@@ -267,6 +285,7 @@ fn parse_entry_with_debug(
         timestamp_ms: utc_dt.timestamp_millis(),
         date_str: date.format(DATE_FORMAT).to_string(),
         message_id: msg.id,
+        session_key: session_key.to_string(),
         session_id: session_id.to_string(),
         project_path: project_path.to_string(),
         model,
@@ -379,7 +398,15 @@ mod tests {
             50,
         );
         let tz = make_timezone();
-        let result = parse_entry(entry, Path::new("test.jsonl"), "sess1", "proj1", tz, 1);
+        let result = parse_entry(
+            entry,
+            Path::new("test.jsonl"),
+            "scope/test",
+            "sess1",
+            "proj1",
+            tz,
+            1,
+        );
         let raw = result.unwrap();
         assert_eq!(raw.input_tokens, 100);
         assert_eq!(raw.output_tokens, 50);
@@ -401,7 +428,7 @@ mod tests {
             }),
         };
         let tz = make_timezone();
-        assert!(parse_entry(entry, Path::new("t.jsonl"), "s", "p", tz, 1).is_none());
+        assert!(parse_entry(entry, Path::new("t.jsonl"), "scope/t", "s", "p", tz, 1).is_none());
     }
 
     #[test]
@@ -412,7 +439,7 @@ mod tests {
             message: None,
         };
         let tz = make_timezone();
-        assert!(parse_entry(entry, Path::new("t.jsonl"), "s", "p", tz, 1).is_none());
+        assert!(parse_entry(entry, Path::new("t.jsonl"), "scope/t", "s", "p", tz, 1).is_none());
     }
 
     #[test]
@@ -428,42 +455,28 @@ mod tests {
             }),
         };
         let tz = make_timezone();
-        assert!(parse_entry(entry, Path::new("t.jsonl"), "s", "p", tz, 1).is_none());
+        assert!(parse_entry(entry, Path::new("t.jsonl"), "scope/t", "s", "p", tz, 1).is_none());
     }
 
     #[test]
     fn test_parse_entry_synthetic_model_filtered() {
         let entry = make_usage_entry("2025-01-15T10:00:00Z", Some("<synthetic>"), None, 10, 5);
         let tz = make_timezone();
-        assert!(parse_entry(entry, Path::new("t.jsonl"), "s", "p", tz, 1).is_none());
+        assert!(parse_entry(entry, Path::new("t.jsonl"), "scope/t", "s", "p", tz, 1).is_none());
     }
 
     #[test]
     fn test_parse_entry_empty_model_filtered() {
         let entry = make_usage_entry("2025-01-15T10:00:00Z", Some(""), None, 10, 5);
         let tz = make_timezone();
-        assert!(parse_entry(entry, Path::new("t.jsonl"), "s", "p", tz, 1).is_none());
-    }
-
-    #[test]
-    fn test_parse_entry_sidechain_filtered() {
-        let mut entry = make_usage_entry(
-            "2025-01-15T10:00:00Z",
-            Some("claude-3-5-sonnet-20241022"),
-            None,
-            10,
-            5,
-        );
-        entry.is_sidechain = true;
-        let tz = make_timezone();
-        assert!(parse_entry(entry, Path::new("t.jsonl"), "s", "p", tz, 1).is_none());
+        assert!(parse_entry(entry, Path::new("t.jsonl"), "scope/t", "s", "p", tz, 1).is_none());
     }
 
     #[test]
     fn test_parse_entry_no_model_uses_unknown() {
         let entry = make_usage_entry("2025-01-15T10:00:00Z", None, None, 10, 5);
         let tz = make_timezone();
-        let raw = parse_entry(entry, Path::new("t.jsonl"), "s", "p", tz, 1).unwrap();
+        let raw = parse_entry(entry, Path::new("t.jsonl"), "scope/t", "s", "p", tz, 1).unwrap();
         assert_eq!(raw.model, UNKNOWN);
     }
 
@@ -477,7 +490,7 @@ mod tests {
             5,
         );
         let tz = make_timezone();
-        assert!(parse_entry(entry, Path::new("t.jsonl"), "s", "p", tz, 1).is_none());
+        assert!(parse_entry(entry, Path::new("t.jsonl"), "scope/t", "s", "p", tz, 1).is_none());
     }
 
     #[test]
@@ -498,7 +511,7 @@ mod tests {
             }),
         };
         let tz = make_timezone();
-        let raw = parse_entry(entry, Path::new("t.jsonl"), "s", "p", tz, 1).unwrap();
+        let raw = parse_entry(entry, Path::new("t.jsonl"), "scope/t", "s", "p", tz, 1).unwrap();
         assert_eq!(raw.cache_creation, 30);
         assert_eq!(raw.cache_read, 20);
     }
@@ -521,7 +534,7 @@ mod tests {
             }),
         };
         let tz = make_timezone();
-        let raw = parse_entry(entry, Path::new("t.jsonl"), "s", "p", tz, 1).unwrap();
+        let raw = parse_entry(entry, Path::new("t.jsonl"), "scope/t", "s", "p", tz, 1).unwrap();
         assert_eq!(raw.input_tokens, 0);
         assert_eq!(raw.output_tokens, 0);
         assert_eq!(raw.cache_creation, 0);

--- a/src/source/codex/parser.rs
+++ b/src/source/codex/parser.rs
@@ -218,6 +218,7 @@ pub(super) fn parse_codex_file_with_debug(
     timezone: Timezone,
     debug: bool,
 ) -> ParseOutput {
+    let session_key = path.display().to_string();
     let session_id = path
         .file_stem()
         .and_then(|s| s.to_str())
@@ -393,6 +394,7 @@ pub(super) fn parse_codex_file_with_debug(
             timestamp_ms: utc_dt.timestamp_millis(),
             date_str: date.format(DATE_FORMAT).to_string(),
             message_id: None, // Codex doesn't use message IDs for dedup
+            session_key: session_key.clone(),
             session_id: session_id.clone(),
             project_path: String::new(), // Codex doesn't track projects
             model,

--- a/src/source/cursor/parser.rs
+++ b/src/source/cursor/parser.rs
@@ -192,6 +192,7 @@ fn entry_from_bubble(
     key: &str,
     value: &Value,
     composers: &HashMap<String, ComposerMeta>,
+    path: &Path,
     timezone: Timezone,
 ) -> Option<RawEntry> {
     let (composer_id, bubble_id) = bubble_ids_from_key(key)?;
@@ -215,6 +216,7 @@ fn entry_from_bubble(
         timestamp_ms: utc_dt.timestamp_millis(),
         date_str: local_dt.date_naive().format(DATE_FORMAT).to_string(),
         message_id: Some(bubble_id.to_string()),
+        session_key: format!("{}:{composer_id}", path.display()),
         session_id: composer_id.to_string(),
         project_path: meta
             .and_then(|m| m.project_path.clone())
@@ -264,6 +266,7 @@ fn entry_from_generation(generation: &Value, path: &Path, timezone: Timezone) ->
         timestamp_ms: utc_dt.timestamp_millis(),
         date_str: local_dt.date_naive().format(DATE_FORMAT).to_string(),
         message_id: Some(session_id.clone()),
+        session_key: format!("{}:{session_id}", path.display()),
         session_id,
         project_path: String::new(),
         model,
@@ -278,6 +281,7 @@ fn entry_from_generation(generation: &Value, path: &Path, timezone: Timezone) ->
 
 fn parse_cursor_disk_kv(
     conn: &Connection,
+    path: &Path,
     timezone: Timezone,
 ) -> rusqlite::Result<(Vec<RawEntry>, usize)> {
     let mut entries = Vec::new();
@@ -307,7 +311,7 @@ fn parse_cursor_disk_kv(
     }
 
     for (key, value) in bubbles {
-        if let Some(entry) = entry_from_bubble(&key, &value, &composers, timezone) {
+        if let Some(entry) = entry_from_bubble(&key, &value, &composers, path, timezone) {
             entries.push(entry);
         }
     }
@@ -368,7 +372,7 @@ pub(super) fn parse_cursor_db_with_debug(
     let mut errors = 0usize;
 
     if table_exists(&conn, "cursorDiskKV") {
-        match parse_cursor_disk_kv(&conn, timezone) {
+        match parse_cursor_disk_kv(&conn, path, timezone) {
             Ok((mut parsed, parse_errors)) => {
                 entries.append(&mut parsed);
                 errors += parse_errors;
@@ -430,6 +434,7 @@ mod tests {
             "bubbleId:composer-1:bubble-1",
             &value,
             &HashMap::new(),
+            Path::new("/tmp/state.vscdb"),
             tz(),
         )
         .unwrap();
@@ -457,8 +462,14 @@ mod tests {
             "tokenCount": {"inputTokens": 10, "outputTokens": 5}
         });
 
-        let entry =
-            entry_from_bubble("bubbleId:composer-1:bubble-1", &value, &composers, tz()).unwrap();
+        let entry = entry_from_bubble(
+            "bubbleId:composer-1:bubble-1",
+            &value,
+            &composers,
+            Path::new("/tmp/state.vscdb"),
+            tz(),
+        )
+        .unwrap();
 
         assert_eq!(entry.model, "gpt-5");
         assert_eq!(entry.project_path, "/tmp/project");

--- a/src/source/loader.rs
+++ b/src/source/loader.rs
@@ -263,6 +263,7 @@ impl<'a> DataLoader<'a> {
 
     fn merge_session_stats(into: &mut SessionStats, incoming: SessionStats) {
         let SessionStats {
+            session_key,
             project_path,
             first_timestamp,
             last_timestamp,
@@ -271,6 +272,9 @@ impl<'a> DataLoader<'a> {
             ..
         } = incoming;
 
+        if into.session_key.is_empty() && !session_key.is_empty() {
+            into.session_key = session_key;
+        }
         if first_timestamp < into.first_timestamp {
             into.first_timestamp = first_timestamp;
         }
@@ -297,11 +301,11 @@ impl<'a> DataLoader<'a> {
             aggregate_sessions_map,
             HashMap::<String, SessionStats>::new,
             |mut acc, partial| {
-                for (session_id, session) in partial {
-                    if let Some(existing) = acc.get_mut(&session_id) {
+                for (session_key, session) in partial {
+                    if let Some(existing) = acc.get_mut(&session_key) {
                         Self::merge_session_stats(existing, session);
                     } else {
-                        acc.insert(session_id, session);
+                        acc.insert(session_key, session);
                     }
                 }
                 acc
@@ -309,13 +313,7 @@ impl<'a> DataLoader<'a> {
         );
 
         match result {
-            Some((merged, _)) => merged
-                .into_iter()
-                .map(|(session_id, mut session)| {
-                    session.session_id = session_id;
-                    session
-                })
-                .collect(),
+            Some((merged, _)) => merged.into_values().collect(),
             None => Vec::new(),
         }
     }
@@ -557,6 +555,7 @@ mod tests {
             timestamp_ms: 0,
             date_str: date_str.to_string(),
             message_id: None,
+            session_key: "s1".to_string(),
             session_id: "s1".to_string(),
             project_path: String::new(),
             model: model.to_string(),
@@ -724,6 +723,7 @@ mod tests {
 
     fn make_session(id: &str, project: &str, first: &str, last: &str, input: i64) -> SessionStats {
         SessionStats {
+            session_key: id.to_string(),
             session_id: id.to_string(),
             project_path: project.to_string(),
             first_timestamp: first.to_string(),

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -775,6 +775,51 @@ fn claude_project_json_aggregates_sessions() {
 }
 
 #[test]
+fn claude_project_json_ignores_sidechain_subagent_logs() {
+    let root = unique_temp_dir("claude-project-subagents");
+    let session_a = root.join(".claude/projects/myapp/session-a.jsonl");
+    let session_b = root.join(".claude/projects/myapp/subagents/agent-a.jsonl");
+
+    write_file(
+        &session_a,
+        r#"{"timestamp":"2026-02-06T10:00:00Z","message":{"id":"msg_1","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":100,"output_tokens":50}}}
+"#,
+    );
+    write_file(
+        &session_b,
+        r#"{"timestamp":"2026-02-06T11:00:00Z","isSidechain":true,"message":{"id":"msg_2","model":"gpt-5.2-codex","stop_reason":"end_turn","usage":{"input_tokens":200,"output_tokens":80}}}
+"#,
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "project",
+            "-j",
+            "-O",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("HOME", &root)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    let arr = json.as_array().expect("array output");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["project"].as_str(), Some("myapp"));
+    assert_eq!(arr[0]["project_path"].as_str(), Some("myapp"));
+    assert_eq!(arr[0]["session_count"].as_i64(), Some(1));
+    assert_eq!(arr[0]["total_tokens"].as_i64(), Some(150));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn claude_session_json_keeps_same_file_stem_from_different_projects_separate() {
     let root = unique_temp_dir("claude-session-separate-stems");
     let session_a = root.join(".claude/projects/projA/shared.jsonl");

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -775,6 +775,94 @@ fn claude_project_json_aggregates_sessions() {
 }
 
 #[test]
+fn claude_session_json_keeps_same_file_stem_from_different_projects_separate() {
+    let root = unique_temp_dir("claude-session-separate-stems");
+    let session_a = root.join(".claude/projects/projA/shared.jsonl");
+    let session_b = root.join(".claude/projects/projB/shared.jsonl");
+
+    write_file(
+        &session_a,
+        r#"{"timestamp":"2026-02-06T10:00:00Z","message":{"id":"msg_a","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":100,"output_tokens":20}}}
+"#,
+    );
+    write_file(
+        &session_b,
+        r#"{"timestamp":"2026-02-06T11:00:00Z","message":{"id":"msg_b","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":200,"output_tokens":30}}}
+"#,
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "session",
+            "-j",
+            "-O",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+            "--order",
+            "desc",
+        ],
+        &[("HOME", &root)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    let arr = json.as_array().expect("array output");
+    assert_eq!(arr.len(), 2);
+    assert_eq!(arr[0]["session_id"].as_str(), Some("shared"));
+    assert_eq!(arr[0]["project_path"].as_str(), Some("projB"));
+    assert_eq!(arr[0]["total_tokens"].as_i64(), Some(230));
+    assert_eq!(arr[1]["session_id"].as_str(), Some("shared"));
+    assert_eq!(arr[1]["project_path"].as_str(), Some("projA"));
+    assert_eq!(arr[1]["total_tokens"].as_i64(), Some(120));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn invalid_currency_falls_back_to_usd_costs() {
+    let root = unique_temp_dir("invalid-currency-fallback");
+    let claude_file = root.join(".claude/projects/myproject/session-a.jsonl");
+    write_file(
+        &claude_file,
+        r#"{"timestamp":"2026-02-06T12:00:00Z","message":{"id":"msg_1","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":100,"output_tokens":50}}}
+"#,
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "-j",
+            "-O",
+            "--timezone",
+            "UTC",
+            "--currency",
+            "ZZZ",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("HOME", &root)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let stderr = String::from_utf8(stderr).expect("utf8 stderr");
+    assert!(stderr.contains("Warning: failed to load exchange rate"));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    let arr = json.as_array().expect("array output");
+    assert_eq!(arr.len(), 1);
+    assert!(arr[0]["cost"].as_f64().is_some());
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn claude_blocks_json_groups_by_5h_window() {
     let root = unique_temp_dir("claude-blocks");
     let session = root.join(".claude/projects/myapp/session-blocks.jsonl");
@@ -869,6 +957,48 @@ fn claude_dedup_keeps_completed_message() {
     assert_eq!(arr.len(), 1);
     // Should use the completed message's tokens (100+50=150), not the streaming one (50+10=60)
     assert_eq!(arr[0]["total_tokens"].as_i64(), Some(150));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn claude_dedup_keeps_same_message_id_from_different_files() {
+    let root = unique_temp_dir("claude-dedup-scope");
+    let file_a = root.join(".claude/projects/projA/a.jsonl");
+    let file_b = root.join(".claude/projects/projB/b.jsonl");
+
+    write_file(
+        &file_a,
+        r#"{"timestamp":"2026-02-06T10:00:00Z","message":{"id":"msg_dup","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":100,"output_tokens":50}}}
+"#,
+    );
+    write_file(
+        &file_b,
+        r#"{"timestamp":"2026-02-06T11:00:00Z","message":{"id":"msg_dup","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":200,"output_tokens":80}}}
+"#,
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "-j",
+            "-O",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("HOME", &root)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    let arr = json.as_array().expect("array output");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["total_tokens"].as_i64(), Some(430));
 
     let _ = fs::remove_dir_all(root);
 }


### PR DESCRIPTION
## Summary
- scope session identity and Claude deduplication per source log file to prevent cross-file collisions
- correct offline fallback pricing for GPT-5.4 model variants and make invalid currency conversion fall back to USD
- align CLI/package/docs copy with the current Claude + Codex surface and clear remaining clippy findings

## Testing
- cargo fmt -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test