### PR TITLE
[codex] Harden release integrity checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,27 @@ permissions:
   contents: write
 
 jobs:
+  preflight:
+    name: Release preflight
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.85.0
+
+      - name: Validate release metadata
+        run: scripts/check-release.sh
+
+      - name: Test
+        run: cargo test --locked
+
+      - name: Package dry run
+        run: cargo publish --dry-run --locked
+
   build:
     name: Build ${{ matrix.target }}
+    needs: preflight
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -52,6 +71,11 @@ jobs:
           cd target/${{ matrix.target }}/release
           tar czvf ../../../ccstats-${{ matrix.target }}.tar.gz ccstats
           cd ../../..
+          if command -v shasum >/dev/null 2>&1; then
+            shasum -a 256 ccstats-${{ matrix.target }}.tar.gz > ccstats-${{ matrix.target }}.tar.gz.sha256
+          else
+            sha256sum ccstats-${{ matrix.target }}.tar.gz > ccstats-${{ matrix.target }}.tar.gz.sha256
+          fi
 
       - name: Package (Windows)
         if: runner.os == 'Windows'
@@ -59,6 +83,7 @@ jobs:
           cd target/${{ matrix.target }}/release
           7z a ../../../ccstats-${{ matrix.target }}.zip ccstats.exe
           cd ../../..
+          (Get-FileHash ccstats-${{ matrix.target }}.zip -Algorithm SHA256).Hash.ToLower() + "  ccstats-${{ matrix.target }}.zip" | Out-File -Encoding ascii ccstats-${{ matrix.target }}.zip.sha256
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.61] - 2026-04-02
+
+### Added
+- `sources` command for discovering available data sources and aliases.
+
+### Changed
+- Improve unsupported-command guidance with actionable source hints.
+- Refresh README landing visuals and crate documentation.
+- Reduce parser, loader, aggregation, JSON serialization, and no-cost execution overhead.
+
 ## [0.2.15] - 2026-02-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ cargo install ccstats
 ### Shell script
 ```bash
 curl -fsSL https://raw.githubusercontent.com/majiayu000/ccstats/main/install.sh | sh
+
+# Install a specific version
+curl -fsSL https://raw.githubusercontent.com/majiayu000/ccstats/main/install.sh | VERSION=v0.2.61 sh
 ```
 
 ### Manual download

--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,7 @@ REPO="majiayu000/ccstats"
 BINARY="ccstats"
 INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
 LATEST_RELEASE_API="https://api.github.com/repos/${REPO}/releases/latest"
+REQUIRE_CHECKSUM="${REQUIRE_CHECKSUM:-0}"
 
 require_cmd() {
     if ! command -v "$1" >/dev/null 2>&1; then
@@ -72,6 +73,14 @@ get_latest_version() {
     sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$tmp_json" | head -n 1
 }
 
+normalize_version() {
+    version="$1"
+    case "$version" in
+        v*) echo "$version" ;;
+        *) echo "v$version" ;;
+    esac
+}
+
 verify_checksum_if_available() {
     archive_url="$1"
     archive_path="$2"
@@ -94,9 +103,17 @@ verify_checksum_if_available() {
             fi
             echo "Checksum verified."
         else
+            if [ "$REQUIRE_CHECKSUM" = "1" ]; then
+                echo "No SHA-256 tool found and REQUIRE_CHECKSUM=1."
+                exit 1
+            fi
             echo "Warning: no SHA-256 tool found, skipping checksum verification."
         fi
     else
+        if [ "$REQUIRE_CHECKSUM" = "1" ]; then
+            echo "Checksum file not found for this release asset."
+            exit 1
+        fi
         echo "Checksum file not found for this release asset, skipping verification."
     fi
 }
@@ -118,7 +135,11 @@ main() {
     }
     trap cleanup EXIT INT TERM
 
-    version="$(get_latest_version "$tmp_json")"
+    if [ -n "${VERSION:-}" ]; then
+        version="$(normalize_version "$VERSION")"
+    else
+        version="$(get_latest_version "$tmp_json")"
+    fi
     if [ -z "$version" ]; then
         echo "Failed to get latest version."
         exit 1
@@ -128,8 +149,16 @@ main() {
 
     # Determine file extension
     case "$platform" in
-        *windows*) ext="zip" ;;
-        *) ext="tar.gz" ;;
+        *windows*)
+            ext="zip"
+            binary_name="${BINARY}.exe"
+            install_name="${BINARY}.exe"
+            ;;
+        *)
+            ext="tar.gz"
+            binary_name="$BINARY"
+            install_name="$BINARY"
+            ;;
     esac
 
     url="https://github.com/${REPO}/releases/download/${version}/${BINARY}-${platform}.${ext}"
@@ -158,21 +187,21 @@ main() {
             ;;
     esac
 
-    bin_path="$(find "$tmp_dir" -type f -name "$BINARY" | head -n 1)"
+    bin_path="$(find "$tmp_dir" -type f -name "$binary_name" | head -n 1)"
     if [ -z "$bin_path" ]; then
-        echo "Failed to locate extracted binary: $BINARY"
+        echo "Failed to locate extracted binary: $binary_name"
         exit 1
     fi
 
     if command -v install >/dev/null 2>&1; then
-        install -m 755 "$bin_path" "$INSTALL_DIR/$BINARY"
+        install -m 755 "$bin_path" "$INSTALL_DIR/$install_name"
     else
-        cp "$bin_path" "$INSTALL_DIR/$BINARY"
-        chmod +x "$INSTALL_DIR/$BINARY"
+        cp "$bin_path" "$INSTALL_DIR/$install_name"
+        chmod +x "$INSTALL_DIR/$install_name"
     fi
 
     echo ""
-    echo "ccstats installed to $INSTALL_DIR/$BINARY"
+    echo "ccstats installed to $INSTALL_DIR/$install_name"
     echo ""
 
     # Check if in PATH

--- a/scripts/check-release.sh
+++ b/scripts/check-release.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Validate release metadata before building release artifacts.
+
+set -eu
+
+manifest_version() {
+    sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)"/\1/p' Cargo.toml | head -n 1
+}
+
+lock_version() {
+    awk '
+        /^\[\[package\]\]/ { in_pkg = 0; name = ""; version = "" }
+        /^name = "ccstats"$/ { in_pkg = 1; name = "ccstats" }
+        in_pkg && /^version = / {
+            gsub(/version = "/, "");
+            gsub(/"/, "");
+            print;
+            exit;
+        }
+    ' Cargo.lock
+}
+
+version="$(manifest_version)"
+if [ -z "$version" ]; then
+    echo "Failed to read package version from Cargo.toml" >&2
+    exit 1
+fi
+
+locked_version="$(lock_version)"
+if [ "$locked_version" != "$version" ]; then
+    echo "Cargo.lock version ($locked_version) does not match Cargo.toml version ($version)." >&2
+    exit 1
+fi
+
+expected_tag="v$version"
+actual_tag="${GITHUB_REF_NAME:-}"
+if [ -n "$actual_tag" ] && [ "$actual_tag" != "$expected_tag" ]; then
+    echo "Release tag ($actual_tag) does not match package version ($expected_tag)." >&2
+    exit 1
+fi
+
+if ! grep -Eq "^## \[$version\]( - |$)" CHANGELOG.md; then
+    echo "CHANGELOG.md is missing a release section for [$version]." >&2
+    exit 1
+fi
+
+echo "Release metadata validated for $expected_tag."


### PR DESCRIPTION
## What

Harden the release path before building GitHub release artifacts.

- Add a release metadata preflight script that checks Cargo.toml, Cargo.lock, tag name, and CHANGELOG alignment.
- Run release preflight, tests, and cargo publish dry-run before matrix artifact builds.
- Generate SHA-256 files for release archives.
- Improve install.sh with VERSION override, optional strict checksum mode, and Windows .exe extraction/install handling.
- Add the missing 0.2.61 CHANGELOG section and document version-pinned install usage.

## Why

The crate version is 0.2.61 while GitHub Releases currently lag behind at v0.2.59. The installer depends on GitHub latest, so release metadata drift can cause users to install a different binary than the crate version suggests.

## Validation

- `sh -n install.sh`
- `sh -n scripts/check-release.sh`
- `GITHUB_REF_NAME=v0.2.61 scripts/check-release.sh`
- `cargo test --locked`
- `cargo publish --dry-run --locked --allow-dirty`
