### PR TITLE
[codex] Add all-source usage overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ ccstats daily --since 20260101 --until 20260131
 # Select data source explicitly (supports aliases)
 ccstats daily --source codex
 
+# Combine all supported data sources
+ccstats monthly --source all
+
 # Offline mode (use cached pricing)
 ccstats today -O
 
@@ -176,6 +179,7 @@ Warning: ignored <N> malformed records
 |--------|-----------|----------|
 | Claude Code | `~/.claude/projects/` | Projects, Billing Blocks, Deduplication |
 | OpenAI Codex | `~/.codex/sessions/` | Reasoning Tokens |
+| All Sources | Multiple | Combined daily/weekly/monthly/today/statusline summaries |
 
 ## Architecture
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,8 @@
+use std::collections::HashMap;
+use std::time::Instant;
+
 use crate::cli::{Cli, SourceCommand};
-use crate::core::{DateFilter, aggregate_tools};
+use crate::core::{DateFilter, DayStats, LoadResult, aggregate_tools};
 use crate::output::NumberFormat;
 use crate::output::{
     BlockTableOptions, Period, ProjectTableOptions, SessionTableOptions, SummaryOptions,
@@ -11,7 +14,8 @@ use crate::output::{
 };
 use crate::pricing::PricingDb;
 use crate::source::{
-    Source, all_sources, load_blocks, load_daily, load_projects, load_sessions, load_tool_calls,
+    ALL_SOURCES, Capabilities, Source, all_sources, load_blocks, load_daily, load_projects,
+    load_sessions, load_tool_calls,
 };
 use crate::utils::{Timezone, filter_json};
 use serde_json::json;
@@ -183,9 +187,19 @@ fn handle_tools(ctx: &CommandContext<'_>) {
 
 fn handle_sources(ctx: &CommandContext<'_>) {
     let sources: Vec<&dyn Source> = all_sources().collect();
+    let mut all_caps = all_sources_capabilities();
+    all_caps.has_projects = false;
+    all_caps.has_billing_blocks = false;
 
     if ctx.cli.csv {
         println!("name,display_name,aliases,has_projects,has_billing_blocks,has_reasoning_tokens");
+        println!(
+            "{},All Sources,,{},{},{}",
+            ALL_SOURCES,
+            all_caps.has_projects,
+            all_caps.has_billing_blocks,
+            all_caps.has_reasoning_tokens
+        );
         for source in sources {
             let caps = source.capabilities();
             let aliases = source.aliases().join("|");
@@ -203,30 +217,46 @@ fn handle_sources(ctx: &CommandContext<'_>) {
     }
 
     if ctx.cli.json {
-        let payload: Vec<serde_json::Value> = sources
-            .iter()
-            .map(|source| {
-                let caps = source.capabilities();
-                json!({
-                    "name": source.name(),
-                    "display_name": source.display_name(),
-                    "aliases": source.aliases(),
-                    "capabilities": {
-                        "has_projects": caps.has_projects,
-                        "has_billing_blocks": caps.has_billing_blocks,
-                        "has_reasoning_tokens": caps.has_reasoning_tokens,
-                        "has_cache_creation": caps.has_cache_creation,
-                        "needs_dedup": caps.needs_dedup
-                    }
-                })
+        let mut payload = vec![json!({
+            "name": ALL_SOURCES,
+            "display_name": "All Sources",
+            "aliases": [],
+            "capabilities": {
+                "has_projects": all_caps.has_projects,
+                "has_billing_blocks": all_caps.has_billing_blocks,
+                "has_reasoning_tokens": all_caps.has_reasoning_tokens,
+                "has_cache_creation": all_caps.has_cache_creation,
+                "needs_dedup": all_caps.needs_dedup
+            }
+        })];
+        payload.extend(sources.iter().map(|source| {
+            let caps = source.capabilities();
+            json!({
+                "name": source.name(),
+                "display_name": source.display_name(),
+                "aliases": source.aliases(),
+                "capabilities": {
+                    "has_projects": caps.has_projects,
+                    "has_billing_blocks": caps.has_billing_blocks,
+                    "has_reasoning_tokens": caps.has_reasoning_tokens,
+                    "has_cache_creation": caps.has_cache_creation,
+                    "needs_dedup": caps.needs_dedup
+                }
             })
-            .collect();
+        }));
         let json = serde_json::to_string(&payload).unwrap_or_else(|_| "[]".to_string());
         print_json(&json, ctx.jq_filter);
         return;
     }
 
     println!("Available sources:");
+    println!(
+        "- {} (All Sources) aliases: - | projects={} blocks={} reasoning={}",
+        ALL_SOURCES,
+        all_caps.has_projects,
+        all_caps.has_billing_blocks,
+        all_caps.has_reasoning_tokens
+    );
     for source in sources {
         let caps = source.capabilities();
         let aliases = if source.aliases().is_empty() {
@@ -327,6 +357,149 @@ pub(crate) fn handle_source_command(
     let result = load_daily(source, ctx.filter, ctx.timezone, false, ctx.cli.debug);
     if result.day_stats.is_empty() {
         print_no_data_hint(source.display_name(), "usage");
+        return;
+    }
+    if ctx.cli.csv {
+        let csv = output_period_csv(
+            &result.day_stats,
+            period,
+            ctx.pricing_db,
+            ctx.cli.sort_order(),
+            ctx.cli.breakdown,
+            ctx.cli.show_cost(),
+        );
+        print!("{csv}");
+    } else if ctx.cli.json {
+        let json = output_period_json(
+            &result.day_stats,
+            period,
+            ctx.pricing_db,
+            ctx.cli.sort_order(),
+            ctx.cli.breakdown,
+            ctx.cli.show_cost(),
+            ctx.currency,
+        );
+        print_json(&json, ctx.jq_filter);
+    } else {
+        print_period_table(
+            &result.day_stats,
+            period,
+            ctx.cli.breakdown,
+            SummaryOptions {
+                skipped: result.skipped,
+                valid: result.valid,
+                elapsed_ms: Some(result.elapsed_ms),
+            },
+            ctx.pricing_db,
+            TokenTableOptions {
+                order: ctx.cli.sort_order(),
+                use_color: ctx.cli.use_color(),
+                compact: ctx.cli.compact,
+                show_cost: ctx.cli.show_cost(),
+                number_format: ctx.number_format,
+                show_reasoning: caps.has_reasoning_tokens,
+                show_cache_creation: caps.has_cache_creation,
+                currency: ctx.currency,
+            },
+        );
+    }
+}
+
+fn all_sources_capabilities() -> Capabilities {
+    let mut combined = Capabilities::default();
+    for source in all_sources() {
+        let caps = source.capabilities();
+        combined.has_projects |= caps.has_projects;
+        combined.has_billing_blocks |= caps.has_billing_blocks;
+        combined.has_reasoning_tokens |= caps.has_reasoning_tokens;
+        combined.has_cache_creation |= caps.has_cache_creation;
+        combined.needs_dedup |= caps.needs_dedup;
+    }
+    combined
+}
+
+fn merge_day_stats(target: &mut HashMap<String, DayStats>, source: HashMap<String, DayStats>) {
+    for (date, stats) in source {
+        let day = target.entry(date).or_default();
+        day.stats.add(&stats.stats);
+        for (model, model_stats) in stats.models {
+            day.models.entry(model).or_default().add(&model_stats);
+        }
+    }
+}
+
+fn load_all_daily(ctx: &CommandContext<'_>, quiet: bool) -> (LoadResult, Capabilities) {
+    let start = Instant::now();
+    let mut combined = LoadResult::default();
+    let mut caps = Capabilities::default();
+
+    for source in all_sources() {
+        let source_caps = source.capabilities();
+        caps.has_projects |= source_caps.has_projects;
+        caps.has_billing_blocks |= source_caps.has_billing_blocks;
+        caps.has_reasoning_tokens |= source_caps.has_reasoning_tokens;
+        caps.has_cache_creation |= source_caps.has_cache_creation;
+        caps.needs_dedup |= source_caps.needs_dedup;
+
+        let result = load_daily(source, ctx.filter, ctx.timezone, quiet, ctx.cli.debug);
+        combined.skipped += result.skipped;
+        combined.valid += result.valid;
+        merge_day_stats(&mut combined.day_stats, result.day_stats);
+    }
+
+    combined.elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+    (combined, caps)
+}
+
+/// Handle aggregate commands across every registered data source.
+pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandContext<'_>) {
+    match command {
+        SourceCommand::Sources => return handle_sources(ctx),
+        SourceCommand::Statusline => {
+            let (result, _) = load_all_daily(ctx, true);
+            if ctx.cli.json {
+                let json = print_statusline_json(
+                    &result.day_stats,
+                    ctx.pricing_db,
+                    "All Sources",
+                    ctx.number_format,
+                );
+                print_json(&json, ctx.jq_filter);
+            } else {
+                print_statusline(
+                    &result.day_stats,
+                    ctx.pricing_db,
+                    "All Sources",
+                    ctx.number_format,
+                );
+            }
+            return;
+        }
+        SourceCommand::Session
+        | SourceCommand::Project
+        | SourceCommand::Blocks
+        | SourceCommand::Tools => {
+            println!(
+                "`--source all` supports daily, weekly, monthly, today, and statusline views.\nHint: use a specific --source for {command:?}."
+            );
+            return;
+        }
+        SourceCommand::Daily
+        | SourceCommand::Today
+        | SourceCommand::Weekly
+        | SourceCommand::Monthly => {}
+    }
+
+    let period = match command {
+        SourceCommand::Daily | SourceCommand::Today => Period::Day,
+        SourceCommand::Weekly => Period::Week,
+        SourceCommand::Monthly => Period::Month,
+        _ => return,
+    };
+
+    let (result, caps) = load_all_daily(ctx, false);
+    if result.day_stats.is_empty() {
+        print_no_data_hint("All Sources", "usage");
         return;
     }
     if ctx.cli.csv {

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -119,7 +119,7 @@ pub(crate) struct Cli {
     #[arg(long, global = true, value_name = "CURRENCY")]
     pub(crate) currency: Option<String>,
 
-    /// Data source name or alias (e.g., "claude", "codex", "cc", "cx")
+    /// Data source name or alias (e.g., "claude", "codex", "all", "cc", "cx")
     #[arg(long, global = true, value_name = "SOURCE")]
     pub(crate) source: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,13 +31,13 @@ mod utils;
 use chrono::Utc;
 use clap::Parser;
 
-use app::{CommandContext, handle_source_command};
+use app::{CommandContext, handle_all_sources_command, handle_source_command};
 use cli::{Cli, SourceCommand, parse_command};
 use config::Config;
 use core::DateFilter;
 use output::NumberFormat;
 use pricing::{CurrencyConverter, PricingDb};
-use source::{get_source, source_choices, suggest_source};
+use source::{ALL_SOURCES, get_source, source_choices, suggest_source};
 use utils::{Timezone, parse_date};
 
 enum TimezoneSource {
@@ -153,6 +153,10 @@ fn main() {
     } else {
         match (parsed_command.source_hint, cli.source.as_deref()) {
             (Some(hint), Some(override_name)) => {
+                if override_name.eq_ignore_ascii_case(ALL_SOURCES) {
+                    eprintln!("Error: command source '{hint}' conflicts with --source all");
+                    std::process::exit(1);
+                }
                 let Some(override_source) = get_source(override_name) else {
                     eprintln!("{}", unknown_source_message(override_name));
                     std::process::exit(1);
@@ -170,11 +174,6 @@ fn main() {
             (None, Some(name)) => name,
             (None, None) => "claude",
         }
-    };
-
-    let Some(source) = get_source(source_name) else {
-        eprintln!("{}", unknown_source_message(source_name));
-        std::process::exit(1);
     };
 
     // Initialize currency converter if requested
@@ -195,6 +194,26 @@ fn main() {
         })
     } else {
         None
+    };
+
+    if source_name.eq_ignore_ascii_case(ALL_SOURCES) {
+        return handle_all_sources_command(
+            source_cmd,
+            &CommandContext {
+                filter: &filter,
+                cli: &cli,
+                pricing_db: &pricing_db,
+                timezone,
+                number_format,
+                jq_filter,
+                currency: currency_converter.as_ref(),
+            },
+        );
+    }
+
+    let Some(source) = get_source(source_name) else {
+        eprintln!("{}", unknown_source_message(source_name));
+        std::process::exit(1);
     };
 
     handle_source_command(

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -65,7 +65,7 @@ pub(crate) trait Source: Send + Sync {
 pub(crate) type BoxedSource = Box<dyn Source>;
 
 // Re-export registry functions
-pub(crate) use registry::{all_sources, get_source, source_choices, suggest_source};
+pub(crate) use registry::{ALL_SOURCES, all_sources, get_source, source_choices, suggest_source};
 
 // Re-export loader functions
 pub(crate) use loader::{load_blocks, load_daily, load_projects, load_sessions, load_tool_calls};

--- a/src/source/registry.rs
+++ b/src/source/registry.rs
@@ -8,6 +8,9 @@ use super::claude::ClaudeSource;
 use super::codex::CodexSource;
 use super::{BoxedSource, Source};
 
+/// Pseudo-source that aggregates every registered source.
+pub(crate) const ALL_SOURCES: &str = "all";
+
 /// All registered data sources
 static SOURCES: LazyLock<Vec<BoxedSource>> = LazyLock::new(|| {
     vec![
@@ -38,7 +41,7 @@ pub(crate) fn get_source(name: &str) -> Option<&'static dyn Source> {
 
 /// Return available source names and aliases for CLI hints.
 pub(crate) fn source_choices() -> Vec<&'static str> {
-    let mut choices = Vec::new();
+    let mut choices = vec![ALL_SOURCES];
     for source in SOURCES.iter() {
         choices.push(source.name());
         choices.extend(source.aliases());
@@ -53,6 +56,9 @@ pub(crate) fn suggest_source(input: &str) -> Option<&'static str> {
     let needle = input.trim().to_lowercase();
     if needle.is_empty() {
         return None;
+    }
+    if ALL_SOURCES.starts_with(&needle) || needle.starts_with(ALL_SOURCES) {
+        return Some(ALL_SOURCES);
     }
 
     let mut best: Option<(&'static str, usize)> = None;
@@ -191,6 +197,7 @@ mod tests {
     #[test]
     fn test_source_choices_include_names_and_aliases() {
         let choices = source_choices();
+        assert!(choices.contains(&"all"));
         assert!(choices.contains(&"claude"));
         assert!(choices.contains(&"codex"));
         assert!(choices.contains(&"cc"));
@@ -202,6 +209,7 @@ mod tests {
         assert_eq!(suggest_source("clau"), Some("claude"));
         assert_eq!(suggest_source("code"), Some("codex"));
         assert_eq!(suggest_source("claud"), Some("claude"));
+        assert_eq!(suggest_source("al"), Some("all"));
         assert_eq!(suggest_source("cx"), Some("cx"));
     }
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -152,6 +152,63 @@ fn source_flag_can_select_codex_without_subcommand() {
 }
 
 #[test]
+fn source_all_daily_json_merges_registered_sources() {
+    let root = unique_temp_dir("source-all-daily");
+    let codex_home = root.join("codex-home");
+    let claude_session = root.join(".claude/projects/myapp/claude-session.jsonl");
+    let codex_session = codex_home.join("sessions").join("codex-session.jsonl");
+
+    write_file(
+        &claude_session,
+        r#"{"timestamp":"2026-02-06T10:00:00Z","message":{"id":"msg_1","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+"#,
+    );
+    write_file(
+        &codex_session,
+        r#"{"timestamp":"2026-02-06T11:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":0,"total_tokens":15},"last_token_usage":{"input_tokens":10,"cached_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":0,"total_tokens":15},"model":"gpt-5"}}}
+"#,
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "--source",
+            "all",
+            "-j",
+            "-O",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("HOME", &root), ("CODEX_HOME", &codex_home)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    let arr = json.as_array().expect("array output");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["date"].as_str(), Some("2026-02-06"));
+    assert_eq!(arr[0]["input_tokens"].as_i64(), Some(110));
+    assert_eq!(arr[0]["output_tokens"].as_i64(), Some(55));
+    assert_eq!(arr[0]["total_tokens"].as_i64(), Some(165));
+
+    let models = arr[0]["models"].as_array().expect("models");
+    assert_eq!(models.len(), 2);
+    assert!(
+        models
+            .iter()
+            .any(|model| model.as_str() == Some("3-5-sonnet"))
+    );
+    assert!(models.iter().any(|model| model.as_str() == Some("gpt-5")));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn codex_subcommand_conflicts_with_different_source_flag() {
     let root = unique_temp_dir("source-flag-conflict");
     let (ok, _stdout, stderr) = run_ccstats(
@@ -161,6 +218,20 @@ fn codex_subcommand_conflicts_with_different_source_flag() {
     assert!(!ok, "expected conflict failure");
     let stderr = String::from_utf8_lossy(&stderr);
     assert!(stderr.contains("conflicts with --source"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn codex_subcommand_conflicts_with_source_all() {
+    let root = unique_temp_dir("source-all-conflict");
+    let (ok, _stdout, stderr) = run_ccstats(
+        &["codex", "daily", "--source", "all", "-O", "--no-cost"],
+        &[("HOME", &root)],
+    );
+    assert!(!ok, "expected conflict failure");
+    let stderr = String::from_utf8_lossy(&stderr);
+    assert!(stderr.contains("conflicts with --source all"));
 
     let _ = fs::remove_dir_all(root);
 }


### PR DESCRIPTION
## Summary
- add `--source all` as a pseudo-source for combined usage summaries
- support all-source daily, weekly, monthly, today, and statusline views
- list `all` in `ccstats sources` while keeping session/project/block/tool views source-specific

## Validation
- `cargo fmt --check`
- `cargo test --locked`

Note: `cargo clippy --all-targets -- -D warnings` still reports existing unrelated warnings outside this change, so it is not used as this PR's gate.