### PR TITLE
[codex] Add monthly budget forecast

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ ccstats monthly --locale de
 # Filter by date
 ccstats daily --since 20260101 --until 20260131
 
+# Monthly budget forecast (uses --until as the as-of date when present)
+ccstats monthly --monthly-budget 25 --until 20260415
+
 # Select data source explicitly (supports aliases)
 ccstats daily --source codex
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,12 +5,13 @@ use crate::cli::{Cli, SourceCommand};
 use crate::core::{DateFilter, DayStats, LoadResult, aggregate_tools};
 use crate::output::NumberFormat;
 use crate::output::{
-    BlockTableOptions, Period, ProjectTableOptions, SessionTableOptions, SummaryOptions,
-    TokenTableOptions, output_block_csv, output_block_json, output_period_csv, output_period_json,
-    output_project_csv, output_project_json, output_session_csv, output_session_json,
-    output_tools_csv, output_tools_json, print_block_table, print_period_table,
-    print_project_table, print_session_table, print_statusline, print_statusline_json,
-    print_tools_table,
+    BlockTableOptions, MonthlyBudgetOptions, Period, ProjectTableOptions, SessionTableOptions,
+    SummaryOptions, TokenTableOptions, add_monthly_budget_to_json, monthly_budget_reports,
+    output_block_csv, output_block_json, output_monthly_budget_csv, output_period_csv,
+    output_period_json, output_project_csv, output_project_json, output_session_csv,
+    output_session_json, output_tools_csv, output_tools_json, print_block_table,
+    print_monthly_budget_table, print_period_table, print_project_table, print_session_table,
+    print_statusline, print_statusline_json, print_tools_table,
 };
 use crate::pricing::PricingDb;
 use crate::source::{
@@ -42,6 +43,7 @@ pub(crate) struct CommandContext<'a> {
     pub(crate) number_format: NumberFormat,
     pub(crate) jq_filter: Option<&'a str>,
     pub(crate) currency: Option<&'a crate::pricing::CurrencyConverter>,
+    pub(crate) budget_as_of: chrono::NaiveDate,
 }
 
 fn print_no_data_hint(source_name: &str, category: &str) {
@@ -297,6 +299,120 @@ fn handle_statusline(source: &dyn Source, ctx: &CommandContext<'_>) {
     }
 }
 
+fn render_period_result(
+    result: &LoadResult,
+    period: Period,
+    caps: &Capabilities,
+    ctx: &CommandContext<'_>,
+) {
+    let monthly_budget = (period == Period::Month)
+        .then_some(ctx.cli.monthly_budget)
+        .flatten();
+
+    if ctx.cli.csv {
+        let csv = if let Some(budget) = monthly_budget {
+            output_monthly_budget_csv(
+                &result.day_stats,
+                ctx.pricing_db,
+                MonthlyBudgetOptions {
+                    order: ctx.cli.sort_order(),
+                    breakdown: ctx.cli.breakdown,
+                    show_cost: ctx.cli.show_cost(),
+                    limit: budget,
+                    as_of: ctx.budget_as_of,
+                    currency: ctx.currency,
+                },
+            )
+        } else {
+            output_period_csv(
+                &result.day_stats,
+                period,
+                ctx.pricing_db,
+                ctx.cli.sort_order(),
+                ctx.cli.breakdown,
+                ctx.cli.show_cost(),
+            )
+        };
+        print!("{csv}");
+    } else if ctx.cli.json {
+        let mut json = output_period_json(
+            &result.day_stats,
+            period,
+            ctx.pricing_db,
+            ctx.cli.sort_order(),
+            ctx.cli.breakdown,
+            ctx.cli.show_cost(),
+            ctx.currency,
+        );
+        if let Some(budget) = monthly_budget {
+            let reports = monthly_budget_reports(
+                &result.day_stats,
+                ctx.pricing_db,
+                ctx.cli.sort_order(),
+                budget,
+                ctx.budget_as_of,
+                ctx.currency,
+            );
+            json = add_monthly_budget_to_json(&json, &reports);
+        }
+        print_json(&json, ctx.jq_filter);
+    } else {
+        print_period_table(
+            &result.day_stats,
+            period,
+            ctx.cli.breakdown,
+            SummaryOptions {
+                skipped: result.skipped,
+                valid: result.valid,
+                elapsed_ms: Some(result.elapsed_ms),
+            },
+            ctx.pricing_db,
+            TokenTableOptions {
+                order: ctx.cli.sort_order(),
+                use_color: ctx.cli.use_color(),
+                compact: ctx.cli.compact,
+                show_cost: ctx.cli.show_cost(),
+                number_format: ctx.number_format,
+                show_reasoning: caps.has_reasoning_tokens,
+                show_cache_creation: caps.has_cache_creation,
+                currency: ctx.currency,
+            },
+        );
+        if let Some(budget) = monthly_budget {
+            let reports = monthly_budget_reports(
+                &result.day_stats,
+                ctx.pricing_db,
+                ctx.cli.sort_order(),
+                budget,
+                ctx.budget_as_of,
+                ctx.currency,
+            );
+            print_monthly_budget_table(&reports, ctx.cli.use_color(), ctx.currency);
+        }
+    }
+}
+
+fn handle_period(
+    source: &dyn Source,
+    command: SourceCommand,
+    caps: &Capabilities,
+    ctx: &CommandContext<'_>,
+) {
+    let period = match command {
+        SourceCommand::Daily | SourceCommand::Today => Period::Day,
+        SourceCommand::Weekly => Period::Week,
+        SourceCommand::Monthly => Period::Month,
+        _ => return,
+    };
+
+    let result = load_daily(source, ctx.filter, ctx.timezone, false, ctx.cli.debug);
+    if result.day_stats.is_empty() {
+        print_no_data_hint(source.display_name(), "usage");
+        return;
+    }
+    render_period_result(&result, period, caps, ctx);
+}
+
 /// Handle commands for a specific data source
 pub(crate) fn handle_source_command(
     source: &dyn Source,
@@ -346,63 +462,7 @@ pub(crate) fn handle_source_command(
     }
 
     // Period-based commands: Daily/Today/Weekly/Monthly
-    let period = match command {
-        SourceCommand::Daily | SourceCommand::Today => Period::Day,
-        SourceCommand::Weekly => Period::Week,
-        SourceCommand::Monthly => Period::Month,
-        // All non-period variants handled above and returned early
-        _ => return,
-    };
-
-    let result = load_daily(source, ctx.filter, ctx.timezone, false, ctx.cli.debug);
-    if result.day_stats.is_empty() {
-        print_no_data_hint(source.display_name(), "usage");
-        return;
-    }
-    if ctx.cli.csv {
-        let csv = output_period_csv(
-            &result.day_stats,
-            period,
-            ctx.pricing_db,
-            ctx.cli.sort_order(),
-            ctx.cli.breakdown,
-            ctx.cli.show_cost(),
-        );
-        print!("{csv}");
-    } else if ctx.cli.json {
-        let json = output_period_json(
-            &result.day_stats,
-            period,
-            ctx.pricing_db,
-            ctx.cli.sort_order(),
-            ctx.cli.breakdown,
-            ctx.cli.show_cost(),
-            ctx.currency,
-        );
-        print_json(&json, ctx.jq_filter);
-    } else {
-        print_period_table(
-            &result.day_stats,
-            period,
-            ctx.cli.breakdown,
-            SummaryOptions {
-                skipped: result.skipped,
-                valid: result.valid,
-                elapsed_ms: Some(result.elapsed_ms),
-            },
-            ctx.pricing_db,
-            TokenTableOptions {
-                order: ctx.cli.sort_order(),
-                use_color: ctx.cli.use_color(),
-                compact: ctx.cli.compact,
-                show_cost: ctx.cli.show_cost(),
-                number_format: ctx.number_format,
-                show_reasoning: caps.has_reasoning_tokens,
-                show_cache_creation: caps.has_cache_creation,
-                currency: ctx.currency,
-            },
-        );
-    }
+    handle_period(source, command, &caps, ctx);
 }
 
 fn all_sources_capabilities() -> Capabilities {
@@ -502,48 +562,5 @@ pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandCo
         print_no_data_hint("All Sources", "usage");
         return;
     }
-    if ctx.cli.csv {
-        let csv = output_period_csv(
-            &result.day_stats,
-            period,
-            ctx.pricing_db,
-            ctx.cli.sort_order(),
-            ctx.cli.breakdown,
-            ctx.cli.show_cost(),
-        );
-        print!("{csv}");
-    } else if ctx.cli.json {
-        let json = output_period_json(
-            &result.day_stats,
-            period,
-            ctx.pricing_db,
-            ctx.cli.sort_order(),
-            ctx.cli.breakdown,
-            ctx.cli.show_cost(),
-            ctx.currency,
-        );
-        print_json(&json, ctx.jq_filter);
-    } else {
-        print_period_table(
-            &result.day_stats,
-            period,
-            ctx.cli.breakdown,
-            SummaryOptions {
-                skipped: result.skipped,
-                valid: result.valid,
-                elapsed_ms: Some(result.elapsed_ms),
-            },
-            ctx.pricing_db,
-            TokenTableOptions {
-                order: ctx.cli.sort_order(),
-                use_color: ctx.cli.use_color(),
-                compact: ctx.cli.compact,
-                show_cost: ctx.cli.show_cost(),
-                number_format: ctx.number_format,
-                show_reasoning: caps.has_reasoning_tokens,
-                show_cache_creation: caps.has_cache_creation,
-                currency: ctx.currency,
-            },
-        );
-    }
+    render_period_result(&result, period, &caps, ctx);
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -119,6 +119,10 @@ pub(crate) struct Cli {
     #[arg(long, global = true, value_name = "CURRENCY")]
     pub(crate) currency: Option<String>,
 
+    /// Monthly budget for monthly forecast output (USD by default, or --currency value)
+    #[arg(long, global = true, value_name = "AMOUNT")]
+    pub(crate) monthly_budget: Option<f64>,
+
     /// Data source name or alias (e.g., "claude", "codex", "all", "cc", "cx")
     #[arg(long, global = true, value_name = "SOURCE")]
     pub(crate) source: Option<String>,
@@ -494,6 +498,12 @@ mod tests {
     fn default_show_cost_is_true() {
         let cli = Cli::parse_from(["ccstats", "daily"]);
         assert!(cli.show_cost());
+    }
+
+    #[test]
+    fn monthly_budget_parses_amount() {
+        let cli = Cli::parse_from(["ccstats", "monthly", "--monthly-budget", "25.5"]);
+        assert_eq!(cli.monthly_budget, Some(25.5));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,9 +115,28 @@ fn main() {
         std::process::exit(1);
     }
 
+    if let Some(monthly_budget) = cli.monthly_budget {
+        if !monthly_budget.is_finite() || monthly_budget <= 0.0 {
+            eprintln!("Error: --monthly-budget must be a positive number");
+            std::process::exit(1);
+        }
+        if source_cmd != SourceCommand::Monthly {
+            eprintln!("Error: --monthly-budget only supports the monthly command");
+            std::process::exit(1);
+        }
+        if !cli.show_cost() {
+            eprintln!(
+                "Error: --monthly-budget requires cost display; remove --no-cost or --cost hide"
+            );
+            std::process::exit(1);
+        }
+    }
+
+    let today = timezone.to_fixed_offset(Utc::now()).date_naive();
+    let budget_as_of = until.map_or(today, |end| end.min(today));
+
     // For "today" and "statusline" commands, set since/until to today
     let filter = if source_cmd.needs_today_filter() {
-        let today = timezone.to_fixed_offset(Utc::now()).date_naive();
         DateFilter::new(Some(today), Some(today))
     } else {
         DateFilter::new(since, until)
@@ -207,6 +226,7 @@ fn main() {
                 number_format,
                 jq_filter,
                 currency: currency_converter.as_ref(),
+                budget_as_of,
             },
         );
     }
@@ -227,6 +247,7 @@ fn main() {
             number_format,
             jq_filter,
             currency: currency_converter.as_ref(),
+            budget_as_of,
         },
     );
 }

--- a/src/output/budget.rs
+++ b/src/output/budget.rs
@@ -1,0 +1,328 @@
+use std::collections::HashMap;
+
+use chrono::{Datelike, NaiveDate};
+use comfy_table::{Cell, Color};
+use serde_json::{Map, Value};
+
+use crate::cli::SortOrder;
+use crate::core::DayStats;
+use crate::output::format::{create_styled_table, header_cell, right_cell, styled_cell};
+use crate::output::period::{Period, aggregate_day_stats_by_period};
+use crate::pricing::{CurrencyConverter, PricingDb, sum_model_costs};
+
+#[derive(Debug, Clone)]
+pub(crate) struct MonthlyBudgetReport {
+    pub(crate) month: String,
+    pub(crate) limit: f64,
+    pub(crate) spent: f64,
+    pub(crate) projected: f64,
+    pub(crate) remaining: f64,
+    pub(crate) used_pct: f64,
+    pub(crate) projected_pct: f64,
+    pub(crate) days_elapsed: u32,
+    pub(crate) days_in_month: u32,
+    pub(crate) status: &'static str,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct MonthlyBudgetOptions<'a> {
+    pub(crate) order: SortOrder,
+    pub(crate) breakdown: bool,
+    pub(crate) show_cost: bool,
+    pub(crate) limit: f64,
+    pub(crate) as_of: NaiveDate,
+    pub(crate) currency: Option<&'a CurrencyConverter>,
+}
+
+fn display_cost(usd: f64, currency: Option<&CurrencyConverter>) -> f64 {
+    currency.map_or(usd, |conv| conv.convert(usd))
+}
+
+fn month_parts(month: &str) -> Option<(i32, u32)> {
+    let (year, month) = month.split_once('-')?;
+    let year = year.parse::<i32>().ok()?;
+    let month = month.parse::<u32>().ok()?;
+    (1..=12).contains(&month).then_some((year, month))
+}
+
+fn days_in_month(year: i32, month: u32) -> Option<u32> {
+    let start = NaiveDate::from_ymd_opt(year, month, 1)?;
+    let (next_year, next_month) = if month == 12 {
+        (year + 1, 1)
+    } else {
+        (year, month + 1)
+    };
+    let next = NaiveDate::from_ymd_opt(next_year, next_month, 1)?;
+    Some((next - start).num_days() as u32)
+}
+
+fn budget_days(month: &str, as_of: NaiveDate) -> (u32, u32) {
+    let Some((year, month_num)) = month_parts(month) else {
+        return (1, 1);
+    };
+    let days_in_month = days_in_month(year, month_num).unwrap_or(1);
+    let elapsed = if (as_of.year(), as_of.month()) == (year, month_num) {
+        as_of.day().min(days_in_month)
+    } else {
+        days_in_month
+    };
+    (elapsed.max(1), days_in_month)
+}
+
+fn percentage(value: f64, limit: f64) -> f64 {
+    if value.is_nan() || limit <= 0.0 {
+        f64::NAN
+    } else {
+        value / limit * 100.0
+    }
+}
+
+fn budget_status(spent: f64, projected: f64, projected_pct: f64, limit: f64) -> &'static str {
+    if spent.is_nan() || projected.is_nan() {
+        "unknown"
+    } else if spent > limit || projected > limit {
+        "over_budget"
+    } else if projected_pct >= 90.0 {
+        "watch"
+    } else {
+        "on_track"
+    }
+}
+
+fn budget_report(month: String, spent: f64, limit: f64, as_of: NaiveDate) -> MonthlyBudgetReport {
+    let (days_elapsed, days_in_month) = budget_days(&month, as_of);
+    let projected = if spent.is_nan() || days_elapsed >= days_in_month {
+        spent
+    } else {
+        spent * f64::from(days_in_month) / f64::from(days_elapsed)
+    };
+    let remaining = if spent.is_nan() {
+        f64::NAN
+    } else {
+        limit - spent
+    };
+    let used_pct = percentage(spent, limit);
+    let projected_pct = percentage(projected, limit);
+    let status = budget_status(spent, projected, projected_pct, limit);
+
+    MonthlyBudgetReport {
+        month,
+        limit,
+        spent,
+        projected,
+        remaining,
+        used_pct,
+        projected_pct,
+        days_elapsed,
+        days_in_month,
+        status,
+    }
+}
+
+pub(crate) fn monthly_budget_reports(
+    day_stats: &HashMap<String, DayStats>,
+    pricing_db: &PricingDb,
+    order: SortOrder,
+    monthly_budget: f64,
+    as_of: NaiveDate,
+    currency: Option<&CurrencyConverter>,
+) -> Vec<MonthlyBudgetReport> {
+    let monthly = aggregate_day_stats_by_period(day_stats, Period::Month);
+    let mut months: Vec<_> = monthly.keys().collect();
+    match order {
+        SortOrder::Asc => months.sort(),
+        SortOrder::Desc => months.sort_by(|a, b| b.cmp(a)),
+    }
+
+    months
+        .into_iter()
+        .filter_map(|month| {
+            monthly.get(month).map(|stats| {
+                let spent = display_cost(sum_model_costs(&stats.models, pricing_db), currency);
+                budget_report(month.clone(), spent, monthly_budget, as_of)
+            })
+        })
+        .collect()
+}
+
+fn json_number(value: f64) -> Value {
+    if value.is_nan() {
+        Value::Null
+    } else {
+        serde_json::json!(value)
+    }
+}
+
+fn report_json(report: &MonthlyBudgetReport) -> Value {
+    let mut obj = Map::new();
+    obj.insert("limit".to_string(), json_number(report.limit));
+    obj.insert("spent".to_string(), json_number(report.spent));
+    obj.insert("projected".to_string(), json_number(report.projected));
+    obj.insert("remaining".to_string(), json_number(report.remaining));
+    obj.insert("used_pct".to_string(), json_number(report.used_pct));
+    obj.insert(
+        "projected_pct".to_string(),
+        json_number(report.projected_pct),
+    );
+    obj.insert(
+        "days_elapsed".to_string(),
+        serde_json::json!(report.days_elapsed),
+    );
+    obj.insert(
+        "days_in_month".to_string(),
+        serde_json::json!(report.days_in_month),
+    );
+    obj.insert("status".to_string(), serde_json::json!(report.status));
+    Value::Object(obj)
+}
+
+pub(crate) fn add_monthly_budget_to_json(json: &str, reports: &[MonthlyBudgetReport]) -> String {
+    let mut rows: Vec<Value> = serde_json::from_str(json).unwrap_or_default();
+    let by_month: HashMap<&str, &MonthlyBudgetReport> = reports
+        .iter()
+        .map(|report| (report.month.as_str(), report))
+        .collect();
+
+    for row in &mut rows {
+        let Some(obj) = row.as_object_mut() else {
+            continue;
+        };
+        let Some(month) = obj.get("month").and_then(Value::as_str) else {
+            continue;
+        };
+        if let Some(report) = by_month.get(month) {
+            obj.insert("budget".to_string(), report_json(report));
+        }
+    }
+
+    serde_json::to_string(&rows).unwrap_or_else(|_| "[]".to_string())
+}
+
+fn format_amount(value: f64, currency: Option<&CurrencyConverter>) -> String {
+    if value.is_nan() {
+        "N/A".to_string()
+    } else if let Some(conv) = currency {
+        let code = conv.currency_code();
+        format!("{code} {value:.2}")
+    } else {
+        format!("${value:.2}")
+    }
+}
+
+fn format_pct(value: f64) -> String {
+    if value.is_nan() {
+        "N/A".to_string()
+    } else {
+        format!("{value:.1}%")
+    }
+}
+
+fn status_color(status: &str, use_color: bool) -> Option<Color> {
+    if !use_color {
+        return None;
+    }
+    match status {
+        "over_budget" => Some(Color::Red),
+        "watch" => Some(Color::Yellow),
+        "on_track" => Some(Color::Green),
+        _ => None,
+    }
+}
+
+pub(crate) fn print_monthly_budget_table(
+    reports: &[MonthlyBudgetReport],
+    use_color: bool,
+    currency: Option<&CurrencyConverter>,
+) {
+    if reports.is_empty() {
+        return;
+    }
+
+    let mut table = create_styled_table();
+    table.set_header(vec![
+        header_cell("Month", use_color),
+        header_cell("Budget", use_color),
+        header_cell("Spent", use_color),
+        header_cell("Projected", use_color),
+        header_cell("Remaining", use_color),
+        header_cell("Used", use_color),
+        header_cell("Projected", use_color),
+        header_cell("Status", use_color),
+    ]);
+
+    for report in reports {
+        table.add_row(vec![
+            Cell::new(&report.month),
+            right_cell(&format_amount(report.limit, currency), None, false),
+            right_cell(&format_amount(report.spent, currency), None, false),
+            right_cell(&format_amount(report.projected, currency), None, false),
+            right_cell(&format_amount(report.remaining, currency), None, false),
+            right_cell(&format_pct(report.used_pct), None, false),
+            right_cell(&format_pct(report.projected_pct), None, false),
+            styled_cell(report.status, status_color(report.status, use_color), false),
+        ]);
+    }
+
+    println!("\n  Monthly Budget Forecast\n");
+    println!("{table}");
+}
+
+#[cfg(test)]
+#[allow(clippy::float_cmp)]
+mod tests {
+    use super::*;
+    use crate::core::Stats;
+
+    fn make_day_stats() -> HashMap<String, DayStats> {
+        let mut stats = HashMap::new();
+        let mut day = DayStats::default();
+        day.add_stats(
+            "sonnet".to_string(),
+            &Stats {
+                input_tokens: 1_000_000,
+                output_tokens: 100_000,
+                count: 1,
+                ..Default::default()
+            },
+        );
+        stats.insert("2026-02-10".to_string(), day);
+        stats
+    }
+
+    #[test]
+    fn monthly_budget_projects_partial_month() {
+        let reports = monthly_budget_reports(
+            &make_day_stats(),
+            &PricingDb::default(),
+            SortOrder::Asc,
+            10.0,
+            NaiveDate::from_ymd_opt(2026, 2, 10).unwrap(),
+            None,
+        );
+
+        assert_eq!(reports.len(), 1);
+        let report = &reports[0];
+        assert_eq!(report.month, "2026-02");
+        assert_eq!(report.days_elapsed, 10);
+        assert_eq!(report.days_in_month, 28);
+        assert!((report.spent - 4.5).abs() < 0.001);
+        assert!((report.projected - 12.6).abs() < 0.001);
+        assert_eq!(report.status, "over_budget");
+    }
+
+    #[test]
+    fn add_monthly_budget_to_json_attaches_budget_object() {
+        let report = budget_report(
+            "2026-02".to_string(),
+            4.5,
+            10.0,
+            NaiveDate::from_ymd_opt(2026, 2, 10).unwrap(),
+        );
+        let json = r#"[{"month":"2026-02","cost":4.5}]"#;
+        let output = add_monthly_budget_to_json(json, &[report]);
+        let parsed: Value = serde_json::from_str(&output).unwrap();
+
+        assert_eq!(parsed[0]["budget"]["status"], "over_budget");
+        assert_eq!(parsed[0]["budget"]["days_elapsed"], 10);
+    }
+}

--- a/src/output/csv.rs
+++ b/src/output/csv.rs
@@ -4,6 +4,7 @@ use std::fmt::Write;
 use super::session::compare_session_last_timestamp;
 use crate::cli::SortOrder;
 use crate::core::{BlockStats, DayStats, ProjectStats, SessionStats};
+use crate::output::budget::{MonthlyBudgetOptions, MonthlyBudgetReport, monthly_budget_reports};
 use crate::output::format::compare_cost;
 use crate::output::period::{Period, aggregate_day_stats_by_period};
 use crate::pricing::{PricingDb, calculate_cost, sum_model_costs};
@@ -101,6 +102,129 @@ pub(crate) fn output_period_csv(
                 let cost = sum_model_costs(&stats.models, pricing_db);
                 let _ = write!(out, ",{cost:.6}");
             }
+            out.push('\n');
+        }
+    }
+
+    out
+}
+
+fn csv_float(value: f64) -> String {
+    if value.is_nan() {
+        "N/A".to_string()
+    } else {
+        format!("{value:.6}")
+    }
+}
+
+fn write_budget_header(out: &mut String) {
+    let _ = write!(
+        out,
+        ",budget_limit,budget_spent,budget_projected,budget_remaining,budget_used_pct,budget_projected_pct,budget_status,budget_days_elapsed,budget_days_in_month"
+    );
+}
+
+fn write_budget_fields(out: &mut String, report: &MonthlyBudgetReport) {
+    let _ = write!(
+        out,
+        ",{},{},{},{},{},{},{},{},{}",
+        csv_float(report.limit),
+        csv_float(report.spent),
+        csv_float(report.projected),
+        csv_float(report.remaining),
+        csv_float(report.used_pct),
+        csv_float(report.projected_pct),
+        report.status,
+        report.days_elapsed,
+        report.days_in_month
+    );
+}
+
+pub(crate) fn output_monthly_budget_csv(
+    day_stats: &HashMap<String, DayStats>,
+    pricing_db: &PricingDb,
+    options: MonthlyBudgetOptions<'_>,
+) -> String {
+    let monthly = aggregate_day_stats_by_period(day_stats, Period::Month);
+    let reports = monthly_budget_reports(
+        day_stats,
+        pricing_db,
+        options.order,
+        options.limit,
+        options.as_of,
+        options.currency,
+    );
+    let mut out = String::new();
+
+    if options.breakdown {
+        let _ = write!(
+            out,
+            "month,model,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,total_tokens"
+        );
+        if options.show_cost {
+            let _ = write!(out, ",cost");
+        }
+        write_budget_header(&mut out);
+        out.push('\n');
+
+        for report in &reports {
+            let Some(stats) = monthly.get(&report.month) else {
+                continue;
+            };
+            let mut models: Vec<_> = stats.models.iter().collect();
+            models.sort_by_key(|(name, _)| name.as_str());
+            for (model, model_stats) in &models {
+                let _ = write!(
+                    out,
+                    "{},{},{},{},{},{},{},{}",
+                    csv_escape(&report.month),
+                    csv_escape(model),
+                    model_stats.input_tokens,
+                    model_stats.output_tokens,
+                    model_stats.reasoning_tokens,
+                    model_stats.cache_creation,
+                    model_stats.cache_read,
+                    model_stats.total_tokens(),
+                );
+                if options.show_cost {
+                    let cost = calculate_cost(model_stats, model, pricing_db);
+                    let _ = write!(out, ",{cost:.6}");
+                }
+                write_budget_fields(&mut out, report);
+                out.push('\n');
+            }
+        }
+    } else {
+        let _ = write!(
+            out,
+            "month,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,total_tokens"
+        );
+        if options.show_cost {
+            let _ = write!(out, ",cost");
+        }
+        write_budget_header(&mut out);
+        out.push('\n');
+
+        for report in &reports {
+            let Some(stats) = monthly.get(&report.month) else {
+                continue;
+            };
+            let _ = write!(
+                out,
+                "{},{},{},{},{},{},{}",
+                csv_escape(&report.month),
+                stats.stats.input_tokens,
+                stats.stats.output_tokens,
+                stats.stats.reasoning_tokens,
+                stats.stats.cache_creation,
+                stats.stats.cache_read,
+                stats.stats.total_tokens(),
+            );
+            if options.show_cost {
+                let cost = sum_model_costs(&stats.models, pricing_db);
+                let _ = write!(out, ",{cost:.6}");
+            }
+            write_budget_fields(&mut out, report);
             out.push('\n');
         }
     }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,4 +1,5 @@
 mod blocks;
+mod budget;
 mod csv;
 mod format;
 mod json;
@@ -10,7 +11,14 @@ mod table;
 mod tools;
 
 pub(crate) use blocks::{BlockTableOptions, output_block_json, print_block_table};
-pub(crate) use csv::{output_block_csv, output_period_csv, output_project_csv, output_session_csv};
+pub(crate) use budget::{
+    MonthlyBudgetOptions, add_monthly_budget_to_json, monthly_budget_reports,
+    print_monthly_budget_table,
+};
+pub(crate) use csv::{
+    output_block_csv, output_monthly_budget_csv, output_period_csv, output_project_csv,
+    output_session_csv,
+};
 pub(crate) use format::NumberFormat;
 pub(crate) use json::output_period_json;
 pub(crate) use period::Period;

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -209,6 +209,103 @@ fn source_all_daily_json_merges_registered_sources() {
 }
 
 #[test]
+fn monthly_budget_json_includes_forecast() {
+    let root = unique_temp_dir("monthly-budget-json");
+    let session_file = root.join(".claude/projects/myapp/session.jsonl");
+    write_file(
+        &session_file,
+        r#"{"timestamp":"2025-02-10T10:00:00Z","message":{"id":"msg_1","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":1000000,"output_tokens":100000,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+"#,
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "monthly",
+            "-j",
+            "-O",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2025-02-01",
+            "--until",
+            "2025-02-10",
+            "--monthly-budget",
+            "10",
+        ],
+        &[("HOME", &root)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    let arr = json.as_array().expect("array output");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["month"].as_str(), Some("2025-02"));
+
+    let budget = &arr[0]["budget"];
+    assert_eq!(budget["days_elapsed"].as_i64(), Some(10));
+    assert_eq!(budget["days_in_month"].as_i64(), Some(28));
+    assert_eq!(budget["status"].as_str(), Some("over_budget"));
+    assert!((budget["spent"].as_f64().unwrap() - 4.5).abs() < 0.001);
+    assert!((budget["projected"].as_f64().unwrap() - 12.6).abs() < 0.001);
+    assert!((budget["projected_pct"].as_f64().unwrap() - 126.0).abs() < 0.001);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn monthly_budget_csv_includes_budget_columns() {
+    let root = unique_temp_dir("monthly-budget-csv");
+    let session_file = root.join(".claude/projects/myapp/session.jsonl");
+    write_file(
+        &session_file,
+        r#"{"timestamp":"2025-02-10T10:00:00Z","message":{"id":"msg_1","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":1000000,"output_tokens":100000,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+"#,
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "monthly",
+            "--csv",
+            "-O",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2025-02-01",
+            "--until",
+            "2025-02-10",
+            "--monthly-budget",
+            "10",
+        ],
+        &[("HOME", &root)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let output = String::from_utf8_lossy(&stdout);
+    let mut lines = output.lines();
+    let header = lines.next().expect("header");
+    let row = lines.next().expect("row");
+    assert!(header.contains("budget_projected"));
+    assert!(header.contains("budget_status"));
+    assert!(row.contains("over_budget"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn monthly_budget_rejects_hidden_costs() {
+    let root = unique_temp_dir("monthly-budget-no-cost");
+    let (ok, _stdout, stderr) = run_ccstats(
+        &["monthly", "-O", "--monthly-budget", "10", "--no-cost"],
+        &[("HOME", &root)],
+    );
+    assert!(!ok, "expected hidden-cost failure");
+    let stderr = String::from_utf8_lossy(&stderr);
+    assert!(stderr.contains("--monthly-budget requires cost display"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn codex_subcommand_conflicts_with_different_source_flag() {
     let root = unique_temp_dir("source-flag-conflict");
     let (ok, _stdout, stderr) = run_ccstats(


### PR DESCRIPTION
## Summary
- add `--monthly-budget <amount>` for monthly reports
- include monthly budget forecast metadata in JSON and CSV output
- print a monthly budget forecast table for terminal output
- validate positive budgets, monthly-only usage, and visible cost output

Budget projection uses `--until` as the as-of date when provided; otherwise it uses today's date in the selected timezone. Amounts are USD by default, or the displayed currency when `--currency` is set.

## Validation
- `cargo fmt --check`
- `cargo test --locked`
- `git diff --check`

Note: `cargo clippy --all-targets -- -D warnings` is still blocked by existing unrelated warnings in files outside this feature. New clippy issues introduced by this change were fixed before PR creation.