### PR TITLE
[codex] Add experimental Cursor source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,7 @@ dependencies = [
  "dirs",
  "glob",
  "rayon",
+ "rusqlite",
  "serde",
  "serde_json",
  "tempfile",
@@ -384,6 +385,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,6 +423,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -456,7 +475,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -464,6 +483,18 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "heck"
@@ -676,6 +707,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,6 +847,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -905,6 +953,31 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsqlite-vfs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -1048,6 +1121,18 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b2c760607300407ddeaee518acf28c795661b7108c75421303dbefb237d3a36"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -1293,6 +1378,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ dirs = "6.0.0"
 ureq = { version = "3.2.0", features = ["json"] }
 thiserror = "2"
 toml = "1.0.0"
+rusqlite = { version = "0.39.0", features = ["bundled"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ ccstats daily --source codex
 # Combine all supported data sources
 ccstats monthly --source all
 
+# Experimental Cursor source (reads local SQLite tokenCount fields)
+ccstats daily --source cursor
+
 # Offline mode (use cached pricing)
 ccstats today -O
 
@@ -183,6 +186,7 @@ Warning: ignored <N> malformed records
 | Claude Code | `~/.claude/projects/` | Projects, Billing Blocks, Deduplication |
 | OpenAI Codex | `~/.codex/sessions/` | Reasoning Tokens |
 | All Sources | Multiple | Combined daily/weekly/monthly/today/statusline summaries |
+| Cursor (experimental) | Cursor `User/globalStorage/state.vscdb` | Local SQLite `tokenCount` fields only |
 
 ## Architecture
 

--- a/src/source/cursor/config.rs
+++ b/src/source/cursor/config.rs
@@ -1,0 +1,57 @@
+//! Cursor data source configuration
+//!
+//! Defines the `CursorSource` implementation of the Source trait.
+
+use std::path::{Path, PathBuf};
+
+use crate::source::{Capabilities, ParseOutput, Source};
+use crate::utils::Timezone;
+
+use super::parser::{find_cursor_files, parse_cursor_db_with_debug};
+
+/// Experimental Cursor data source.
+pub(crate) struct CursorSource;
+
+impl CursorSource {
+    pub(crate) fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for CursorSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Source for CursorSource {
+    fn name(&self) -> &'static str {
+        "cursor"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Cursor"
+    }
+
+    fn aliases(&self) -> &'static [&'static str] {
+        &["cur"]
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            has_projects: false,
+            has_billing_blocks: false,
+            has_reasoning_tokens: false,
+            has_cache_creation: false,
+            needs_dedup: false,
+        }
+    }
+
+    fn find_files(&self) -> Vec<PathBuf> {
+        find_cursor_files()
+    }
+
+    fn parse_file(&self, path: &Path, timezone: Timezone, debug: bool) -> ParseOutput {
+        parse_cursor_db_with_debug(path, timezone, debug)
+    }
+}

--- a/src/source/cursor/mod.rs
+++ b/src/source/cursor/mod.rs
@@ -1,0 +1,8 @@
+//! Cursor data source
+//!
+//! Parses read-only `SQLite` state databases from Cursor's local user data dir.
+
+mod config;
+mod parser;
+
+pub(crate) use config::CursorSource;

--- a/src/source/cursor/parser.rs
+++ b/src/source/cursor/parser.rs
@@ -1,0 +1,467 @@
+//! Cursor `SQLite` parser
+//!
+//! Cursor's schema is not a public API. This parser intentionally only trusts
+//! explicit token count fields and skips records that would require estimation.
+
+use std::collections::HashMap;
+use std::env;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, TimeZone, Utc};
+use rusqlite::types::ValueRef;
+use rusqlite::{Connection, OpenFlags};
+use serde_json::Value;
+
+use crate::consts::{DATE_FORMAT, UNKNOWN};
+use crate::core::RawEntry;
+use crate::source::ParseOutput;
+use crate::utils::Timezone;
+
+const CURSOR_HOME_ENV: &str = "CURSOR_HOME";
+const CURSOR_MODEL: &str = "cursor";
+
+#[derive(Debug, Clone, Default)]
+struct ComposerMeta {
+    model: Option<String>,
+    project_path: Option<String>,
+}
+
+fn cursor_user_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Ok(path) = env::var(CURSOR_HOME_ENV) {
+        return vec![PathBuf::from(path)];
+    }
+
+    if let Some(home) = dirs::home_dir() {
+        dirs.push(
+            home.join("Library")
+                .join("Application Support")
+                .join("Cursor")
+                .join("User"),
+        );
+        dirs.push(home.join(".config").join("Cursor").join("User"));
+    }
+
+    if let Some(data_dir) = dirs::data_dir() {
+        dirs.push(data_dir.join("Cursor").join("User"));
+    }
+
+    dirs.sort();
+    dirs.dedup();
+    dirs
+}
+
+pub(super) fn find_cursor_files() -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    for user_dir in cursor_user_dirs() {
+        let global = user_dir.join("globalStorage").join("state.vscdb");
+        if global.is_file() {
+            files.push(global);
+        }
+
+        let workspace_glob = user_dir
+            .join("workspaceStorage")
+            .join("*")
+            .join("state.vscdb");
+        if let Ok(entries) = glob::glob(&workspace_glob.display().to_string()) {
+            files.extend(entries.flatten().filter(|path| path.is_file()));
+        }
+    }
+    files.sort();
+    files.dedup();
+    files
+}
+
+fn open_readonly(path: &Path) -> rusqlite::Result<Connection> {
+    Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+}
+
+fn table_exists(conn: &Connection, table: &str) -> bool {
+    conn.query_row(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1 LIMIT 1",
+        [table],
+        |_| Ok(()),
+    )
+    .is_ok()
+}
+
+fn value_from_blob(blob: &[u8]) -> Option<Value> {
+    serde_json::from_slice(blob).ok().or_else(|| {
+        std::str::from_utf8(blob)
+            .ok()
+            .and_then(|text| serde_json::from_str(text).ok())
+    })
+}
+
+fn row_value_bytes(row: &rusqlite::Row<'_>, index: usize) -> rusqlite::Result<Vec<u8>> {
+    match row.get_ref(index)? {
+        ValueRef::Blob(bytes) | ValueRef::Text(bytes) => Ok(bytes.to_vec()),
+        _ => Ok(Vec::new()),
+    }
+}
+
+fn string_at<'a>(value: &'a Value, path: &[&str]) -> Option<&'a str> {
+    let mut current = value;
+    for part in path {
+        current = current.get(*part)?;
+    }
+    current.as_str()
+}
+
+fn integer_at(value: &Value, path: &[&str]) -> Option<i64> {
+    let mut current = value;
+    for part in path {
+        current = current.get(*part)?;
+    }
+    current
+        .as_i64()
+        .or_else(|| current.as_u64().and_then(|n| i64::try_from(n).ok()))
+}
+
+fn first_string(value: &Value, paths: &[&[&str]]) -> Option<String> {
+    paths
+        .iter()
+        .find_map(|path| string_at(value, path))
+        .filter(|s| !s.trim().is_empty())
+        .map(std::string::ToString::to_string)
+}
+
+fn timestamp_from_value(value: &Value) -> Option<DateTime<Utc>> {
+    if let Some(timestamp) = string_at(value, &["createdAt"])
+        .or_else(|| string_at(value, &["timestamp"]))
+        .or_else(|| string_at(value, &["time"]))
+    {
+        return timestamp.parse::<DateTime<Utc>>().ok();
+    }
+
+    let millis = integer_at(value, &["createdAt"])
+        .or_else(|| integer_at(value, &["unixMs"]))
+        .or_else(|| integer_at(value, &["timestampMs"]))?;
+    Utc.timestamp_millis_opt(millis).single()
+}
+
+fn token_counts(value: &Value) -> Option<(i64, i64)> {
+    let input = integer_at(value, &["tokenCount", "inputTokens"])
+        .or_else(|| integer_at(value, &["tokenCount", "input_tokens"]))
+        .or_else(|| integer_at(value, &["usage", "inputTokens"]))
+        .or_else(|| integer_at(value, &["inputTokens"]))
+        .unwrap_or(0);
+    let output = integer_at(value, &["tokenCount", "outputTokens"])
+        .or_else(|| integer_at(value, &["tokenCount", "output_tokens"]))
+        .or_else(|| integer_at(value, &["usage", "outputTokens"]))
+        .or_else(|| integer_at(value, &["outputTokens"]))
+        .unwrap_or(0);
+
+    (input > 0 || output > 0).then_some((input, output))
+}
+
+fn composer_id_from_key(key: &str) -> Option<&str> {
+    key.strip_prefix("composerData:")
+}
+
+fn bubble_ids_from_key(key: &str) -> Option<(&str, &str)> {
+    let rest = key.strip_prefix("bubbleId:")?;
+    rest.split_once(':')
+}
+
+fn composer_meta_from_value(value: &Value) -> ComposerMeta {
+    ComposerMeta {
+        model: first_string(
+            value,
+            &[
+                &["modelConfig", "modelName"],
+                &["modelInfo", "modelName"],
+                &["model"],
+            ],
+        ),
+        project_path: first_string(
+            value,
+            &[
+                &["workspaceIdentifier", "uri", "fsPath"],
+                &["workspaceIdentifier", "uri", "path"],
+                &["workspaceIdentifier", "path"],
+            ],
+        ),
+    }
+}
+
+fn entry_from_bubble(
+    key: &str,
+    value: &Value,
+    composers: &HashMap<String, ComposerMeta>,
+    timezone: Timezone,
+) -> Option<RawEntry> {
+    let (composer_id, bubble_id) = bubble_ids_from_key(key)?;
+    let (input_tokens, output_tokens) = token_counts(value)?;
+    let utc_dt = timestamp_from_value(value)?;
+    let local_dt = timezone.to_fixed_offset(utc_dt);
+    let meta = composers.get(composer_id);
+    let model = first_string(
+        value,
+        &[
+            &["modelInfo", "modelName"],
+            &["modelConfig", "modelName"],
+            &["model"],
+        ],
+    )
+    .or_else(|| meta.and_then(|m| m.model.clone()))
+    .unwrap_or_else(|| CURSOR_MODEL.to_string());
+
+    Some(RawEntry {
+        timestamp: utc_dt.to_rfc3339(),
+        timestamp_ms: utc_dt.timestamp_millis(),
+        date_str: local_dt.date_naive().format(DATE_FORMAT).to_string(),
+        message_id: Some(bubble_id.to_string()),
+        session_id: composer_id.to_string(),
+        project_path: meta
+            .and_then(|m| m.project_path.clone())
+            .unwrap_or_default(),
+        model,
+        input_tokens,
+        output_tokens,
+        cache_creation: 0,
+        cache_read: 0,
+        reasoning_tokens: 0,
+        stop_reason: Some("complete".to_string()),
+    })
+}
+
+fn entry_from_generation(generation: &Value, path: &Path, timezone: Timezone) -> Option<RawEntry> {
+    let (input_tokens, output_tokens) = token_counts(generation)?;
+    let utc_dt = timestamp_from_value(generation)?;
+    let local_dt = timezone.to_fixed_offset(utc_dt);
+    let session_id = first_string(
+        generation,
+        &[
+            &["generationUUID"],
+            &["generationId"],
+            &["id"],
+            &["sessionId"],
+        ],
+    )
+    .unwrap_or_else(|| {
+        path.file_stem()
+            .and_then(|stem| stem.to_str())
+            .unwrap_or(UNKNOWN)
+            .to_string()
+    });
+    let model = first_string(
+        generation,
+        &[
+            &["model"],
+            &["modelName"],
+            &["modelInfo", "modelName"],
+            &["modelConfig", "modelName"],
+        ],
+    )
+    .unwrap_or_else(|| CURSOR_MODEL.to_string());
+
+    Some(RawEntry {
+        timestamp: utc_dt.to_rfc3339(),
+        timestamp_ms: utc_dt.timestamp_millis(),
+        date_str: local_dt.date_naive().format(DATE_FORMAT).to_string(),
+        message_id: Some(session_id.clone()),
+        session_id,
+        project_path: String::new(),
+        model,
+        input_tokens,
+        output_tokens,
+        cache_creation: 0,
+        cache_read: 0,
+        reasoning_tokens: 0,
+        stop_reason: Some("complete".to_string()),
+    })
+}
+
+fn parse_cursor_disk_kv(
+    conn: &Connection,
+    timezone: Timezone,
+) -> rusqlite::Result<(Vec<RawEntry>, usize)> {
+    let mut entries = Vec::new();
+    let mut errors = 0usize;
+    let mut composers = HashMap::new();
+
+    let mut stmt = conn.prepare(
+        "SELECT key, value FROM cursorDiskKV \
+         WHERE key LIKE 'composerData:%' OR key LIKE 'bubbleId:%'",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, row_value_bytes(row, 1)?))
+    })?;
+
+    let mut bubbles = Vec::new();
+    for row in rows {
+        let (key, blob) = row?;
+        let Some(value) = value_from_blob(&blob) else {
+            errors += 1;
+            continue;
+        };
+        if let Some(composer_id) = composer_id_from_key(&key) {
+            composers.insert(composer_id.to_string(), composer_meta_from_value(&value));
+        } else {
+            bubbles.push((key, value));
+        }
+    }
+
+    for (key, value) in bubbles {
+        if let Some(entry) = entry_from_bubble(&key, &value, &composers, timezone) {
+            entries.push(entry);
+        }
+    }
+
+    Ok((entries, errors))
+}
+
+fn parse_item_table(
+    conn: &Connection,
+    path: &Path,
+    timezone: Timezone,
+) -> rusqlite::Result<(Vec<RawEntry>, usize)> {
+    let mut entries = Vec::new();
+    let mut errors = 0usize;
+    let mut stmt = conn.prepare(
+        "SELECT value FROM ItemTable \
+         WHERE key IN ('aiService.generations', 'workbench.panel.aichat.view.aichat.chatdata')",
+    )?;
+    let rows = stmt.query_map([], |row| row_value_bytes(row, 0))?;
+
+    for row in rows {
+        let blob = row?;
+        let Some(value) = value_from_blob(&blob) else {
+            errors += 1;
+            continue;
+        };
+        if let Some(generations) = value.as_array() {
+            for generation in generations {
+                if let Some(entry) = entry_from_generation(generation, path, timezone) {
+                    entries.push(entry);
+                }
+            }
+        }
+    }
+
+    Ok((entries, errors))
+}
+
+pub(super) fn parse_cursor_db_with_debug(
+    path: &Path,
+    timezone: Timezone,
+    debug: bool,
+) -> ParseOutput {
+    let conn = match open_readonly(path) {
+        Ok(conn) => conn,
+        Err(err) => {
+            if debug {
+                eprintln!("Failed to open Cursor database {}: {}", path.display(), err);
+            }
+            return ParseOutput {
+                entries: Vec::new(),
+                errors: 1,
+            };
+        }
+    };
+
+    let mut entries = Vec::new();
+    let mut errors = 0usize;
+
+    if table_exists(&conn, "cursorDiskKV") {
+        match parse_cursor_disk_kv(&conn, timezone) {
+            Ok((mut parsed, parse_errors)) => {
+                entries.append(&mut parsed);
+                errors += parse_errors;
+            }
+            Err(err) => {
+                if debug {
+                    eprintln!(
+                        "Failed to parse cursorDiskKV in {}: {}",
+                        path.display(),
+                        err
+                    );
+                }
+                errors += 1;
+            }
+        }
+    }
+
+    if table_exists(&conn, "ItemTable") {
+        match parse_item_table(&conn, path, timezone) {
+            Ok((mut parsed, parse_errors)) => {
+                entries.append(&mut parsed);
+                errors += parse_errors;
+            }
+            Err(err) => {
+                if debug {
+                    eprintln!("Failed to parse ItemTable in {}: {}", path.display(), err);
+                }
+                errors += 1;
+            }
+        }
+    }
+
+    ParseOutput { entries, errors }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn tz() -> Timezone {
+        Timezone::parse(Some("UTC")).unwrap()
+    }
+
+    #[test]
+    fn token_counts_skips_zero_records() {
+        let value = json!({"tokenCount": {"inputTokens": 0, "outputTokens": 0}});
+        assert!(token_counts(&value).is_none());
+    }
+
+    #[test]
+    fn entry_from_bubble_reads_token_counts() {
+        let value = json!({
+            "createdAt": "2026-02-06T10:00:00Z",
+            "tokenCount": {"inputTokens": 100, "outputTokens": 40},
+            "modelInfo": {"modelName": "claude-4-sonnet"}
+        });
+        let entry = entry_from_bubble(
+            "bubbleId:composer-1:bubble-1",
+            &value,
+            &HashMap::new(),
+            tz(),
+        )
+        .unwrap();
+
+        assert_eq!(entry.session_id, "composer-1");
+        assert_eq!(entry.message_id.as_deref(), Some("bubble-1"));
+        assert_eq!(entry.date_str, "2026-02-06");
+        assert_eq!(entry.model, "claude-4-sonnet");
+        assert_eq!(entry.input_tokens, 100);
+        assert_eq!(entry.output_tokens, 40);
+    }
+
+    #[test]
+    fn entry_from_bubble_uses_composer_model_fallback() {
+        let mut composers = HashMap::new();
+        composers.insert(
+            "composer-1".to_string(),
+            ComposerMeta {
+                model: Some("gpt-5".to_string()),
+                project_path: Some("/tmp/project".to_string()),
+            },
+        );
+        let value = json!({
+            "createdAt": 1_770_372_000_000_i64,
+            "tokenCount": {"inputTokens": 10, "outputTokens": 5}
+        });
+
+        let entry =
+            entry_from_bubble("bubbleId:composer-1:bubble-1", &value, &composers, tz()).unwrap();
+
+        assert_eq!(entry.model, "gpt-5");
+        assert_eq!(entry.project_path, "/tmp/project");
+        assert_eq!(entry.timestamp, "2026-02-06T10:00:00+00:00");
+    }
+}

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -5,6 +5,7 @@
 
 mod claude;
 mod codex;
+mod cursor;
 mod loader;
 mod registry;
 

--- a/src/source/registry.rs
+++ b/src/source/registry.rs
@@ -6,6 +6,7 @@ use std::sync::LazyLock;
 
 use super::claude::ClaudeSource;
 use super::codex::CodexSource;
+use super::cursor::CursorSource;
 use super::{BoxedSource, Source};
 
 /// Pseudo-source that aggregates every registered source.
@@ -16,8 +17,8 @@ static SOURCES: LazyLock<Vec<BoxedSource>> = LazyLock::new(|| {
     vec![
         Box::new(ClaudeSource::new()),
         Box::new(CodexSource::new()),
+        Box::new(CursorSource::new()),
         // Add new sources here:
-        // Box::new(CursorSource::new()),
         // Box::new(WindsurfSource::new()),
     ]
 });
@@ -122,6 +123,7 @@ mod tests {
     fn test_get_source_by_name() {
         assert!(get_source("claude").is_some());
         assert!(get_source("codex").is_some());
+        assert!(get_source("cursor").is_some());
         assert!(get_source("unknown").is_none());
     }
 
@@ -129,6 +131,7 @@ mod tests {
     fn test_get_source_by_alias() {
         assert!(get_source("cc").is_some());
         assert!(get_source("cx").is_some());
+        assert!(get_source("cur").is_some());
     }
 
     #[test]
@@ -136,6 +139,7 @@ mod tests {
         assert!(get_source("Claude").is_some());
         assert!(get_source("CLAUDE").is_some());
         assert!(get_source("Codex").is_some());
+        assert!(get_source("Cursor").is_some());
         assert!(get_source("CC").is_some());
     }
 
@@ -153,6 +157,14 @@ mod tests {
         assert_eq!(source.name(), "codex");
         assert_eq!(source.display_name(), "OpenAI Codex");
         assert!(source.aliases().contains(&"cx"));
+    }
+
+    #[test]
+    fn test_cursor_source_properties() {
+        let source = get_source("cursor").unwrap();
+        assert_eq!(source.name(), "cursor");
+        assert_eq!(source.display_name(), "Cursor");
+        assert!(source.aliases().contains(&"cur"));
     }
 
     #[test]
@@ -178,9 +190,20 @@ mod tests {
     }
 
     #[test]
+    fn test_cursor_capabilities() {
+        let source = get_source("cursor").unwrap();
+        let caps = source.capabilities();
+        assert!(!caps.has_projects);
+        assert!(!caps.has_billing_blocks);
+        assert!(!caps.has_cache_creation);
+        assert!(!caps.needs_dedup);
+        assert!(!caps.has_reasoning_tokens);
+    }
+
+    #[test]
     fn test_sources_count() {
-        // Verify we have exactly 2 registered sources
-        assert_eq!(SOURCES.len(), 2);
+        // Verify all built-in sources are registered
+        assert_eq!(SOURCES.len(), 3);
     }
 
     #[test]
@@ -192,6 +215,10 @@ mod tests {
         let by_name = get_source("codex").unwrap();
         let by_alias = get_source("cx").unwrap();
         assert_eq!(by_name.name(), by_alias.name());
+
+        let by_name = get_source("cursor").unwrap();
+        let by_alias = get_source("cur").unwrap();
+        assert_eq!(by_name.name(), by_alias.name());
     }
 
     #[test]
@@ -200,14 +227,17 @@ mod tests {
         assert!(choices.contains(&"all"));
         assert!(choices.contains(&"claude"));
         assert!(choices.contains(&"codex"));
+        assert!(choices.contains(&"cursor"));
         assert!(choices.contains(&"cc"));
         assert!(choices.contains(&"cx"));
+        assert!(choices.contains(&"cur"));
     }
 
     #[test]
     fn test_suggest_source_prefix_and_typo() {
         assert_eq!(suggest_source("clau"), Some("claude"));
         assert_eq!(suggest_source("code"), Some("codex"));
+        assert_eq!(suggest_source("curs"), Some("cursor"));
         assert_eq!(suggest_source("claud"), Some("claude"));
         assert_eq!(suggest_source("al"), Some("all"));
         assert_eq!(suggest_source("cx"), Some("cx"));

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1,3 +1,4 @@
+use rusqlite::Connection;
 use serde_json::Value;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -19,6 +20,34 @@ fn write_file(path: &Path, content: &str) {
         fs::create_dir_all(parent).expect("create parent dirs");
     }
     fs::write(path, content).expect("write test file");
+}
+
+fn write_cursor_state_db(path: &Path) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create cursor db parent");
+    }
+    let conn = Connection::open(path).expect("open cursor db");
+    conn.execute(
+        "CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value BLOB)",
+        [],
+    )
+    .expect("create cursorDiskKV");
+    conn.execute(
+        "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+        (
+            "composerData:composer-1",
+            r#"{"composerId":"composer-1","modelConfig":{"modelName":"claude-4-sonnet"},"workspaceIdentifier":{"uri":{"fsPath":"/tmp/cursor-project"}}}"#,
+        ),
+    )
+    .expect("insert composer");
+    conn.execute(
+        "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+        (
+            "bubbleId:composer-1:bubble-1",
+            r#"{"createdAt":"2026-02-06T10:00:00Z","tokenCount":{"inputTokens":100,"outputTokens":40}}"#,
+        ),
+    )
+    .expect("insert bubble");
 }
 
 fn resolve_ccstats_binary() -> PathBuf {
@@ -204,6 +233,46 @@ fn source_all_daily_json_merges_registered_sources() {
             .any(|model| model.as_str() == Some("3-5-sonnet"))
     );
     assert!(models.iter().any(|model| model.as_str() == Some("gpt-5")));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn source_flag_can_select_cursor_without_subcommand() {
+    let root = unique_temp_dir("source-flag-cursor");
+    let cursor_home = root.join("cursor-user");
+    write_cursor_state_db(&cursor_home.join("globalStorage").join("state.vscdb"));
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "--source",
+            "cursor",
+            "-j",
+            "-O",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("CURSOR_HOME", &cursor_home)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    let arr = json.as_array().expect("array output");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["date"].as_str(), Some("2026-02-06"));
+    assert_eq!(arr[0]["input_tokens"].as_i64(), Some(100));
+    assert_eq!(arr[0]["output_tokens"].as_i64(), Some(40));
+    assert_eq!(arr[0]["total_tokens"].as_i64(), Some(140));
+    assert_eq!(
+        arr[0]["models"].as_array().unwrap()[0].as_str(),
+        Some("claude-4-sonnet")
+    );
 
     let _ = fs::remove_dir_all(root);
 }


### PR DESCRIPTION
## Summary
- add an experimental `cursor` / `cur` source
- read Cursor local SQLite `state.vscdb` files in read-only mode
- parse `cursorDiskKV` bubble records and legacy `ItemTable` generation records when explicit `tokenCount` fields are present
- skip records without real token counts instead of estimating from message text
- document the source and add an isolated SQLite integration test

## Notes
Cursor's local chat schema is not a stable public API. This PR intentionally keeps the source conservative: if Cursor does not persist non-zero token counts, ccstats reports no Cursor usage rather than showing approximate cost data.

References used for storage layout:
- https://docs.cursor.com/agent/chat/history
- https://forum.cursor.com/t/deleting-global-state-vscdb-causes-infinite-loading-chat-in-projects-history-not-recoverable-without-corrupted-backup/153220

## Validation
- `cargo fmt --check`
- `cargo test --locked`
- `git diff --check`

Note: `cargo clippy --all-targets -- -D warnings` remains blocked by existing unrelated warnings. New clippy warnings introduced by this change were fixed before PR creation.