### PR TITLE
[codex] Fix clippy quality warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/src/app.rs
+++ b/src/app.rs
@@ -169,7 +169,7 @@ fn handle_blocks(source: &dyn Source, ctx: &CommandContext<'_>) {
 
 fn handle_tools(ctx: &CommandContext<'_>) {
     let calls = load_tool_calls(ctx.filter, ctx.timezone);
-    let summary = aggregate_tools(calls);
+    let summary = aggregate_tools(&calls);
     if ctx.cli.csv {
         let csv = output_tools_csv(&summary);
         print!("{csv}");

--- a/src/core/aggregator.rs
+++ b/src/core/aggregator.rs
@@ -160,7 +160,7 @@ pub(crate) fn aggregate_projects(sessions: Vec<SessionStats>) -> Vec<ProjectStat
     }
 
     let mut projects: Vec<ProjectStats> = project_map.into_values().collect();
-    projects.sort_by(|a, b| b.stats.total_tokens().cmp(&a.stats.total_tokens()));
+    projects.sort_by_key(|project| std::cmp::Reverse(project.stats.total_tokens()));
     projects
 }
 

--- a/src/core/aggregator.rs
+++ b/src/core/aggregator.rs
@@ -78,7 +78,7 @@ impl SessionAccumulator {
         let update_last = self.last_timestamp.is_empty() || timestamp_ms > self.last_timestamp_ms;
 
         if update_first {
-            self.first_timestamp = timestamp.clone();
+            self.first_timestamp.clone_from(&timestamp);
             self.first_timestamp_ms = timestamp_ms;
         }
         if update_last {

--- a/src/core/tool_aggregator.rs
+++ b/src/core/tool_aggregator.rs
@@ -5,9 +5,9 @@ use std::collections::HashMap;
 use super::tool_types::{ToolCall, ToolStats, ToolSummary};
 
 /// Aggregate tool calls into a sorted summary
-pub(crate) fn aggregate_tools(calls: Vec<ToolCall>) -> ToolSummary {
+pub(crate) fn aggregate_tools(calls: &[ToolCall]) -> ToolSummary {
     let mut counts: HashMap<String, u64> = HashMap::with_capacity(calls.len());
-    for call in &calls {
+    for call in calls {
         *counts.entry(call.name.clone()).or_default() += 1;
     }
 
@@ -36,7 +36,7 @@ mod tests {
 
     #[test]
     fn aggregate_empty() {
-        let summary = aggregate_tools(vec![]);
+        let summary = aggregate_tools(&[]);
         assert_eq!(summary.total, 0);
         assert!(summary.tools.is_empty());
     }
@@ -44,7 +44,7 @@ mod tests {
     #[test]
     fn aggregate_single_tool() {
         let calls = vec![make_call("Read"), make_call("Read"), make_call("Read")];
-        let summary = aggregate_tools(calls);
+        let summary = aggregate_tools(&calls);
         assert_eq!(summary.total, 3);
         assert_eq!(summary.tools.len(), 1);
         assert_eq!(summary.tools[0].name, "Read");
@@ -61,7 +61,7 @@ mod tests {
             make_call("Bash"),
             make_call("Read"),
         ];
-        let summary = aggregate_tools(calls);
+        let summary = aggregate_tools(&calls);
         assert_eq!(summary.total, 6);
         assert_eq!(summary.tools.len(), 3);
         assert_eq!(summary.tools[0].name, "Read");

--- a/src/core/tool_aggregator.rs
+++ b/src/core/tool_aggregator.rs
@@ -18,7 +18,7 @@ pub(crate) fn aggregate_tools(calls: &[ToolCall]) -> ToolSummary {
         .collect();
 
     // Sort by call count descending
-    tools.sort_by(|a, b| b.calls.cmp(&a.calls));
+    tools.sort_by_key(|tool| std::cmp::Reverse(tool.calls));
 
     ToolSummary { tools, total }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 //! `ccstats` is a local-first CLI for token and cost analytics from Claude Code and
-//! OpenAI Codex session logs.
+//! `OpenAI` Codex session logs.
 //!
 //! Common commands:
 //! - `ccstats today` / `ccstats daily` for Claude Code usage
@@ -179,24 +179,20 @@ fn main() {
 
     // Initialize currency converter if requested
     let currency_converter = if show_cost {
-        cli.currency
-            .as_ref()
-            .map(|code| match CurrencyConverter::load(code, cli.offline) {
-                Some(conv) => {
-                    if !is_statusline {
-                        eprintln!(
-                            "Converting costs to {} (rate: displayed as {})",
-                            conv.currency_code(),
-                            conv.format(1.0)
-                        );
-                    }
-                    conv
-                }
-                None => {
-                    eprintln!("Error: failed to load exchange rate for '{code}'");
-                    std::process::exit(1);
-                }
-            })
+        cli.currency.as_ref().map(|code| {
+            let Some(conv) = CurrencyConverter::load(code, cli.offline) else {
+                eprintln!("Error: failed to load exchange rate for '{code}'");
+                std::process::exit(1);
+            };
+            if !is_statusline {
+                eprintln!(
+                    "Converting costs to {} (rate: displayed as {})",
+                    conv.currency_code(),
+                    conv.format(1.0)
+                );
+            }
+            conv
+        })
     } else {
         None
     };

--- a/src/output/tools.rs
+++ b/src/output/tools.rs
@@ -1,6 +1,7 @@
 //! Output formatters for tool usage statistics
 
 use comfy_table::CellAlignment;
+use std::fmt::Write;
 
 use crate::core::ToolSummary;
 
@@ -80,9 +81,9 @@ pub(crate) fn output_tools_csv(summary: &ToolSummary) -> String {
         } else {
             0.0
         };
-        out.push_str(&format!("{},{},{:.1}\n", tool.name, tool.calls, pct));
+        let _ = writeln!(out, "{},{},{pct:.1}", tool.name, tool.calls);
     }
-    out.push_str(&format!("Total,{},100.0\n", summary.total));
+    let _ = writeln!(out, "Total,{},100.0", summary.total);
     out
 }
 

--- a/src/pricing/currency.rs
+++ b/src/pricing/currency.rs
@@ -1,7 +1,7 @@
 //! Currency conversion with exchange rate caching
 //!
 //! Fetches rates from open.er-api.com (free, no API key required).
-//! Caches to ~/.cache/ccstats/exchange_rates.json for 24h.
+//! Caches to `~/.cache/ccstats/exchange_rates.json` for 24h.
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -72,10 +72,9 @@ impl CurrencyConverter {
 
 fn currency_symbol(code: &str) -> String {
     match code {
-        "CNY" | "RMB" => "¥".to_string(),
+        "CNY" | "RMB" | "JPY" => "¥".to_string(),
         "EUR" => "€".to_string(),
         "GBP" => "£".to_string(),
-        "JPY" => "¥".to_string(),
         "KRW" => "₩".to_string(),
         "INR" => "₹".to_string(),
         "BRL" => "R$".to_string(),
@@ -169,7 +168,7 @@ mod tests {
     #[test]
     fn usd_converter_is_identity() {
         let conv = CurrencyConverter::load("USD", true).unwrap();
-        assert_eq!(conv.convert(10.0), 10.0);
+        assert!((conv.convert(10.0) - 10.0).abs() < f64::EPSILON);
         assert_eq!(conv.format(10.0), "$10.00");
     }
 

--- a/src/pricing/resolver.rs
+++ b/src/pricing/resolver.rs
@@ -151,9 +151,7 @@ pub(super) fn fallback_pricing(model: &str) -> ModelPricing {
         openai_pricing(1.25e-6, 10e-6, 0.125e-6)
     } else if model_lower.contains("codex-mini") {
         openai_pricing(1.5e-6, 6e-6, 0.375e-6)
-    } else if model_lower.contains("codex") {
-        openai_pricing(1.25e-6, 10e-6, 0.125e-6)
-    } else if model_lower.contains("gpt-5") {
+    } else if model_lower.contains("codex") || model_lower.contains("gpt-5") {
         openai_pricing(1.25e-6, 10e-6, 0.125e-6)
     } else if model_lower.contains("gpt-4") {
         openai_pricing(2.5e-6, 10e-6, 0.0)

--- a/src/source/claude/tool_parser.rs
+++ b/src/source/claude/tool_parser.rs
@@ -1,7 +1,7 @@
-//! Parser for tool_use blocks in Claude Code JSONL logs
+//! Parser for `tool_use` blocks in Claude Code JSONL logs
 //!
 //! Extracts tool call names from assistant messages using partial
-//! serde_json::Value parsing to avoid full deserialization.
+//! `serde_json::Value` parsing to avoid full deserialization.
 
 use chrono::{DateTime, Utc};
 use std::fs::File;
@@ -14,17 +14,15 @@ use crate::utils::Timezone;
 
 /// Parse a single JSONL file and extract tool calls
 pub(crate) fn parse_tool_calls(path: &Path, timezone: Timezone) -> Vec<ToolCall> {
-    let file = match File::open(path) {
-        Ok(f) => f,
-        Err(_) => return Vec::new(),
+    let Ok(file) = File::open(path) else {
+        return Vec::new();
     };
     let reader = BufReader::new(file);
 
     let mut calls = Vec::new();
     for line in reader.lines() {
-        let line = match line {
-            Ok(l) => l,
-            Err(_) => continue,
+        let Ok(line) = line else {
+            continue;
         };
         if line.trim().is_empty() {
             continue;

--- a/src/source/codex/parser.rs
+++ b/src/source/codex/parser.rs
@@ -105,6 +105,7 @@ impl TokenUsage {
 }
 
 #[derive(Debug, Clone, Copy, Default)]
+#[allow(clippy::struct_field_names)] // field names mirror normalized token fields
 struct UsageTotals {
     input_tokens: i64,
     cached_input_tokens: i64,
@@ -196,20 +197,14 @@ fn non_empty_model(model: Option<&str>) -> Option<&str> {
 
 fn extract_model_ref<'a>(payload: &'a Payload<'a>) -> Option<&'a str> {
     if let Some(info) = &payload.info
-        && let Some(model) = non_empty_model(info.model.as_deref())
-            .or_else(|| non_empty_model(info.model_name.as_deref()))
-            .or_else(|| {
-                non_empty_model(
-                    info.metadata
-                        .as_ref()
-                        .and_then(|metadata| metadata.model.as_deref()),
-                )
-            })
+        && let Some(model) = non_empty_model(info.model)
+            .or_else(|| non_empty_model(info.model_name))
+            .or_else(|| non_empty_model(info.metadata.as_ref().and_then(|metadata| metadata.model)))
     {
         return Some(model);
     }
 
-    non_empty_model(payload.model.as_deref())
+    non_empty_model(payload.model)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- resolve existing clippy warnings without changing CLI behavior
- make tool aggregation borrow slices instead of consuming vectors
- clean up doc markdown, string building, timestamp cloning, model fallback matching, and small parser patterns
- make `cargo clippy --all-targets -- -D warnings` usable as a quality gate

## Validation
- `cargo fmt --check`
- `cargo test --locked`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`