### PR TITLE
chore(release): prepare v0.2.62

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.85.0
+        uses: dtolnay/rust-toolchain@1.88.0
 
       - name: Validate release metadata
         run: scripts/check-release.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.62] - 2026-04-27
+
+### Added
+- `--source all` overview support for registered sources.
+- Monthly budget forecasting for monthly reports.
+- Experimental Cursor usage source support.
+
+### Fixed
+- Harden release metadata checks and align release preflight with the current dependency MSRV.
+- Scope session and message deduplication by source file to avoid cross-file collisions.
+- Add GPT-5.4 pricing fallback and fall back to USD when currency conversion cannot be loaded.
+
 ## [0.2.61] - 2026-04-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "ccstats"
-version = "0.2.61"
+version = "0.2.62"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ccstats"
-version = "0.2.61"
+version = "0.2.62"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 description = "Fast token and cost usage statistics CLI for Claude Code and OpenAI Codex"
 license = "MIT"
 repository = "https://github.com/majiayu000/ccstats"

--- a/src/pricing/currency.rs
+++ b/src/pricing/currency.rs
@@ -114,11 +114,11 @@ fn save_cached_rates(rates: &HashMap<String, f64>) {
     let Some(path) = cache_path() else {
         return;
     };
-    if let Some(parent) = path.parent() {
-        if let Err(e) = std::fs::create_dir_all(parent) {
-            eprintln!("Warning: failed to create cache dir: {e}");
-            return;
-        }
+    if let Some(parent) = path.parent()
+        && let Err(e) = std::fs::create_dir_all(parent)
+    {
+        eprintln!("Warning: failed to create cache dir: {e}");
+        return;
     }
     match File::create(&path) {
         Ok(file) => {

--- a/src/source/claude/tool_parser.rs
+++ b/src/source/claude/tool_parser.rs
@@ -94,11 +94,11 @@ fn extract_date(val: &serde_json::Value, timezone: Timezone) -> String {
                 .and_then(serde_json::Value::as_str)
         });
 
-    if let Some(ts) = ts {
-        if let Ok(utc_dt) = ts.parse::<DateTime<Utc>>() {
-            let local_dt = timezone.to_fixed_offset(utc_dt);
-            return local_dt.date_naive().format(DATE_FORMAT).to_string();
-        }
+    if let Some(ts) = ts
+        && let Ok(utc_dt) = ts.parse::<DateTime<Utc>>()
+    {
+        let local_dt = timezone.to_fixed_offset(utc_dt);
+        return local_dt.date_naive().format(DATE_FORMAT).to_string();
     }
 
     UNKNOWN.to_string()


### PR DESCRIPTION
## Summary
- bump package metadata to v0.2.62 because v0.2.61 already exists on crates.io
- align release preflight with the dependency MSRV required by current locked dependencies
- update changelog and satisfy clippy after the MSRV bump

## Verification
- GITHUB_REF_NAME=v0.2.62 scripts/check-release.sh
- cargo fmt --check
- cargo +1.95 clippy --all-targets -- -D warnings
- cargo +1.95 test --locked
- cargo deny check advisories bans licenses sources
- cargo publish --dry-run --locked --allow-dirty