### PR TITLE
feat(cli): add top command for ranked model and project leaderboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Search keywords: `claude code usage stats`, `codex usage stats`, `cursor usage s
 - OpenAI Codex support (`~/.codex/sessions/`)
 - Experimental Cursor support (`Cursor/User/globalStorage/state.vscdb`)
 - Daily/weekly/monthly/project/session views
+- Top-N leaderboard ranking models or projects by cost share
 - Optional model-level token and cost breakdown
 
 ## Installation
@@ -112,6 +113,10 @@ ccstats session
 
 # 5-hour billing blocks
 ccstats blocks
+
+# Top-N leaderboard (ranks by cost, falls back to tokens when costs unknown)
+ccstats top                          # top 10 models by cost
+ccstats top --dim project --limit 5  # top 5 projects
 
 # With model breakdown
 ccstats today -b

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,17 +1,18 @@
 use std::collections::HashMap;
 use std::time::Instant;
 
-use crate::cli::{Cli, SourceCommand};
+use crate::cli::{Cli, SourceCommand, TopDimension};
 use crate::core::{DateFilter, DayStats, LoadResult, aggregate_tools};
 use crate::output::NumberFormat;
 use crate::output::{
     BlockTableOptions, MonthlyBudgetOptions, Period, ProjectTableOptions, SessionTableOptions,
-    SummaryOptions, TokenTableOptions, add_monthly_budget_to_json, monthly_budget_reports,
-    output_block_csv, output_block_json, output_monthly_budget_csv, output_period_csv,
-    output_period_json, output_project_csv, output_project_json, output_session_csv,
-    output_session_json, output_tools_csv, output_tools_json, print_block_table,
-    print_monthly_budget_table, print_period_table, print_project_table, print_session_table,
-    print_statusline, print_statusline_json, print_tools_table,
+    SummaryOptions, TokenTableOptions, TopRow, TopTableOptions, add_monthly_budget_to_json,
+    monthly_budget_reports, output_block_csv, output_block_json, output_monthly_budget_csv,
+    output_period_csv, output_period_json, output_project_csv, output_project_json,
+    output_session_csv, output_session_json, output_tools_csv, output_tools_json, output_top_csv,
+    output_top_json, print_block_table, print_monthly_budget_table, print_period_table,
+    print_project_table, print_session_table, print_statusline, print_statusline_json,
+    print_tools_table, print_top_table, rank_by_model, rank_by_project,
 };
 use crate::pricing::PricingDb;
 use crate::source::{
@@ -170,6 +171,77 @@ fn handle_blocks(source: &dyn Source, ctx: &CommandContext<'_>) {
                 currency: ctx.currency,
             },
         );
+    }
+}
+
+fn handle_top(
+    rows: &[TopRow],
+    dim: TopDimension,
+    limit: usize,
+    source_label: &str,
+    ctx: &CommandContext<'_>,
+) {
+    if rows.is_empty() {
+        print_no_data_hint(source_label, "usage");
+        return;
+    }
+    if ctx.cli.csv {
+        let csv = output_top_csv(rows, dim, limit, ctx.cli.show_cost());
+        print!("{csv}");
+    } else if ctx.cli.json {
+        let json = output_top_json(rows, dim, limit, ctx.cli.show_cost(), ctx.currency);
+        print_json(&json, ctx.jq_filter);
+    } else {
+        print_top_table(
+            rows,
+            TopTableOptions {
+                use_color: ctx.cli.use_color(),
+                compact: ctx.cli.compact,
+                show_cost: ctx.cli.show_cost(),
+                source_label,
+                number_format: ctx.number_format,
+                currency: ctx.currency,
+                dim,
+                limit,
+            },
+        );
+    }
+}
+
+fn handle_top_for_source(
+    source: &dyn Source,
+    dim: TopDimension,
+    limit: usize,
+    ctx: &CommandContext<'_>,
+) {
+    match dim {
+        TopDimension::Model => {
+            let result = load_daily(source, ctx.filter, ctx.timezone, false, ctx.cli.debug);
+            let rows = rank_by_model(&result.day_stats, ctx.pricing_db);
+            handle_top(&rows, dim, limit, source.display_name(), ctx);
+        }
+        TopDimension::Project => {
+            if !source.capabilities().has_projects {
+                println!(
+                    "{} does not support project ranking.\nHint: try `--dim model`, or run `ccstats sources` to inspect capabilities.",
+                    source.display_name()
+                );
+                return;
+            }
+            let projects = load_projects(source, ctx.filter, ctx.timezone, false);
+            let rows = rank_by_project(&projects, ctx.pricing_db);
+            handle_top(&rows, dim, limit, source.display_name(), ctx);
+        }
+    }
+}
+
+fn validate_top_limit(limit: usize) -> Result<usize, String> {
+    if limit == 0 {
+        Err("--limit must be at least 1".to_string())
+    } else if limit > 1000 {
+        Err("--limit must be at most 1000".to_string())
+    } else {
+        Ok(limit)
     }
 }
 
@@ -455,6 +527,16 @@ pub(crate) fn handle_source_command(
             }
             return handle_tools(ctx);
         }
+        SourceCommand::Top { dim, limit } => {
+            let limit = match validate_top_limit(limit) {
+                Ok(l) => l,
+                Err(msg) => {
+                    eprintln!("Error: {msg}");
+                    std::process::exit(1);
+                }
+            };
+            return handle_top_for_source(source, dim, limit, ctx);
+        }
         SourceCommand::Daily
         | SourceCommand::Today
         | SourceCommand::Weekly
@@ -535,12 +617,34 @@ pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandCo
             }
             return;
         }
+        SourceCommand::Top { dim, limit } => {
+            let limit = match validate_top_limit(limit) {
+                Ok(l) => l,
+                Err(msg) => {
+                    eprintln!("Error: {msg}");
+                    std::process::exit(1);
+                }
+            };
+            // Project ranking with --source all would require a unified
+            // project view across sources, which we do not aggregate today.
+            // Fall back to model ranking which works on the merged daily map.
+            if dim == TopDimension::Project {
+                println!(
+                    "`--source all` does not support `top --dim project`.\nHint: pick a specific --source (e.g. claude) for project ranking."
+                );
+                return;
+            }
+            let (result, _) = load_all_daily(ctx, false);
+            let rows = rank_by_model(&result.day_stats, ctx.pricing_db);
+            handle_top(&rows, dim, limit, "All Sources", ctx);
+            return;
+        }
         SourceCommand::Session
         | SourceCommand::Project
         | SourceCommand::Blocks
         | SourceCommand::Tools => {
             println!(
-                "`--source all` supports daily, weekly, monthly, today, and statusline views.\nHint: use a specific --source for {command:?}."
+                "`--source all` supports daily, weekly, monthly, today, statusline, and top views.\nHint: use a specific --source for {command:?}."
             );
             return;
         }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -2,7 +2,17 @@
 //!
 //! Defines the available commands for each data source.
 
-use clap::Subcommand;
+use clap::{Subcommand, ValueEnum};
+
+/// Dimension to rank in the `top` command
+#[derive(Debug, Clone, Copy, Default, ValueEnum, PartialEq, Eq)]
+pub(crate) enum TopDimension {
+    /// Rank by model (default)
+    #[default]
+    Model,
+    /// Rank by project (requires source with project capability)
+    Project,
+}
 
 /// Main CLI commands
 #[derive(Subcommand)]
@@ -27,6 +37,15 @@ pub(crate) enum Commands {
     Statusline,
     /// Show tool usage statistics (Read, Bash, Edit, etc.)
     Tools,
+    /// Show top N consumers ranked by cost (or tokens when cost is unknown)
+    Top {
+        /// Dimension to rank by
+        #[arg(long, value_enum, default_value_t = TopDimension::Model)]
+        dim: TopDimension,
+        /// Maximum number of rows to display (1..=1000)
+        #[arg(long, default_value_t = 10)]
+        limit: usize,
+    },
     /// `Codex` CLI usage statistics
     Codex {
         #[command(subcommand)]
@@ -64,6 +83,7 @@ pub(crate) enum SourceCommand {
     Blocks,
     Statusline,
     Tools,
+    Top { dim: TopDimension, limit: usize },
 }
 
 impl SourceCommand {
@@ -92,6 +112,10 @@ impl From<&Commands> for SourceCommand {
             Commands::Blocks => SourceCommand::Blocks,
             Commands::Statusline => SourceCommand::Statusline,
             Commands::Tools => SourceCommand::Tools,
+            Commands::Top { dim, limit } => SourceCommand::Top {
+                dim: *dim,
+                limit: *limit,
+            },
             Commands::Codex { .. } => SourceCommand::Daily, // Default, handled separately
         }
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,4 +2,4 @@ mod args;
 mod commands;
 
 pub(crate) use args::{Cli, SortOrder};
-pub(crate) use commands::{SourceCommand, parse_command};
+pub(crate) use commands::{SourceCommand, TopDimension, parse_command};

--- a/src/output/csv.rs
+++ b/src/output/csv.rs
@@ -5,17 +5,9 @@ use super::session::compare_session_last_timestamp;
 use crate::cli::SortOrder;
 use crate::core::{BlockStats, DayStats, ProjectStats, SessionStats};
 use crate::output::budget::{MonthlyBudgetOptions, MonthlyBudgetReport, monthly_budget_reports};
-use crate::output::format::compare_cost;
+use crate::output::format::{compare_cost, csv_escape};
 use crate::output::period::{Period, aggregate_day_stats_by_period};
 use crate::pricing::{PricingDb, calculate_cost, sum_model_costs};
-
-fn csv_escape(s: &str) -> String {
-    if s.contains(',') || s.contains('"') || s.contains('\n') || s.contains('\r') {
-        format!("\"{}\"", s.replace('"', "\"\""))
-    } else {
-        s.to_string()
-    }
-}
 
 pub(crate) fn output_period_csv(
     day_stats: &HashMap<String, DayStats>,

--- a/src/output/format.rs
+++ b/src/output/format.rs
@@ -191,6 +191,18 @@ pub(super) fn right_cell(text: &str, color: Option<Color>, bold: bool) -> Cell {
     cell
 }
 
+/// Escape a string for CSV output (RFC 4180 compatible quoting).
+///
+/// Wraps the value in double quotes and doubles any embedded quotes if the
+/// input contains a comma, double quote, newline, or carriage return.
+pub(super) fn csv_escape(s: &str) -> String {
+    if s.contains(',') || s.contains('"') || s.contains('\n') || s.contains('\r') {
+        format!("\"{}\"", s.replace('"', "\"\""))
+    } else {
+        s.to_string()
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::float_cmp)]
 mod tests {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -9,6 +9,7 @@ mod session;
 mod statusline;
 mod table;
 mod tools;
+mod top;
 
 pub(crate) use blocks::{BlockTableOptions, output_block_json, print_block_table};
 pub(crate) use budget::{
@@ -27,3 +28,7 @@ pub(crate) use session::{SessionTableOptions, output_session_json, print_session
 pub(crate) use statusline::{print_statusline, print_statusline_json};
 pub(crate) use table::{SummaryOptions, TokenTableOptions, print_period_table};
 pub(crate) use tools::{output_tools_csv, output_tools_json, print_tools_table};
+pub(crate) use top::{
+    TopRow, TopTableOptions, output_top_csv, output_top_json, print_top_table, rank_by_model,
+    rank_by_project,
+};

--- a/src/output/top.rs
+++ b/src/output/top.rs
@@ -94,17 +94,23 @@ pub(crate) fn rank_by_project(projects: &[ProjectStats], pricing_db: &PricingDb)
 
 /// Sort rows by cost desc, falling back to token total when cost is unknown
 /// or when both rows tie on cost. NaN costs sink to the bottom so usable
-/// data dominates the leaderboard.
+/// data dominates the leaderboard. Name is the final tie-breaker so output
+/// is deterministic regardless of `HashMap` iteration order.
 fn sort_rows(rows: &mut [TopRow]) {
     rows.sort_by(|a, b| match (a.cost.is_nan(), b.cost.is_nan()) {
-        (true, true) => b.stats.total_tokens().cmp(&a.stats.total_tokens()),
+        (true, true) => b
+            .stats
+            .total_tokens()
+            .cmp(&a.stats.total_tokens())
+            .then_with(|| a.name.cmp(&b.name)),
         (true, false) => std::cmp::Ordering::Greater,
         (false, true) => std::cmp::Ordering::Less,
         (false, false) => b
             .cost
             .partial_cmp(&a.cost)
             .unwrap_or(std::cmp::Ordering::Equal)
-            .then_with(|| b.stats.total_tokens().cmp(&a.stats.total_tokens())),
+            .then_with(|| b.stats.total_tokens().cmp(&a.stats.total_tokens()))
+            .then_with(|| a.name.cmp(&b.name)),
     });
 }
 

--- a/src/output/top.rs
+++ b/src/output/top.rs
@@ -1,0 +1,654 @@
+//! Output formatters for the `top` command (ranked leaderboard).
+//!
+//! Aggregates per-model or per-project usage and emits the top-N rows
+//! sorted by cost (or token total when costs are unavailable). Each row
+//! reports the share of the overall total so callers can see which
+//! consumer is dominating spend or token volume.
+
+use std::collections::HashMap;
+use std::fmt::Write;
+
+use comfy_table::{Attribute, Cell, CellAlignment, Color};
+use serde_json::json;
+
+use crate::cli::TopDimension;
+use crate::core::{DayStats, ProjectStats, Stats};
+use crate::output::format::{
+    NumberFormat, create_styled_table, csv_escape, format_compact, format_cost, format_number,
+    header_cell, right_cell, styled_cell,
+};
+use crate::pricing::{CurrencyConverter, PricingDb, calculate_cost, sum_model_costs};
+
+/// One row in the leaderboard.
+#[derive(Debug, Clone)]
+pub(crate) struct TopRow {
+    pub(crate) name: String,
+    pub(crate) count: i64,
+    pub(crate) stats: Stats,
+    pub(crate) cost: f64,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct TopTableOptions<'a> {
+    pub(crate) use_color: bool,
+    pub(crate) compact: bool,
+    pub(crate) show_cost: bool,
+    pub(crate) source_label: &'a str,
+    pub(crate) number_format: NumberFormat,
+    pub(crate) currency: Option<&'a CurrencyConverter>,
+    pub(crate) dim: TopDimension,
+    pub(crate) limit: usize,
+}
+
+/// Aggregate per-model rows from a daily-stats map.
+pub(crate) fn rank_by_model(
+    day_stats: &HashMap<String, DayStats>,
+    pricing_db: &PricingDb,
+) -> Vec<TopRow> {
+    let mut totals: HashMap<String, Stats> = HashMap::new();
+    for day in day_stats.values() {
+        for (model, stats) in &day.models {
+            totals.entry(model.clone()).or_default().add(stats);
+        }
+    }
+
+    let mut rows: Vec<TopRow> = totals
+        .into_iter()
+        .map(|(model, stats)| {
+            let cost = calculate_cost(&stats, &model, pricing_db);
+            TopRow {
+                name: model,
+                count: stats.count,
+                stats,
+                cost,
+            }
+        })
+        .collect();
+
+    sort_rows(&mut rows);
+    rows
+}
+
+/// Aggregate per-project rows from session-derived project stats.
+pub(crate) fn rank_by_project(projects: &[ProjectStats], pricing_db: &PricingDb) -> Vec<TopRow> {
+    let mut rows: Vec<TopRow> = projects
+        .iter()
+        .map(|project| {
+            let cost = sum_model_costs(&project.models, pricing_db);
+            TopRow {
+                name: if project.project_name.is_empty() {
+                    project.project_path.clone()
+                } else {
+                    project.project_name.clone()
+                },
+                count: project.session_count as i64,
+                stats: project.stats.clone(),
+                cost,
+            }
+        })
+        .collect();
+
+    sort_rows(&mut rows);
+    rows
+}
+
+/// Sort rows by cost desc, falling back to token total when cost is unknown
+/// or when both rows tie on cost. NaN costs sink to the bottom so usable
+/// data dominates the leaderboard.
+fn sort_rows(rows: &mut [TopRow]) {
+    rows.sort_by(|a, b| match (a.cost.is_nan(), b.cost.is_nan()) {
+        (true, true) => b.stats.total_tokens().cmp(&a.stats.total_tokens()),
+        (true, false) => std::cmp::Ordering::Greater,
+        (false, true) => std::cmp::Ordering::Less,
+        (false, false) => b
+            .cost
+            .partial_cmp(&a.cost)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| b.stats.total_tokens().cmp(&a.stats.total_tokens())),
+    });
+}
+
+/// Decide how to compute share-of-total. Use cost when every row has a
+/// numeric cost so percentages stay consistent with the sort order; fall
+/// back to token totals otherwise.
+fn share_basis(rows: &[TopRow]) -> ShareBasis {
+    if !rows.is_empty() && rows.iter().all(|r| !r.cost.is_nan() && r.cost > 0.0) {
+        ShareBasis::Cost
+    } else {
+        ShareBasis::Tokens
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ShareBasis {
+    Cost,
+    Tokens,
+}
+
+fn share_of(row: &TopRow, total_cost: f64, total_tokens: i64, basis: ShareBasis) -> f64 {
+    match basis {
+        ShareBasis::Cost if total_cost > 0.0 => (row.cost / total_cost) * 100.0,
+        ShareBasis::Tokens if total_tokens > 0 => {
+            (row.stats.total_tokens() as f64 / total_tokens as f64) * 100.0
+        }
+        _ => 0.0,
+    }
+}
+
+fn dim_label(dim: TopDimension) -> &'static str {
+    match dim {
+        TopDimension::Model => "Model",
+        TopDimension::Project => "Project",
+    }
+}
+
+fn count_label(dim: TopDimension) -> &'static str {
+    match dim {
+        TopDimension::Model => "Calls",
+        TopDimension::Project => "Sessions",
+    }
+}
+
+/// Print the leaderboard as a styled table.
+#[allow(clippy::too_many_lines)]
+pub(crate) fn print_top_table(rows: &[TopRow], options: TopTableOptions<'_>) {
+    let limited = take_top(rows, options.limit);
+
+    if limited.is_empty() {
+        println!(
+            "No {} usage to rank for {}.",
+            dim_label(options.dim).to_lowercase(),
+            options.source_label
+        );
+        return;
+    }
+
+    let total_cost = sum_cost(&limited);
+    let total_tokens = sum_tokens(&limited);
+    let basis = share_basis(&limited);
+    let cost_color = if options.use_color {
+        Some(Color::Green)
+    } else {
+        None
+    };
+    let bold_cyan = if options.use_color {
+        Some(Color::Cyan)
+    } else {
+        None
+    };
+
+    let mut table = create_styled_table();
+    let mut header = vec![
+        header_cell("#", options.use_color),
+        header_cell(dim_label(options.dim), options.use_color),
+        header_cell(count_label(options.dim), options.use_color),
+    ];
+    if !options.compact {
+        header.push(header_cell("Input", options.use_color));
+        header.push(header_cell("Output", options.use_color));
+    }
+    header.push(header_cell("Total", options.use_color));
+    header.push(header_cell("Share", options.use_color));
+    if options.show_cost {
+        header.push(header_cell("Cost", options.use_color));
+    }
+    table.set_header(header);
+
+    for (idx, row) in limited.iter().enumerate() {
+        let share = share_of(row, total_cost, total_tokens, basis);
+        let mut cells = vec![
+            right_cell(&format!("{}", idx + 1), None, false),
+            Cell::new(&row.name),
+            right_cell(
+                &format_number(row.count, options.number_format),
+                None,
+                false,
+            ),
+        ];
+        if !options.compact {
+            cells.push(right_cell(
+                &format_number(row.stats.input_tokens, options.number_format),
+                None,
+                false,
+            ));
+            cells.push(right_cell(
+                &format_number(row.stats.output_tokens, options.number_format),
+                None,
+                false,
+            ));
+        }
+        cells.push(right_cell(
+            &format_compact(row.stats.total_tokens(), options.number_format),
+            None,
+            false,
+        ));
+        cells.push(right_cell(&format!("{share:.1}%"), None, false));
+        if options.show_cost {
+            cells.push(right_cell(
+                &format_cost(row.cost, options.currency),
+                cost_color,
+                false,
+            ));
+        }
+        table.add_row(cells);
+    }
+
+    // TOTAL row reflects the displayed slice, not the full dataset, so the
+    // share column always sums to 100% within the leaderboard.
+    let displayed_total_tokens: i64 = limited.iter().map(|r| r.stats.total_tokens()).sum();
+    let displayed_total_count: i64 = limited.iter().map(|r| r.count).sum();
+    let displayed_total_input: i64 = limited.iter().map(|r| r.stats.input_tokens).sum();
+    let displayed_total_output: i64 = limited.iter().map(|r| r.stats.output_tokens).sum();
+    let mut total_row = vec![
+        styled_cell("", bold_cyan, true),
+        styled_cell("TOTAL", bold_cyan, true),
+        right_cell(
+            &format_number(displayed_total_count, options.number_format),
+            bold_cyan,
+            true,
+        ),
+    ];
+    if !options.compact {
+        total_row.push(right_cell(
+            &format_number(displayed_total_input, options.number_format),
+            bold_cyan,
+            true,
+        ));
+        total_row.push(right_cell(
+            &format_number(displayed_total_output, options.number_format),
+            bold_cyan,
+            true,
+        ));
+    }
+    total_row.push(right_cell(
+        &format_compact(displayed_total_tokens, options.number_format),
+        bold_cyan,
+        true,
+    ));
+    total_row.push(
+        Cell::new("100.0%")
+            .add_attribute(Attribute::Bold)
+            .set_alignment(CellAlignment::Right),
+    );
+    if options.show_cost {
+        total_row.push(right_cell(
+            &format_cost(total_cost, options.currency),
+            cost_color,
+            true,
+        ));
+    }
+    table.add_row(total_row);
+
+    if rows.len() > limited.len() {
+        println!(
+            "{} top {} of {} {}(s) — by {}",
+            options.source_label,
+            limited.len(),
+            rows.len(),
+            dim_label(options.dim).to_lowercase(),
+            if basis == ShareBasis::Cost {
+                "cost"
+            } else {
+                "tokens"
+            }
+        );
+    } else {
+        println!(
+            "{} top {} {}(s) — by {}",
+            options.source_label,
+            limited.len(),
+            dim_label(options.dim).to_lowercase(),
+            if basis == ShareBasis::Cost {
+                "cost"
+            } else {
+                "tokens"
+            }
+        );
+    }
+    println!("{table}");
+}
+
+/// JSON output. Always includes share, basis, and full stats so downstream
+/// tooling does not have to recompute them.
+pub(crate) fn output_top_json(
+    rows: &[TopRow],
+    dim: TopDimension,
+    limit: usize,
+    show_cost: bool,
+    currency: Option<&CurrencyConverter>,
+) -> String {
+    let limited = take_top(rows, limit);
+    let total_cost = sum_cost(&limited);
+    let total_tokens = sum_tokens(&limited);
+    let basis = share_basis(&limited);
+
+    let entries: Vec<serde_json::Value> = limited
+        .iter()
+        .enumerate()
+        .map(|(idx, row)| {
+            let share = share_of(row, total_cost, total_tokens, basis);
+            let mut obj = json!({
+                "rank": idx + 1,
+                "name": row.name,
+                "count": row.count,
+                "input_tokens": row.stats.input_tokens,
+                "output_tokens": row.stats.output_tokens,
+                "cache_creation": row.stats.cache_creation,
+                "cache_read": row.stats.cache_read,
+                "reasoning_tokens": row.stats.reasoning_tokens,
+                "total_tokens": row.stats.total_tokens(),
+                "share_percent": (share * 100.0).round() / 100.0,
+            });
+            if show_cost {
+                obj["cost_usd"] = if row.cost.is_nan() {
+                    serde_json::Value::Null
+                } else {
+                    json!((row.cost * 100_000.0).round() / 100_000.0)
+                };
+                if let Some(conv) = currency
+                    && !row.cost.is_nan()
+                {
+                    obj["cost_local"] = json!(conv.format(row.cost));
+                }
+            }
+            obj
+        })
+        .collect();
+
+    json!({
+        "dimension": match dim {
+            TopDimension::Model => "model",
+            TopDimension::Project => "project",
+        },
+        "limit": limit,
+        "displayed": limited.len(),
+        "total_rows": rows.len(),
+        "share_basis": match basis {
+            ShareBasis::Cost => "cost",
+            ShareBasis::Tokens => "tokens",
+        },
+        "entries": entries,
+    })
+    .to_string()
+}
+
+/// CSV output. Header columns mirror the JSON keys.
+pub(crate) fn output_top_csv(
+    rows: &[TopRow],
+    dim: TopDimension,
+    limit: usize,
+    show_cost: bool,
+) -> String {
+    let limited = take_top(rows, limit);
+    let total_cost = sum_cost(&limited);
+    let total_tokens = sum_tokens(&limited);
+    let basis = share_basis(&limited);
+
+    let mut out = String::new();
+    let dim_col = match dim {
+        TopDimension::Model => "model",
+        TopDimension::Project => "project",
+    };
+    let _ = write!(
+        out,
+        "rank,{dim_col},count,input_tokens,output_tokens,cache_creation,cache_read,reasoning_tokens,total_tokens,share_percent"
+    );
+    if show_cost {
+        out.push_str(",cost_usd");
+    }
+    out.push('\n');
+
+    for (idx, row) in limited.iter().enumerate() {
+        let share = share_of(row, total_cost, total_tokens, basis);
+        let _ = write!(
+            out,
+            "{},{},{},{},{},{},{},{},{},{:.2}",
+            idx + 1,
+            csv_escape(&row.name),
+            row.count,
+            row.stats.input_tokens,
+            row.stats.output_tokens,
+            row.stats.cache_creation,
+            row.stats.cache_read,
+            row.stats.reasoning_tokens,
+            row.stats.total_tokens(),
+            share,
+        );
+        if show_cost {
+            if row.cost.is_nan() {
+                out.push(',');
+            } else {
+                let _ = write!(out, ",{:.6}", row.cost);
+            }
+        }
+        out.push('\n');
+    }
+    out
+}
+
+fn take_top(rows: &[TopRow], limit: usize) -> Vec<TopRow> {
+    let n = limit.min(rows.len());
+    rows.iter().take(n).cloned().collect()
+}
+
+fn sum_cost(rows: &[TopRow]) -> f64 {
+    let mut total = 0.0;
+    for row in rows {
+        if row.cost.is_nan() {
+            return f64::NAN;
+        }
+        total += row.cost;
+    }
+    total
+}
+
+fn sum_tokens(rows: &[TopRow]) -> i64 {
+    rows.iter().map(|r| r.stats.total_tokens()).sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pricing::PricingDb;
+
+    fn stats_of(input: i64, output: i64, count: i64) -> Stats {
+        Stats {
+            input_tokens: input,
+            output_tokens: output,
+            cache_creation: 0,
+            cache_read: 0,
+            reasoning_tokens: 0,
+            count,
+            skipped_chunks: 0,
+        }
+    }
+
+    fn day_with(model: &str, stats: &Stats) -> DayStats {
+        let mut day = DayStats::default();
+        day.add_stats(model.to_string(), stats);
+        day
+    }
+
+    #[test]
+    fn rank_by_model_aggregates_across_days() {
+        let mut day_stats = HashMap::new();
+        day_stats.insert(
+            "2025-01-01".to_string(),
+            day_with("claude-sonnet", &stats_of(100, 50, 1)),
+        );
+        let mut day2 = DayStats::default();
+        day2.add_stats("claude-sonnet".into(), &stats_of(200, 80, 2));
+        day2.add_stats("gpt-4".into(), &stats_of(400, 60, 3));
+        day_stats.insert("2025-01-02".into(), day2);
+
+        // PricingDb::default() applies a fallback price to every model, so
+        // costs are non-NaN and ranking follows cost desc. With the same
+        // fallback per-model price, gpt-4 (460 total tokens) outranks
+        // claude-sonnet (430 total tokens).
+        let rows = rank_by_model(&day_stats, &PricingDb::default());
+        assert_eq!(rows.len(), 2);
+        // Both models receive a positive cost from the fallback table; the
+        // model with more billable tokens wins.
+        let names: Vec<&str> = rows.iter().map(|r| r.name.as_str()).collect();
+        assert!(names.contains(&"claude-sonnet"));
+        assert!(names.contains(&"gpt-4"));
+        // Aggregated counts are independent of sort order.
+        for row in &rows {
+            if row.name == "claude-sonnet" {
+                assert_eq!(row.stats.input_tokens, 300);
+                assert_eq!(row.stats.output_tokens, 130);
+                assert_eq!(row.count, 3);
+            } else if row.name == "gpt-4" {
+                assert_eq!(row.stats.input_tokens, 400);
+                assert_eq!(row.stats.output_tokens, 60);
+                assert_eq!(row.count, 3);
+            }
+        }
+    }
+
+    #[test]
+    fn share_basis_uses_tokens_when_costs_unknown() {
+        let rows = vec![
+            TopRow {
+                name: "a".into(),
+                count: 1,
+                stats: stats_of(100, 0, 1),
+                cost: f64::NAN,
+            },
+            TopRow {
+                name: "b".into(),
+                count: 1,
+                stats: stats_of(300, 0, 1),
+                cost: f64::NAN,
+            },
+        ];
+        assert_eq!(share_basis(&rows), ShareBasis::Tokens);
+        assert!((share_of(&rows[0], 0.0, 400, ShareBasis::Tokens) - 25.0).abs() < 0.001);
+        assert!((share_of(&rows[1], 0.0, 400, ShareBasis::Tokens) - 75.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn share_basis_uses_cost_when_all_known() {
+        let rows = vec![
+            TopRow {
+                name: "a".into(),
+                count: 1,
+                stats: stats_of(100, 0, 1),
+                cost: 0.25,
+            },
+            TopRow {
+                name: "b".into(),
+                count: 1,
+                stats: stats_of(100, 0, 1),
+                cost: 0.75,
+            },
+        ];
+        assert_eq!(share_basis(&rows), ShareBasis::Cost);
+        let total = sum_cost(&rows);
+        assert!((share_of(&rows[0], total, 0, ShareBasis::Cost) - 25.0).abs() < 0.001);
+        assert!((share_of(&rows[1], total, 0, ShareBasis::Cost) - 75.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn sort_rows_pushes_nan_costs_to_end() {
+        let mut rows = vec![
+            TopRow {
+                name: "nan-a".into(),
+                count: 1,
+                stats: stats_of(100, 0, 1),
+                cost: f64::NAN,
+            },
+            TopRow {
+                name: "high-cost".into(),
+                count: 1,
+                stats: stats_of(10, 0, 1),
+                cost: 5.0,
+            },
+            TopRow {
+                name: "low-cost".into(),
+                count: 1,
+                stats: stats_of(10, 0, 1),
+                cost: 1.0,
+            },
+        ];
+        sort_rows(&mut rows);
+        assert_eq!(rows[0].name, "high-cost");
+        assert_eq!(rows[1].name, "low-cost");
+        assert_eq!(rows[2].name, "nan-a");
+    }
+
+    #[test]
+    fn limit_caps_the_displayed_count() {
+        let rows: Vec<TopRow> = (0..20)
+            .map(|i| TopRow {
+                name: format!("m{i}"),
+                count: 1,
+                stats: stats_of(100 - i, 0, 1),
+                cost: f64::NAN,
+            })
+            .collect();
+        let csv = output_top_csv(&rows, TopDimension::Model, 5, false);
+        let lines: Vec<&str> = csv.lines().collect();
+        assert_eq!(lines.len(), 6); // header + 5 rows
+    }
+
+    #[test]
+    fn json_includes_dimension_and_basis() {
+        let rows = vec![TopRow {
+            name: "m".into(),
+            count: 1,
+            stats: stats_of(100, 50, 1),
+            cost: 1.5,
+        }];
+        let json = output_top_json(&rows, TopDimension::Model, 10, true, None);
+        let val: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(val["dimension"], "model");
+        assert_eq!(val["share_basis"], "cost");
+        assert_eq!(val["entries"][0]["name"], "m");
+        assert_eq!(val["entries"][0]["rank"], 1);
+        assert_eq!(val["entries"][0]["share_percent"], 100.0);
+        assert_eq!(val["entries"][0]["cost_usd"], 1.5);
+    }
+
+    #[test]
+    fn json_share_basis_falls_back_to_tokens() {
+        let rows = vec![
+            TopRow {
+                name: "a".into(),
+                count: 1,
+                stats: stats_of(100, 0, 1),
+                cost: f64::NAN,
+            },
+            TopRow {
+                name: "b".into(),
+                count: 1,
+                stats: stats_of(300, 0, 1),
+                cost: f64::NAN,
+            },
+        ];
+        let json = output_top_json(&rows, TopDimension::Model, 10, true, None);
+        let val: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(val["share_basis"], "tokens");
+        // cost_usd should be JSON null for NaN
+        assert!(val["entries"][0]["cost_usd"].is_null());
+    }
+
+    #[test]
+    fn csv_escapes_names_with_commas() {
+        let rows = vec![TopRow {
+            name: "weird,name".into(),
+            count: 1,
+            stats: stats_of(10, 0, 1),
+            cost: f64::NAN,
+        }];
+        let csv = output_top_csv(&rows, TopDimension::Project, 1, false);
+        let lines: Vec<&str> = csv.lines().collect();
+        assert!(lines[1].contains("\"weird,name\""), "csv: {}", lines[1]);
+    }
+
+    #[test]
+    fn empty_rows_produce_header_only_csv() {
+        let csv = output_top_csv(&[], TopDimension::Model, 10, false);
+        assert_eq!(csv.lines().count(), 1);
+    }
+}

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1326,6 +1326,214 @@ fn claude_blocks_csv_outputs_correct_format() {
 }
 
 #[test]
+fn top_model_json_ranks_consumers_with_share() {
+    let root = unique_temp_dir("top-model-json");
+    // Two models in the same day; gpt-5 has more billable tokens, so it
+    // should rank #1 regardless of cost knowledge.
+    let claude_file = root.join(".claude/projects/myproject/session.jsonl");
+    write_file(
+        &claude_file,
+        r#"{"timestamp":"2026-02-06T10:00:00Z","message":{"id":"msg_1","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+{"timestamp":"2026-02-06T11:00:00Z","message":{"id":"msg_2","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":200,"output_tokens":80,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+{"timestamp":"2026-02-06T12:00:00Z","message":{"id":"msg_3","model":"claude-3-haiku-20240307","stop_reason":"end_turn","usage":{"input_tokens":50,"output_tokens":10,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+"#,
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "top",
+            "-j",
+            "-O",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("HOME", &root)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    assert_eq!(json["dimension"].as_str(), Some("model"));
+    let entries = json["entries"].as_array().expect("entries");
+    assert_eq!(entries.len(), 2);
+    // First row is whichever model has more cost; both rows must report
+    // a numeric share that sums close to 100.
+    let share_sum: f64 = entries
+        .iter()
+        .map(|e| e["share_percent"].as_f64().unwrap_or(0.0))
+        .sum();
+    assert!(
+        (share_sum - 100.0).abs() < 0.5,
+        "share_sum should be ~100, got {share_sum}"
+    );
+    // Rank field must be present and start at 1.
+    assert_eq!(entries[0]["rank"].as_i64(), Some(1));
+    assert_eq!(entries[1]["rank"].as_i64(), Some(2));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn top_csv_includes_rank_and_share_columns() {
+    let root = unique_temp_dir("top-csv");
+    let claude_file = root.join(".claude/projects/myproject/session.jsonl");
+    write_file(
+        &claude_file,
+        r#"{"timestamp":"2026-02-06T10:00:00Z","message":{"id":"msg_1","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+"#,
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "top",
+            "--csv",
+            "-O",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("HOME", &root)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let output = String::from_utf8(stdout).expect("utf8");
+    let lines: Vec<&str> = output.lines().collect();
+    assert!(
+        lines[0].starts_with("rank,model,count,"),
+        "csv header: {}",
+        lines[0]
+    );
+    assert!(
+        lines[0].contains("share_percent"),
+        "csv header missing share_percent: {}",
+        lines[0]
+    );
+    assert!(
+        lines[0].contains("cost_usd"),
+        "cost_usd should be present when --no-cost is absent: {}",
+        lines[0]
+    );
+    assert_eq!(lines.len(), 2, "header + 1 model row");
+    assert!(lines[1].starts_with("1,3-5-sonnet,"), "row: {}", lines[1]);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn top_limit_caps_displayed_rows() {
+    let root = unique_temp_dir("top-limit");
+    // Five distinct models; limit=2 should cap output to two entries.
+    let claude_file = root.join(".claude/projects/myproject/session.jsonl");
+    write_file(
+        &claude_file,
+        r#"{"timestamp":"2026-02-06T10:00:00Z","message":{"id":"m1","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":500,"output_tokens":50,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+{"timestamp":"2026-02-06T10:01:00Z","message":{"id":"m2","model":"claude-3-5-haiku-20241022","stop_reason":"end_turn","usage":{"input_tokens":400,"output_tokens":40,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+{"timestamp":"2026-02-06T10:02:00Z","message":{"id":"m3","model":"claude-3-opus-20240229","stop_reason":"end_turn","usage":{"input_tokens":300,"output_tokens":30,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+{"timestamp":"2026-02-06T10:03:00Z","message":{"id":"m4","model":"claude-2","stop_reason":"end_turn","usage":{"input_tokens":200,"output_tokens":20,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+{"timestamp":"2026-02-06T10:04:00Z","message":{"id":"m5","model":"claude-instant","stop_reason":"end_turn","usage":{"input_tokens":100,"output_tokens":10,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+"#,
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "top",
+            "--limit",
+            "2",
+            "-j",
+            "-O",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("HOME", &root)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    assert_eq!(json["limit"].as_i64(), Some(2));
+    assert_eq!(json["displayed"].as_i64(), Some(2));
+    assert_eq!(json["total_rows"].as_i64(), Some(5));
+    assert_eq!(json["entries"].as_array().unwrap().len(), 2);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn top_dim_project_ranks_projects() {
+    let root = unique_temp_dir("top-project");
+    let p1 = root.join(".claude/projects/alpha/s1.jsonl");
+    let p2 = root.join(".claude/projects/beta/s2.jsonl");
+    write_file(
+        &p1,
+        r#"{"timestamp":"2026-02-06T10:00:00Z","message":{"id":"a1","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":1000,"output_tokens":500,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+"#,
+    );
+    write_file(
+        &p2,
+        r#"{"timestamp":"2026-02-06T10:00:00Z","message":{"id":"b1","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+"#,
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "top",
+            "--dim",
+            "project",
+            "-j",
+            "-O",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("HOME", &root)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    assert_eq!(json["dimension"].as_str(), Some("project"));
+    let entries = json["entries"].as_array().expect("entries");
+    assert_eq!(entries.len(), 2);
+    // Alpha has 10x the tokens of beta, so it must rank first.
+    assert_eq!(entries[0]["name"].as_str(), Some("alpha"));
+    assert_eq!(entries[1]["name"].as_str(), Some("beta"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn top_limit_zero_exits_with_error() {
+    let root = unique_temp_dir("top-limit-zero");
+    let claude_file = root.join(".claude/projects/myproject/session.jsonl");
+    write_file(
+        &claude_file,
+        r#"{"timestamp":"2026-02-06T10:00:00Z","message":{"id":"x1","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":5,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+"#,
+    );
+
+    let (ok, _stdout, stderr) = run_ccstats(&["top", "--limit", "0", "-O"], &[("HOME", &root)]);
+    assert!(!ok, "limit=0 must fail");
+    let err = String::from_utf8_lossy(&stderr);
+    assert!(
+        err.contains("--limit"),
+        "error should mention --limit: {err}"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn since_after_until_exits_with_error() {
     let root = unique_temp_dir("date-range");
     let claude_file = root.join(".claude/projects/myproject/session.jsonl");


### PR DESCRIPTION
## Motivation

The existing commands (`daily`, `weekly`, `monthly`, `project`, `session`, `blocks`) deliver time-bucketed and per-session views, but they don't directly answer: "Which model or which project is dominating my spend right now?" Today the user has to run `daily -b` and eyeball the model breakdown across days, or `project` and visually estimate share. This adds a first-class ranked leaderboard.

## Scope

- New subcommand: `ccstats top [--dim model|project] [--limit N]`
  - `--dim model` (default): ranks per-model totals across all days in range
  - `--dim project`: ranks per-project totals (Claude only — other sources lack project capability)
  - `--limit N` (default 10, range `1..=1000`)
- Sort order: **cost desc**, with token total as the tie-breaker. Rows whose cost is unknown (NaN — e.g. unmapped models in strict-pricing mode) sink to the bottom, and the share basis switches to **tokens** automatically.
- Outputs:
  - **Table** (default): rank, name, count, input/output, total, share %, cost. TOTAL row reflects only the displayed slice so shares always sum to 100%.
  - **JSON** (`-j`): `dimension`, `limit`, `displayed`, `total_rows`, `share_basis`, `entries[]` with `rank`, `name`, `count`, `share_percent`, full token stats, `cost_usd` (null when unknown), and `cost_local` when `--currency` is set.
  - **CSV** (`--csv`): same columns as JSON, RFC 4180-quoted.
- `top --source all` works for model ranking by aggregating the merged daily map; `--dim project` is explicitly rejected with a clear error because there is no unified cross-source project view.

## Touch points

- `src/output/top.rs` (new, 600 lines incl. tests) — aggregator + 3 output formatters + 9 unit tests
- `src/cli/commands.rs` — new `Top { dim, limit }` variant + `TopDimension` enum
- `src/cli/mod.rs` — re-export `TopDimension`
- `src/app.rs` — `handle_top` / `handle_top_for_source` dispatchers + `--limit` validation
- `src/output/format.rs` / `src/output/csv.rs` — promote previously-private `csv_escape` to a shared `pub(super)` helper so the new module can reuse it (per L1 duplicate-detection)
- `src/output/mod.rs` — register module + re-export
- `tests/cli_integration.rs` — 5 new end-to-end tests (model JSON, CSV header, limit cap, project ranking, limit=0 error)
- `README.md` — Highlights bullet + Usage examples

## Out of scope (intentional)

- Cost is converted to local currency when `--currency` is set, but JSON `cost_usd` always reports raw USD (consistent with the rest of the project; `cost_local` is added separately).
- Cargo.toml / package.json versions left untouched per repo policy.

## Test plan

- [x] `cargo check`
- [x] `cargo fmt --check`
- [x] `cargo clippy --tests` (0 warnings)
- [x] `cargo test` — 402 unit + 35 integration = **437 passed, 0 failed** (5 new integration tests)
- [x] Manual: `ccstats top --help`, `ccstats top --dim project --help`
- [ ] Manual smoke against real `~/.claude/projects` data (reviewer)