### PR TITLE
ci: use static crate URL for Homebrew release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,6 @@ jobs:
           formula-path: Formula/ccstats.rb
           homebrew-tap: majiayu000/homebrew-tap
           tag-name: ${{ github.ref_name }}
-          download-url: https://crates.io/api/v1/crates/ccstats/${{ steps.release-version.outputs.version }}/download
+          download-url: https://static.crates.io/crates/ccstats/ccstats-${{ steps.release-version.outputs.version }}.crate
         env:
           COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
## Summary
- use the versioned static crates.io artifact URL for Homebrew formula bumps
- avoids mislav/bump-homebrew-formula-action parsing the crates.io API download endpoint as version `download` and skipping the update

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "ok"'`\n- `git diff --check`