### PR TITLE
[codex] align SDK cost summaries with CLI config

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,20 +93,18 @@ ccstats daily --source cur
 `ccstats` can be used as a Rust library when another app needs structured local usage and cost data without spawning the CLI.
 
 ```rust
-use ccstats::{SummaryOptions, UsageRange, UsageSource, summarize_cost};
+use ccstats::{SummaryOptions, UsageRange, UsageSource, summarize_cost_with_cli_config};
 
-let summary = summarize_cost(SummaryOptions {
+let summary = summarize_cost_with_cli_config(SummaryOptions {
     source: UsageSource::Codex,
     range: UsageRange::Today,
-    timezone: Some("UTC".to_string()),
-    offline: true,
     ..SummaryOptions::default()
 })?;
 
 println!("today: ${:.2}", summary.cost_usd.unwrap_or(0.0));
 ```
 
-The SDK uses the same source registry, parsers, aggregation logic, pricing cache, and fallback pricing as the CLI. Returned summaries include total tokens, cache read/create tokens, reasoning tokens, per-model breakdowns, `cost_usd`, and an optional converted `cost` when `SummaryOptions::currency` is set.
+The SDK uses the same source registry, parsers, aggregation logic, pricing cache, and fallback pricing as the CLI. Use `summarize_cost_with_cli_config` when SDK output should follow the same persisted CLI defaults for timezone, offline pricing, strict pricing, and currency. Use `summarize_cost` when the caller wants fully explicit options. Returned summaries include total tokens, cache read/create tokens, reasoning tokens, per-model breakdowns, `cost_usd`, and an optional converted `cost` when `SummaryOptions::currency` is set.
 
 ## Usage
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -151,7 +151,7 @@ pub struct RawEntry {
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
-SDK 调用通过 `summarize_cost(SummaryOptions)` 复用同一套 source registry、loader、聚合和 pricing 逻辑，但返回结构化 `CostSummary`，不经过 table/JSON 输出层。
+SDK 调用通过 `summarize_cost(SummaryOptions)` 复用同一套 source registry、loader、聚合和 pricing 逻辑，但返回结构化 `CostSummary`，不经过 table/JSON 输出层。需要和 CLI 持久化配置同口径时，SDK 使用 `summarize_cost_with_cli_config` 复用 timezone、offline pricing、strict pricing 和 currency 默认值。
 
 ## 添加新数据源
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,9 @@
 //! `ccstats` is a local-first library and CLI for token and cost analytics from
 //! Claude Code, `OpenAI` Codex, and Cursor session logs.
 //!
-//! The public SDK entry point is [`summarize_cost`]. The binary target calls
-//! [`run_cli`] to preserve the existing command-line behavior.
+//! The public SDK entry points are [`summarize_cost`] for explicit options and
+//! [`summarize_cost_with_cli_config`] for CLI-aligned config defaults. The binary
+//! target calls [`run_cli`] to preserve the existing command-line behavior.
 
 #![warn(clippy::pedantic)]
 #![allow(
@@ -26,7 +27,7 @@ mod utils;
 
 pub use sdk::{
     CostSummary, ModelCostSummary, SdkError, SummaryOptions, TokenBreakdown, UsageRange,
-    UsageSource, summarize_cost,
+    UsageSource, summarize_cost, summarize_cost_with_cli_config,
 };
 
 use chrono::Utc;
@@ -49,8 +50,8 @@ enum TimezoneSource {
 /// Run the `ccstats` CLI using process arguments.
 ///
 /// This is intended for the binary target. SDK consumers should prefer
-/// [`summarize_cost`] so they receive structured data instead of rendered CLI
-/// output.
+/// [`summarize_cost`] or [`summarize_cost_with_cli_config`] so they receive
+/// structured data instead of rendered CLI output.
 #[allow(clippy::too_many_lines)] // CLI setup intentionally stays in one dispatch function.
 pub fn run_cli() {
     let raw_cli = Cli::parse();

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -8,6 +8,7 @@ use chrono::{Datelike, Days, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use crate::config::Config;
 use crate::core::{DateFilter, DayStats, Stats};
 use crate::pricing::{CurrencyConverter, PricingDb, calculate_cost, sum_model_costs};
 use crate::source::{get_source, load_daily};
@@ -100,6 +101,9 @@ impl UsageRange {
 }
 
 /// Options for [`summarize_cost`].
+///
+/// Use [`summarize_cost_with_cli_config`] when SDK output should follow the
+/// same persisted defaults as the CLI for timezone, pricing, and currency.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SummaryOptions {
     /// Usage source to read.
@@ -228,6 +232,38 @@ pub fn summarize_cost(options: SummaryOptions) -> Result<CostSummary, SdkError> 
         skipped_entries: result.skipped,
         elapsed_ms: result.elapsed_ms,
     })
+}
+
+/// Summarize local token usage using the same reusable config defaults as the CLI.
+///
+/// This preserves the explicit SDK source and range, then fills unset timezone
+/// and currency from config and applies config-enabled pricing flags. That makes
+/// calls like `ccstats codex today` and SDK `Codex + Today` use the same date
+/// boundary and pricing mode by default.
+///
+/// # Errors
+///
+/// Returns an error when the resolved source or timezone is invalid, or when an
+/// explicit date range has `since` after `until`.
+pub fn summarize_cost_with_cli_config(options: SummaryOptions) -> Result<CostSummary, SdkError> {
+    summarize_cost(apply_cli_config(options, &Config::load_quiet()))
+}
+
+fn apply_cli_config(mut options: SummaryOptions, config: &Config) -> SummaryOptions {
+    if !options.offline && config.offline {
+        options.offline = true;
+    }
+    if !options.strict_pricing && config.strict_pricing {
+        options.strict_pricing = true;
+    }
+    if options.timezone.is_none() {
+        options.timezone.clone_from(&config.timezone);
+    }
+    if options.currency.is_none() {
+        options.currency.clone_from(&config.currency);
+    }
+
+    options
 }
 
 impl TokenBreakdown {
@@ -367,5 +403,53 @@ mod tests {
         assert_eq!(rows[0].model, "gpt-5-alpha");
         assert_eq!(rows[1].model, "gpt-5-zeta");
         assert_eq!(rows[0].cost_usd, rows[1].cost_usd);
+    }
+
+    #[test]
+    fn cli_config_fills_sdk_summary_defaults() {
+        let config = Config {
+            offline: true,
+            strict_pricing: true,
+            timezone: Some("Asia/Shanghai".to_string()),
+            currency: Some("CNY".to_string()),
+            ..Config::default()
+        };
+
+        let options = apply_cli_config(
+            SummaryOptions {
+                source: UsageSource::Codex,
+                range: UsageRange::Today,
+                ..SummaryOptions::default()
+            },
+            &config,
+        );
+
+        assert_eq!(options.source, UsageSource::Codex);
+        assert_eq!(options.range, UsageRange::Today);
+        assert!(options.offline);
+        assert!(options.strict_pricing);
+        assert_eq!(options.timezone.as_deref(), Some("Asia/Shanghai"));
+        assert_eq!(options.currency.as_deref(), Some("CNY"));
+    }
+
+    #[test]
+    fn explicit_sdk_summary_options_win_over_cli_config() {
+        let config = Config {
+            timezone: Some("Asia/Shanghai".to_string()),
+            currency: Some("CNY".to_string()),
+            ..Config::default()
+        };
+
+        let options = apply_cli_config(
+            SummaryOptions {
+                timezone: Some("UTC".to_string()),
+                currency: Some("EUR".to_string()),
+                ..SummaryOptions::default()
+            },
+            &config,
+        );
+
+        assert_eq!(options.timezone.as_deref(), Some("UTC"));
+        assert_eq!(options.currency.as_deref(), Some("EUR"));
     }
 }


### PR DESCRIPTION
## Summary
- Add `summarize_cost_with_cli_config` for SDK consumers that want CLI-aligned config defaults.
- Preserve `summarize_cost` as the explicit-options SDK entry point.
- Update Rust SDK docs to avoid hardcoding UTC/offline defaults when matching CLI output.

## Root cause
The CLI merges persisted config before loading usage data, while SDK callers previously had to pass every option explicitly. That made timezone, offline pricing, strict pricing, and currency easy to drift between `ccstats codex ...` and SDK summaries.

## Validation
- `cargo check`
- `cargo test`