### PR TITLE
Fix tool usage deduplication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "ccstats"
-version = "0.2.64"
+version = "0.2.65"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccstats"
-version = "0.2.64"
+version = "0.2.65"
 edition = "2024"
 rust-version = "1.88"
 description = "Fast token and cost usage statistics CLI for Claude Code, OpenAI Codex, Cursor, and Grok"

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -14,7 +14,7 @@ pub(crate) use dedup::DedupAccumulator;
 pub(crate) use tool_aggregator::aggregate_tools;
 #[cfg(test)]
 pub(crate) use tool_types::ToolStats;
-pub(crate) use tool_types::{ToolCall, ToolSummary};
+pub(crate) use tool_types::{ToolCall, ToolCallIdentity, ToolSummary};
 pub(crate) use types::{
     BlockStats, DateFilter, DayStats, LoadResult, ProjectStats, RawEntry, SessionStats, Stats,
 };

--- a/src/core/tool_aggregator.rs
+++ b/src/core/tool_aggregator.rs
@@ -1,17 +1,25 @@
 //! Aggregation logic for tool call statistics
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
-use super::tool_types::{ToolCall, ToolStats, ToolSummary};
+use super::tool_types::{ToolCall, ToolCallIdentity, ToolStats, ToolSummary};
 
 /// Aggregate tool calls into a sorted summary
 pub(crate) fn aggregate_tools(calls: &[ToolCall]) -> ToolSummary {
     let mut counts: HashMap<String, u64> = HashMap::with_capacity(calls.len());
+    let mut seen_identities: HashSet<ToolCallIdentity> = HashSet::new();
+    let mut total = 0;
+
     for call in calls {
+        if let Some(identity) = &call.identity
+            && !seen_identities.insert(identity.clone())
+        {
+            continue;
+        }
         *counts.entry(call.name.clone()).or_default() += 1;
+        total += 1;
     }
 
-    let total = calls.len() as u64;
     let mut tools: Vec<ToolStats> = counts
         .into_iter()
         .map(|(name, calls)| ToolStats { name, calls })
@@ -31,6 +39,15 @@ mod tests {
         ToolCall {
             name: name.to_string(),
             date_str: "2025-01-01".to_string(),
+            identity: None,
+        }
+    }
+
+    fn make_identified_call(name: &str, message_id: &str, tool_use_id: &str) -> ToolCall {
+        ToolCall {
+            name: name.to_string(),
+            date_str: "2025-01-01".to_string(),
+            identity: Some(ToolCallIdentity::new("session-a", message_id, tool_use_id)),
         }
     }
 
@@ -70,5 +87,29 @@ mod tests {
         assert_eq!(summary.tools[1].calls, 2);
         assert_eq!(summary.tools[2].name, "Edit");
         assert_eq!(summary.tools[2].calls, 1);
+    }
+
+    #[test]
+    fn aggregate_deduplicates_repeated_tool_identity() {
+        let calls = vec![
+            make_identified_call("Read", "msg_1", "toolu_1"),
+            make_identified_call("Read", "msg_1", "toolu_1"),
+            make_identified_call("Bash", "msg_1", "toolu_2"),
+        ];
+        let summary = aggregate_tools(&calls);
+        assert_eq!(summary.total, 2);
+        assert_eq!(summary.tools.len(), 2);
+        assert!(
+            summary
+                .tools
+                .iter()
+                .any(|tool| tool.name == "Read" && tool.calls == 1)
+        );
+        assert!(
+            summary
+                .tools
+                .iter()
+                .any(|tool| tool.name == "Bash" && tool.calls == 1)
+        );
     }
 }

--- a/src/core/tool_types.rs
+++ b/src/core/tool_types.rs
@@ -2,11 +2,30 @@
 
 use serde::Serialize;
 
+/// Stable identity for a tool call in Claude JSONL logs.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ToolCallIdentity {
+    pub(crate) session_key: String,
+    pub(crate) message_id: String,
+    pub(crate) tool_use_id: String,
+}
+
+impl ToolCallIdentity {
+    pub(crate) fn new(session_key: &str, message_id: &str, tool_use_id: &str) -> Self {
+        Self {
+            session_key: session_key.to_string(),
+            message_id: message_id.to_string(),
+            tool_use_id: tool_use_id.to_string(),
+        }
+    }
+}
+
 /// A single tool call extracted from JSONL
 #[derive(Debug, Clone)]
 pub(crate) struct ToolCall {
     pub(crate) name: String,
     pub(crate) date_str: String,
+    pub(crate) identity: Option<ToolCallIdentity>,
 }
 
 /// Aggregated statistics for a single tool

--- a/src/source/claude/tool_parser.rs
+++ b/src/source/claude/tool_parser.rs
@@ -9,7 +9,7 @@ use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 use crate::consts::{DATE_FORMAT, UNKNOWN};
-use crate::core::ToolCall;
+use crate::core::{ToolCall, ToolCallIdentity};
 use crate::utils::Timezone;
 
 /// Parse a single JSONL file and extract tool calls
@@ -18,6 +18,7 @@ pub(crate) fn parse_tool_calls(path: &Path, timezone: Timezone) -> Vec<ToolCall>
         return Vec::new();
     };
     let reader = BufReader::new(file);
+    let session_key = path.display().to_string();
 
     let mut calls = Vec::new();
     for line in reader.lines() {
@@ -46,12 +47,12 @@ pub(crate) fn parse_tool_calls(path: &Path, timezone: Timezone) -> Vec<ToolCall>
             .pointer("/message/content")
             .and_then(serde_json::Value::as_array)
         {
+            let message_id = val
+                .pointer("/message/id")
+                .and_then(serde_json::Value::as_str);
             for item in content {
-                if let Some(name) = extract_tool_name(item) {
-                    calls.push(ToolCall {
-                        name,
-                        date_str: date_str.clone(),
-                    });
+                if let Some(call) = extract_tool_call(item, &session_key, message_id, &date_str) {
+                    calls.push(call);
                 }
             }
         }
@@ -61,12 +62,13 @@ pub(crate) fn parse_tool_calls(path: &Path, timezone: Timezone) -> Vec<ToolCall>
             .pointer("/data/message/message/content")
             .and_then(serde_json::Value::as_array)
         {
+            let message_id = val
+                .pointer("/data/message/message/id")
+                .or_else(|| val.pointer("/data/message/id"))
+                .and_then(serde_json::Value::as_str);
             for item in content {
-                if let Some(name) = extract_tool_name(item) {
-                    calls.push(ToolCall {
-                        name,
-                        date_str: date_str.clone(),
-                    });
+                if let Some(call) = extract_tool_call(item, &session_key, message_id, &date_str) {
+                    calls.push(call);
                 }
             }
         }
@@ -75,9 +77,24 @@ pub(crate) fn parse_tool_calls(path: &Path, timezone: Timezone) -> Vec<ToolCall>
     calls
 }
 
-fn extract_tool_name(item: &serde_json::Value) -> Option<String> {
+fn extract_tool_call(
+    item: &serde_json::Value,
+    session_key: &str,
+    message_id: Option<&str>,
+    date_str: &str,
+) -> Option<ToolCall> {
     if item.get("type")?.as_str()? == "tool_use" {
-        Some(item.get("name")?.as_str()?.to_string())
+        let name = item.get("name")?.as_str()?.to_string();
+        let identity = message_id.and_then(|msg_id| {
+            item.get("id")
+                .and_then(serde_json::Value::as_str)
+                .map(|tool_id| ToolCallIdentity::new(session_key, msg_id, tool_id))
+        });
+        Some(ToolCall {
+            name,
+            date_str: date_str.to_string(),
+            identity,
+        })
     } else {
         None
     }
@@ -107,6 +124,7 @@ fn extract_date(val: &serde_json::Value, timezone: Timezone) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::aggregate_tools;
     use std::io::Write;
     use tempfile::NamedTempFile;
 
@@ -144,11 +162,25 @@ mod tests {
 
     #[test]
     fn parse_progress_tool_use() {
-        let line = r#"{"type":"progress","data":{"message":{"timestamp":"2025-03-01T10:00:00Z","message":{"content":[{"type":"tool_use","name":"Grep","id":"t1","input":{}}]}}},"toolUseID":"agent_123"}"#;
+        let line = r#"{"type":"progress","data":{"message":{"timestamp":"2025-03-01T10:00:00Z","message":{"id":"msg_1","content":[{"type":"tool_use","name":"Grep","id":"t1","input":{}}]}}},"toolUseID":"agent_123"}"#;
         let f = write_jsonl(&[line]);
         let calls = parse_tool_calls(f.path(), tz());
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].name, "Grep");
+    }
+
+    #[test]
+    fn repeated_tool_use_records_are_deduplicated_by_identity() {
+        let line = r#"{"type":"assistant","timestamp":"2025-03-01T10:00:00Z","message":{"id":"msg_1","content":[{"type":"tool_use","name":"Read","id":"toolu_1","input":{}}]}}"#;
+        let f = write_jsonl(&[line, line]);
+        let calls = parse_tool_calls(f.path(), tz());
+        let summary = aggregate_tools(&calls);
+
+        assert_eq!(calls.len(), 2);
+        assert_eq!(summary.total, 1);
+        assert_eq!(summary.tools.len(), 1);
+        assert_eq!(summary.tools[0].name, "Read");
+        assert_eq!(summary.tools[0].calls, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- carry Claude tool call identity from session, message id, and tool_use id
- deduplicate repeated tool call identities during aggregation while preserving count behavior for calls without identity
- add regression coverage for repeated tool_use records

## Validation
- cargo fmt --check
- cargo check --locked
- cargo test --locked

Closes #20