### PR TITLE
Fix currency conversion across output modes

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -65,6 +65,7 @@ fn handle_session(source: &dyn Source, ctx: &CommandContext<'_>) {
             ctx.pricing_db,
             ctx.cli.sort_order(),
             ctx.cli.show_cost(),
+            ctx.currency,
         );
         print!("{csv}");
     } else if ctx.cli.json {
@@ -106,6 +107,7 @@ fn handle_project(source: &dyn Source, ctx: &CommandContext<'_>) {
             ctx.pricing_db,
             ctx.cli.sort_order(),
             ctx.cli.show_cost(),
+            ctx.currency,
         );
         print!("{csv}");
     } else if ctx.cli.json {
@@ -146,6 +148,7 @@ fn handle_blocks(source: &dyn Source, ctx: &CommandContext<'_>) {
             ctx.pricing_db,
             ctx.cli.sort_order(),
             ctx.cli.show_cost(),
+            ctx.currency,
         );
         print!("{csv}");
     } else if ctx.cli.json {
@@ -186,7 +189,7 @@ fn handle_top(
         return;
     }
     if ctx.cli.csv {
-        let csv = output_top_csv(rows, dim, limit, ctx.cli.show_cost());
+        let csv = output_top_csv(rows, dim, limit, ctx.cli.show_cost(), ctx.currency);
         print!("{csv}");
     } else if ctx.cli.json {
         let json = output_top_json(rows, dim, limit, ctx.cli.show_cost(), ctx.currency);
@@ -359,6 +362,7 @@ fn handle_statusline(source: &dyn Source, ctx: &CommandContext<'_>) {
             ctx.pricing_db,
             source.display_name(),
             ctx.number_format,
+            ctx.currency,
         );
         print_json(&json, ctx.jq_filter);
     } else {
@@ -367,6 +371,7 @@ fn handle_statusline(source: &dyn Source, ctx: &CommandContext<'_>) {
             ctx.pricing_db,
             source.display_name(),
             ctx.number_format,
+            ctx.currency,
         );
     }
 }
@@ -403,6 +408,7 @@ fn render_period_result(
                 ctx.cli.sort_order(),
                 ctx.cli.breakdown,
                 ctx.cli.show_cost(),
+                ctx.currency,
             )
         };
         print!("{csv}");
@@ -605,6 +611,7 @@ pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandCo
                     ctx.pricing_db,
                     "All Sources",
                     ctx.number_format,
+                    ctx.currency,
                 );
                 print_json(&json, ctx.jq_filter);
             } else {
@@ -613,6 +620,7 @@ pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandCo
                     ctx.pricing_db,
                     "All Sources",
                     ctx.number_format,
+                    ctx.currency,
                 );
             }
             return;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,21 +194,13 @@ pub fn run_cli() {
         }
     };
 
-    let currency_converter = if show_cost {
+    let currency_converter = if needs_pricing {
         cli.currency.as_ref().map(|code| {
-            let conv = if let Some(conv) = CurrencyConverter::load(code, cli.offline) {
-                conv
-            } else {
-                if !is_statusline {
-                    eprintln!(
-                        "Warning: failed to load exchange rate for '{code}', showing USD costs."
-                    );
-                }
-                let Some(conv) = CurrencyConverter::load("USD", true) else {
-                    eprintln!("Error: failed to initialize USD currency converter");
-                    std::process::exit(1);
-                };
-                conv
+            let Some(conv) = CurrencyConverter::load(code, cli.offline) else {
+                eprintln!(
+                    "Error: failed to load exchange rate for '{code}'. Use a supported currency with cached rates, refresh rates without --offline, or omit --currency."
+                );
+                std::process::exit(1);
             };
             if !is_statusline && conv.currency_code() != "USD" {
                 eprintln!(

--- a/src/output/csv.rs
+++ b/src/output/csv.rs
@@ -7,7 +7,7 @@ use crate::core::{BlockStats, DayStats, ProjectStats, SessionStats};
 use crate::output::budget::{MonthlyBudgetOptions, MonthlyBudgetReport, monthly_budget_reports};
 use crate::output::format::{compare_cost, csv_escape};
 use crate::output::period::{Period, aggregate_day_stats_by_period};
-use crate::pricing::{PricingDb, calculate_cost, sum_model_costs};
+use crate::pricing::{CurrencyConverter, PricingDb, calculate_cost, sum_model_costs};
 
 pub(crate) fn output_period_csv(
     day_stats: &HashMap<String, DayStats>,
@@ -16,6 +16,7 @@ pub(crate) fn output_period_csv(
     order: SortOrder,
     breakdown: bool,
     show_cost: bool,
+    currency: Option<&CurrencyConverter>,
 ) -> String {
     let aggregated;
     let stats_ref = if period == Period::Day {
@@ -62,7 +63,7 @@ pub(crate) fn output_period_csv(
                 );
                 if show_cost {
                     let cost = calculate_cost(model_stats, model, pricing_db);
-                    let _ = write!(out, ",{cost:.6}");
+                    let _ = write!(out, ",{}", csv_cost(cost, currency));
                 }
                 out.push('\n');
             }
@@ -92,7 +93,7 @@ pub(crate) fn output_period_csv(
             );
             if show_cost {
                 let cost = sum_model_costs(&stats.models, pricing_db);
-                let _ = write!(out, ",{cost:.6}");
+                let _ = write!(out, ",{}", csv_cost(cost, currency));
             }
             out.push('\n');
         }
@@ -107,6 +108,11 @@ fn csv_float(value: f64) -> String {
     } else {
         format!("{value:.6}")
     }
+}
+
+fn csv_cost(usd: f64, currency: Option<&CurrencyConverter>) -> String {
+    let amount = currency.map_or(usd, |conv| conv.convert(usd));
+    csv_float(amount)
 }
 
 fn write_budget_header(out: &mut String) {
@@ -180,7 +186,7 @@ pub(crate) fn output_monthly_budget_csv(
                 );
                 if options.show_cost {
                     let cost = calculate_cost(model_stats, model, pricing_db);
-                    let _ = write!(out, ",{cost:.6}");
+                    let _ = write!(out, ",{}", csv_cost(cost, options.currency));
                 }
                 write_budget_fields(&mut out, report);
                 out.push('\n');
@@ -214,7 +220,7 @@ pub(crate) fn output_monthly_budget_csv(
             );
             if options.show_cost {
                 let cost = sum_model_costs(&stats.models, pricing_db);
-                let _ = write!(out, ",{cost:.6}");
+                let _ = write!(out, ",{}", csv_cost(cost, options.currency));
             }
             write_budget_fields(&mut out, report);
             out.push('\n');
@@ -229,6 +235,7 @@ pub(crate) fn output_session_csv(
     pricing_db: &PricingDb,
     order: SortOrder,
     show_cost: bool,
+    currency: Option<&CurrencyConverter>,
 ) -> String {
     let mut sorted: Vec<_> = sessions.iter().collect();
     match order {
@@ -263,7 +270,7 @@ pub(crate) fn output_session_csv(
         );
         if show_cost {
             let cost = sum_model_costs(&s.models, pricing_db);
-            let _ = write!(out, ",{cost:.6}");
+            let _ = write!(out, ",{}", csv_cost(cost, currency));
         }
         out.push('\n');
     }
@@ -275,6 +282,7 @@ pub(crate) fn output_project_csv(
     pricing_db: &PricingDb,
     order: SortOrder,
     show_cost: bool,
+    currency: Option<&CurrencyConverter>,
 ) -> String {
     let mut sorted: Vec<_> = projects.iter().collect();
     match order {
@@ -315,7 +323,7 @@ pub(crate) fn output_project_csv(
         );
         if show_cost {
             let cost = sum_model_costs(&p.models, pricing_db);
-            let _ = write!(out, ",{cost:.6}");
+            let _ = write!(out, ",{}", csv_cost(cost, currency));
         }
         out.push('\n');
     }
@@ -328,6 +336,7 @@ pub(crate) fn output_block_csv(
     pricing_db: &PricingDb,
     order: SortOrder,
     show_cost: bool,
+    currency: Option<&CurrencyConverter>,
 ) -> String {
     let mut sorted: Vec<_> = blocks.iter().collect();
     match order {
@@ -359,7 +368,7 @@ pub(crate) fn output_block_csv(
         );
         if show_cost {
             let cost = sum_model_costs(&b.models, pricing_db);
-            let _ = write!(out, ",{cost:.6}");
+            let _ = write!(out, ",{}", csv_cost(cost, currency));
         }
         out.push('\n');
     }
@@ -410,7 +419,15 @@ mod tests {
         );
 
         let db = PricingDb::default();
-        let csv = output_period_csv(&day_stats, Period::Day, &db, SortOrder::Asc, false, false);
+        let csv = output_period_csv(
+            &day_stats,
+            Period::Day,
+            &db,
+            SortOrder::Asc,
+            false,
+            false,
+            None,
+        );
 
         let lines: Vec<&str> = csv.lines().collect();
         assert_eq!(
@@ -430,11 +447,46 @@ mod tests {
         );
 
         let db = PricingDb::default();
-        let csv = output_period_csv(&day_stats, Period::Day, &db, SortOrder::Asc, false, true);
+        let csv = output_period_csv(
+            &day_stats,
+            Period::Day,
+            &db,
+            SortOrder::Asc,
+            false,
+            true,
+            None,
+        );
 
         let lines: Vec<&str> = csv.lines().collect();
         assert!(lines[0].ends_with(",cost"));
         assert_eq!(lines.len(), 2); // header + 1 row
+    }
+
+    #[test]
+    fn period_csv_converts_cost_when_currency_is_set() {
+        let mut day_stats = HashMap::new();
+        day_stats.insert(
+            "2025-01-01".to_string(),
+            make_day_stats(&[("sonnet", 1_000_000)]),
+        );
+        let converter = CurrencyConverter::from_rate_for_test("CNY", 7.0, "CNY ");
+
+        let db = PricingDb::default();
+        let csv = output_period_csv(
+            &day_stats,
+            Period::Day,
+            &db,
+            SortOrder::Asc,
+            false,
+            true,
+            Some(&converter),
+        );
+
+        let lines: Vec<&str> = csv.lines().collect();
+        assert_eq!(
+            lines[1],
+            "2025-01-01,1000000,500000,0,0,0,1500000,73.500000"
+        );
     }
 
     #[test]
@@ -444,7 +496,15 @@ mod tests {
         day_stats.insert("2025-01-02".to_string(), make_day_stats(&[("sonnet", 200)]));
 
         let db = PricingDb::default();
-        let csv = output_period_csv(&day_stats, Period::Day, &db, SortOrder::Desc, false, false);
+        let csv = output_period_csv(
+            &day_stats,
+            Period::Day,
+            &db,
+            SortOrder::Desc,
+            false,
+            false,
+            None,
+        );
 
         let lines: Vec<&str> = csv.lines().collect();
         assert!(lines[1].starts_with("2025-01-02"));
@@ -469,7 +529,7 @@ mod tests {
         }];
 
         let db = PricingDb::default();
-        let csv = output_session_csv(&sessions, &db, SortOrder::Asc, false);
+        let csv = output_session_csv(&sessions, &db, SortOrder::Asc, false, None);
 
         let lines: Vec<&str> = csv.lines().collect();
         assert_eq!(
@@ -500,7 +560,7 @@ mod tests {
         }];
 
         let db = PricingDb::default();
-        let csv = output_session_csv(&sessions, &db, SortOrder::Asc, false);
+        let csv = output_session_csv(&sessions, &db, SortOrder::Asc, false, None);
         let lines: Vec<&str> = csv.lines().collect();
 
         assert_eq!(
@@ -525,7 +585,7 @@ mod tests {
         }];
 
         let db = PricingDb::default();
-        let csv = output_project_csv(&projects, &db, SortOrder::Asc, true);
+        let csv = output_project_csv(&projects, &db, SortOrder::Asc, true, None);
 
         let lines: Vec<&str> = csv.lines().collect();
         assert!(lines[0].ends_with(",cost"));
@@ -548,7 +608,7 @@ mod tests {
         }];
 
         let db = PricingDb::default();
-        let csv = output_block_csv(&blocks, &db, SortOrder::Asc, false);
+        let csv = output_block_csv(&blocks, &db, SortOrder::Asc, false, None);
 
         let lines: Vec<&str> = csv.lines().collect();
         assert_eq!(
@@ -569,6 +629,7 @@ mod tests {
             SortOrder::Asc,
             false,
             false,
+            None,
         );
         let lines: Vec<&str> = csv.lines().collect();
         assert_eq!(lines.len(), 1); // header only
@@ -583,7 +644,15 @@ mod tests {
         );
 
         let db = PricingDb::default();
-        let csv = output_period_csv(&day_stats, Period::Day, &db, SortOrder::Asc, true, false);
+        let csv = output_period_csv(
+            &day_stats,
+            Period::Day,
+            &db,
+            SortOrder::Asc,
+            true,
+            false,
+            None,
+        );
 
         let lines: Vec<&str> = csv.lines().collect();
         assert_eq!(
@@ -601,7 +670,15 @@ mod tests {
         );
 
         let db = PricingDb::default();
-        let csv = output_period_csv(&day_stats, Period::Day, &db, SortOrder::Asc, true, false);
+        let csv = output_period_csv(
+            &day_stats,
+            Period::Day,
+            &db,
+            SortOrder::Asc,
+            true,
+            false,
+            None,
+        );
 
         let lines: Vec<&str> = csv.lines().collect();
         assert_eq!(lines.len(), 3); // header + 2 model rows
@@ -619,7 +696,15 @@ mod tests {
         );
 
         let db = PricingDb::default();
-        let csv = output_period_csv(&day_stats, Period::Day, &db, SortOrder::Asc, true, true);
+        let csv = output_period_csv(
+            &day_stats,
+            Period::Day,
+            &db,
+            SortOrder::Asc,
+            true,
+            true,
+            None,
+        );
 
         let lines: Vec<&str> = csv.lines().collect();
         assert!(lines[0].ends_with(",cost"));
@@ -638,6 +723,7 @@ mod tests {
             SortOrder::Asc,
             true,
             false,
+            None,
         );
         let lines: Vec<&str> = csv.lines().collect();
         assert_eq!(lines.len(), 1); // header only
@@ -652,7 +738,15 @@ mod tests {
         day_stats.insert("2025-01-08".to_string(), make_day_stats(&[("sonnet", 200)]));
 
         let db = PricingDb::default();
-        let csv = output_period_csv(&day_stats, Period::Week, &db, SortOrder::Asc, true, false);
+        let csv = output_period_csv(
+            &day_stats,
+            Period::Week,
+            &db,
+            SortOrder::Asc,
+            true,
+            false,
+            None,
+        );
 
         let lines: Vec<&str> = csv.lines().collect();
         assert_eq!(lines.len(), 2); // header + 1 aggregated model row

--- a/src/output/statusline.rs
+++ b/src/output/statusline.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::core::{DayStats, Stats};
 use crate::output::format::{NumberFormat, cost_json_value, format_compact, format_cost};
-use crate::pricing::{PricingDb, sum_model_costs};
+use crate::pricing::{CurrencyConverter, PricingDb, sum_model_costs};
 
 struct Totals {
     stats: Stats,
@@ -26,11 +26,12 @@ pub(crate) fn print_statusline(
     pricing_db: &PricingDb,
     source_label: &str,
     number_format: NumberFormat,
+    currency: Option<&CurrencyConverter>,
 ) {
     let t = aggregate_totals(day_stats, pricing_db);
 
     let mut parts = vec![
-        format!("{}: {}", source_label, format_cost(t.cost, None)),
+        format!("{}: {}", source_label, format_cost(t.cost, currency)),
         format!(
             "In: {} Out: {}",
             format_compact(t.stats.input_tokens, number_format),
@@ -52,6 +53,7 @@ pub(crate) fn print_statusline_json(
     pricing_db: &PricingDb,
     source_label: &str,
     number_format: NumberFormat,
+    currency: Option<&CurrencyConverter>,
 ) -> String {
     let t = aggregate_totals(day_stats, pricing_db);
 
@@ -63,9 +65,9 @@ pub(crate) fn print_statusline_json(
         "cache_creation_tokens": t.stats.cache_creation,
         "cache_read_tokens": t.stats.cache_read,
         "total_tokens": t.stats.total_tokens(),
-        "cost": cost_json_value(t.cost, None),
+        "cost": cost_json_value(t.cost, currency),
         "formatted": {
-            "cost": format_cost(t.cost, None),
+            "cost": format_cost(t.cost, currency),
             "input": format_compact(t.stats.input_tokens, number_format),
             "output": format_compact(t.stats.output_tokens, number_format),
             "reasoning": format_compact(t.stats.reasoning_tokens, number_format),
@@ -123,6 +125,7 @@ mod tests {
             &PricingDb::default(),
             "OpenAI Codex",
             NumberFormat::default(),
+            None,
         );
         let value: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(value["reasoning_tokens"].as_i64(), Some(50));
@@ -138,6 +141,7 @@ mod tests {
             &PricingDb::default(),
             "Claude Code",
             NumberFormat::default(),
+            None,
         );
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(v["input_tokens"].as_i64(), Some(0));
@@ -160,6 +164,7 @@ mod tests {
             &PricingDb::default(),
             "CC",
             NumberFormat::default(),
+            None,
         );
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(v["input_tokens"].as_i64(), Some(4000));
@@ -180,6 +185,7 @@ mod tests {
             &PricingDb::default(),
             "CC",
             NumberFormat::default(),
+            None,
         );
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(v["reasoning_tokens"].as_i64(), Some(0));
@@ -199,6 +205,7 @@ mod tests {
             &PricingDb::default(),
             "CC",
             NumberFormat::default(),
+            None,
         );
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(v["formatted"]["input"].as_str(), Some("1.5M"));
@@ -213,9 +220,32 @@ mod tests {
             &PricingDb::default(),
             "CC",
             NumberFormat::default(),
+            None,
         );
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         // Cost should be a number (0.0), not null
         assert!(v["cost"].is_number());
+    }
+
+    #[test]
+    fn statusline_json_converts_cost_when_currency_is_set() {
+        let mut day_stats = HashMap::new();
+        day_stats.insert(
+            "2026-02-12".to_string(),
+            make_day(1_000_000, 100_000, 0, 0, 0),
+        );
+        let converter = CurrencyConverter::from_rate_for_test("CNY", 7.0, "CNY ");
+
+        let json = print_statusline_json(
+            &day_stats,
+            &PricingDb::default(),
+            "CC",
+            NumberFormat::default(),
+            Some(&converter),
+        );
+
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["cost"].as_f64(), Some(31.5));
+        assert_eq!(v["formatted"]["cost"].as_str(), Some("CNY 31.50"));
     }
 }

--- a/src/output/top.rs
+++ b/src/output/top.rs
@@ -384,6 +384,7 @@ pub(crate) fn output_top_csv(
     dim: TopDimension,
     limit: usize,
     show_cost: bool,
+    currency: Option<&CurrencyConverter>,
 ) -> String {
     let limited = take_top(rows, limit);
     let total_cost = sum_cost(&limited);
@@ -401,6 +402,9 @@ pub(crate) fn output_top_csv(
     );
     if show_cost {
         out.push_str(",cost_usd");
+        if currency.is_some() {
+            out.push_str(",cost_local");
+        }
     }
     out.push('\n');
 
@@ -423,8 +427,14 @@ pub(crate) fn output_top_csv(
         if show_cost {
             if row.cost.is_nan() {
                 out.push(',');
+                if currency.is_some() {
+                    out.push(',');
+                }
             } else {
                 let _ = write!(out, ",{:.6}", row.cost);
+                if let Some(conv) = currency {
+                    let _ = write!(out, ",{}", csv_escape(&conv.format(row.cost)));
+                }
             }
         }
         out.push('\n');
@@ -593,7 +603,7 @@ mod tests {
                 cost: f64::NAN,
             })
             .collect();
-        let csv = output_top_csv(&rows, TopDimension::Model, 5, false);
+        let csv = output_top_csv(&rows, TopDimension::Model, 5, false, None);
         let lines: Vec<&str> = csv.lines().collect();
         assert_eq!(lines.len(), 6); // header + 5 rows
     }
@@ -647,14 +657,31 @@ mod tests {
             stats: stats_of(10, 0, 1),
             cost: f64::NAN,
         }];
-        let csv = output_top_csv(&rows, TopDimension::Project, 1, false);
+        let csv = output_top_csv(&rows, TopDimension::Project, 1, false, None);
         let lines: Vec<&str> = csv.lines().collect();
         assert!(lines[1].contains("\"weird,name\""), "csv: {}", lines[1]);
     }
 
     #[test]
+    fn csv_includes_local_cost_when_currency_is_set() {
+        let rows = vec![TopRow {
+            name: "model".into(),
+            count: 1,
+            stats: stats_of(10, 0, 1),
+            cost: 1.5,
+        }];
+        let converter = CurrencyConverter::from_rate_for_test("CNY", 7.0, "CNY ");
+
+        let csv = output_top_csv(&rows, TopDimension::Model, 1, true, Some(&converter));
+
+        let lines: Vec<&str> = csv.lines().collect();
+        assert!(lines[0].ends_with(",cost_usd,cost_local"));
+        assert!(lines[1].ends_with(",1.500000,CNY 10.50"));
+    }
+
+    #[test]
     fn empty_rows_produce_header_only_csv() {
-        let csv = output_top_csv(&[], TopDimension::Model, 10, false);
+        let csv = output_top_csv(&[], TopDimension::Model, 10, false, None);
         assert_eq!(csv.lines().count(), 1);
     }
 }

--- a/src/pricing/currency.rs
+++ b/src/pricing/currency.rs
@@ -68,6 +68,15 @@ impl CurrencyConverter {
     pub(crate) fn currency_code(&self) -> &str {
         &self.currency
     }
+
+    #[cfg(test)]
+    pub(crate) fn from_rate_for_test(currency: &str, rate: f64, symbol: &str) -> Self {
+        Self {
+            currency: currency.to_string(),
+            rate,
+            symbol: symbol.to_string(),
+        }
+    }
 }
 
 fn currency_symbol(code: &str) -> String {

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -120,7 +120,7 @@ pub struct SummaryOptions {
     pub offline: bool,
     /// Return unknown model costs as `None` instead of using fallback pricing.
     pub strict_pricing: bool,
-    /// Optional display currency. Falls back to USD if rates are unavailable.
+    /// Optional display currency. Returns an error if rates are unavailable.
     pub currency: Option<String>,
 }
 
@@ -206,10 +206,7 @@ pub fn summarize_cost(options: SummaryOptions) -> Result<CostSummary, SdkError> 
         name: options.source.as_str().to_string(),
     })?;
     let pricing_db = PricingDb::load_quiet(options.offline, options.strict_pricing);
-    let currency = options
-        .currency
-        .as_deref()
-        .and_then(|code| CurrencyConverter::load(code, options.offline));
+    let currency = load_requested_currency(options.currency.as_deref(), options.offline)?;
     let currency_code = currency.as_ref().map_or_else(
         || "USD".to_string(),
         |conv| conv.currency_code().to_string(),
@@ -310,6 +307,20 @@ fn convert_cost(cost_usd: Option<f64>, currency: Option<&CurrencyConverter>) -> 
         (Some(cost), None) => Some(cost),
         (None, _) => None,
     }
+}
+
+fn load_requested_currency(
+    currency: Option<&str>,
+    offline: bool,
+) -> Result<Option<CurrencyConverter>, SdkError> {
+    let Some(code) = currency else {
+        return Ok(None);
+    };
+    CurrencyConverter::load(code, offline).map(Some).ok_or_else(|| {
+        SdkError::Configuration(format!(
+            "failed to load exchange rate for '{code}'; use a supported currency with cached rates, refresh rates online, or omit currency"
+        ))
+    })
 }
 
 fn summarize_models(
@@ -457,5 +468,11 @@ mod tests {
 
         assert_eq!(options.timezone.as_deref(), Some("UTC"));
         assert_eq!(options.currency.as_deref(), Some("EUR"));
+    }
+
+    #[test]
+    fn requested_currency_requires_available_rate() {
+        let err = load_requested_currency(Some("ZZZ"), true).expect_err("currency should fail");
+        assert!(err.to_string().contains("failed to load exchange rate"));
     }
 }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1,3 +1,4 @@
+use chrono::Utc;
 use rusqlite::Connection;
 use serde_json::Value;
 use std::fs;
@@ -20,6 +21,10 @@ fn write_file(path: &Path, content: &str) {
         fs::create_dir_all(parent).expect("create parent dirs");
     }
     fs::write(path, content).expect("write test file");
+}
+
+fn write_exchange_rates_cache(home: &Path, rates: &str) {
+    write_file(&home.join(".cache/ccstats/exchange_rates.json"), rates);
 }
 
 fn write_cursor_state_db(path: &Path) {
@@ -1105,8 +1110,8 @@ fn claude_session_json_keeps_same_file_stem_from_different_projects_separate() {
 }
 
 #[test]
-fn invalid_currency_falls_back_to_usd_costs() {
-    let root = unique_temp_dir("invalid-currency-fallback");
+fn invalid_currency_rejects_missing_rate() {
+    let root = unique_temp_dir("invalid-currency-rejected");
     let claude_file = root.join(".claude/projects/myproject/session-a.jsonl");
     write_file(
         &claude_file,
@@ -1130,15 +1135,86 @@ fn invalid_currency_falls_back_to_usd_costs() {
         ],
         &[("HOME", &root)],
     );
-    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    assert!(!ok, "stdout: {}", String::from_utf8_lossy(&stdout));
 
     let stderr = String::from_utf8(stderr).expect("utf8 stderr");
-    assert!(stderr.contains("Warning: failed to load exchange rate"));
+    assert!(stderr.contains("Error: failed to load exchange rate for 'ZZZ'"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn daily_csv_uses_requested_currency() {
+    let root = unique_temp_dir("daily-csv-currency");
+    write_exchange_rates_cache(&root, r#"{"CNY":7.0}"#);
+    let claude_file = root.join(".claude/projects/myproject/session-a.jsonl");
+    write_file(
+        &claude_file,
+        r#"{"timestamp":"2026-02-06T12:00:00Z","message":{"id":"msg_1","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":100,"output_tokens":50}}}
+"#,
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "--csv",
+            "-O",
+            "--timezone",
+            "UTC",
+            "--currency",
+            "CNY",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("HOME", &root)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let output = String::from_utf8(stdout).expect("utf8 stdout");
+    let lines: Vec<&str> = output.lines().collect();
+    assert_eq!(
+        lines[0],
+        "date,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,total_tokens,cost"
+    );
+    assert!(lines[1].ends_with(",0.007350"), "row: {}", lines[1]);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn statusline_json_uses_requested_currency() {
+    let root = unique_temp_dir("statusline-currency");
+    write_exchange_rates_cache(&root, r#"{"CNY":7.0}"#);
+    let today = Utc::now().format("%Y-%m-%dT12:00:00Z").to_string();
+    let claude_file = root.join(".claude/projects/myproject/session-a.jsonl");
+    write_file(
+        &claude_file,
+        &format!(
+            r#"{{"timestamp":"{today}","message":{{"id":"msg_1","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{{"input_tokens":100,"output_tokens":50}}}}}}
+"#
+        ),
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "statusline",
+            "-j",
+            "-O",
+            "--timezone",
+            "UTC",
+            "--currency",
+            "CNY",
+        ],
+        &[("HOME", &root)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
 
     let json: Value = serde_json::from_slice(&stdout).expect("json");
-    let arr = json.as_array().expect("array output");
-    assert_eq!(arr.len(), 1);
-    assert!(arr[0]["cost"].as_f64().is_some());
+    assert_eq!(json["source"].as_str(), Some("Claude Code"));
+    let cost = json["cost"].as_f64().expect("numeric cost");
+    assert!((cost - 0.00735).abs() < f64::EPSILON);
 
     let _ = fs::remove_dir_all(root);
 }


### PR DESCRIPTION
## Summary
- fail fast when a requested currency cannot be resolved instead of silently falling back to USD
- thread the resolved currency converter through CSV, top CSV, and statusline renderers
- align SDK currency handling with CLI behavior and add regression tests

Fixes #19

## Validation
- cargo check
- cargo test currency
- cargo test