### PR TITLE
Add changelog for v0.2.65

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.65] - 2026-05-31
+
+### Fixed
+- Deduplicate repeated Claude tool-use records in `ccstats tools` so streaming progress entries with the same tool identity count once.
+
 ## [0.2.64] - 2026-05-26
 
 ### Added


### PR DESCRIPTION
## Summary
- Add the missing 0.2.65 changelog entry required by release preflight.

## Verification
- GITHUB_REF_NAME=v0.2.65 scripts/check-release.sh
- cargo test --locked