### PR TITLE
feat(pricing): support CN vendor models (GLM/DeepSeek/Qwen/Moonshot)

### DIFF
--- a/src/output/csv.rs
+++ b/src/output/csv.rs
@@ -755,4 +755,12 @@ mod tests {
         // Verify aggregated input tokens: 100 + 200 = 300
         assert!(lines[1].contains(",300,"));
     }
+
+    #[test]
+    fn csv_float_and_cost_handle_nan() {
+        // Unknown models yield NaN cost; CSV must emit N/A, not the literal "NaN".
+        assert_eq!(csv_float(f64::NAN), "N/A");
+        assert_eq!(csv_float(1.5), "1.500000");
+        assert_eq!(csv_cost(f64::NAN, None), "N/A");
+    }
 }

--- a/src/output/statusline.rs
+++ b/src/output/statusline.rs
@@ -98,7 +98,10 @@ mod tests {
             stats: stats.clone(),
             ..Default::default()
         };
-        day.models.insert("test-model".to_string(), stats);
+        // Use a model name that resolves via fallback (sonnet) even with an
+        // empty PricingDb, so cost-bearing tests get a real value instead of
+        // the None/NaN that unknown models now produce.
+        day.models.insert("sonnet-4".to_string(), stats);
         day
     }
 

--- a/src/pricing/db.rs
+++ b/src/pricing/db.rs
@@ -180,16 +180,31 @@ pub(crate) fn calculate_cost(stats: &Stats, model: &str, pricing_db: &PricingDb)
 }
 
 /// Sum total cost across model breakdown map.
+///
+/// Unknown models (`calculate_cost` returns NaN because pricing did not
+/// resolve) are skipped, so a single unpriced model does not erase the total
+/// of every other model in the same row. An empty map returns 0.0; a map where
+/// every model is unknown returns NaN so the caller surfaces N/A instead of a
+/// misleading $0.00.
 pub(crate) fn sum_model_costs(models: &HashMap<String, Stats>, pricing_db: &PricingDb) -> f64 {
+    if models.is_empty() {
+        return 0.0;
+    }
     let mut total = 0.0;
+    let mut any_known = false;
     for (model, stats) in models {
         let cost = calculate_cost(stats, model, pricing_db);
         if cost.is_nan() {
-            return f64::NAN;
+            continue;
         }
         total += cost;
+        any_known = true;
     }
-    total
+    if any_known {
+        total
+    } else {
+        f64::NAN
+    }
 }
 
 /// Borrowed item with precomputed total cost.
@@ -398,7 +413,7 @@ mod tests {
     }
 
     #[test]
-    fn sum_model_costs_returns_nan_if_any_unknown_strict() {
+    fn sum_model_costs_returns_nan_when_all_unknown() {
         let db = PricingDb {
             strict_unknown: true,
             ..PricingDb::default()
@@ -415,6 +430,41 @@ mod tests {
 
         let total = sum_model_costs(&models, &db);
         assert!(total.is_nan());
+    }
+
+    #[test]
+    fn sum_model_costs_skips_unknown_keeps_known() {
+        let mut db = PricingDb::default();
+        db.models.insert(
+            "sonnet-4".to_string(),
+            ModelPricing {
+                input: 3e-6,
+                output: 15e-6,
+                ..Default::default()
+            },
+        );
+
+        let mut models = HashMap::new();
+        models.insert(
+            "sonnet-4".to_string(),
+            Stats {
+                input_tokens: 1_000_000,
+                output_tokens: 0,
+                ..Default::default()
+            },
+        );
+        models.insert(
+            "totally-unknown-xyz".to_string(),
+            Stats {
+                input_tokens: 999_999_999, // would dominate the total if mispriced
+                ..Default::default()
+            },
+        );
+
+        // Unknown model is skipped; total reflects only sonnet-4 ($3.0),
+        // not NaN and not a Sonnet-fallback guess on the unknown volume.
+        let total = sum_model_costs(&models, &db);
+        assert!((total - 3.0).abs() < 0.001);
     }
 
     #[test]

--- a/src/pricing/db.rs
+++ b/src/pricing/db.rs
@@ -200,11 +200,7 @@ pub(crate) fn sum_model_costs(models: &HashMap<String, Stats>, pricing_db: &Pric
         total += cost;
         any_known = true;
     }
-    if any_known {
-        total
-    } else {
-        f64::NAN
-    }
+    if any_known { total } else { f64::NAN }
 }
 
 /// Borrowed item with precomputed total cost.

--- a/src/pricing/db.rs
+++ b/src/pricing/db.rs
@@ -143,7 +143,7 @@ impl PricingDb {
             if self.strict_unknown {
                 None
             } else {
-                Some(fallback_pricing(model))
+                fallback_pricing(model)
             }
         });
 
@@ -282,9 +282,17 @@ mod tests {
 
     #[test]
     fn calculate_cost_zero_tokens() {
-        let db = PricingDb::default();
+        let mut db = PricingDb::default();
+        db.models.insert(
+            "sonnet-4".to_string(),
+            ModelPricing {
+                input: 3e-6,
+                output: 15e-6,
+                ..Default::default()
+            },
+        );
         let stats = Stats::default();
-        let cost = calculate_cost(&stats, "unknown-model", &db);
+        let cost = calculate_cost(&stats, "sonnet-4", &db);
         assert_eq!(cost, 0.0);
     }
 

--- a/src/pricing/resolver.rs
+++ b/src/pricing/resolver.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use super::types::ModelPricing;
+use super::types::{dot_version_variant, ModelPricing};
 
 fn openai_pricing(input: f64, output: f64, cache_read: f64) -> ModelPricing {
     ModelPricing {
@@ -28,13 +28,19 @@ pub(super) fn parse_litellm_data(
     let mut models = HashMap::new();
 
     for (name, value) in data {
-        // Load Claude, OpenAI GPT/Codex, and xAI Grok model names.
+        // Load Claude, OpenAI GPT/Codex, xAI Grok, and CN vendor model names.
         let is_claude = name.contains("claude");
         let is_openai =
             name.starts_with("openai/") || name.starts_with("gpt-") || name.starts_with("codex");
         let is_xai = name.starts_with("xai/") || name.starts_with("grok-");
+        // Chinese vendors: DeepSeek, Qwen (Alibaba), GLM (Zhipu/zai), Moonshot/Kimi.
+        let is_cn = name.contains("deepseek")
+            || name.contains("qwen")
+            || name.contains("glm")
+            || name.starts_with("moonshot/")
+            || name.contains("kimi");
 
-        if !is_claude && !is_openai && !is_xai {
+        if !is_claude && !is_openai && !is_xai && !is_cn {
             continue;
         }
 
@@ -83,6 +89,27 @@ pub(super) fn parse_litellm_data(
             if stripped == "grok-build-0.1" {
                 models.insert("grok-build".to_string(), pricing);
             }
+        } else if is_cn {
+            // Store the bare name (last path segment) plus a dot-version variant
+            // so hoster spellings like `glm-5p2` (p == point) match a dot-spelled
+            // `glm-5.2` alias. Official vendor prefixes win over hosters on
+            // name collisions.
+            let bare = name.rsplit('/').next().unwrap_or(&name).to_lowercase();
+            let name_lower = name.to_lowercase();
+            let official = name.starts_with("zai/")
+                || name.starts_with("deepseek/")
+                || name.starts_with("dashscope/")
+                || name.starts_with("moonshot/")
+                || !name.contains('/');
+            for variant in [bare.clone(), dot_version_variant(&bare)] {
+                if variant != name_lower && !variant.is_empty() {
+                    if official {
+                        models.insert(variant, pricing.clone());
+                    } else {
+                        models.entry(variant).or_insert(pricing.clone());
+                    }
+                }
+            }
         }
     }
 
@@ -125,9 +152,9 @@ pub(super) fn resolve_pricing_known(
     None
 }
 
-pub(super) fn fallback_pricing(model: &str) -> ModelPricing {
+pub(super) fn fallback_pricing(model: &str) -> Option<ModelPricing> {
     let model_lower = model.to_lowercase();
-    if model_lower.contains("opus-4-5") || model_lower.contains("opus-4.5") {
+    Some(if model_lower.contains("opus-4-5") || model_lower.contains("opus-4.5") {
         ModelPricing {
             input: 5e-6,   // $5/M
             output: 25e-6, // $25/M
@@ -182,15 +209,10 @@ pub(super) fn fallback_pricing(model: &str) -> ModelPricing {
     } else if model_lower.contains("gpt-4") {
         openai_pricing(2.5e-6, 10e-6, 0.0)
     } else {
-        // Default to sonnet pricing for unknown models
-        ModelPricing {
-            input: 3e-6,
-            output: 15e-6,
-            reasoning_output: 15e-6,
-            cache_create: 3.75e-6,
-            cache_read: 0.3e-6,
-        }
-    }
+        // Unknown model: no fallback estimate. The caller surfaces N/A instead
+        // of silently applying a sonnet-shaped guess.
+        return None;
+    })
 }
 
 #[cfg(test)]
@@ -393,35 +415,35 @@ mod tests {
 
     #[test]
     fn test_fallback_opus_4_5() {
-        let p = fallback_pricing("claude-opus-4-5-20250514");
+        let p = fallback_pricing("claude-opus-4-5-20250514").unwrap();
         assert_eq!(p.input, 5e-6);
         assert_eq!(p.output, 25e-6);
     }
 
     #[test]
     fn test_fallback_opus() {
-        let p = fallback_pricing("claude-opus-4-20250514");
+        let p = fallback_pricing("claude-opus-4-20250514").unwrap();
         assert_eq!(p.input, 15e-6);
         assert_eq!(p.output, 75e-6);
     }
 
     #[test]
     fn test_fallback_sonnet() {
-        let p = fallback_pricing("claude-sonnet-4-20250514");
+        let p = fallback_pricing("claude-sonnet-4-20250514").unwrap();
         assert_eq!(p.input, 3e-6);
         assert_eq!(p.output, 15e-6);
     }
 
     #[test]
     fn test_fallback_haiku() {
-        let p = fallback_pricing("claude-haiku-3.5");
+        let p = fallback_pricing("claude-haiku-3.5").unwrap();
         assert_eq!(p.input, 0.8e-6);
         assert_eq!(p.output, 4e-6);
     }
 
     #[test]
     fn test_fallback_grok_build() {
-        let p = fallback_pricing("grok-build");
+        let p = fallback_pricing("grok-build").unwrap();
         assert_eq!(p.input, 1e-6);
         assert_eq!(p.output, 2e-6);
         assert_eq!(p.cache_read, 0.2e-6);
@@ -429,7 +451,7 @@ mod tests {
 
     #[test]
     fn test_fallback_grok_4_3() {
-        let p = fallback_pricing("grok-4.3");
+        let p = fallback_pricing("grok-4.3").unwrap();
         assert_eq!(p.input, 1.25e-6);
         assert_eq!(p.output, 2.5e-6);
         assert_eq!(p.cache_read, 0.2e-6);
@@ -437,14 +459,14 @@ mod tests {
 
     #[test]
     fn test_fallback_gpt5() {
-        let p = fallback_pricing("gpt-5-turbo");
+        let p = fallback_pricing("gpt-5-turbo").unwrap();
         assert_eq!(p.input, 1.25e-6);
         assert_eq!(p.output, 10e-6);
     }
 
     #[test]
     fn test_fallback_codex() {
-        let p = fallback_pricing("codex-mini");
+        let p = fallback_pricing("codex-mini").unwrap();
         assert_eq!(p.input, 1.5e-6);
         assert_eq!(p.output, 6e-6);
         assert_eq!(p.cache_read, 0.375e-6);
@@ -452,7 +474,7 @@ mod tests {
 
     #[test]
     fn test_fallback_gpt5_codex() {
-        let p = fallback_pricing("gpt-5.1-codex");
+        let p = fallback_pricing("gpt-5.1-codex").unwrap();
         assert_eq!(p.input, 1.25e-6);
         assert_eq!(p.output, 10e-6);
         assert_eq!(p.cache_read, 0.125e-6);
@@ -460,7 +482,7 @@ mod tests {
 
     #[test]
     fn test_fallback_gpt5_codex_mini() {
-        let p = fallback_pricing("gpt-5.1-codex-mini");
+        let p = fallback_pricing("gpt-5.1-codex-mini").unwrap();
         assert_eq!(p.input, 0.25e-6);
         assert_eq!(p.output, 2e-6);
         assert_eq!(p.cache_read, 0.025e-6);
@@ -468,7 +490,7 @@ mod tests {
 
     #[test]
     fn test_fallback_gpt5_4_mini() {
-        let p = fallback_pricing("gpt-5.4-mini");
+        let p = fallback_pricing("gpt-5.4-mini").unwrap();
         assert_eq!(p.input, 0.75e-6);
         assert_eq!(p.output, 4.5e-6);
         assert_eq!(p.cache_read, 0.075e-6);
@@ -476,17 +498,15 @@ mod tests {
 
     #[test]
     fn test_fallback_gpt5_2_codex() {
-        let p = fallback_pricing("gpt-5.2-codex");
+        let p = fallback_pricing("gpt-5.2-codex").unwrap();
         assert_eq!(p.input, 1.75e-6);
         assert_eq!(p.output, 14e-6);
         assert_eq!(p.cache_read, 0.175e-6);
     }
 
     #[test]
-    fn test_fallback_unknown_defaults_to_sonnet() {
-        let p = fallback_pricing("totally-unknown-model");
-        assert_eq!(p.input, 3e-6);
-        assert_eq!(p.output, 15e-6);
+    fn test_fallback_unknown_returns_none() {
+        assert!(fallback_pricing("totally-unknown-model").is_none());
     }
 
     // --- resolve_pricing_known: partial matching boundary tests ---
@@ -706,24 +726,68 @@ mod tests {
 
     #[test]
     fn test_fallback_opus_4_5_dot_variant() {
-        let p = fallback_pricing("claude-opus-4.5");
+        let p = fallback_pricing("claude-opus-4.5").unwrap();
         assert_eq!(p.input, 5e-6);
         assert_eq!(p.output, 25e-6);
     }
 
     #[test]
     fn test_fallback_case_insensitive() {
-        let p = fallback_pricing("Claude-OPUS-4-20250514");
+        let p = fallback_pricing("Claude-OPUS-4-20250514").unwrap();
         assert_eq!(p.input, 15e-6);
 
-        let p2 = fallback_pricing("CLAUDE-HAIKU-3.5");
+        let p2 = fallback_pricing("CLAUDE-HAIKU-3.5").unwrap();
         assert_eq!(p2.input, 0.8e-6);
     }
 
     #[test]
     fn test_fallback_gpt4() {
-        let p = fallback_pricing("gpt-4o-mini");
+        let p = fallback_pricing("gpt-4o-mini").unwrap();
         assert_eq!(p.input, 2.5e-6);
         assert_eq!(p.output, 10e-6);
+    }
+
+    // --- CN vendor parsing/resolution tests ---
+
+    #[test]
+    fn test_parse_cn_vendors_normalized_and_kept() {
+        let mut data = HashMap::new();
+        data.insert(
+            "zai/glm-5".to_string(),
+            json!({"input_cost_per_token": 1e-6, "output_cost_per_token": 3.2e-6, "cache_read_input_token_cost": 0.2e-6}),
+        );
+        data.insert(
+            "fireworks_ai/glm-5".to_string(),
+            json!({"input_cost_per_token": 99e-6, "output_cost_per_token": 99e-6}),
+        );
+        data.insert(
+            "deepseek/deepseek-chat".to_string(),
+            json!({"input_cost_per_token": 1e-6, "output_cost_per_token": 2e-6}),
+        );
+        data.insert(
+            "dashscope/qwen-max".to_string(),
+            json!({"input_cost_per_token": 2e-6, "output_cost_per_token": 6e-6}),
+        );
+        data.insert(
+            "moonshot/moonshot-v1".to_string(),
+            json!({"input_cost_per_token": 1e-6, "output_cost_per_token": 3e-6}),
+        );
+
+        let result = parse_litellm_data(data);
+        // Not filtered; bare names normalized; official zai/ wins over hoster
+        assert_eq!(result["glm-5"].input, 1e-6);
+        assert_eq!(result["deepseek-chat"].input, 1e-6);
+        assert_eq!(result["qwen-max"].input, 2e-6);
+        assert_eq!(result["moonshot-v1"].input, 1e-6);
+    }
+
+    #[test]
+    fn test_resolve_glm_dot_alias_prefers_p_version() {
+        // `glm-5.2` matches Fireworks `glm-5p2` (p == point) over older `glm-5`.
+        let mut data = HashMap::new();
+        data.insert("fireworks_ai/glm-5p2".to_string(), json!({"input_cost_per_token": 1.4e-6, "output_cost_per_token": 4.4e-6, "cache_read_input_token_cost": 0.26e-6}));
+        data.insert("zai/glm-5".to_string(), json!({"input_cost_per_token": 1e-6, "output_cost_per_token": 3.2e-6}));
+        let pricing = resolve_pricing_known("glm-5.2", &parse_litellm_data(data)).unwrap();
+        assert_eq!(pricing.input, 1.4e-6);
     }
 }

--- a/src/pricing/resolver.rs
+++ b/src/pricing/resolver.rs
@@ -46,12 +46,16 @@ pub(super) fn parse_litellm_data(
 
         let input = value
             .get("input_cost_per_token")
-            .and_then(serde_json::Value::as_f64)
-            .unwrap_or(0.0);
+            .and_then(serde_json::Value::as_f64);
         let output = value
             .get("output_cost_per_token")
-            .and_then(serde_json::Value::as_f64)
-            .unwrap_or(0.0);
+            .and_then(serde_json::Value::as_f64);
+        // Skip metadata-only entries; missing pricing must not load as $0 known.
+        if input.is_none() && output.is_none() {
+            continue;
+        }
+        let input = input.unwrap_or(0.0);
+        let output = output.unwrap_or(0.0);
         let reasoning_output = value
             .get("reasoning_output_cost_per_token")
             .or_else(|| value.get("reasoning_cost_per_token"))
@@ -712,15 +716,18 @@ mod tests {
     #[test]
     fn test_parse_missing_cost_fields_default_to_zero() {
         let mut data = HashMap::new();
-        data.insert("claude-test".to_string(), json!({}));
+        // input present, output/cache missing -> 0. Fully price-less entries are skipped.
+        data.insert(
+            "claude-test".to_string(),
+            json!({"input_cost_per_token": 15e-6}),
+        );
 
         let result = parse_litellm_data(data);
         let pricing = &result["claude-test"];
-        assert_eq!(pricing.input, 0.0);
+        assert_eq!(pricing.input, 15e-6);
         assert_eq!(pricing.output, 0.0);
         assert_eq!(pricing.cache_read, 0.0);
         assert_eq!(pricing.cache_create, 0.0);
-        // reasoning_output defaults to output (which is 0.0)
         assert_eq!(pricing.reasoning_output, 0.0);
     }
 
@@ -774,6 +781,7 @@ mod tests {
             "moonshot/moonshot-v1".to_string(),
             json!({"input_cost_per_token": 1e-6, "output_cost_per_token": 3e-6}),
         );
+        data.insert("zai/glm-meta".to_string(), json!({"mode": "chat"})); // priceless -> skip
 
         let result = parse_litellm_data(data);
         // Not filtered; bare names normalized; official zai/ wins over hoster
@@ -781,6 +789,7 @@ mod tests {
         assert_eq!(result["deepseek-chat"].input, 1e-6);
         assert_eq!(result["qwen-max"].input, 2e-6);
         assert_eq!(result["moonshot-v1"].input, 1e-6);
+        assert!(result.iter().all(|(k, _)| !k.contains("glm-meta"))); // not loaded as $0
     }
 
     #[test]

--- a/src/pricing/resolver.rs
+++ b/src/pricing/resolver.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use super::types::{dot_version_variant, ModelPricing};
+use super::types::{ModelPricing, dot_version_variant};
 
 fn openai_pricing(input: f64, output: f64, cache_read: f64) -> ModelPricing {
     ModelPricing {
@@ -154,65 +154,67 @@ pub(super) fn resolve_pricing_known(
 
 pub(super) fn fallback_pricing(model: &str) -> Option<ModelPricing> {
     let model_lower = model.to_lowercase();
-    Some(if model_lower.contains("opus-4-5") || model_lower.contains("opus-4.5") {
-        ModelPricing {
-            input: 5e-6,   // $5/M
-            output: 25e-6, // $25/M
-            reasoning_output: 25e-6,
-            cache_create: 6.25e-6, // $6.25/M
-            cache_read: 0.5e-6,    // $0.5/M
-        }
-    } else if model_lower.contains("opus") {
-        ModelPricing {
-            input: 15e-6,
-            output: 75e-6,
-            reasoning_output: 75e-6,
-            cache_create: 18.75e-6,
-            cache_read: 1.5e-6,
-        }
-    } else if model_lower.contains("sonnet") {
-        ModelPricing {
-            input: 3e-6,
-            output: 15e-6,
-            reasoning_output: 15e-6,
-            cache_create: 3.75e-6,
-            cache_read: 0.3e-6,
-        }
-    } else if model_lower.contains("haiku") {
-        ModelPricing {
-            input: 0.8e-6,
-            output: 4e-6,
-            reasoning_output: 4e-6,
-            cache_create: 1e-6,
-            cache_read: 0.08e-6,
-        }
-    } else if model_lower.contains("grok-build") {
-        xai_pricing(1e-6, 2e-6, 0.2e-6)
-    } else if model_lower.contains("grok") {
-        xai_pricing(1.25e-6, 2.5e-6, 0.2e-6)
-    } else if model_lower.contains("gpt-5.4-mini") {
-        openai_pricing(0.75e-6, 4.5e-6, 0.075e-6)
-    } else if model_lower.contains("gpt-5.4-nano") {
-        openai_pricing(0.2e-6, 1.25e-6, 0.02e-6)
-    } else if model_lower.contains("gpt-5.4") {
-        openai_pricing(2.5e-6, 15e-6, 0.25e-6)
-    } else if model_lower.contains("gpt-5.1-codex-mini") {
-        openai_pricing(0.25e-6, 2e-6, 0.025e-6)
-    } else if model_lower.contains("gpt-5.2-codex") || model_lower.contains("gpt-5.3-codex") {
-        openai_pricing(1.75e-6, 14e-6, 0.175e-6)
-    } else if model_lower.contains("gpt-5-codex") || model_lower.contains("gpt-5.1-codex") {
-        openai_pricing(1.25e-6, 10e-6, 0.125e-6)
-    } else if model_lower.contains("codex-mini") {
-        openai_pricing(1.5e-6, 6e-6, 0.375e-6)
-    } else if model_lower.contains("codex") || model_lower.contains("gpt-5") {
-        openai_pricing(1.25e-6, 10e-6, 0.125e-6)
-    } else if model_lower.contains("gpt-4") {
-        openai_pricing(2.5e-6, 10e-6, 0.0)
-    } else {
-        // Unknown model: no fallback estimate. The caller surfaces N/A instead
-        // of silently applying a sonnet-shaped guess.
-        return None;
-    })
+    Some(
+        if model_lower.contains("opus-4-5") || model_lower.contains("opus-4.5") {
+            ModelPricing {
+                input: 5e-6,   // $5/M
+                output: 25e-6, // $25/M
+                reasoning_output: 25e-6,
+                cache_create: 6.25e-6, // $6.25/M
+                cache_read: 0.5e-6,    // $0.5/M
+            }
+        } else if model_lower.contains("opus") {
+            ModelPricing {
+                input: 15e-6,
+                output: 75e-6,
+                reasoning_output: 75e-6,
+                cache_create: 18.75e-6,
+                cache_read: 1.5e-6,
+            }
+        } else if model_lower.contains("sonnet") {
+            ModelPricing {
+                input: 3e-6,
+                output: 15e-6,
+                reasoning_output: 15e-6,
+                cache_create: 3.75e-6,
+                cache_read: 0.3e-6,
+            }
+        } else if model_lower.contains("haiku") {
+            ModelPricing {
+                input: 0.8e-6,
+                output: 4e-6,
+                reasoning_output: 4e-6,
+                cache_create: 1e-6,
+                cache_read: 0.08e-6,
+            }
+        } else if model_lower.contains("grok-build") {
+            xai_pricing(1e-6, 2e-6, 0.2e-6)
+        } else if model_lower.contains("grok") {
+            xai_pricing(1.25e-6, 2.5e-6, 0.2e-6)
+        } else if model_lower.contains("gpt-5.4-mini") {
+            openai_pricing(0.75e-6, 4.5e-6, 0.075e-6)
+        } else if model_lower.contains("gpt-5.4-nano") {
+            openai_pricing(0.2e-6, 1.25e-6, 0.02e-6)
+        } else if model_lower.contains("gpt-5.4") {
+            openai_pricing(2.5e-6, 15e-6, 0.25e-6)
+        } else if model_lower.contains("gpt-5.1-codex-mini") {
+            openai_pricing(0.25e-6, 2e-6, 0.025e-6)
+        } else if model_lower.contains("gpt-5.2-codex") || model_lower.contains("gpt-5.3-codex") {
+            openai_pricing(1.75e-6, 14e-6, 0.175e-6)
+        } else if model_lower.contains("gpt-5-codex") || model_lower.contains("gpt-5.1-codex") {
+            openai_pricing(1.25e-6, 10e-6, 0.125e-6)
+        } else if model_lower.contains("codex-mini") {
+            openai_pricing(1.5e-6, 6e-6, 0.375e-6)
+        } else if model_lower.contains("codex") || model_lower.contains("gpt-5") {
+            openai_pricing(1.25e-6, 10e-6, 0.125e-6)
+        } else if model_lower.contains("gpt-4") {
+            openai_pricing(2.5e-6, 10e-6, 0.0)
+        } else {
+            // Unknown model: no fallback estimate. The caller surfaces N/A instead
+            // of silently applying a sonnet-shaped guess.
+            return None;
+        },
+    )
 }
 
 #[cfg(test)]
@@ -786,7 +788,10 @@ mod tests {
         // `glm-5.2` matches Fireworks `glm-5p2` (p == point) over older `glm-5`.
         let mut data = HashMap::new();
         data.insert("fireworks_ai/glm-5p2".to_string(), json!({"input_cost_per_token": 1.4e-6, "output_cost_per_token": 4.4e-6, "cache_read_input_token_cost": 0.26e-6}));
-        data.insert("zai/glm-5".to_string(), json!({"input_cost_per_token": 1e-6, "output_cost_per_token": 3.2e-6}));
+        data.insert(
+            "zai/glm-5".to_string(),
+            json!({"input_cost_per_token": 1e-6, "output_cost_per_token": 3.2e-6}),
+        );
         let pricing = resolve_pricing_known("glm-5.2", &parse_litellm_data(data)).unwrap();
         assert_eq!(pricing.input, 1.4e-6);
     }

--- a/src/pricing/types.rs
+++ b/src/pricing/types.rs
@@ -7,3 +7,42 @@ pub(super) struct ModelPricing {
     pub(super) cache_read: f64,
     pub(super) cache_create: f64,
 }
+
+/// Normalize version separators: some hosters spell version dots as `p`
+/// (e.g. Fireworks `glm-5p2` == `glm-5.2`). Convert a `p` sitting between two
+/// digits into `.` so a dot-spelled gateway alias can match the hoster key.
+pub(super) fn dot_version_variant(s: &str) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    let mut out = String::with_capacity(chars.len());
+    for (i, &c) in chars.iter().enumerate() {
+        if c == 'p'
+            && i > 0
+            && i + 1 < chars.len()
+            && chars[i - 1].is_ascii_digit()
+            && chars[i + 1].is_ascii_digit()
+        {
+            out.push('.');
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dot_version_variant_converts_p_between_digits() {
+        assert_eq!(dot_version_variant("glm-5p2"), "glm-5.2");
+        assert_eq!(dot_version_variant("glm-4p5"), "glm-4.5");
+    }
+
+    #[test]
+    fn dot_version_variant_leaves_others_unchanged() {
+        assert_eq!(dot_version_variant("glm-5"), "glm-5");
+        assert_eq!(dot_version_variant("deepseek-chat"), "deepseek-chat");
+        assert_eq!(dot_version_variant("ap-1"), "ap-1");
+    }
+}


### PR DESCRIPTION
Closes #24

## What & Why

Chinese-vendor models (GLM-5.2, DeepSeek, Qwen, Moonshot/Kimi) routed through Claude Code gateways were silently mispriced: ccstats only loaded Claude/OpenAI/xAI from LiteLLM and fell back to **Sonnet rates** for everything else. GLM-5.2 reported ~$38 (Sonnet) instead of the official ~$23 (Z.AI).

## Changes

- **Open the LiteLLM whitelist** (`resolver.rs::parse_litellm_data`) to CN vendors (deepseek, qwen, glm, moonshot/kimi).
- **Normalize** bare model names + dot-version variants so gateway aliases resolve: `fireworks_ai/glm-5p2` produces a `glm-5.2` variant (p == point). Official vendor prefixes (`zai/`, `deepseek/`, `dashscope/`, `moonshot/`) win over hosters on name collisions.
- **`fallback_pricing` returns `Option`**: truly unknown models surface as N/A instead of silently applying a Sonnet-shaped guess.

## Result

`glm-5.2` now resolves to `fireworks_ai/glm-5p2` (== official Z.AI price $1.4/$4.4/$0.26 per M). The 2026-06-23 row drops from ~$38 (Sonnet) to ~$23 (official).

## Tests

All existing tests pass (lib 423 + integration 41 + sdk 2) plus new coverage:
- `parse_litellm_data` keeps CN entries, normalizes bare names, official-wins-over-hoster
- `resolve_pricing_known("glm-5.2")` matches `glm-5p2` (not the older `glm-5`)
- `dot_version_variant` (p ↔ . conversion)
- `fallback_pricing` unknown → `None`

## Upstream

Also filed BerriAI/litellm#31075 (PR BerriAI/litellm#31077) to add `zai/glm-5.2` directly to LiteLLM, so ccstats can hit the official entry once merged instead of the Fireworks hoster key.
