### PR TITLE
SDK: add multi-range cost summary API

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,30 @@ println!("today: ${:.2}", summary.cost_usd.unwrap_or(0.0));
 
 The SDK uses the same source registry, parsers, aggregation logic, pricing cache, and fallback pricing as the CLI. Use `summarize_cost_with_cli_config` when SDK output should follow the same persisted CLI defaults for timezone, offline pricing, strict pricing, and currency. Use `summarize_cost` when the caller wants fully explicit options. Returned summaries include total tokens, cache read/create tokens, reasoning tokens, per-model breakdowns, `cost_usd`, and an optional converted `cost` when `SummaryOptions::currency` is set.
 
+Apps that need several windows at once can use the batch API so source logs,
+pricing, and currency are loaded once for the request:
+
+```rust
+use ccstats::{MultiSummaryOptions, UsageRange, UsageSource, summarize_cost_ranges};
+
+let overview = summarize_cost_ranges(MultiSummaryOptions {
+    source: UsageSource::Claude,
+    ranges: vec![
+        UsageRange::Today,
+        UsageRange::ThisWeek,
+        UsageRange::ThisMonth,
+    ],
+    timezone: None,
+    offline: true,
+    strict_pricing: false,
+    currency: Some("USD".to_string()),
+})?;
+
+for summary in overview.summaries {
+    println!("{:?}: ${:.2}", summary.range, summary.cost_usd.unwrap_or(0.0));
+}
+```
+
 ## Usage
 
 ### Claude Code

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,12 @@
 //! `ccstats` is a local-first library and CLI for token and cost analytics from
 //! Claude Code, `OpenAI` Codex, Cursor, and Grok session logs.
 //!
-//! The public SDK entry points are [`summarize_cost`] for explicit options and
-//! [`summarize_cost_with_cli_config`] for CLI-aligned config defaults. The binary
-//! target calls [`run_cli`] to preserve the existing command-line behavior.
+//! The public SDK entry points are [`summarize_cost`] and
+//! [`summarize_cost_ranges`] for explicit options, plus
+//! [`summarize_cost_with_cli_config`] and
+//! [`summarize_cost_ranges_with_cli_config`] for CLI-aligned config defaults.
+//! The binary target calls [`run_cli`] to preserve the existing command-line
+//! behavior.
 
 #![warn(clippy::pedantic)]
 #![allow(
@@ -26,8 +29,9 @@ mod source;
 mod utils;
 
 pub use sdk::{
-    CostSummary, ModelCostSummary, SdkError, SummaryOptions, TokenBreakdown, UsageRange,
-    UsageSource, summarize_cost, summarize_cost_with_cli_config,
+    CostSummary, ModelCostSummary, MultiCostSummary, MultiSummaryOptions, SdkError, SummaryOptions,
+    TokenBreakdown, UsageRange, UsageSource, summarize_cost, summarize_cost_ranges,
+    summarize_cost_ranges_with_cli_config, summarize_cost_with_cli_config,
 };
 
 use chrono::Utc;
@@ -50,8 +54,8 @@ enum TimezoneSource {
 /// Run the `ccstats` CLI using process arguments.
 ///
 /// This is intended for the binary target. SDK consumers should prefer
-/// [`summarize_cost`] or [`summarize_cost_with_cli_config`] so they receive
-/// structured data instead of rendered CLI output.
+/// [`summarize_cost`], [`summarize_cost_ranges`], or their CLI-config variants
+/// so they receive structured data instead of rendered CLI output.
 #[allow(clippy::too_many_lines)] // CLI setup intentionally stays in one dispatch function.
 pub fn run_cli() {
     let raw_cli = Cli::parse();

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::module_name_repetitions)]
 
+mod batch;
+
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -9,10 +11,15 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::config::Config;
-use crate::core::{DateFilter, DayStats, Stats};
+use crate::core::{DateFilter, DayStats, LoadResult, Stats};
 use crate::pricing::{CurrencyConverter, PricingDb, calculate_cost, sum_model_costs};
-use crate::source::{get_source, load_daily};
+use crate::source::{Source, get_source, load_daily};
 use crate::utils::Timezone;
+
+pub use batch::{
+    MultiCostSummary, MultiSummaryOptions, summarize_cost_ranges,
+    summarize_cost_ranges_with_cli_config,
+};
 
 /// Supported local usage sources.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -75,7 +82,7 @@ pub enum UsageRange {
 }
 
 impl UsageRange {
-    fn resolve(
+    pub(in crate::sdk) fn resolve(
         &self,
         today: NaiveDate,
     ) -> Result<(Option<NaiveDate>, Option<NaiveDate>), SdkError> {
@@ -213,26 +220,17 @@ pub fn summarize_cost(options: SummaryOptions) -> Result<CostSummary, SdkError> 
     );
 
     let result = load_daily(source, &filter, timezone, true, false);
-    let (stats, models) = merge_days(&result.day_stats);
-    let cost_usd = finite_cost(sum_model_costs(&models, &pricing_db));
-    let model_summaries = summarize_models(&models, &pricing_db, currency.as_ref());
-
-    Ok(CostSummary {
-        source: options.source,
-        source_name: source.name().to_string(),
-        display_name: source.display_name().to_string(),
-        range: options.range,
+    Ok(build_cost_summary(
+        options.source,
+        source,
+        options.range,
         since,
         until,
-        currency: currency_code,
-        cost: convert_cost(cost_usd, currency.as_ref()),
-        cost_usd,
-        tokens: TokenBreakdown::from_stats(&stats),
-        models: model_summaries,
-        valid_entries: result.valid,
-        skipped_entries: result.skipped,
-        elapsed_ms: result.elapsed_ms,
-    })
+        &result,
+        &pricing_db,
+        currency.as_ref(),
+        &currency_code,
+    ))
 }
 
 /// Summarize local token usage using the same reusable config defaults as the CLI.
@@ -280,6 +278,39 @@ impl TokenBreakdown {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+pub(in crate::sdk) fn build_cost_summary(
+    usage_source: UsageSource,
+    source: &dyn Source,
+    range: UsageRange,
+    since: Option<NaiveDate>,
+    until: Option<NaiveDate>,
+    result: &LoadResult,
+    pricing_db: &PricingDb,
+    currency: Option<&CurrencyConverter>,
+    currency_code: &str,
+) -> CostSummary {
+    let (stats, models) = merge_days(&result.day_stats);
+    let cost_usd = finite_cost(sum_model_costs(&models, pricing_db));
+
+    CostSummary {
+        source: usage_source,
+        source_name: source.name().to_string(),
+        display_name: source.display_name().to_string(),
+        range,
+        since,
+        until,
+        currency: currency_code.to_string(),
+        cost: convert_cost(cost_usd, currency),
+        cost_usd,
+        tokens: TokenBreakdown::from_stats(&stats),
+        models: summarize_models(&models, pricing_db, currency),
+        valid_entries: result.valid,
+        skipped_entries: result.skipped,
+        elapsed_ms: result.elapsed_ms,
+    }
+}
+
 fn merge_days(day_stats: &HashMap<String, DayStats>) -> (Stats, HashMap<String, Stats>) {
     let mut stats = Stats::default();
     let mut models = HashMap::new();
@@ -309,7 +340,7 @@ fn convert_cost(cost_usd: Option<f64>, currency: Option<&CurrencyConverter>) -> 
     }
 }
 
-fn load_requested_currency(
+pub(in crate::sdk) fn load_requested_currency(
     currency: Option<&str>,
     offline: bool,
 ) -> Result<Option<CurrencyConverter>, SdkError> {

--- a/src/sdk/batch.rs
+++ b/src/sdk/batch.rs
@@ -104,8 +104,7 @@ pub fn summarize_cost_ranges(options: MultiSummaryOptions) -> Result<MultiCostSu
         |conv| conv.currency_code().to_string(),
     );
 
-    let union_filter = union_filter(&resolved_ranges);
-    let results = load_daily_ranges(source, &union_filter, &resolved_ranges, timezone);
+    let results = load_daily_ranges(source, &resolved_ranges, timezone);
     let summaries = resolved_ranges
         .into_iter()
         .zip(results.iter())
@@ -192,24 +191,12 @@ fn resolve_ranges(ranges: &[UsageRange], today: NaiveDate) -> Result<Vec<Resolve
         .collect()
 }
 
-fn union_filter(ranges: &[ResolvedRange]) -> DateFilter {
-    let since = if ranges.iter().any(|range| range.since.is_none()) {
-        None
-    } else {
-        ranges.iter().filter_map(|range| range.since).min()
-    };
-    let until = if ranges.iter().any(|range| range.until.is_none()) {
-        None
-    } else {
-        ranges.iter().filter_map(|range| range.until).max()
-    };
-
-    DateFilter::new(since, until)
+fn contains_any_range(date: NaiveDate, ranges: &[ResolvedRange]) -> bool {
+    ranges.iter().any(|range| range.filter.contains(date))
 }
 
 fn load_daily_ranges(
     source: &dyn Source,
-    union_filter: &DateFilter,
     ranges: &[ResolvedRange],
     timezone: Timezone,
 ) -> Vec<LoadResult> {
@@ -228,7 +215,7 @@ fn load_daily_ranges(
                 .into_iter()
                 .filter_map(|mut entry| {
                     let date = normalize_entry_date(&mut entry, timezone)?;
-                    union_filter.contains(date).then_some(entry)
+                    contains_any_range(date, ranges).then_some(entry)
                 })
                 .collect::<Vec<_>>()
         })
@@ -386,30 +373,29 @@ mod tests {
     }
 
     #[test]
-    fn batch_union_filter_uses_min_since_and_max_until() {
+    fn range_membership_keeps_requested_days_and_excludes_gaps() {
         let ranges = resolve_ranges(
             &[
                 UsageRange::DateRange {
-                    since: Some(d(2026, 5, 5)),
-                    until: Some(d(2026, 5, 6)),
+                    since: Some(d(2026, 1, 10)),
+                    until: Some(d(2026, 1, 10)),
                 },
                 UsageRange::DateRange {
-                    since: Some(d(2026, 5, 1)),
-                    until: Some(d(2026, 5, 12)),
+                    since: Some(d(2026, 12, 10)),
+                    until: Some(d(2026, 12, 10)),
                 },
             ],
-            d(2026, 5, 9),
+            d(2026, 12, 10),
         )
         .unwrap();
 
-        let filter = union_filter(&ranges);
-
-        assert_eq!(filter.since, Some(d(2026, 5, 1)));
-        assert_eq!(filter.until, Some(d(2026, 5, 12)));
+        assert!(contains_any_range(d(2026, 1, 10), &ranges));
+        assert!(!contains_any_range(d(2026, 6, 1), &ranges));
+        assert!(contains_any_range(d(2026, 12, 10), &ranges));
     }
 
     #[test]
-    fn batch_union_filter_keeps_any_unbounded_side() {
+    fn range_membership_honors_unbounded_sides() {
         let ranges = resolve_ranges(
             &[
                 UsageRange::DateRange {
@@ -417,7 +403,7 @@ mod tests {
                     until: Some(d(2026, 5, 6)),
                 },
                 UsageRange::DateRange {
-                    since: Some(d(2026, 5, 1)),
+                    since: Some(d(2026, 5, 10)),
                     until: None,
                 },
             ],
@@ -425,10 +411,9 @@ mod tests {
         )
         .unwrap();
 
-        let filter = union_filter(&ranges);
-
-        assert_eq!(filter.since, None);
-        assert_eq!(filter.until, None);
+        assert!(contains_any_range(d(2020, 1, 1), &ranges));
+        assert!(!contains_any_range(d(2026, 5, 7), &ranges));
+        assert!(contains_any_range(d(2026, 12, 31), &ranges));
     }
 
     #[test]
@@ -449,9 +434,8 @@ mod tests {
             d(2026, 5, 9),
         )
         .unwrap();
-        let filter = union_filter(&ranges);
 
-        let results = load_daily_ranges(&source, &filter, &ranges, Timezone::Named(chrono_tz::UTC));
+        let results = load_daily_ranges(&source, &ranges, Timezone::Named(chrono_tz::UTC));
 
         assert_eq!(source.find_calls.load(Ordering::SeqCst), 1);
         assert_eq!(source.parse_calls.load(Ordering::SeqCst), 2);

--- a/src/sdk/batch.rs
+++ b/src/sdk/batch.rs
@@ -1,0 +1,483 @@
+use std::time::Instant;
+
+use chrono::{DateTime, NaiveDate, Utc};
+use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use super::{
+    CostSummary, SdkError, UsageRange, UsageSource, build_cost_summary, load_requested_currency,
+};
+use crate::config::Config;
+use crate::consts::DATE_FORMAT;
+use crate::core::{DateFilter, DedupAccumulator, LoadResult, RawEntry, aggregate_daily};
+use crate::pricing::PricingDb;
+use crate::source::{Source, get_source};
+use crate::utils::Timezone;
+
+/// Options for [`summarize_cost_ranges`].
+///
+/// Use [`summarize_cost_ranges_with_cli_config`] when SDK output should follow
+/// the same persisted defaults as the CLI for timezone, pricing, and currency.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MultiSummaryOptions {
+    /// Usage source to read.
+    pub source: UsageSource,
+    /// Date ranges to summarize, preserving this order in the returned summaries.
+    pub ranges: Vec<UsageRange>,
+    /// Optional timezone name, such as `UTC` or `Asia/Shanghai`.
+    pub timezone: Option<String>,
+    /// Use cached pricing only.
+    pub offline: bool,
+    /// Return unknown model costs as `None` instead of using fallback pricing.
+    pub strict_pricing: bool,
+    /// Optional display currency. Returns an error if rates are unavailable.
+    pub currency: Option<String>,
+}
+
+impl Default for MultiSummaryOptions {
+    fn default() -> Self {
+        Self {
+            source: UsageSource::Claude,
+            ranges: vec![UsageRange::Today],
+            timezone: None,
+            offline: false,
+            strict_pricing: false,
+            currency: None,
+        }
+    }
+}
+
+/// Multi-range usage and cost summary for SDK consumers.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MultiCostSummary {
+    pub source: UsageSource,
+    pub source_name: String,
+    pub display_name: String,
+    pub currency: String,
+    pub generated_at: String,
+    pub summaries: Vec<CostSummary>,
+    pub elapsed_ms: f64,
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedRange {
+    range: UsageRange,
+    since: Option<NaiveDate>,
+    until: Option<NaiveDate>,
+    filter: DateFilter,
+}
+
+/// Summarize multiple local token usage ranges while reusing source and pricing work.
+///
+/// This preserves the ordering of `options.ranges` in `summaries`, resolves
+/// timezone/source/pricing/currency once, scans source files once, and then
+/// applies each range's filtering, deduplication, and aggregation semantics to
+/// the shared parsed entries.
+///
+/// # Errors
+///
+/// Returns an error when no ranges are requested, when the source or timezone is
+/// invalid, or when any explicit date range has `since` after `until`.
+pub fn summarize_cost_ranges(options: MultiSummaryOptions) -> Result<MultiCostSummary, SdkError> {
+    let start = Instant::now();
+    let timezone = Timezone::parse(options.timezone.as_deref())
+        .map_err(|err| SdkError::Configuration(err.to_string()))?;
+    let today = timezone.to_fixed_offset(Utc::now()).date_naive();
+    let resolved_ranges = resolve_ranges(&options.ranges, today)?;
+
+    let source = get_source(options.source.as_str()).ok_or_else(|| SdkError::InvalidSource {
+        name: options.source.as_str().to_string(),
+    })?;
+    let pricing_db = PricingDb::load_quiet(options.offline, options.strict_pricing);
+    let currency = load_requested_currency(options.currency.as_deref(), options.offline)?;
+    let currency_code = currency.as_ref().map_or_else(
+        || "USD".to_string(),
+        |conv| conv.currency_code().to_string(),
+    );
+
+    let union_filter = union_filter(&resolved_ranges);
+    let results = load_daily_ranges(source, &union_filter, &resolved_ranges, timezone);
+    let summaries = resolved_ranges
+        .into_iter()
+        .zip(results.iter())
+        .map(|(range, result)| {
+            build_cost_summary(
+                options.source,
+                source,
+                range.range,
+                range.since,
+                range.until,
+                result,
+                &pricing_db,
+                currency.as_ref(),
+                &currency_code,
+            )
+        })
+        .collect();
+
+    Ok(MultiCostSummary {
+        source: options.source,
+        source_name: source.name().to_string(),
+        display_name: source.display_name().to_string(),
+        currency: currency_code,
+        generated_at: Utc::now().to_rfc3339(),
+        summaries,
+        elapsed_ms: start.elapsed().as_secs_f64() * 1000.0,
+    })
+}
+
+/// Summarize multiple local token usage ranges using CLI-aligned config defaults.
+///
+/// This preserves the explicit SDK source and ranges, then fills unset timezone
+/// and currency from config and applies config-enabled pricing flags.
+///
+/// # Errors
+///
+/// Returns an error when no ranges are requested, when the resolved source or
+/// timezone is invalid, or when any explicit date range has `since` after
+/// `until`.
+pub fn summarize_cost_ranges_with_cli_config(
+    options: MultiSummaryOptions,
+) -> Result<MultiCostSummary, SdkError> {
+    summarize_cost_ranges(apply_cli_config_multi(options, &Config::load_quiet()))
+}
+
+fn apply_cli_config_multi(
+    mut options: MultiSummaryOptions,
+    config: &Config,
+) -> MultiSummaryOptions {
+    if !options.offline && config.offline {
+        options.offline = true;
+    }
+    if !options.strict_pricing && config.strict_pricing {
+        options.strict_pricing = true;
+    }
+    if options.timezone.is_none() {
+        options.timezone.clone_from(&config.timezone);
+    }
+    if options.currency.is_none() {
+        options.currency.clone_from(&config.currency);
+    }
+
+    options
+}
+
+fn resolve_ranges(ranges: &[UsageRange], today: NaiveDate) -> Result<Vec<ResolvedRange>, SdkError> {
+    if ranges.is_empty() {
+        return Err(SdkError::Configuration(
+            "at least one usage range is required".to_string(),
+        ));
+    }
+
+    ranges
+        .iter()
+        .map(|range| {
+            let (since, until) = range.resolve(today)?;
+            Ok(ResolvedRange {
+                range: range.clone(),
+                since,
+                until,
+                filter: DateFilter::new(since, until),
+            })
+        })
+        .collect()
+}
+
+fn union_filter(ranges: &[ResolvedRange]) -> DateFilter {
+    let since = if ranges.iter().any(|range| range.since.is_none()) {
+        None
+    } else {
+        ranges.iter().filter_map(|range| range.since).min()
+    };
+    let until = if ranges.iter().any(|range| range.until.is_none()) {
+        None
+    } else {
+        ranges.iter().filter_map(|range| range.until).max()
+    };
+
+    DateFilter::new(since, until)
+}
+
+fn load_daily_ranges(
+    source: &dyn Source,
+    union_filter: &DateFilter,
+    ranges: &[ResolvedRange],
+    timezone: Timezone,
+) -> Vec<LoadResult> {
+    let start = Instant::now();
+    let files = source.find_files();
+    if files.is_empty() {
+        return ranges.iter().map(|_| LoadResult::default()).collect();
+    }
+
+    let entries: Vec<RawEntry> = files
+        .par_iter()
+        .flat_map(|path| {
+            source
+                .parse_file(path, timezone, false)
+                .entries
+                .into_iter()
+                .filter_map(|mut entry| {
+                    let date = normalize_entry_date(&mut entry, timezone)?;
+                    union_filter.contains(date).then_some(entry)
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+    ranges
+        .iter()
+        .map(|range| {
+            let mut result = aggregate_entries_for_filter(
+                &entries,
+                &range.filter,
+                source.capabilities().needs_dedup,
+            );
+            result.elapsed_ms = elapsed_ms;
+            result
+        })
+        .collect()
+}
+
+fn normalize_entry_date(entry: &mut RawEntry, timezone: Timezone) -> Option<NaiveDate> {
+    if let Ok(date) = NaiveDate::parse_from_str(&entry.date_str, DATE_FORMAT) {
+        return Some(date);
+    }
+
+    let utc_dt = entry.timestamp.parse::<DateTime<Utc>>().ok()?;
+    let date = timezone.to_fixed_offset(utc_dt).date_naive();
+    entry.date_str = date.format(DATE_FORMAT).to_string();
+    entry.timestamp_ms = utc_dt.timestamp_millis();
+    Some(date)
+}
+
+fn aggregate_entries_for_filter(
+    entries: &[RawEntry],
+    filter: &DateFilter,
+    needs_dedup: bool,
+) -> LoadResult {
+    let filtered: Vec<_> = entries
+        .iter()
+        .filter(|entry| {
+            NaiveDate::parse_from_str(&entry.date_str, DATE_FORMAT)
+                .is_ok_and(|date| filter.contains(date))
+        })
+        .cloned()
+        .collect();
+
+    if filtered.is_empty() {
+        return LoadResult::default();
+    }
+
+    if needs_dedup {
+        let mut accumulator = DedupAccumulator::new();
+        accumulator.extend(filtered);
+        let (deduped, skipped) = accumulator.finalize();
+        return load_result_from_entries(deduped, skipped);
+    }
+
+    load_result_from_entries(filtered, 0)
+}
+
+fn load_result_from_entries(entries: Vec<RawEntry>, skipped: i64) -> LoadResult {
+    let valid = entries.len() as i64;
+    LoadResult {
+        day_stats: aggregate_daily(entries),
+        skipped,
+        valid,
+        elapsed_ms: 0.0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use crate::core::RawEntry;
+    use crate::source::{Capabilities, ParseOutput};
+
+    fn d(year: i32, month: u32, day: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(year, month, day).unwrap()
+    }
+
+    struct CountingSource {
+        files: Vec<PathBuf>,
+        find_calls: AtomicUsize,
+        parse_calls: AtomicUsize,
+    }
+
+    impl CountingSource {
+        fn new(files: Vec<PathBuf>) -> Self {
+            Self {
+                files,
+                find_calls: AtomicUsize::new(0),
+                parse_calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl Source for CountingSource {
+        fn name(&self) -> &'static str {
+            "counting"
+        }
+
+        fn capabilities(&self) -> Capabilities {
+            Capabilities::default()
+        }
+
+        fn find_files(&self) -> Vec<PathBuf> {
+            self.find_calls.fetch_add(1, Ordering::SeqCst);
+            self.files.clone()
+        }
+
+        fn parse_file(&self, _path: &Path, _timezone: Timezone, _debug: bool) -> ParseOutput {
+            self.parse_calls.fetch_add(1, Ordering::SeqCst);
+            ParseOutput {
+                entries: vec![RawEntry {
+                    timestamp: "2026-05-09T12:00:00Z".to_string(),
+                    timestamp_ms: 1_778_326_400_000,
+                    date_str: "2026-05-09".to_string(),
+                    message_id: None,
+                    session_key: "counting".to_string(),
+                    session_id: "counting".to_string(),
+                    project_path: String::new(),
+                    model: "gpt-5".to_string(),
+                    input_tokens: 10,
+                    output_tokens: 5,
+                    cache_creation: 0,
+                    cache_read: 0,
+                    reasoning_tokens: 0,
+                    stop_reason: Some("complete".to_string()),
+                }],
+                errors: 0,
+            }
+        }
+    }
+
+    #[test]
+    fn batch_ranges_reject_empty_list() {
+        let err = resolve_ranges(&[], d(2026, 5, 9)).expect_err("empty ranges should fail");
+
+        assert!(err.to_string().contains("at least one usage range"));
+    }
+
+    #[test]
+    fn batch_ranges_reject_reversed_date_range() {
+        let ranges = vec![UsageRange::DateRange {
+            since: Some(d(2026, 5, 10)),
+            until: Some(d(2026, 5, 9)),
+        }];
+
+        let err = resolve_ranges(&ranges, d(2026, 5, 9)).expect_err("reversed range should fail");
+
+        assert!(matches!(err, SdkError::InvalidDateRange { .. }));
+    }
+
+    #[test]
+    fn batch_union_filter_uses_min_since_and_max_until() {
+        let ranges = resolve_ranges(
+            &[
+                UsageRange::DateRange {
+                    since: Some(d(2026, 5, 5)),
+                    until: Some(d(2026, 5, 6)),
+                },
+                UsageRange::DateRange {
+                    since: Some(d(2026, 5, 1)),
+                    until: Some(d(2026, 5, 12)),
+                },
+            ],
+            d(2026, 5, 9),
+        )
+        .unwrap();
+
+        let filter = union_filter(&ranges);
+
+        assert_eq!(filter.since, Some(d(2026, 5, 1)));
+        assert_eq!(filter.until, Some(d(2026, 5, 12)));
+    }
+
+    #[test]
+    fn batch_union_filter_keeps_any_unbounded_side() {
+        let ranges = resolve_ranges(
+            &[
+                UsageRange::DateRange {
+                    since: None,
+                    until: Some(d(2026, 5, 6)),
+                },
+                UsageRange::DateRange {
+                    since: Some(d(2026, 5, 1)),
+                    until: None,
+                },
+            ],
+            d(2026, 5, 9),
+        )
+        .unwrap();
+
+        let filter = union_filter(&ranges);
+
+        assert_eq!(filter.since, None);
+        assert_eq!(filter.until, None);
+    }
+
+    #[test]
+    fn load_daily_ranges_discovers_and_parses_source_once() {
+        let source =
+            CountingSource::new(vec![PathBuf::from("one.jsonl"), PathBuf::from("two.jsonl")]);
+        let ranges = resolve_ranges(
+            &[
+                UsageRange::DateRange {
+                    since: Some(d(2026, 5, 9)),
+                    until: Some(d(2026, 5, 9)),
+                },
+                UsageRange::DateRange {
+                    since: Some(d(2026, 5, 1)),
+                    until: Some(d(2026, 5, 31)),
+                },
+            ],
+            d(2026, 5, 9),
+        )
+        .unwrap();
+        let filter = union_filter(&ranges);
+
+        let results = load_daily_ranges(&source, &filter, &ranges, Timezone::Named(chrono_tz::UTC));
+
+        assert_eq!(source.find_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(source.parse_calls.load(Ordering::SeqCst), 2);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].valid, 2);
+        assert_eq!(results[1].valid, 2);
+    }
+
+    #[test]
+    fn cli_config_fills_multi_summary_defaults() {
+        let config = Config {
+            offline: true,
+            strict_pricing: true,
+            timezone: Some("Asia/Shanghai".to_string()),
+            currency: Some("CNY".to_string()),
+            ..Config::default()
+        };
+
+        let options = apply_cli_config_multi(
+            MultiSummaryOptions {
+                source: UsageSource::Codex,
+                ranges: vec![UsageRange::Today, UsageRange::ThisWeek],
+                ..MultiSummaryOptions::default()
+            },
+            &config,
+        );
+
+        assert_eq!(options.source, UsageSource::Codex);
+        assert_eq!(
+            options.ranges,
+            vec![UsageRange::Today, UsageRange::ThisWeek]
+        );
+        assert!(options.offline);
+        assert!(options.strict_pricing);
+        assert_eq!(options.timezone.as_deref(), Some("Asia/Shanghai"));
+        assert_eq!(options.currency.as_deref(), Some("CNY"));
+    }
+}

--- a/src/sdk/batch.rs
+++ b/src/sdk/batch.rs
@@ -80,16 +80,25 @@ struct ResolvedRange {
 /// invalid, or when any explicit date range has `since` after `until`.
 pub fn summarize_cost_ranges(options: MultiSummaryOptions) -> Result<MultiCostSummary, SdkError> {
     let start = Instant::now();
-    let timezone = Timezone::parse(options.timezone.as_deref())
+    let MultiSummaryOptions {
+        source: usage_source,
+        ranges,
+        timezone,
+        offline,
+        strict_pricing,
+        currency: requested_currency,
+    } = options;
+
+    let timezone = Timezone::parse(timezone.as_deref())
         .map_err(|err| SdkError::Configuration(err.to_string()))?;
     let today = timezone.to_fixed_offset(Utc::now()).date_naive();
-    let resolved_ranges = resolve_ranges(&options.ranges, today)?;
+    let resolved_ranges = resolve_ranges(&ranges, today)?;
 
-    let source = get_source(options.source.as_str()).ok_or_else(|| SdkError::InvalidSource {
-        name: options.source.as_str().to_string(),
+    let source = get_source(usage_source.as_str()).ok_or_else(|| SdkError::InvalidSource {
+        name: usage_source.as_str().to_string(),
     })?;
-    let pricing_db = PricingDb::load_quiet(options.offline, options.strict_pricing);
-    let currency = load_requested_currency(options.currency.as_deref(), options.offline)?;
+    let pricing_db = PricingDb::load_quiet(offline, strict_pricing);
+    let currency = load_requested_currency(requested_currency.as_deref(), offline)?;
     let currency_code = currency.as_ref().map_or_else(
         || "USD".to_string(),
         |conv| conv.currency_code().to_string(),
@@ -102,7 +111,7 @@ pub fn summarize_cost_ranges(options: MultiSummaryOptions) -> Result<MultiCostSu
         .zip(results.iter())
         .map(|(range, result)| {
             build_cost_summary(
-                options.source,
+                usage_source,
                 source,
                 range.range,
                 range.since,
@@ -116,7 +125,7 @@ pub fn summarize_cost_ranges(options: MultiSummaryOptions) -> Result<MultiCostSu
         .collect();
 
     Ok(MultiCostSummary {
-        source: options.source,
+        source: usage_source,
         source_name: source.name().to_string(),
         display_name: source.display_name().to_string(),
         currency: currency_code,

--- a/tests/sdk_integration.rs
+++ b/tests/sdk_integration.rs
@@ -2,8 +2,11 @@ use std::fs;
 use std::path::Path;
 use std::sync::Mutex;
 
-use ccstats::{SummaryOptions, UsageRange, UsageSource, summarize_cost};
-use chrono::NaiveDate;
+use ccstats::{
+    CostSummary, MultiSummaryOptions, SummaryOptions, UsageRange, UsageSource, summarize_cost,
+    summarize_cost_ranges,
+};
+use chrono::{Datelike, Days, NaiveDate, Utc};
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
 
@@ -12,6 +15,23 @@ fn write_file(path: &Path, content: &str) {
         fs::create_dir_all(parent).expect("create parent dirs");
     }
     fs::write(path, content).expect("write test file");
+}
+
+fn assert_stable_summary_eq(actual: &CostSummary, expected: &CostSummary) {
+    assert_eq!(actual.source, expected.source);
+    assert_eq!(actual.source_name, expected.source_name);
+    assert_eq!(actual.display_name, expected.display_name);
+    assert_eq!(actual.range, expected.range);
+    assert_eq!(actual.since, expected.since);
+    assert_eq!(actual.until, expected.until);
+    assert_eq!(actual.currency, expected.currency);
+    assert_eq!(actual.cost, expected.cost);
+    assert_eq!(actual.cost_usd, expected.cost_usd);
+    assert_eq!(actual.tokens, expected.tokens);
+    assert_eq!(actual.models, expected.models);
+    assert_eq!(actual.valid_entries, expected.valid_entries);
+    assert_eq!(actual.skipped_entries, expected.skipped_entries);
+    assert!(actual.elapsed_ms.is_finite());
 }
 
 #[test]
@@ -65,6 +85,149 @@ fn sdk_summarizes_codex_cost_without_running_cli() {
     assert_eq!(summary.models.len(), 1);
     assert_eq!(summary.models[0].model, "gpt-5");
     assert!(summary.cost_usd.is_some_and(|cost| cost > 0.0));
+}
+
+#[test]
+fn sdk_batch_summarizes_codex_ranges_like_repeated_single_calls() {
+    let _guard = ENV_LOCK.lock().expect("env lock");
+    let root = tempfile::tempdir().expect("temp dir");
+    let codex_home = root.path().join("codex-home");
+    let session_file = codex_home.join("sessions").join("sdk-batch-session.jsonl");
+
+    let today = Utc::now().date_naive();
+    let week_start = today
+        .checked_sub_days(Days::new(u64::from(today.weekday().num_days_from_monday())))
+        .unwrap();
+    let month_start = today.with_day(1).unwrap();
+    write_file(
+        &session_file,
+        &format!(
+            r#"{{"timestamp":"{month_start}T12:00:00Z","type":"turn_context","payload":{{"model":"gpt-5"}}}}
+{{"timestamp":"{month_start}T12:00:00Z","type":"event_msg","payload":{{"type":"token_count","info":{{"total_token_usage":{{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"reasoning_output_tokens":10,"total_tokens":140}},"last_token_usage":{{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"reasoning_output_tokens":10,"total_tokens":140}},"model":"gpt-5"}}}}}}
+{{"timestamp":"{week_start}T12:00:00Z","type":"event_msg","payload":{{"type":"token_count","info":{{"total_token_usage":{{"input_tokens":220,"cached_input_tokens":40,"output_tokens":80,"reasoning_output_tokens":20,"total_tokens":300}},"last_token_usage":{{"input_tokens":120,"cached_input_tokens":20,"output_tokens":50,"reasoning_output_tokens":10,"total_tokens":160}},"model":"gpt-5"}}}}}}
+{{"timestamp":"{today}T12:00:00Z","type":"event_msg","payload":{{"type":"token_count","info":{{"total_token_usage":{{"input_tokens":360,"cached_input_tokens":70,"output_tokens":140,"reasoning_output_tokens":40,"total_tokens":500}},"last_token_usage":{{"input_tokens":140,"cached_input_tokens":30,"output_tokens":60,"reasoning_output_tokens":20,"total_tokens":200}},"model":"gpt-5"}}}}}}
+"#
+        ),
+    );
+
+    let previous_codex_home = std::env::var_os("CODEX_HOME");
+    unsafe {
+        std::env::set_var("CODEX_HOME", &codex_home);
+    }
+
+    let ranges = vec![
+        UsageRange::Today,
+        UsageRange::ThisWeek,
+        UsageRange::ThisMonth,
+    ];
+    let batch = summarize_cost_ranges(MultiSummaryOptions {
+        source: UsageSource::Codex,
+        ranges: ranges.clone(),
+        timezone: Some("UTC".to_string()),
+        offline: true,
+        strict_pricing: false,
+        currency: None,
+    })
+    .expect("summarize codex ranges");
+
+    let repeated: Vec<_> = ranges
+        .iter()
+        .cloned()
+        .map(|range| {
+            summarize_cost(SummaryOptions {
+                source: UsageSource::Codex,
+                range,
+                timezone: Some("UTC".to_string()),
+                offline: true,
+                ..SummaryOptions::default()
+            })
+            .expect("summarize codex single range")
+        })
+        .collect();
+
+    match previous_codex_home {
+        Some(value) => unsafe {
+            std::env::set_var("CODEX_HOME", value);
+        },
+        None => unsafe {
+            std::env::remove_var("CODEX_HOME");
+        },
+    }
+
+    assert_eq!(batch.source, UsageSource::Codex);
+    assert_eq!(batch.source_name, "codex");
+    assert_eq!(batch.currency, "USD");
+    assert_eq!(batch.summaries.len(), ranges.len());
+    assert!(batch.elapsed_ms.is_finite());
+    assert!(!batch.generated_at.is_empty());
+    for (actual, expected) in batch.summaries.iter().zip(repeated.iter()) {
+        assert_stable_summary_eq(actual, expected);
+    }
+}
+
+#[test]
+fn sdk_batch_respects_timezone_boundaries_like_single_range() {
+    let _guard = ENV_LOCK.lock().expect("env lock");
+    let root = tempfile::tempdir().expect("temp dir");
+    let codex_home = root.path().join("codex-home");
+    let session_file = codex_home
+        .join("sessions")
+        .join("sdk-timezone-session.jsonl");
+    write_file(
+        &session_file,
+        r#"{"timestamp":"2026-02-05T16:30:00Z","type":"turn_context","payload":{"model":"gpt-5"}}
+{"timestamp":"2026-02-05T16:30:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"reasoning_output_tokens":10,"total_tokens":140},"last_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"reasoning_output_tokens":10,"total_tokens":140},"model":"gpt-5"}}}
+"#,
+    );
+
+    let previous_codex_home = std::env::var_os("CODEX_HOME");
+    unsafe {
+        std::env::set_var("CODEX_HOME", &codex_home);
+    }
+
+    let range = UsageRange::DateRange {
+        since: Some(NaiveDate::from_ymd_opt(2026, 2, 6).unwrap()),
+        until: Some(NaiveDate::from_ymd_opt(2026, 2, 6).unwrap()),
+    };
+    let shanghai_batch = summarize_cost_ranges(MultiSummaryOptions {
+        source: UsageSource::Codex,
+        ranges: vec![range.clone()],
+        timezone: Some("Asia/Shanghai".to_string()),
+        offline: true,
+        strict_pricing: false,
+        currency: None,
+    })
+    .expect("summarize shanghai range");
+    let shanghai_single = summarize_cost(SummaryOptions {
+        source: UsageSource::Codex,
+        range: range.clone(),
+        timezone: Some("Asia/Shanghai".to_string()),
+        offline: true,
+        ..SummaryOptions::default()
+    })
+    .expect("summarize shanghai single range");
+    let utc_batch = summarize_cost_ranges(MultiSummaryOptions {
+        source: UsageSource::Codex,
+        ranges: vec![range],
+        timezone: Some("UTC".to_string()),
+        offline: true,
+        strict_pricing: false,
+        currency: None,
+    })
+    .expect("summarize utc range");
+
+    match previous_codex_home {
+        Some(value) => unsafe {
+            std::env::set_var("CODEX_HOME", value);
+        },
+        None => unsafe {
+            std::env::remove_var("CODEX_HOME");
+        },
+    }
+
+    assert_stable_summary_eq(&shanghai_batch.summaries[0], &shanghai_single);
+    assert_eq!(shanghai_batch.summaries[0].valid_entries, 1);
+    assert_eq!(utc_batch.summaries[0].valid_entries, 0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `summarize_cost_ranges` and `summarize_cost_ranges_with_cli_config` for SDK consumers that need several cost windows at once
- reuse pricing/currency/source parsing once per batch request while preserving per-range filtering, deduplication, aggregation, and `CostSummary` fields
- export the new public SDK types/functions and document a QuotaBar-like example

## Root cause
SDK callers previously had to call `summarize_cost` once per `UsageRange`, which repeated pricing/currency loading and source log scans for multi-window UIs.

## Validation
- `cargo test`
- `cargo fmt --check`
- `git diff --check`

Fixes #27