### PR TITLE
fix: deduplicate replayed Codex token counts

### DIFF
--- a/src/core/dedup.rs
+++ b/src/core/dedup.rs
@@ -6,6 +6,8 @@
 use crate::core::types::RawEntry;
 use std::collections::HashMap;
 
+const SOURCE_WIDE_DEDUP_PREFIX: &str = "source-wide:";
+
 /// Trait for entries that can be deduplicated
 pub(crate) trait Deduplicatable {
     fn timestamp_ms(&self) -> i64;
@@ -30,6 +32,13 @@ impl Deduplicatable for RawEntry {
     }
 
     fn dedup_scope(&self) -> Option<&str> {
+        if self
+            .message_id
+            .as_deref()
+            .is_some_and(|id| id.starts_with(SOURCE_WIDE_DEDUP_PREFIX))
+        {
+            return None;
+        }
         Some(&self.session_key)
     }
 }

--- a/src/source/codex/config.rs
+++ b/src/source/codex/config.rs
@@ -43,7 +43,7 @@ impl Source for CodexSource {
             has_billing_blocks: false, // Different billing model
             has_reasoning_tokens: true,
             has_cache_creation: false,
-            needs_dedup: false, // Codex already handles dedup internally
+            needs_dedup: true,
         }
     }
 

--- a/src/source/codex/parser.rs
+++ b/src/source/codex/parser.rs
@@ -18,6 +18,8 @@ use crate::utils::Timezone;
 const DEFAULT_CODEX_DIR: &str = ".codex";
 const CODEX_HOME_ENV: &str = "CODEX_HOME";
 const SESSION_SUBDIR: &str = "sessions";
+const CODEX_USAGE_MESSAGE_PREFIX: &str = "source-wide:codex-token-count";
+const SESSION_USAGE_MESSAGE_PREFIX: &str = "codex-token-count";
 
 // ============================================================================
 // Internal types for JSONL parsing
@@ -36,6 +38,7 @@ struct RawJsonEntry<'a> {
 struct Payload<'a> {
     #[serde(rename = "type")]
     payload_type: Option<&'a str>,
+    id: Option<&'a str>,
     info: Option<TokenInfo<'a>>,
     model: Option<&'a str>,
 }
@@ -104,7 +107,7 @@ impl TokenUsage {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
 #[allow(clippy::struct_field_names)] // field names mirror normalized token fields
 struct UsageTotals {
     input_tokens: i64,
@@ -207,6 +210,32 @@ fn extract_model_ref<'a>(payload: &'a Payload<'a>) -> Option<&'a str> {
     non_empty_model(payload.model)
 }
 
+fn usage_message_id(
+    model: &str,
+    logical_session_key: &str,
+    total: UsageTotals,
+    delta: UsageTotals,
+) -> String {
+    let prefix = if total == delta {
+        SESSION_USAGE_MESSAGE_PREFIX
+    } else {
+        CODEX_USAGE_MESSAGE_PREFIX
+    };
+    format!(
+        "{prefix}:{logical_session_key}:{model}:total={},{},{},{},{}:delta={},{},{},{},{}",
+        total.input_tokens,
+        total.cached_input_tokens,
+        total.output_tokens,
+        total.reasoning_output_tokens,
+        total.total_tokens,
+        delta.input_tokens,
+        delta.cached_input_tokens,
+        delta.output_tokens,
+        delta.reasoning_output_tokens,
+        delta.total_tokens
+    )
+}
+
 #[cfg(test)]
 fn extract_model(payload: &Payload<'_>) -> Option<String> {
     extract_model_ref(payload).map(std::string::ToString::to_string)
@@ -244,6 +273,7 @@ pub(super) fn parse_codex_file_with_debug(
     let mut parse_errors = 0usize;
     let mut previous_totals: Option<UsageTotals> = None;
     let mut current_model: Option<String> = None;
+    let mut logical_session_key = session_key.clone();
     let mut line = String::new();
     let mut line_no = 0usize;
     let mut reader = reader;
@@ -289,6 +319,15 @@ pub(super) fn parse_codex_file_with_debug(
         let Some(entry_type) = raw_entry.entry_type else {
             continue;
         };
+
+        if entry_type == "session_meta" {
+            if let Some(payload) = &raw_entry.payload
+                && let Some(id) = non_empty_model(payload.id)
+            {
+                logical_session_key = format!("codex-session:{id}");
+            }
+            continue;
+        }
 
         // Handle turn_context to get model info
         if entry_type == "turn_context" {
@@ -388,12 +427,13 @@ pub(super) fn parse_codex_file_with_debug(
         let raw_output = delta.output_tokens;
         let reasoning = delta.reasoning_output_tokens;
         let non_reasoning_output = (raw_output - reasoning).max(0);
+        let message_id = usage_message_id(&model, &logical_session_key, total, delta);
 
         entries.push(RawEntry {
             timestamp: timestamp.to_string(),
             timestamp_ms: utc_dt.timestamp_millis(),
             date_str: date.format(DATE_FORMAT).to_string(),
-            message_id: None, // Codex doesn't use message IDs for dedup
+            message_id: Some(message_id),
             session_key: session_key.clone(),
             session_id: session_id.clone(),
             project_path: String::new(), // Codex doesn't track projects
@@ -560,6 +600,7 @@ mod tests {
     fn test_extract_model_from_info_model() {
         let payload = Payload {
             payload_type: None,
+            id: None,
             model: Some("fallback-model"),
             info: Some(TokenInfo {
                 total_token_usage: None,
@@ -578,6 +619,7 @@ mod tests {
     fn test_extract_model_falls_back_to_model_name() {
         let payload = Payload {
             payload_type: None,
+            id: None,
             model: Some("fallback"),
             info: Some(TokenInfo {
                 total_token_usage: None,
@@ -594,6 +636,7 @@ mod tests {
     fn test_extract_model_falls_back_to_metadata() {
         let payload = Payload {
             payload_type: None,
+            id: None,
             model: Some("fallback"),
             info: Some(TokenInfo {
                 total_token_usage: None,
@@ -612,6 +655,7 @@ mod tests {
     fn test_extract_model_falls_back_to_payload_model() {
         let payload = Payload {
             payload_type: None,
+            id: None,
             model: Some("payload-model"),
             info: Some(TokenInfo {
                 total_token_usage: None,
@@ -628,6 +672,7 @@ mod tests {
     fn test_extract_model_no_info_uses_payload() {
         let payload = Payload {
             payload_type: None,
+            id: None,
             model: Some("payload-only"),
             info: None,
         };
@@ -638,6 +683,7 @@ mod tests {
     fn test_extract_model_all_none_returns_none() {
         let payload = Payload {
             payload_type: None,
+            id: None,
             model: None,
             info: None,
         };
@@ -648,6 +694,7 @@ mod tests {
     fn test_extract_model_empty_strings_skipped() {
         let payload = Payload {
             payload_type: None,
+            id: None,
             model: Some("real-model"),
             info: Some(TokenInfo {
                 total_token_usage: None,

--- a/src/source/registry.rs
+++ b/src/source/registry.rs
@@ -198,7 +198,7 @@ mod tests {
         assert!(!caps.has_projects);
         assert!(!caps.has_billing_blocks);
         assert!(!caps.has_cache_creation);
-        assert!(!caps.needs_dedup);
+        assert!(caps.needs_dedup);
         assert!(caps.has_reasoning_tokens);
     }
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -194,6 +194,93 @@ fn codex_daily_json_reads_session_data() {
 }
 
 #[test]
+fn codex_daily_json_deduplicates_replayed_token_counts_across_files() {
+    let root = unique_temp_dir("codex-replay-dedup");
+    let codex_home = root.join("codex-home");
+    let replay_a = codex_home.join("sessions").join("replay-a.jsonl");
+    let replay_b = codex_home.join("sessions").join("replay-b.jsonl");
+    let parent_meta = r#"{"timestamp":"2026-02-06T10:00:00Z","type":"session_meta","payload":{"id":"parent-session"}}"#;
+    let fork_meta = r#"{"timestamp":"2026-02-06T10:00:00Z","type":"session_meta","payload":{"id":"forked-session"}}"#;
+    let replayed = r#"{"timestamp":"2026-02-06T10:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":220,"cached_input_tokens":40,"output_tokens":80,"reasoning_output_tokens":20,"total_tokens":300},"last_token_usage":{"input_tokens":120,"cached_input_tokens":20,"output_tokens":50,"reasoning_output_tokens":10,"total_tokens":160},"model":"gpt-5"}}}"#;
+    write_file(&replay_a, &format!("{parent_meta}\n{replayed}\n"));
+    write_file(
+        &replay_b,
+        &format!(
+            r#"{fork_meta}
+{parent_meta}
+{replayed}
+{{"timestamp":"2026-02-06T10:01:00Z","type":"event_msg","payload":{{"type":"token_count","info":{{"total_token_usage":{{"input_tokens":360,"cached_input_tokens":70,"output_tokens":140,"reasoning_output_tokens":40,"total_tokens":500}},"last_token_usage":{{"input_tokens":140,"cached_input_tokens":30,"output_tokens":60,"reasoning_output_tokens":20,"total_tokens":200}},"model":"gpt-5"}}}}}}
+"#
+        ),
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "codex",
+            "daily",
+            "-j",
+            "-O",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("CODEX_HOME", &codex_home)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    let arr = json.as_array().expect("array output");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["date"].as_str(), Some("2026-02-06"));
+    assert_eq!(arr[0]["total_tokens"].as_i64(), Some(370));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn codex_daily_json_keeps_identical_token_count_sequences_per_session() {
+    let root = unique_temp_dir("codex-initial-session-scope");
+    let codex_home = root.join("codex-home");
+    let session_a = codex_home.join("sessions").join("session-a.jsonl");
+    let session_b = codex_home.join("sessions").join("session-b.jsonl");
+    let meta_a = r#"{"timestamp":"2026-02-06T10:00:00Z","type":"session_meta","payload":{"id":"session-a"}}"#;
+    let meta_b = r#"{"timestamp":"2026-02-06T10:00:00Z","type":"session_meta","payload":{"id":"session-b"}}"#;
+    let initial = r#"{"timestamp":"2026-02-06T10:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"reasoning_output_tokens":10,"total_tokens":130},"last_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"reasoning_output_tokens":10,"total_tokens":130},"model":"gpt-5"}}}"#;
+    let second = r#"{"timestamp":"2026-02-06T10:01:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":220,"cached_input_tokens":40,"output_tokens":80,"reasoning_output_tokens":20,"total_tokens":300},"last_token_usage":{"input_tokens":120,"cached_input_tokens":20,"output_tokens":50,"reasoning_output_tokens":10,"total_tokens":160},"model":"gpt-5"}}}"#;
+    write_file(&session_a, &format!("{meta_a}\n{initial}\n{second}\n"));
+    write_file(&session_b, &format!("{meta_b}\n{initial}\n{second}\n"));
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "codex",
+            "daily",
+            "-j",
+            "-O",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("CODEX_HOME", &codex_home)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    let arr = json.as_array().expect("array output");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["total_tokens"].as_i64(), Some(600));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn source_flag_can_select_codex_without_subcommand() {
     let root = unique_temp_dir("source-flag-codex");
     let codex_home = root.join("codex-home");

--- a/tests/sdk_integration.rs
+++ b/tests/sdk_integration.rs
@@ -166,6 +166,61 @@ fn sdk_batch_summarizes_codex_ranges_like_repeated_single_calls() {
 }
 
 #[test]
+fn sdk_batch_deduplicates_replayed_codex_token_counts_across_files() {
+    let _guard = ENV_LOCK.lock().expect("env lock");
+    let root = tempfile::tempdir().expect("temp dir");
+    let codex_home = root.path().join("codex-home");
+    let replay_a = codex_home.join("sessions").join("replay-a.jsonl");
+    let replay_b = codex_home.join("sessions").join("replay-b.jsonl");
+    let parent_meta = r#"{"timestamp":"2026-02-06T10:00:00Z","type":"session_meta","payload":{"id":"parent-session"}}"#;
+    let fork_meta = r#"{"timestamp":"2026-02-06T10:00:00Z","type":"session_meta","payload":{"id":"forked-session"}}"#;
+    let replayed = r#"{"timestamp":"2026-02-06T10:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":220,"cached_input_tokens":40,"output_tokens":80,"reasoning_output_tokens":20,"total_tokens":300},"last_token_usage":{"input_tokens":120,"cached_input_tokens":20,"output_tokens":50,"reasoning_output_tokens":10,"total_tokens":160},"model":"gpt-5"}}}"#;
+    write_file(&replay_a, &format!("{parent_meta}\n{replayed}\n"));
+    write_file(
+        &replay_b,
+        &format!(
+            r#"{fork_meta}
+{parent_meta}
+{replayed}
+{{"timestamp":"2026-02-06T10:01:00Z","type":"event_msg","payload":{{"type":"token_count","info":{{"total_token_usage":{{"input_tokens":360,"cached_input_tokens":70,"output_tokens":140,"reasoning_output_tokens":40,"total_tokens":500}},"last_token_usage":{{"input_tokens":140,"cached_input_tokens":30,"output_tokens":60,"reasoning_output_tokens":20,"total_tokens":200}},"model":"gpt-5"}}}}}}
+"#
+        ),
+    );
+
+    let previous_codex_home = std::env::var_os("CODEX_HOME");
+    unsafe {
+        std::env::set_var("CODEX_HOME", &codex_home);
+    }
+
+    let batch = summarize_cost_ranges(MultiSummaryOptions {
+        source: UsageSource::Codex,
+        ranges: vec![UsageRange::DateRange {
+            since: Some(NaiveDate::from_ymd_opt(2026, 2, 6).unwrap()),
+            until: Some(NaiveDate::from_ymd_opt(2026, 2, 6).unwrap()),
+        }],
+        timezone: Some("UTC".to_string()),
+        offline: true,
+        strict_pricing: false,
+        currency: None,
+    })
+    .expect("summarize codex ranges");
+
+    match previous_codex_home {
+        Some(value) => unsafe {
+            std::env::set_var("CODEX_HOME", value);
+        },
+        None => unsafe {
+            std::env::remove_var("CODEX_HOME");
+        },
+    }
+
+    let summary = &batch.summaries[0];
+    assert_eq!(summary.valid_entries, 2);
+    assert_eq!(summary.skipped_entries, 1);
+    assert_eq!(summary.tokens.total_tokens, 370);
+}
+
+#[test]
 fn sdk_batch_respects_timezone_boundaries_like_single_range() {
     let _guard = ENV_LOCK.lock().expect("env lock");
     let root = tempfile::tempdir().expect("temp dir");


### PR DESCRIPTION
## Summary
- enable deduplication for Codex usage entries
- synthesize stable message IDs for Codex token_count events
- deduplicate replayed cumulative token_count events across session files while keeping identical initial usage scoped per session
- add CLI and SDK regressions for replayed Codex logs

Fixes #29

## Test Plan
- [x] cargo fmt -- --check
- [x] cargo check
- [x] cargo test
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [x] cargo run --quiet -- codex today --json --offline --timezone Asia/Shanghai --breakdown

## Local Smoke
Before this fix, the same local Codex dataset was observed at roughly 6.6B tokens / $4.8K for today. With this branch, the current smoke reports 1,341,498,189 tokens / $1000.44 after deduplicating replayed entries.