### PR TITLE
spec(GH36): Codex token delta completeness

### DIFF
--- a/specs/GH36/product.md
+++ b/specs/GH36/product.md
@@ -1,0 +1,48 @@
+# Product Spec
+
+## Linked Issue
+
+GH-36
+
+## 用户问题
+
+Codex `token_count` 事件可能缺失 `total_tokens`，但仍携带递增的 `input_tokens`、`cached_input_tokens`、`output_tokens` 或 `reasoning_output_tokens`。当前重复事件判定只比较 `total_tokens`，缺失时等价为 0，导致后续真实增量被静默跳过，daily/monthly 总量偏低。
+
+## 目标
+
+- Codex 重复事件判定基于完整 usage 向量，而不是单一 `total_tokens`。
+- 缺失 `total_tokens` 但分项 token 递增时必须计入增量。
+- 真正重复的 `token_count` 事件仍被跳过，避免重放日志双计。
+- 现有 `last_token_usage` 优先逻辑保持不变。
+
+## 非目标
+
+- 不改变跨文件重放去重机制（GH29/PR30）。
+- 不改变 OpenAI output/reasoning token 口径。
+- 不改变未知模型、成本计算或输出格式。
+
+## Behavior Invariants
+
+1. 两个连续 `token_count` 事件只有在完整累计 usage 向量等价时才可判为重复。
+2. 当 `total_tokens` 缺失或为 0，但任一分项累计 token 增长时，事件必须产生非零 delta。
+3. 当 `last_token_usage` 存在时，仍优先使用 `last_token_usage` 作为 delta。
+4. 当完整累计 usage 向量完全相同，事件继续被跳过且不改变输出。
+5. 现有跨 session/source-wide dedup 行为保持不变。
+
+## 验收标准
+
+- [ ] 缺失 `total_tokens`、分项递增的 Codex fixture 在 `daily --json` 中计入全部增量。
+- [ ] 完整 usage 向量相同的重复事件仍不会双计。
+- [ ] 现有 Codex reasoning/cache 口径测试继续通过。
+- [ ] debug/skipped 行为不引入新的静默降级。
+
+## 边界情况
+
+- `total_tokens` 缺失但 `last_token_usage` 存在。
+- `total_tokens` 为 0 但分项 token 非零。
+- 分项 token 缺失但 `total_tokens` 递增。
+- 所有字段缺失或为 0 的空 usage。
+
+## 发布说明
+
+修复 Codex 日志变体下的静默少计。受影响用户可能看到 Codex token/cost 统计上升到正确值。

--- a/specs/GH36/tasks.md
+++ b/specs/GH36/tasks.md
@@ -1,0 +1,32 @@
+# Task Plan
+
+## Linked Issue
+
+GH-36
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP36-T1` Owner: implementation. Done when: Codex duplicate detection compares the normalized cumulative usage vector instead of only `total_tokens`. Verify: parser unit tests for equal and differing vectors.
+- [ ] `SP36-T2` Owner: implementation. Done when: missing or zero `total_tokens` with growing component tokens produces a non-zero delta. Verify: focused parser test plus CLI integration fixture.
+- [ ] `SP36-T3` Owner: implementation. Done when: existing `last_token_usage` priority and source-wide replay dedup behavior are unchanged. Verify: existing Codex integration tests.
+- [ ] `SP36-T4` Owner: verification. Done when: deterministic Rust and SpecRail gates pass before PR readiness is claimed. Verify: `cargo check`, `cargo test`, `python3 checks/check_workflow.py --repo .`, and `python3 checks/check_workflow.py --repo . --spec-dir specs/GH36`.
+
+## 并行拆分
+
+- Parser semantics owns `src/source/codex/parser.rs`.
+- CLI regression owns `tests/cli_integration.rs` or a split Codex integration file if GH47 lands first.
+- Verification is coordinator-only.
+
+## 验证
+
+- [ ] `SP36-T5` Owner: verification. Done when: existing replay, cache, reasoning, and date-boundary Codex tests still pass. Verify: `cargo test codex`.
+- [ ] `SP36-T6` Owner: verification. Done when: no assertions are weakened. Verify: code review plus full `cargo test`.
+
+## Handoff Notes
+
+实现 PR 应 use closing keyword only when all acceptance criteria are met. 本 spec packet 本身不代表 `ready_to_implement`;仍需 maintainer spec approval。

--- a/specs/GH36/tech.md
+++ b/specs/GH36/tech.md
@@ -1,0 +1,63 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-36
+
+## Product Spec
+
+`specs/GH36/product.md`
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Codex parser | `src/source/codex/parser.rs` | `previous_totals` duplicate check compares only `total.total_tokens == prev.total_tokens`. | Primary bug surface. |
+| Usage model | `src/source/codex/parser.rs` | `TokenUsage` fields are optional; `UsageTotals::from_usage` converts missing fields to 0. | Needs complete-vector comparison after normalization. |
+| CLI fixtures | `tests/cli_integration.rs` | Existing Codex tests cover replay, reasoning, cache, and source-wide dedup. | Add regression without weakening existing assertions. |
+| Dedup core | `src/core/dedup.rs` | Handles source-wide message id dedup after parser emits entries. | Should remain unchanged. |
+
+## 设计方案
+
+1. Add an explicit helper on `UsageTotals` such as `is_duplicate_of(&self, prev: &Self) -> bool` that compares every cumulative field used for delta calculation.
+2. Replace the current `total_tokens`-only duplicate guard with that helper.
+3. Keep delta calculation unchanged: use `last_token_usage` when present, otherwise subtract previous cumulative totals.
+4. Add focused parser/unit tests for missing `total_tokens` with growing component fields.
+5. Add or update CLI integration fixture proving `ccstats codex daily --json` reports the full expected total.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1, P4 | `UsageTotals::is_duplicate_of` | Unit tests for equal and different vectors. |
+| P2 | `parse_codex_file_with_debug` | Fixture with missing `total_tokens` and growing components. |
+| P3 | last-token path | Regression with `last_token_usage` present. |
+| P5 | `dedup.rs` unchanged | Existing replay/source-wide tests. |
+
+## 数据流
+
+Codex JSONL line -> `TokenUsage` -> normalized `UsageTotals` -> complete-vector duplicate check -> delta selection -> `RawEntry` -> existing dedup/aggregation.
+
+## 备选方案
+
+- Compare raw optional `TokenUsage` directly: rejected because aliases and missing fields should normalize consistently before comparison.
+- Remove duplicate guard entirely: rejected because replayed identical cumulative events would double count.
+
+## 风险
+
+- Security: no new external input execution.
+- Compatibility: only fixes undercounting; expected totals may increase for affected logs.
+- Performance: comparing five integers per event is negligible.
+- Maintenance: helper centralizes duplicate semantics and makes future usage fields visible in tests.
+
+## 测试计划
+
+- [ ] Unit tests: equal usage vector, differing component with same `total_tokens`, missing `total_tokens`.
+- [ ] Integration tests: Codex JSONL missing `total_tokens` but growing components.
+- [ ] Regression: existing Codex replay/dedup/reasoning/cache tests.
+- [ ] `cargo check`
+- [ ] `cargo test`
+
+## 回滚方案
+
+Revert the helper and duplicate guard change. No data migration.


### PR DESCRIPTION
# Summary

为 #36 提交 SpecRail spec packet（product.md + tech.md + tasks.md），覆盖 Codex `token_count` 重复判定只比较 `total_tokens` 导致缺失字段时静默丢增量的问题。

## Linked Work

- Issue: #36
- Spec packet: `specs/GH36/`

## Readiness Gate

- [x] GitHub issue evidence confirms `triaged` label.
- [x] 本 PR 是 spec/task plan，无实现代码。
- [x] 不涉及安全敏感区域。

## Review Gate

- [x] `python3 checks/route_gate.py --repo . --route write_spec --issue 36 --evidence /tmp/ccstats-issue-36-evidence.json --json` => `allowed`.
- [x] `python3 checks/check_workflow.py --repo . --spec-dir specs/GH36` passed.
- [x] `python3 checks/check_workflow.py --repo .` passed.
- [ ] 请求 human spec review；`spec_approved` / `ready_to_implement` 仍是 maintainer gate。

## Verification

- [x] 纯文档/spec 变更，无代码测试影响。

## Agent Disclosure

- [x] Agent 起草，需 human review 后方可进入实现。