### PR TITLE
spec(GH37): single owner for day stat merging

### DIFF
--- a/specs/GH37/product.md
+++ b/specs/GH37/product.md
@@ -1,0 +1,47 @@
+# Product Spec
+
+## Linked Issue
+
+GH-37
+
+## 用户问题
+
+`merge_day_stats` 在 loader 与 app 两处一字不差重复。未来 `DayStats` 或 `Stats` 新增字段时，只改其中一处会导致某些命令静默漏合并，用户看到不同入口的 daily/all 统计不一致。
+
+## 目标
+
+- `merge_day_stats` 只有一个生产实现。
+- 现有 loader 与 all-source 聚合路径共用同一个 helper。
+- 现有合并语义与测试结果保持不变。
+
+## 非目标
+
+- 不重构 `LoadResult`、`DayStats` 或 `Stats` 数据结构。
+- 不改变 all-source 聚合输出。
+- 不拆分 loader/table/csv 大文件（GH47 单独处理）。
+
+## Behavior Invariants
+
+1. 相同日期的 `DayStats` 合并时，token、成本、计数和模型 map 按现有语义累加。
+2. 不同日期的记录都保留。
+3. 空 source 合并为 no-op。
+4. loader 与 app all-source 路径调用同一实现。
+5. 移动 helper 后现有公开 API 不新增兼容 shim。
+
+## 验收标准
+
+- [ ] `src/source/loader.rs` 和 `src/app.rs` 不再各自定义重复的 `merge_day_stats`。
+- [ ] 原 loader 合并测试迁移到单一 helper 所在模块或继续覆盖共享 helper。
+- [ ] all-source 聚合行为有至少一个回归测试或现有测试证明不变。
+- [ ] `cargo test` 全部通过。
+
+## 边界情况
+
+- source map 为空。
+- target 中不存在 source 日期。
+- target/source 有相同日期但模型集合不重叠。
+- target/source 有相同日期且模型名相同。
+
+## 发布说明
+
+内部维护性修复，无用户可见行为变化。

--- a/specs/GH37/tasks.md
+++ b/specs/GH37/tasks.md
@@ -1,0 +1,31 @@
+# Task Plan
+
+## Linked Issue
+
+GH-37
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP37-T1` Owner: implementation. Done when: `merge_day_stats` lives in one shared core module and both loader/app callers use it. Verify: `rg "fn merge_day_stats" src` shows one definition.
+- [ ] `SP37-T2` Owner: implementation. Done when: existing merge behavior tests cover the shared helper owner. Verify: `cargo test merge_day_stats`.
+- [ ] `SP37-T3` Owner: implementation. Done when: no compatibility wrappers or duplicate helper bodies remain. Verify: code review and `rg "merge_day_stats" src/source/loader.rs src/app.rs src/core`.
+- [ ] `SP37-T4` Owner: verification. Done when: deterministic Rust and SpecRail gates pass before PR readiness is claimed. Verify: `cargo check`, `cargo test`, `python3 checks/check_workflow.py --repo .`, and `python3 checks/check_workflow.py --repo . --spec-dir specs/GH37`.
+
+## 并行拆分
+
+- Shared helper move owns `src/core/aggregator.rs`, `src/source/loader.rs`, and `src/app.rs`.
+- Test migration owns the helper unit tests in the chosen owner module.
+- Verification is coordinator-only.
+
+## 验证
+
+- [ ] `SP37-T5` Owner: verification. Done when: all-source aggregation still compiles and existing CLI integration tests pass. Verify: `cargo test`.
+
+## Handoff Notes
+
+这是可作为 `exception_allowed` 的小型维护修复，但本 PR 仅提交 spec packet。实现 PR 可保持很小并关闭 #37。

--- a/specs/GH37/tech.md
+++ b/specs/GH37/tech.md
@@ -1,0 +1,60 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-37
+
+## Product Spec
+
+`specs/GH37/product.md`
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Loader helper | `src/source/loader.rs` | Private `DataLoader::merge_day_stats` plus tests. | Existing tested implementation to preserve. |
+| All-source aggregation | `src/app.rs` | Local free function duplicates loader helper and has no direct tests. | Duplicate risk. |
+| Shared core | `src/core/aggregator.rs` | Existing aggregation module for shared logic. | Natural owner for shared helper. |
+| Tests | `src/source/loader.rs`, `tests/cli_integration.rs` | Helper tests currently live near loader. | Need migrate or call shared helper. |
+
+## 设计方案
+
+1. Move the helper implementation to `src/core/aggregator.rs` as `pub(crate) fn merge_day_stats(...)`.
+2. Update loader and app all-source aggregation to call the shared helper.
+3. Move existing helper unit tests to the helper owner module, or keep tests in loader only if they call the shared function directly.
+4. Remove both duplicate definitions; do not leave compatibility wrappers.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1-P3 | `core/aggregator.rs` | Unit tests ported from loader. |
+| P4 | `src/source/loader.rs`, `src/app.rs` | Compile check plus focused test/all-source regression. |
+| P5 | duplicate removal | `rg "fn merge_day_stats" src` shows one definition. |
+
+## 数据流
+
+No runtime data flow changes. Existing callers pass `HashMap<String, DayStats>` into a shared helper and receive the same merged map effects.
+
+## 备选方案
+
+- Keep loader helper and expose it through `DataLoader`: rejected because app should not depend on source loader internals.
+- Copy tests only and leave duplicate code: rejected because it preserves the maintenance hazard.
+
+## 风险
+
+- Security: no external input handling changes.
+- Compatibility: no user-visible behavior change.
+- Performance: unchanged.
+- Maintenance: lower risk after single owner.
+
+## 测试计划
+
+- [ ] Unit tests for disjoint dates, overlapping dates, model preservation, empty source.
+- [ ] `rg "fn merge_day_stats" src` confirms one definition.
+- [ ] `cargo check`
+- [ ] `cargo test`
+
+## 回滚方案
+
+Revert the helper move and caller updates. No data migration.


### PR DESCRIPTION
# Summary

为 #37 提交 SpecRail spec packet（product.md + tech.md + tasks.md），收敛重复的 `merge_day_stats` 实现，避免后续 `DayStats`/`Stats` 字段扩展时出现静默不一致。

## Linked Work

- Issue: #37
- Spec packet: `specs/GH37/`

## Readiness Gate

- [x] GitHub issue evidence confirms `triaged` label.
- [x] 本 PR 是 spec/task plan，无实现代码。
- [x] 不涉及安全敏感区域。

## Review Gate

- [x] `route_gate` write_spec => `allowed`.
- [x] `python3 checks/check_workflow.py --repo . --spec-dir specs/GH37` passed.
- [x] `python3 checks/check_workflow.py --repo .` passed.
- [ ] 请求 human spec review；`spec_approved` / `ready_to_implement` 仍是 maintainer gate。

## Verification

- [x] 纯文档/spec 变更，无代码测试影响。

## Agent Disclosure

- [x] Agent 起草，需 human review 后方可进入实现。