### PR TITLE
spec(GH39): normalize token boundaries across sources

### DIFF
--- a/specs/GH39/product.md
+++ b/specs/GH39/product.md
@@ -1,0 +1,47 @@
+# Product Spec
+
+## Linked Issue
+
+GH-39
+
+## 用户问题
+
+Claude 与 Cursor 解析器会接受负 token 值，导致 daily/monthly 总量被静默拉低，甚至出现负成本。Codex 与 Grok 已经对负值做 `.max(0)` 处理，四源行为不一致，用户无法信任跨源聚合结果。
+
+## 目标
+
+- 所有源都禁止负 token 进入 `RawEntry` 和聚合层。
+- Claude/Cursor 与 Codex/Grok 的边界行为保持一致。
+- 负值处理可测试、可审查，不依赖输出层补救。
+
+## 非目标
+
+- 不改变正常正数 token 的解析结果。
+- 不改变未知模型或定价 fallback。
+- 不新增 schema 兼容层或历史数据迁移。
+
+## Behavior Invariants
+
+1. 任一源解析出的 `input_tokens`、`output_tokens`、`cache_creation`、`cache_read`、`reasoning` 都不得为负。
+2. Claude 记录中的负 usage 字段按与 Codex/Grok 一致的策略钳制为 0。
+3. Cursor 两张表解析出的负 token 字段按同一策略钳制为 0；仅有负 token 且没有正 token 的记录不应产生有效用量。
+4. 正常正值、缺失字段和现有 0 值行为保持不变。
+5. all-source 聚合不得因为单源负值出现负 total/cost。
+
+## 验收标准
+
+- [ ] Claude parser 单测覆盖负 input/output/cache 字段。
+- [ ] Cursor parser 单测覆盖 bubble 与 generation 两路负 token 字段。
+- [ ] Codex/Grok 既有负值钳制测试或新增一致性断言通过。
+- [ ] CLI/integration 层证明负值不会进入 JSON 输出总量。
+
+## 边界情况
+
+- `{input_tokens: -100, output_tokens: 50}` -> input 0、output 50。
+- `{input_tokens: -100, output_tokens: -50}` -> 不产生正用量或产生全 0 后被现有空记录逻辑过滤。
+- cache token 为负。
+- 字段缺失与字段为负同时出现。
+
+## 发布说明
+
+修复异常日志中的静默少计/负成本。正常日志输出不变。

--- a/specs/GH39/tasks.md
+++ b/specs/GH39/tasks.md
@@ -1,0 +1,31 @@
+# Task Plan
+
+## Linked Issue
+
+GH-39
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP39-T1` Owner: implementation. Done when: Claude parser clamps negative usage fields before constructing `RawEntry`. Verify: `cargo test claude`.
+- [ ] `SP39-T2` Owner: implementation. Done when: Cursor bubble and generation parse paths clamp negative token fields and all-negative records do not produce meaningful usage. Verify: `cargo test cursor`.
+- [ ] `SP39-T3` Owner: implementation. Done when: no negative token can reach aggregate JSON output from malformed Claude/Cursor fixtures. Verify: focused CLI integration test if unit tests do not cover output boundary.
+- [ ] `SP39-T4` Owner: verification. Done when: deterministic Rust and SpecRail gates pass before PR readiness is claimed. Verify: `cargo check`, `cargo test`, `python3 checks/check_workflow.py --repo .`, and `python3 checks/check_workflow.py --repo . --spec-dir specs/GH39`.
+
+## 并行拆分
+
+- Claude parser work owns `src/source/claude/parser.rs`.
+- Cursor parser work owns `src/source/cursor/parser.rs`.
+- Integration verification owns test fixtures only.
+
+## 验证
+
+- [ ] `SP39-T5` Owner: verification. Done when: positive and missing-field parser tests remain unchanged. Verify: existing parser test suite.
+
+## Handoff Notes
+
+实现应遵循现有 Codex/Grok `.max(0)` 先例。不要在输出层隐藏负值；负值必须在 parser boundary 处理。

--- a/specs/GH39/tech.md
+++ b/specs/GH39/tech.md
@@ -1,0 +1,63 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-39
+
+## Product Spec
+
+`specs/GH39/product.md`
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Claude parser | `src/source/claude/parser.rs` | `usage.input_tokens.unwrap_or(0)` and related fields preserve negative values. | Primary bug surface. |
+| Cursor parser | `src/source/cursor/parser.rs` | Accepts a record if input or output is positive; negative counterpart can remain negative. | Primary bug surface. |
+| Codex/Grok parsers | `src/source/codex/parser.rs`, `src/source/grok/parser.rs` | Existing logic clamps deltas/signals with `.max(0)`. | Consistency reference. |
+| Aggregation/cost | `src/core`, `src/pricing` | Assumes token counts are non-negative. | Should not need defensive fixes if parsers normalize. |
+
+## 设计方案
+
+1. Add a small parser-local helper or shared utility for token normalization only if it removes duplication; otherwise use explicit `.max(0)` at each parse boundary.
+2. Apply normalization in Claude `parse_entry` before constructing `RawEntry`.
+3. Apply normalization in Cursor bubble and generation parse paths before filtering/constructing `RawEntry`.
+4. Ensure Cursor's "has any usage" filter runs after normalization so all-negative records do not survive as meaningful usage.
+5. Add targeted unit tests in parser modules and one integration regression if needed.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1, P2 | `claude/parser.rs` | Unit tests for negative usage fields. |
+| P1, P3 | `cursor/parser.rs` | Unit tests for both table parse paths. |
+| P4 | parser modules | Existing positive/missing field tests unchanged. |
+| P5 | CLI aggregation | Integration regression or existing tests with new fixture. |
+
+## 数据流
+
+Raw source record -> parser field extraction -> non-negative normalization -> `RawEntry` -> existing dedup/aggregation/cost. No persistence changes.
+
+## 备选方案
+
+- Clamp in aggregation layer: rejected because invalid parser output would still leak into session/model-level views before aggregation.
+- Reject entire record on any negative field: stricter but can discard valid positive counterpart fields; current project precedent is clamp-to-zero.
+
+## 风险
+
+- Security: no new external input execution.
+- Compatibility: malformed logs with negative values now report non-negative totals; normal logs unaffected.
+- Performance: negligible.
+- Maintenance: keep normalization close to source schema parsing.
+
+## 测试计划
+
+- [ ] Claude parser unit tests for negative input/output/cache fields.
+- [ ] Cursor parser unit tests for bubble and generation records with mixed positive/negative values.
+- [ ] Existing Codex/Grok tests continue to pass.
+- [ ] `cargo check`
+- [ ] `cargo test`
+
+## 回滚方案
+
+Revert parser normalization and tests. No data migration.


### PR DESCRIPTION
# Summary

为 #39 提交 SpecRail spec packet（product.md + tech.md + tasks.md），统一 Claude/Cursor/Codex/Grok 的负 token 边界处理，防止负值进入聚合与成本。

## Linked Work

- Issue: #39
- Spec packet: `specs/GH39/`

## Readiness Gate

- [x] GitHub issue evidence confirms `triaged` label.
- [x] 本 PR 是 spec/task plan，无实现代码。
- [x] 不涉及安全敏感区域。

## Review Gate

- [x] `route_gate` write_spec => `allowed`.
- [x] `python3 checks/check_workflow.py --repo . --spec-dir specs/GH39` passed.
- [x] `python3 checks/check_workflow.py --repo .` passed.
- [ ] 请求 human spec review；`spec_approved` / `ready_to_implement` 仍是 maintainer gate。

## Verification

- [x] 纯文档/spec 变更，无代码测试影响。

## Agent Disclosure

- [x] Agent 起草，需 human review 后方可进入实现。