### PR TITLE
spec(GH40): expose parse quality metadata

### DIFF
--- a/specs/GH40/product.md
+++ b/specs/GH40/product.md
@@ -1,0 +1,49 @@
+# Product Spec
+
+## Linked Issue
+
+GH-40
+
+## 用户问题
+
+解析失败或被丢弃的记录只在非 quiet 模式写 stderr，JSON/CSV/statusline 等结构化消费者完全看不到数据是否不完整。增量加载路径还硬编码 `skipped: 0`，让 debug 和 summary metadata 误导用户。
+
+## 目标
+
+- 结构化输出携带本次加载的数据质量 metadata。
+- 区分 malformed/parse error count 与 dedup skipped count。
+- 增量路径不再硬编码 skipped 为 0；无法准确统计时必须显式建模，而不是静默假值。
+- 现有表格 stderr warning 可保留，但不能作为唯一信号。
+
+## 非目标
+
+- 不改变 parser 对 malformed 行的容错策略。
+- 不要求把每条错误明细输出到 JSON。
+- 不依赖 GH38 OutputFormat 重构；若 GH38 先合并，可复用其输出注入点。
+
+## Behavior Invariants
+
+1. JSON 输出包含可机器读取的 parse/malformed count 与 dedup skipped count。
+2. CSV 输出携带同等 metadata，形态需兼容现有列消费（注释行或明确 metadata 行）。
+3. statusline JSON 变体保留数据质量字段；普通单行 statusline 不被破坏。
+4. quiet 模式不再意味着结构化 metadata 丢失。
+5. 增量路径只有在实际 skipped 为 0 时才报告 0；否则报告真实值或显式 unknown/unsupported 状态。
+
+## 验收标准
+
+- [ ] malformed jsonl fixture 在 `daily --json` 中显示 parse error count。
+- [ ] dedup fixture 在结构化输出中显示 skipped count。
+- [ ] 增量路径 debug/metadata 不再硬编码假 0。
+- [ ] quiet/statusline JSON 路径保留 metadata。
+- [ ] 现有 stderr warning 测试继续通过或按新 metadata 增补。
+
+## 边界情况
+
+- malformed 行很多但有效行也存在。
+- 全部行 malformed。
+- source 不需要 dedup。
+- all-source 聚合多个源时 metadata 累加。
+
+## 发布说明
+
+JSON/CSV/statusline JSON 新增数据质量字段，向后兼容；可帮助管道消费者识别不完整统计。

--- a/specs/GH40/tasks.md
+++ b/specs/GH40/tasks.md
@@ -1,0 +1,33 @@
+# Task Plan
+
+## Linked Issue
+
+GH-40
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP40-T1` Owner: implementation. Done when: load metadata distinguishes `valid`, `dedup_skipped`, and `parse_errors`. Verify: loader unit tests.
+- [ ] `SP40-T2` Owner: implementation. Done when: incremental path no longer reports fake skipped 0 and uses true skipped count or explicit unavailable state. Verify: focused incremental loader test.
+- [ ] `SP40-T3` Owner: implementation. Done when: JSON/CSV/statusline JSON expose data-quality metadata without removing existing fields. Verify: CLI integration tests.
+- [ ] `SP40-T4` Owner: implementation. Done when: all-source aggregation sums metadata across sources. Verify: mixed-source fixture test.
+- [ ] `SP40-T5` Owner: verification. Done when: deterministic Rust and SpecRail gates pass before PR readiness is claimed. Verify: `cargo check`, `cargo test`, `python3 checks/check_workflow.py --repo .`, and `python3 checks/check_workflow.py --repo . --spec-dir specs/GH40`.
+
+## 并行拆分
+
+- Loader metadata owns `src/source/mod.rs` and `src/source/loader.rs`.
+- Output metadata owns `src/output/{json,csv,statusline}.rs` and app call sites.
+- All-source aggregation owns `src/app.rs`.
+- Verification is coordinator-only.
+
+## 验证
+
+- [ ] `SP40-T6` Owner: verification. Done when: existing malformed stderr warning test still passes or is explicitly expanded. Verify: `cargo test malformed`.
+
+## Handoff Notes
+
+若 GH33 或 GH38 先合并，优先复用它们的 metadata/output context rather than adding another parallel metadata path.

--- a/specs/GH40/tech.md
+++ b/specs/GH40/tech.md
@@ -1,0 +1,65 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-40
+
+## Product Spec
+
+`specs/GH40/product.md`
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Parser output | `src/source/mod.rs` | `ParseOutput` has `errors`; `LoadResult` has `skipped`/`valid`. | Data exists but is not fully surfaced. |
+| Loader | `src/source/loader.rs` | Non-incremental path prints malformed warnings; incremental path hardcodes skipped 0. | Primary behavior gap. |
+| App summary | `src/app.rs`, `src/output/table.rs` | Summary footer uses `LoadResult.skipped`/`valid`. | Table footer already has partial data. |
+| Structured output | `src/output/json.rs`, `src/output/csv.rs`, `src/output/statusline.rs` | Outputs mostly data rows, not data-quality metadata. | Need metadata injection. |
+
+## 设计方案
+
+1. Extend `LoadResult` or add a nested metadata struct to carry `valid`, `dedup_skipped`, and `parse_errors` explicitly.
+2. Accumulate `parse_errors` from every source and all-source path.
+3. Fix incremental loading to return real skipped/dedup information if it dedups, or explicitly mark skipped count unavailable if the path cannot calculate it. Prefer computing true skipped count by reusing the same dedup finalization result.
+4. Add JSON metadata field at the least disruptive top-level location used by daily/monthly/session outputs.
+5. Add CSV metadata as comment/header metadata if current parser expectations allow it; otherwise document and test a dedicated metadata row.
+6. Preserve table stderr warning while ensuring structured metadata is authoritative.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 | JSON output | malformed fixture assertion. |
+| P2 | CSV output | metadata assertion without changing data columns. |
+| P3 | statusline JSON | statusline JSON test. |
+| P4 | quiet mode | quiet structured output test. |
+| P5 | loader incremental path | loader unit test for skipped accounting. |
+
+## 数据流
+
+Parser returns entries + parse errors -> loader filters/dedups and builds `LoadResult` metadata -> app all-source aggregation sums metadata -> output layer renders metadata alongside rows.
+
+## 备选方案
+
+- Keep stderr-only warnings: rejected because statusline/JSON consumers remain blind.
+- Add a single `skipped` field for all causes: rejected because malformed parse errors and dedup skips mean different things.
+
+## 风险
+
+- Security: no new external input execution.
+- Compatibility: JSON/CSV add metadata; strict consumers may need to ignore new fields/comments.
+- Performance: negligible.
+- Maintenance: overlaps with GH33/GH38 output metadata work; implementation should share helpers if those land first.
+
+## 测试计划
+
+- [ ] Loader/unit tests for parse error and dedup skipped accounting.
+- [ ] CLI integration tests for JSON, CSV, statusline JSON, quiet mode.
+- [ ] All-source aggregation metadata test.
+- [ ] `cargo check`
+- [ ] `cargo test`
+
+## 回滚方案
+
+Revert metadata plumbing and output fields. No data migration.


### PR DESCRIPTION
# Summary

为 #40 提交 SpecRail spec packet（product.md + tech.md + tasks.md），让 parse errors / dedup skipped counts 进入结构化输出，并修复增量路径硬编码 skipped=0 的设计。

## Linked Work

- Issue: #40
- Spec packet: `specs/GH40/`

## Readiness Gate

- [x] GitHub issue evidence confirms `triaged` label.
- [x] 本 PR 是 spec/task plan，无实现代码。
- [x] 不涉及安全敏感区域。

## Review Gate

- [x] `route_gate` write_spec => `allowed`.
- [x] `python3 checks/check_workflow.py --repo . --spec-dir specs/GH40` passed.
- [x] `python3 checks/check_workflow.py --repo .` passed.
- [ ] 请求 human spec review；`spec_approved` / `ready_to_implement` 仍是 maintainer gate。

## Verification

- [x] 纯文档/spec 变更，无代码测试影响。

## Agent Disclosure

- [x] Agent 起草，需 human review 后方可进入实现。