### PR TITLE
spec(GH41): cursor source integrity

### DIFF
--- a/specs/GH41/product.md
+++ b/specs/GH41/product.md
@@ -1,0 +1,48 @@
+# Product Spec
+
+## Linked Issue
+
+GH-41
+
+## 用户问题
+
+Cursor 源当前同时读取 `cursorDiskKV` 与 `ItemTable`，但没有证明两表记录不会描述同一轮对话；若重叠会双计。只读 SQLite 连接也没有 `busy_timeout`，Cursor 正在写入时可能让整库读取失败。解析器还提取 `project_path`，但能力位声明 `has_projects: false`，用户永远无法通过 project 命令使用该信息。
+
+## 目标
+
+- Cursor 双表读取的去重/不重叠语义有证据或代码约束。
+- SQLite 忙碌时给只读解析一个合理等待窗口，减少整库丢失。
+- `project_path` 与 source capabilities 一致：要么可用，要么不再提取/承诺。
+
+## 非目标
+
+- 不把 Cursor 源从 experimental 改为稳定。
+- 不引入写数据库或迁移 Cursor 数据。
+- 不改变 Claude/Codex/Grok 源行为。
+
+## Behavior Invariants
+
+1. 若实证确认两表可能重叠，同一 Cursor 交互不得在一次统计中计两次。
+2. 若实证确认两表不重叠，代码注释/测试必须记录不变量，避免未来误改。
+3. 只读打开 Cursor DB 后应设置 `busy_timeout`，短暂写锁不应立即导致整库记录丢失。
+4. Cursor `project_path` 的解析结果不得处于不可达状态。
+5. Cursor 解析错误仍计入 errors，不被静默吞掉。
+
+## 验收标准
+
+- [ ] 有双表重叠调查记录或可复现 fixture。
+- [ ] `busy_timeout` 行为有测试或最小可验证实现。
+- [ ] `has_projects` 与 `project_path` 输出/解析策略一致。
+- [ ] Cursor 现有测试继续通过。
+
+## 边界情况
+
+- 只有 `cursorDiskKV` 表存在。
+- 只有 `ItemTable` 表存在。
+- 两表都有相同或近似 token/timestamp 记录。
+- DB 被短暂锁住。
+- workspace/project path 缺失。
+
+## 发布说明
+
+Cursor 源仍为 experimental；本变更提升统计完整性与可解释性。

--- a/specs/GH41/tasks.md
+++ b/specs/GH41/tasks.md
@@ -1,0 +1,33 @@
+# Task Plan
+
+## Linked Issue
+
+GH-41
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP41-T1` Owner: investigation. Done when: PR records whether `cursorDiskKV` and `ItemTable` can overlap, without committing private Cursor DB data. Verify: documented query/fixture and maintainer-reviewable conclusion.
+- [ ] `SP41-T2` Owner: implementation. Done when: overlap conclusion is encoded as either dedup behavior or a tested non-overlap invariant. Verify: Cursor parser tests.
+- [ ] `SP41-T3` Owner: implementation. Done when: readonly Cursor DB connections set a conservative `busy_timeout`. Verify: focused parser/open test or code-level assertion.
+- [ ] `SP41-T4` Owner: implementation. Done when: `project_path` and `has_projects` are consistent. Verify: CLI project test if enabled, or parser test proving no dead field is exposed.
+- [ ] `SP41-T5` Owner: verification. Done when: deterministic Rust and SpecRail gates pass before PR readiness is claimed. Verify: `cargo check`, `cargo test`, `python3 checks/check_workflow.py --repo .`, and `python3 checks/check_workflow.py --repo . --spec-dir specs/GH41`.
+
+## 并行拆分
+
+- Investigation is read-only and owns no production files.
+- Cursor parser work owns `src/source/cursor/parser.rs`.
+- Capability work owns `src/source/cursor/config.rs` and output/project tests.
+- Verification is coordinator-only.
+
+## 验证
+
+- [ ] `SP41-T6` Owner: verification. Done when: basic Cursor source tests still pass and no new double-count risk is introduced. Verify: `cargo test cursor`.
+
+## Handoff Notes
+
+不要在没有 `SP41-T1` 证据的情况下直接选择双表 dedup 策略。Cursor 源仍保持 experimental。

--- a/specs/GH41/tech.md
+++ b/specs/GH41/tech.md
@@ -1,0 +1,66 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-41
+
+## Product Spec
+
+`specs/GH41/product.md`
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Cursor DB open | `src/source/cursor/parser.rs` | `Connection::open_with_flags` without `busy_timeout`. | Lock handling gap. |
+| `cursorDiskKV` parser | `src/source/cursor/parser.rs` | Parses bubbles with ids from keys. | Potential overlap source. |
+| `ItemTable` parser | `src/source/cursor/parser.rs` | Parses `aiService.generations` with `generationUUID`. | Potential overlap source. |
+| Capabilities | `src/source/cursor/config.rs` | `has_projects: false`, `needs_dedup: false`. | Inconsistent with parsed `project_path`. |
+| Tests | `tests/cli_integration.rs`, parser tests | Cursor fixture currently covers basic parse. | Need targeted coverage. |
+
+## 设计方案
+
+1. Add an investigation step that samples real Cursor DB rows or builds fixtures showing whether both tables can represent the same interaction. Do not commit private DB data.
+2. If overlap is possible, introduce a Cursor-specific dedup key derived from stable id when possible, otherwise timestamp/model/token tuple with documented collision risk, and set `needs_dedup` appropriately.
+3. If overlap is not possible, add comments/tests documenting the table ownership invariant and leave `needs_dedup` false.
+4. Set a conservative `busy_timeout` immediately after opening a readonly connection.
+5. Resolve `project_path`: either enable `has_projects` with tested project output, or stop extracting it and document Cursor projects as unsupported until a real product requirement exists.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1/P2 | Cursor table parsing/dedup | Investigation artifact plus fixture tests. |
+| P3 | `open_readonly` | Unit/integration test or code-level assertion around timeout setup. |
+| P4 | `CursorSource::capabilities` and parser | CLI project test or removal test. |
+| P5 | parser error path | Existing errors tests plus new lock/parse regression. |
+
+## 数据流
+
+Cursor DB -> readonly connection with timeout -> table existence checks -> per-table parse -> optional dedup/merge -> `ParseOutput { entries, errors }` -> existing loader.
+
+## 备选方案
+
+- Disable one table unconditionally: rejected until evidence identifies the authoritative source.
+- Mark `needs_dedup: true` without stable keys: rejected because it may hide valid records.
+- Leave project_path dead: rejected because it keeps a misleading internal contract.
+
+## 风险
+
+- Security: read-only DB access remains read-only.
+- Compatibility: project output may become newly available or dead field removed; document in changelog if user-visible.
+- Performance: busy_timeout can add bounded wait under lock.
+- Maintenance: investigation evidence is required before choosing dedup behavior.
+
+## 测试计划
+
+- [ ] Cursor parser unit tests for both table paths.
+- [ ] Fixture for overlapping or documented non-overlap behavior.
+- [ ] Busy timeout setup test where practical.
+- [ ] CLI project/source capability test if enabling projects.
+- [ ] `cargo check`
+- [ ] `cargo test`
+
+## 回滚方案
+
+Revert Cursor parser/capability changes. No data migration.


### PR DESCRIPTION
# Summary

为 #41 提交 SpecRail spec packet（product.md + tech.md + tasks.md），覆盖 Cursor 双表重叠风险、SQLite `busy_timeout`、以及 `project_path`/capability 不一致。

## Linked Work

- Issue: #41
- Spec packet: `specs/GH41/`

## Readiness Gate

- [x] GitHub issue evidence confirms `triaged` label.
- [x] 本 PR 是 spec/task plan，无实现代码。
- [x] 不涉及安全敏感区域。

## Review Gate

- [x] `route_gate` write_spec => `allowed`.
- [x] `python3 checks/check_workflow.py --repo . --spec-dir specs/GH41` passed.
- [x] `python3 checks/check_workflow.py --repo .` passed.
- [ ] 请求 human spec review；`spec_approved` / `ready_to_implement` 仍是 maintainer gate。

## Verification

- [x] 纯文档/spec 变更，无代码测试影响。

## Agent Disclosure

- [x] Agent 起草，需 human review 后方可进入实现。