### PR TITLE
spec(GH42): support Claude config directory override

### DIFF
--- a/specs/GH42/product.md
+++ b/specs/GH42/product.md
@@ -1,0 +1,47 @@
+# Product Spec
+
+## Linked Issue
+
+GH-42
+
+## 用户问题
+
+Claude Code 支持通过 `CLAUDE_CONFIG_DIR` 迁移配置目录，但 ccstats Claude 源只扫描 `~/.claude/projects`。迁移过配置目录的用户会看到 Claude 用量为 0，且没有 CLI 或环境变量方式指向真实目录。
+
+## 目标
+
+- Claude 源优先尊重 `CLAUDE_CONFIG_DIR`。
+- 默认行为仍扫描 `~/.claude/projects`。
+- 文档说明 Claude/Codex/Cursor/Grok 的环境变量覆盖方式。
+
+## 非目标
+
+- 不新增 ccstats 自有 Claude 专用变量。
+- 不改变 Claude JSONL 解析、去重或过滤规则。
+- 不改变其他源 env override 行为。
+
+## Behavior Invariants
+
+1. `CLAUDE_CONFIG_DIR=/path/to/claude-config` 时，Claude 源扫描 `/path/to/claude-config/projects/**/*.jsonl`。
+2. 未设置 `CLAUDE_CONFIG_DIR` 时，行为保持 `~/.claude/projects/**/*.jsonl`。
+3. 空字符串或无效路径不应 panic；应按既有“无文件”行为返回空结果。
+4. README/docs 记录 `CLAUDE_CONFIG_DIR` 与现有 `CODEX_HOME`、`CURSOR_HOME`、`GROK_HOME`。
+5. tools/tool-call 路径若依赖 Claude 文件发现，应复用同一配置目录逻辑。
+
+## 验收标准
+
+- [ ] 集成测试证明 `CLAUDE_CONFIG_DIR` 下的 Claude JSONL 被读取。
+- [ ] 默认 `HOME/.claude/projects` 测试继续通过。
+- [ ] README 至少记录 `CLAUDE_CONFIG_DIR` 和 `CODEX_HOME`。
+- [ ] 若 GH45 先合并，tool-call discovery 同样尊重该 helper。
+
+## 边界情况
+
+- env var 指向不存在目录。
+- env var 指向相对路径。
+- env var 路径末尾带斜杠。
+- `HOME` 和 `CLAUDE_CONFIG_DIR` 同时设置。
+
+## 发布说明
+
+新增 Claude 配置目录环境变量支持，迁移配置目录的用户可直接统计 Claude 数据。

--- a/specs/GH42/tasks.md
+++ b/specs/GH42/tasks.md
@@ -1,0 +1,32 @@
+# Task Plan
+
+## Linked Issue
+
+GH-42
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP42-T1` Owner: implementation. Done when: Claude file discovery uses `CLAUDE_CONFIG_DIR` as config root before falling back to `$HOME/.claude`. Verify: integration test with temp config dir.
+- [ ] `SP42-T2` Owner: implementation. Done when: default Claude path behavior remains unchanged. Verify: existing Claude tests.
+- [ ] `SP42-T3` Owner: docs. Done when: README/docs document `CLAUDE_CONFIG_DIR` and `CODEX_HOME` alongside existing source env vars. Verify: docs diff review.
+- [ ] `SP42-T4` Owner: compatibility. Done when: if GH45 is present, tool-call discovery reuses the same helper. Verify: tools/Claude test or code review.
+- [ ] `SP42-T5` Owner: verification. Done when: deterministic Rust and SpecRail gates pass before PR readiness is claimed. Verify: `cargo check`, `cargo test`, `python3 checks/check_workflow.py --repo .`, and `python3 checks/check_workflow.py --repo . --spec-dir specs/GH42`.
+
+## 并行拆分
+
+- Claude discovery owns `src/source/claude/parser.rs` and Claude tests.
+- Docs owns `README.md` and relevant docs files.
+- GH45 compatibility is conditional and must avoid conflicting edits if GH45 lands first.
+
+## 验证
+
+- [ ] `SP42-T6` Owner: verification. Done when: nonexistent `CLAUDE_CONFIG_DIR` does not panic. Verify: focused test or manual no-data command.
+
+## Handoff Notes
+
+实现应 use Claude Code's existing variable name exactly: `CLAUDE_CONFIG_DIR`.

--- a/specs/GH42/tech.md
+++ b/specs/GH42/tech.md
@@ -1,0 +1,67 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-42
+
+## Product Spec
+
+`specs/GH42/product.md`
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Claude file discovery | `src/source/claude/parser.rs` | Builds `home.join(".claude").join("projects")`. | Primary change surface. |
+| Claude source | `src/source/claude/config.rs` | Calls `find_claude_files()`. | Should consume shared helper. |
+| Other env overrides | `src/source/codex/parser.rs`, `cursor/parser.rs`, `grok/parser.rs` | Support `CODEX_HOME`, `CURSOR_HOME`, `GROK_HOME`. | Consistency reference. |
+| Docs | `README.md`, `docs/algorithm/authoritative-token-accounting.md` | README lists Cursor/Grok env override but not Claude/Codex consistently. | Documentation gap. |
+
+## 设计方案
+
+1. Add `CLAUDE_CONFIG_DIR` constant and helper returning the Claude config root:
+   - env var when present
+   - otherwise `$HOME/.claude`
+2. Build project glob from `claude_config_root().join("projects")`.
+3. Keep path handling non-panicking; invalid/missing dirs simply yield no files, matching current behavior.
+4. Add integration test with temp `CLAUDE_CONFIG_DIR` and no `HOME/.claude` data.
+5. Update README/docs env override matrix.
+6. If GH45 lands first, wire tool-call file discovery through the same helper.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 | `find_claude_files` | Integration test with `CLAUDE_CONFIG_DIR`. |
+| P2 | default path | Existing Claude tests. |
+| P3 | missing path | Unit/integration no-data test. |
+| P4 | docs | README/docs diff review. |
+| P5 | tool discovery | GH45 compatibility test if applicable. |
+
+## 数据流
+
+Environment -> Claude config root helper -> `projects/**/*.jsonl` glob -> existing parser/loader. No persistence changes.
+
+## 备选方案
+
+- Add `CLAUDE_HOME`: rejected because Claude Code already defines `CLAUDE_CONFIG_DIR`.
+- Add CLI flag: rejected as unnecessary until a broader source path override design exists.
+
+## 风险
+
+- Security: env var only influences local file discovery; no command execution.
+- Compatibility: default path unchanged.
+- Performance: unchanged.
+- Maintenance: central helper prevents future tool-call path divergence.
+
+## 测试计划
+
+- [ ] Integration test for `CLAUDE_CONFIG_DIR`.
+- [ ] Existing Claude default path tests.
+- [ ] Docs check/review.
+- [ ] `cargo check`
+- [ ] `cargo test`
+
+## 回滚方案
+
+Revert helper, docs, and tests. Default `~/.claude` behavior remains available.


### PR DESCRIPTION
# Summary

为 #42 提交 SpecRail spec packet（product.md + tech.md + tasks.md），要求 Claude 源支持 `CLAUDE_CONFIG_DIR` 并补齐环境变量覆盖文档。

## Linked Work

- Issue: #42
- Spec packet: `specs/GH42/`

## Readiness Gate

- [x] GitHub issue evidence confirms `triaged` label.
- [x] 本 PR 是 spec/task plan，无实现代码。
- [x] 不涉及安全敏感区域。

## Review Gate

- [x] `route_gate` write_spec => `allowed`.
- [x] `python3 checks/check_workflow.py --repo . --spec-dir specs/GH42` passed.
- [x] `python3 checks/check_workflow.py --repo .` passed.
- [ ] 请求 human spec review；`spec_approved` / `ready_to_implement` 仍是 maintainer gate。

## Verification

- [x] 纯文档/spec 变更，无代码测试影响。

## Agent Disclosure

- [x] Agent 起草，需 human review 后方可进入实现。