### PR TITLE
spec(GH43): platform pricing cache directory

### DIFF
--- a/specs/GH43/product.md
+++ b/specs/GH43/product.md
@@ -1,0 +1,47 @@
+# Product Spec
+
+## Linked Issue
+
+GH-43
+
+## 用户问题
+
+pricing cache 路径硬编码为 `~/.cache/ccstats/pricing.json`，在 macOS/Windows 上不符合平台缓存目录惯例。用户清理系统缓存或排查文件位置时会困惑，代码也与 `config.rs` 的平台目录策略不一致。
+
+## 目标
+
+- 新的 pricing cache 默认写入 `dirs::cache_dir()/ccstats/pricing.json`。
+- 平台 cache dir 不可用时有明确 fallback。
+- 旧硬编码路径已有缓存不会造成离线模式突然全部失效。
+
+## 非目标
+
+- 不改变 pricing JSON 内容格式。
+- 不改变 exchange rate cache（除非作为单独后续 issue）。
+- 不改变 online fetch/fallback 定价语义。
+
+## Behavior Invariants
+
+1. 在支持平台 cache dir 的系统上，新写入使用 `dirs::cache_dir()/ccstats/pricing.json`。
+2. `dirs::cache_dir()` 不可用时，fallback 行为明确且可测试。
+3. 如果新路径没有缓存但旧 `~/.cache/ccstats/pricing.json` 存在，读取路径应有兼容策略或明确迁移提示，避免离线用户静默失效。
+4. 成功在线拉取后的保存目标是新平台路径。
+5. cache path 逻辑集中在单一 helper，避免读写路径分叉。
+
+## 验收标准
+
+- [ ] cache path helper 使用 `dirs::cache_dir()`。
+- [ ] 读写路径共享同一目标选择逻辑。
+- [ ] 旧路径兼容/迁移行为有测试。
+- [ ] macOS/Linux/Windows 路径决策有单元测试或可注入 helper 测试。
+
+## 边界情况
+
+- 平台 cache dir 缺失。
+- 新旧 cache 同时存在。
+- 只有旧 cache 存在且 `--offline`。
+- cache 目录创建失败。
+
+## 发布说明
+
+pricing cache 位置改为平台标准缓存目录；如需清理旧缓存，可手动删除旧 `~/.cache/ccstats/pricing.json`。

--- a/specs/GH43/tasks.md
+++ b/specs/GH43/tasks.md
@@ -1,0 +1,32 @@
+# Task Plan
+
+## Linked Issue
+
+GH-43
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP43-T1` Owner: implementation. Done when: pricing cache path helper prefers `dirs::cache_dir()/ccstats/pricing.json`. Verify: unit tests for path selection.
+- [ ] `SP43-T2` Owner: implementation. Done when: load path can read legacy `~/.cache/ccstats/pricing.json` when preferred cache is absent. Verify: legacy fallback test.
+- [ ] `SP43-T3` Owner: implementation. Done when: save path writes to the current preferred/fallback platform path, not the legacy path. Verify: save target test.
+- [ ] `SP43-T4` Owner: implementation. Done when: `PricingDb` callers do not duplicate cache path logic. Verify: code review and `rg "\\.cache.*pricing\\.json" src`.
+- [ ] `SP43-T5` Owner: verification. Done when: deterministic Rust and SpecRail gates pass before PR readiness is claimed. Verify: `cargo check`, `cargo test`, `python3 checks/check_workflow.py --repo .`, and `python3 checks/check_workflow.py --repo . --spec-dir specs/GH43`.
+
+## 并行拆分
+
+- Cache helper work owns `src/pricing/cache.rs`.
+- Pricing DB integration owns `src/pricing/db.rs` only if API shape changes.
+- Tests own pricing cache/db tests.
+
+## 验证
+
+- [ ] `SP43-T6` Owner: verification. Done when: offline mode with legacy-only cache remains usable. Verify: focused pricing DB test.
+
+## Handoff Notes
+
+GH32 may change cache read/write error handling. If GH32 lands first, implement GH43 by extending the new cache-state API rather than reintroducing `Option` ambiguity.

--- a/specs/GH43/tech.md
+++ b/specs/GH43/tech.md
@@ -1,0 +1,68 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-43
+
+## Product Spec
+
+`specs/GH43/product.md`
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Pricing cache | `src/pricing/cache.rs` | `cache_file()` uses `$HOME/.cache/ccstats/pricing.json`. | Primary change surface. |
+| Pricing DB | `src/pricing/db.rs` | Calls cache load/save helpers. | Should remain unaware of path details. |
+| Config paths | `src/config.rs` | Uses `dirs::config_dir()` plus fallbacks. | Style reference for platform path fallback. |
+| Tests | pricing unit tests | Cache path is not currently platform-injected. | Need testable helper design. |
+
+## 设计方案
+
+1. Refactor cache path selection into helpers:
+   - preferred platform path via `dirs::cache_dir()`
+   - legacy path via `$HOME/.cache/ccstats/pricing.json`
+   - fallback path when platform path unavailable
+2. Load order:
+   - preferred path first
+   - legacy path as compatibility fallback if preferred missing
+3. Save target:
+   - always preferred/fallback current path, not legacy, after successful online fetch
+4. Keep `PricingDb` API unchanged.
+5. Add tests by injecting path roots or extracting pure path-selection helpers so tests do not depend on the host OS.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1/P2 | cache path helper | Unit tests with injected dirs. |
+| P3 | load helper | Test legacy-only offline cache read. |
+| P4 | save helper | Test save target path selection. |
+| P5 | code structure | Code review and focused unit tests. |
+
+## 数据流
+
+Pricing load -> cache helper chooses read candidates -> parse raw cache -> pricing DB. Online fetch -> save helper writes preferred platform cache path.
+
+## 备选方案
+
+- Hard switch with no legacy fallback: rejected because offline users with existing cache would see avoidable breakage.
+- Keep `~/.cache` forever: rejected because it preserves platform inconsistency.
+
+## 风险
+
+- Security: local path resolution only; no command execution.
+- Compatibility: cache file location changes; legacy read fallback mitigates.
+- Performance: one extra metadata check when preferred path missing.
+- Maintenance: centralized helper reduces path drift.
+
+## 测试计划
+
+- [ ] Unit tests for preferred path, fallback path, legacy read fallback.
+- [ ] Existing pricing cache/load tests.
+- [ ] `cargo check`
+- [ ] `cargo test`
+
+## 回滚方案
+
+Revert cache path helper changes. Existing legacy cache remains readable at old path.


### PR DESCRIPTION
# Summary

为 #43 提交 SpecRail spec packet（product.md + tech.md + tasks.md），把 pricing cache path 从硬编码 `~/.cache` 收敛到平台 cache dir，并规划旧路径兼容读取。

## Linked Work

- Issue: #43
- Spec packet: `specs/GH43/`

## Readiness Gate

- [x] GitHub issue evidence confirms `triaged` label.
- [x] 本 PR 是 spec/task plan，无实现代码。
- [x] 不涉及安全敏感区域。

## Review Gate

- [x] `route_gate` write_spec => `allowed`.
- [x] `python3 checks/check_workflow.py --repo . --spec-dir specs/GH43` passed.
- [x] `python3 checks/check_workflow.py --repo .` passed.
- [ ] 请求 human spec review；`spec_approved` / `ready_to_implement` 仍是 maintainer gate。

## Verification

- [x] 纯文档/spec 变更，无代码测试影响。

## Agent Disclosure

- [x] Agent 起草，需 human review 后方可进入实现。