### PR TITLE
spec(GH44): safer pricing match strategy

### DIFF
--- a/specs/GH44/product.md
+++ b/specs/GH44/product.md
@@ -1,0 +1,47 @@
+# Product Spec
+
+## Linked Issue
+
+GH-44
+
+## 用户问题
+
+LiteLLM pricing 解析的模糊匹配使用双向 `contains`，短名或命名相近的模型可能匹配到无关价格。错误价格会静默进入成本输出，用户无法发现预算数字已错配。
+
+## 目标
+
+- 定价匹配策略可解释、可测试，避免任意双向 substring 错配。
+- 保留已知需要的模型规范化/版本变体匹配能力。
+- 无法可靠匹配时返回 unknown，让输出显示 `N/A` 或 fallback，而不是套错 LiteLLM 价格。
+
+## 非目标
+
+- 不重写 hardcoded fallback pricing。
+- 不改变 LiteLLM 原始数据下载格式。
+- 不把 unknown model 强行匹配到相近价格。
+
+## Behavior Invariants
+
+1. Exact normalized match 优先于任何模糊候选。
+2. 允许的非 exact 匹配必须来自明确规则（如 vendor prefix stripping、dot/hyphen version variant），不能是任意 `contains`。
+3. 当多个候选都可能匹配且无法确定唯一性时，返回 unknown/None，而不是最长字符串获胜。
+4. 已有合法场景（如 `sonnet-4` 对 `claude-sonnet-4-*`）继续可解析，前提是规则明确。
+5. 错配风险样本有回归测试。
+
+## 验收标准
+
+- [ ] `resolve_pricing_known` 不再使用无约束双向 `contains`。
+- [ ] 保留 exact、normalized、known variant 的成功测试。
+- [ ] 新增至少一个相似命名但不应匹配的负例测试。
+- [ ] unknown 不因短 substring 返回错误价格。
+
+## 边界情况
+
+- 空模型名。
+- 多个候选共享同一短 token。
+- vendor prefix 存在/缺失。
+- dot version 与 hyphen version（如 `glm-5.2`/`glm-5p2`）。
+
+## 发布说明
+
+定价匹配更保守；少数之前被模糊匹配的模型可能变为 `N/A`，这是避免错价的预期变化。

--- a/specs/GH44/tasks.md
+++ b/specs/GH44/tasks.md
@@ -1,0 +1,32 @@
+# Task Plan
+
+## Linked Issue
+
+GH-44
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP44-T1` Owner: implementation. Done when: `resolve_pricing_known` removes unbounded bidirectional `contains` matching. Verify: code review and resolver unit tests.
+- [ ] `SP44-T2` Owner: implementation. Done when: exact, normalized prefix, and approved version variant matches still work. Verify: resolver tests.
+- [ ] `SP44-T3` Owner: implementation. Done when: ambiguous or substring-only candidates return `None` rather than a silent wrong price. Verify: negative resolver tests.
+- [ ] `SP44-T4` Owner: verification. Done when: pricing DB fallback/unknown behavior remains correct. Verify: `cargo test pricing`.
+- [ ] `SP44-T5` Owner: verification. Done when: deterministic Rust and SpecRail gates pass before PR readiness is claimed. Verify: `cargo check`, `cargo test`, `python3 checks/check_workflow.py --repo .`, and `python3 checks/check_workflow.py --repo . --spec-dir specs/GH44`.
+
+## 并行拆分
+
+- Resolver strategy owns `src/pricing/resolver/resolve.rs`.
+- Variant preservation owns resolver/parse tests.
+- Verification is coordinator-only.
+
+## 验证
+
+- [ ] `SP44-T6` Owner: verification. Done when: at least one realistic false-positive fixture is documented or encoded as a regression test. Verify: resolver test name and PR body evidence.
+
+## Handoff Notes
+
+This issue is medium-confidence until a concrete key-space fixture is added. Implementation should prefer returning unknown over guessing.

--- a/specs/GH44/tech.md
+++ b/specs/GH44/tech.md
@@ -1,0 +1,66 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-44
+
+## Product Spec
+
+`specs/GH44/product.md`
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Resolver | `src/pricing/resolver/resolve.rs` | Filters candidates with `name_lower.contains(model_lower) || model_lower.contains(name_lower)` and picks longest. | Primary bug surface. |
+| Parser variants | `src/pricing/resolver/parse.rs` | Adds variant keys such as dot-version forms. | Existing safe matching mechanism. |
+| Fallback pricing | `src/pricing/resolver/fallback.rs` | Handles broad family estimates separately. | Should remain the fallback, not LiteLLM mis-match. |
+| Pricing DB | `src/pricing/db.rs` | Calls known resolver then fallback. | Unknown path should remain valid. |
+
+## 设计方案
+
+1. Keep exact lowercase key lookup as first path.
+2. Define a small normalization function for accepted aliases/prefixes:
+   - known provider prefix stripping where already expected
+   - version punctuation variants from existing parse logic
+3. Replace arbitrary substring filter with ordered deterministic candidates from normalization only.
+4. If more than one distinct candidate remains after normalization, return `None` and let fallback/unknown handling decide.
+5. Add tests for existing positive cases plus negative ambiguous/substring cases.
+6. Optionally add a fixture using a small LiteLLM-like key set that reproduces the current risk.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 | `resolve_pricing_known` | exact match test. |
+| P2/P4 | normalization helper | sonnet/version variant tests. |
+| P3 | ambiguity handling | multi-candidate test returns None. |
+| P5 | regression fixture | substring false-positive test. |
+
+## 数据流
+
+Model name -> normalized candidate generation -> exact candidate lookup -> optional unambiguous variant lookup -> known pricing or None -> fallback pricing path.
+
+## 备选方案
+
+- Keep longest substring but add denylist: rejected because key space changes over time.
+- Fuzzy string distance matching: rejected because silent price selection still lacks deterministic safety.
+
+## 风险
+
+- Security: no external execution.
+- Compatibility: some previous fuzzy matches may become `N/A` or fallback; safer than wrong known price.
+- Performance: fewer candidate scans likely faster.
+- Maintenance: normalization rules must be explicit and tested.
+
+## 测试计划
+
+- [ ] Unit tests for exact, provider prefix, version variant, no match.
+- [ ] Negative tests for substring false positives and ambiguity.
+- [ ] Existing pricing DB/fallback tests.
+- [ ] `cargo check`
+- [ ] `cargo test`
+
+## 回滚方案
+
+Revert resolver strategy and tests. No data migration.


### PR DESCRIPTION
# Summary

为 #44 提交 SpecRail spec packet（product.md + tech.md + tasks.md），收敛 LiteLLM known-pricing 匹配策略，避免双向 `contains` 静默错配价格。

## Linked Work

- Issue: #44
- Spec packet: `specs/GH44/`

## Readiness Gate

- [x] GitHub issue evidence confirms `triaged` label.
- [x] 本 PR 是 spec/task plan，无实现代码。
- [x] 不涉及安全敏感区域。

## Review Gate

- [x] `route_gate` write_spec => `allowed`.
- [x] `python3 checks/check_workflow.py --repo . --spec-dir specs/GH44` passed.
- [x] `python3 checks/check_workflow.py --repo .` passed.
- [ ] 请求 human spec review；`spec_approved` / `ready_to_implement` 仍是 maintainer gate。

## Verification

- [x] 纯文档/spec 变更，无代码测试影响。

## Agent Disclosure

- [x] Agent 起草，需 human review 后方可进入实现。