### PR TITLE
spec(GH46): document config and fail invalid config

### DIFF
--- a/specs/GH46/product.md
+++ b/specs/GH46/product.md
@@ -1,0 +1,49 @@
+# Product Spec
+
+## Linked Issue
+
+GH-46
+
+## 用户问题
+
+ccstats 支持 `config.toml`、多个配置搜索路径和 `CODEX_HOME`，但 README/docs 没有完整说明。更严重的是，存在但非法的 config 只 warning 后回落默认值；quiet/statusline 场景下用户可能完全不知道 `strict_pricing`、`offline`、`currency` 等设置被忽略。
+
+## 目标
+
+- 文档完整列出 config 文件名、搜索路径、可用键和 source env overrides。
+- `CODEX_HOME` 与其他 source env vars 一样被记录。
+- 存在但无法解析的 config 不得静默回落默认值。
+- quiet/statusline 路径也不能隐藏会影响输出正确性的 config parse failure。
+
+## 非目标
+
+- 不新增配置键。
+- 不改变合法 config 的解析语义。
+- 不引入交互式 config 初始化。
+
+## Behavior Invariants
+
+1. 用户可以从 README/docs 找到 config 文件位置和所有支持键。
+2. 用户可以从 README/docs 找到 `CODEX_HOME`、`CURSOR_HOME`、`GROK_HOME`，以及若 GH42 已合并则 `CLAUDE_CONFIG_DIR`。
+3. Config 文件不存在时，默认配置行为保持不变。
+4. Config 文件存在但 TOML 无法解析时，命令返回明确错误或显式错误状态，不得继续使用默认值生成误导输出。
+5. quiet 模式不抑制 config parse failure。
+
+## 验收标准
+
+- [ ] README/docs 包含 config 示例和键表。
+- [ ] README/docs 包含 source env override 矩阵。
+- [ ] 非法 config fixture 让 CLI 返回失败并显示明确错误。
+- [ ] 缺失 config 仍正常使用 default。
+- [ ] statusline/quiet 路径覆盖非法 config。
+
+## 边界情况
+
+- config 文件不存在。
+- config 文件存在但 TOML 语法错误。
+- config 文件存在但字段类型错误。
+- 多个搜索路径中较高优先级 config 非法。
+
+## 发布说明
+
+非法 config 从 warning+default 变为明确错误，避免静默忽略用户配置。

--- a/specs/GH46/tasks.md
+++ b/specs/GH46/tasks.md
@@ -1,0 +1,32 @@
+# Task Plan
+
+## Linked Issue
+
+GH-46
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP46-T1` Owner: implementation. Done when: config loading distinguishes missing config from invalid existing config. Verify: config unit tests.
+- [ ] `SP46-T2` Owner: implementation. Done when: invalid config exits with clear error in normal, quiet, and statusline paths. Verify: CLI integration tests.
+- [ ] `SP46-T3` Owner: docs. Done when: README/docs document config search order, supported keys, example config, and source env vars including `CODEX_HOME`. Verify: docs diff review.
+- [ ] `SP46-T4` Owner: verification. Done when: legal config and missing-config defaults still work. Verify: config/CLI regression tests.
+- [ ] `SP46-T5` Owner: verification. Done when: deterministic Rust and SpecRail gates pass before PR readiness is claimed. Verify: `cargo check`, `cargo test`, `python3 checks/check_workflow.py --repo .`, and `python3 checks/check_workflow.py --repo . --spec-dir specs/GH46`.
+
+## 并行拆分
+
+- Config behavior owns `src/config.rs` and startup error propagation files.
+- Docs own `README.md` and relevant docs.
+- Tests own config/CLI integration fixtures.
+
+## 验证
+
+- [ ] `SP46-T6` Owner: verification. Done when: no test weakens invalid-config expectations. Verify: full `cargo test`.
+
+## Handoff Notes
+
+GH42 may add `CLAUDE_CONFIG_DIR`; if it lands first, include it in the env override docs for this issue.

--- a/specs/GH46/tech.md
+++ b/specs/GH46/tech.md
@@ -1,0 +1,69 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-46
+
+## Product Spec
+
+`specs/GH46/product.md`
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Config loading | `src/config.rs` | Parse failures warn and return default. | Primary correctness gap. |
+| CLI/app startup | `src/main.rs`, `src/app.rs` | Consumes config before command execution. | Needs error propagation. |
+| Docs | `README.md`, `docs/algorithm/authoritative-token-accounting.md`, `docs/ARCHITECTURE.md` | Config and env docs incomplete. | Documentation gap. |
+| Tests | `tests/cli_integration.rs` | Covers env vars and some errors, not config parse failure. | Need integration coverage. |
+
+## 设计方案
+
+1. Change config loader return shape from unconditional `Config` to `Result<Config, ConfigError>` or equivalent, preserving default only when no config file exists.
+2. Distinguish:
+   - no config found -> `Ok(Config::default())`
+   - config found and valid -> `Ok(parsed)`
+   - config found but invalid/unreadable -> `Err`
+3. Propagate the error to CLI exit path, including quiet/statusline commands.
+4. Add docs:
+   - config search order
+   - example `config.toml`
+   - supported keys
+   - env overrides
+5. Add tests for missing config, invalid TOML, wrong field type, and quiet/statusline behavior.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1/P2 | docs | Docs review. |
+| P3 | config loader | Missing config test. |
+| P4/P5 | config loader + CLI | Invalid config integration tests. |
+
+## 数据流
+
+Startup -> config search -> `Result<Config, ConfigError>` -> CLI either runs with config or exits with clear error. No persistent data changes.
+
+## 备选方案
+
+- Keep warning but make it louder: rejected because quiet/statusline and automation still get wrong output.
+- Ignore only unknown keys: not in scope; current issue is invalid parse/type failure.
+
+## 风险
+
+- Security: no secret handling changes.
+- Compatibility: invalid config now fails fast; intentional user-visible correctness fix.
+- Performance: negligible.
+- Maintenance: typed error improves future config behavior.
+
+## 测试计划
+
+- [ ] Unit tests for config search/load result states.
+- [ ] CLI integration tests for invalid config and missing config.
+- [ ] Docs review.
+- [ ] `cargo check`
+- [ ] `cargo test`
+
+## 回滚方案
+
+Revert config error propagation and docs/tests. Existing default fallback returns.


### PR DESCRIPTION
# Summary

为 #46 提交 SpecRail spec packet（product.md + tech.md + tasks.md），覆盖 config.toml/CODEX_HOME 文档缺口，以及非法 config 静默回默认值的问题。

## Linked Work

- Issue: #46
- Spec packet: `specs/GH46/`

## Readiness Gate

- [x] GitHub issue evidence confirms `triaged` label.
- [x] 本 PR 是 spec/task plan，无实现代码。
- [x] 不涉及安全敏感区域。

## Review Gate

- [x] `route_gate` write_spec => `allowed`.
- [x] `python3 checks/check_workflow.py --repo . --spec-dir specs/GH46` passed.
- [x] `python3 checks/check_workflow.py --repo .` passed.
- [ ] 请求 human spec review；`spec_approved` / `ready_to_implement` 仍是 maintainer gate。

## Verification

- [x] 纯文档/spec 变更，无代码测试影响。

## Agent Disclosure

- [x] Agent 起草，需 human review 后方可进入实现。