### PR TITLE
spec(GH47): technical debt slice plan

### DIFF
--- a/specs/GH47/product.md
+++ b/specs/GH47/product.md
@@ -1,0 +1,51 @@
+# Product Spec
+
+## Linked Issue
+
+GH-47
+
+## 用户问题
+
+代码库出现多处维护性风险：若干文件超过或接近 AGENTS 的行数上限，公开 SDK `SummaryOptions` 与内部 output `SummaryOptions` 同名，集成测试文件过大，关键函数用 `#[allow(clippy::too_many_lines)]` 压住复杂度。这些不会立即改变用户输出，但会降低后续修复速度并增加误改风险。
+
+## 目标
+
+- 将 #47 列出的技术债拆成可独立 review 的实现 slice。
+- 超过 800 行的文件降到上限以下，接近上限的文件有明确拆分计划。
+- 消除公开/内部 `SummaryOptions` 命名冲突。
+- 拆分超大集成测试文件，保持测试语义不变。
+- 移除 issue 点名的 `too_many_lines` allow，或用可测试子函数替代。
+
+## 非目标
+
+- 不改变 CLI 输出、SDK API 行为或统计语义。
+- 不顺手处理 issue 未点名的其他 clippy allow。
+- 不做大规模架构重写。
+
+## Behavior Invariants
+
+1. 文件拆分后，所有公开命令输出逐字节保持不变。
+2. SDK `SummaryOptions` 的公开名称和行为保持不变；内部 output 类型改名不得泄漏到 SDK。
+3. 测试拆分后，原测试覆盖不减少，fixture/helper 不重复发散。
+4. `parse_codex_file_with_debug` 与 `run_cli` 的行为保持不变，但复杂步骤拆成命名 helper 并可单测。
+5. 每个实现 PR 都有明确文件所有权和回归验证。
+
+## 验收标准
+
+- [ ] `src/source/loader.rs` 与 `src/output/table.rs` 降到 800 行以下。
+- [ ] `src/output/csv.rs` 有拆分或保持低于上限且有后续计划。
+- [ ] 内部 output `SummaryOptions` 改名，SDK `SummaryOptions` 不变。
+- [ ] `tests/cli_integration.rs` 拆为 source/feature 维度文件。
+- [ ] issue 点名的 `parse_codex_file_with_debug` 与 `run_cli` 不再需要 `#[allow(clippy::too_many_lines)]`。
+- [ ] `cargo test` 全部通过。
+
+## 边界情况
+
+- 测试 helper 共享导致模块循环。
+- 重命名内部 type 影响 `pub(crate)` re-export。
+- 文件拆分造成 snapshot/order 输出变化。
+- 多个 refactor PR 并行修改同一大文件。
+
+## 发布说明
+
+内部维护性改进，无用户可见行为变化。

--- a/specs/GH47/tasks.md
+++ b/specs/GH47/tasks.md
@@ -1,0 +1,37 @@
+# Task Plan
+
+## Linked Issue
+
+GH-47
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP47-T1` Owner: implementation. Done when: internal output `SummaryOptions` is renamed without changing SDK `SummaryOptions` or output behavior. Verify: `cargo check` and SDK/output tests.
+- [ ] `SP47-T2` Owner: implementation. Done when: loader tests are split out so `src/source/loader.rs` is below 800 lines. Verify: `wc -l src/source/loader.rs` and `cargo test merge_day_stats`.
+- [ ] `SP47-T3` Owner: implementation. Done when: table output is split below 800 lines with exported function contracts preserved. Verify: `wc -l src/output/table.rs` and affected CLI output tests.
+- [ ] `SP47-T4` Owner: implementation. Done when: CSV output has a concrete split or remains below 800 with a documented follow-up boundary. Verify: `wc -l src/output/csv.rs` and CSV CLI tests.
+- [ ] `SP47-T5` Owner: implementation. Done when: `tests/cli_integration.rs` is split into focused integration files with shared helpers. Verify: `cargo test --test <new-targets>` and full `cargo test`.
+- [ ] `SP47-T6` Owner: implementation. Done when: issue-named `too_many_lines` allows on `parse_codex_file_with_debug` and `run_cli` are removed through helper extraction. Verify: `rg "allow\\(clippy::too_many_lines\\)" src/source/codex/parser.rs src/lib.rs` has no matches.
+- [ ] `SP47-T7` Owner: verification. Done when: deterministic Rust and SpecRail gates pass before PR readiness is claimed. Verify: `cargo check`, `cargo test`, `python3 checks/check_workflow.py --repo .`, and `python3 checks/check_workflow.py --repo . --spec-dir specs/GH47`.
+
+## 并行拆分
+
+- `SP47-T1` owns `src/output/table.rs`, `src/output/mod.rs`, `src/app.rs`.
+- `SP47-T2` owns loader test module files only.
+- `SP47-T3` and `SP47-T4` must not edit the same output helper modules concurrently.
+- `SP47-T5` owns `tests/` integration layout and shared helper.
+- `SP47-T6` owns `src/source/codex/parser.rs` and `src/lib.rs`.
+
+## 验证
+
+- [ ] `SP47-T8` Owner: verification. Done when: before/after `wc -l` evidence is recorded for `loader.rs`, `table.rs`, `csv.rs`, and `cli_integration.rs`. Verify: `wc -l ...`.
+- [ ] `SP47-T9` Owner: verification. Done when: full `cargo test` passes after each slice before the next slice starts. Verify: per-PR verification logs.
+
+## Handoff Notes
+
+This issue should produce multiple implementation PRs. Use `Refs #47` for partial slices and closing keywords only on the final slice that satisfies all acceptance criteria.

--- a/specs/GH47/tech.md
+++ b/specs/GH47/tech.md
@@ -1,0 +1,71 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-47
+
+## Product Spec
+
+`specs/GH47/product.md`
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Loader | `src/source/loader.rs` | 845 lines, includes production loader and many tests. | Over hard ceiling. |
+| Table output | `src/output/table.rs` | 821 lines. | Over hard ceiling. |
+| CSV output | `src/output/csv.rs` | 766 lines. | Near hard ceiling. |
+| CLI integration tests | `tests/cli_integration.rs` | 1964 lines. | Needs source/feature split. |
+| Naming | `src/sdk.rs`, `src/output/table.rs`, `src/output/mod.rs`, `src/app.rs` | SDK and internal output both use `SummaryOptions`. | Confusing type identity. |
+| Too-many-lines allows | `src/source/codex/parser.rs`, `src/lib.rs` | Issue points to parser and CLI dispatch allows. | Should be extracted into helpers. |
+
+## 设计方案
+
+Implement as multiple PR slices rather than one large refactor:
+
+1. **Naming slice**: Rename internal output `SummaryOptions` to `PeriodSummaryFooter` or equivalent; update `output/mod.rs` re-export and app call site.
+2. **Loader test split slice**: Move loader unit tests into `src/source/loader/tests.rs` or module-local submodule to bring `loader.rs` under 800 without behavior changes.
+3. **Output split slice**: Split table/csv renderers by data shape or helper modules while preserving function exports.
+4. **Integration test split slice**: Move `tests/cli_integration.rs` into focused files such as `cli_codex.rs`, `cli_claude.rs`, `cli_grok_cursor.rs`, `cli_budget_currency.rs`, sharing helper module.
+5. **Complex function extraction slice**: Extract `parse_codex_file_with_debug` steps and `run_cli` setup/dispatch helpers enough to remove the issue-named clippy allows.
+
+Each slice must run `cargo test`; large output splits should also run targeted CLI tests for affected commands.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 | output split | Existing CLI output tests. |
+| P2 | naming slice | Compile + SDK tests. |
+| P3 | integration split | Full test count/coverage parity and `cargo test`. |
+| P4 | parser/lib extraction | Parser unit tests and CLI command tests. |
+| P5 | PR slicing | PR bodies list owned files and verification. |
+
+## 数据流
+
+No intended runtime data-flow change. This is code organization: exported functions keep their current call contracts while implementation moves into smaller modules/helpers.
+
+## 备选方案
+
+- One giant refactor PR: rejected due review risk.
+- Add more `allow` attributes: rejected by project guidance.
+- Split only tests and ignore production files: rejected because table.rs remains above hard ceiling.
+
+## 风险
+
+- Security: no auth/secrets surface.
+- Compatibility: no intended behavior change; output regressions are main risk.
+- Performance: unchanged.
+- Maintenance: reduced file size and clearer names.
+
+## 测试计划
+
+- [ ] `cargo check`
+- [ ] `cargo test`
+- [ ] Focused CLI tests after each output/test split.
+- [ ] `wc -l` evidence for targeted files.
+- [ ] `rg "allow\\(clippy::too_many_lines\\)"` evidence for issue-named functions.
+
+## 回滚方案
+
+Each slice should be independently revertible. Because behavior is unchanged, rollback is standard git revert per PR.


### PR DESCRIPTION
# Summary

为 #47 提交 SpecRail spec packet（product.md + tech.md + tasks.md），将超行数文件拆分、SummaryOptions 重名、集成测试拆分和 issue 点名的 `too_many_lines` 移除拆成可独立 review 的实现 slices。

## Linked Work

- Issue: #47
- Spec packet: `specs/GH47/`

## Readiness Gate

- [x] GitHub issue evidence confirms `triaged` label.
- [x] 本 PR 是 spec/task plan，无实现代码。
- [x] 不涉及安全敏感区域。

## Review Gate

- [x] `route_gate` write_spec => `allowed`.
- [x] `python3 checks/check_workflow.py --repo . --spec-dir specs/GH47` passed.
- [x] `python3 checks/check_workflow.py --repo .` passed.
- [ ] 请求 human spec review；`spec_approved` / `ready_to_implement` 仍是 maintainer gate。

## Verification

- [x] 纯文档/spec 变更，无代码测试影响。

## Agent Disclosure

- [x] Agent 起草，需 human review 后方可进入实现。