### PR TITLE
Clamp negative Claude and Cursor tokens

### DIFF
--- a/src/source/claude/parser.rs
+++ b/src/source/claude/parser.rs
@@ -114,6 +114,10 @@ fn derive_project_path(path: &Path) -> String {
         .to_string()
 }
 
+fn non_negative_tokens(tokens: Option<i64>) -> i64 {
+    tokens.unwrap_or(0).max(0)
+}
+
 pub(super) fn parse_claude_file_with_debug(
     path: &Path,
     timezone: Timezone,
@@ -289,10 +293,10 @@ fn parse_entry_with_debug(
         session_id: session_id.to_string(),
         project_path: project_path.to_string(),
         model,
-        input_tokens: usage.input_tokens.unwrap_or(0),
-        output_tokens: usage.output_tokens.unwrap_or(0),
-        cache_creation: usage.cache_creation_input_tokens.unwrap_or(0),
-        cache_read: usage.cache_read_input_tokens.unwrap_or(0),
+        input_tokens: non_negative_tokens(usage.input_tokens),
+        output_tokens: non_negative_tokens(usage.output_tokens),
+        cache_creation: non_negative_tokens(usage.cache_creation_input_tokens),
+        cache_read: non_negative_tokens(usage.cache_read_input_tokens),
         reasoning_tokens: 0, // Claude doesn't have reasoning tokens
         stop_reason: msg.stop_reason,
     })
@@ -542,6 +546,31 @@ mod tests {
                     output_tokens: None,
                     cache_creation_input_tokens: None,
                     cache_read_input_tokens: None,
+                }),
+            }),
+        };
+        let tz = make_timezone();
+        let raw = parse_entry(entry, Path::new("t.jsonl"), "scope/t", "s", "p", tz, 1).unwrap();
+        assert_eq!(raw.input_tokens, 0);
+        assert_eq!(raw.output_tokens, 0);
+        assert_eq!(raw.cache_creation, 0);
+        assert_eq!(raw.cache_read, 0);
+    }
+
+    #[test]
+    fn test_parse_entry_clamps_negative_tokens_to_zero() {
+        let entry = UsageEntry {
+            is_sidechain: false,
+            timestamp: Some("2025-01-15T10:00:00Z".to_string()),
+            message: Some(Message {
+                id: Some("msg_004".to_string()),
+                model: Some("claude-3-5-sonnet-20241022".to_string()),
+                stop_reason: Some("end_turn".to_string()),
+                usage: Some(Usage {
+                    input_tokens: Some(-100),
+                    output_tokens: Some(-50),
+                    cache_creation_input_tokens: Some(-30),
+                    cache_read_input_tokens: Some(-20),
                 }),
             }),
         };

--- a/src/source/cursor/parser.rs
+++ b/src/source/cursor/parser.rs
@@ -121,6 +121,14 @@ fn integer_at(value: &Value, path: &[&str]) -> Option<i64> {
         .or_else(|| current.as_u64().and_then(|n| i64::try_from(n).ok()))
 }
 
+fn token_count_at(value: &Value, paths: &[&[&str]]) -> i64 {
+    paths
+        .iter()
+        .find_map(|path| integer_at(value, path))
+        .unwrap_or(0)
+        .max(0)
+}
+
 fn first_string(value: &Value, paths: &[&[&str]]) -> Option<String> {
     paths
         .iter()
@@ -144,16 +152,24 @@ fn timestamp_from_value(value: &Value) -> Option<DateTime<Utc>> {
 }
 
 fn token_counts(value: &Value) -> Option<(i64, i64)> {
-    let input = integer_at(value, &["tokenCount", "inputTokens"])
-        .or_else(|| integer_at(value, &["tokenCount", "input_tokens"]))
-        .or_else(|| integer_at(value, &["usage", "inputTokens"]))
-        .or_else(|| integer_at(value, &["inputTokens"]))
-        .unwrap_or(0);
-    let output = integer_at(value, &["tokenCount", "outputTokens"])
-        .or_else(|| integer_at(value, &["tokenCount", "output_tokens"]))
-        .or_else(|| integer_at(value, &["usage", "outputTokens"]))
-        .or_else(|| integer_at(value, &["outputTokens"]))
-        .unwrap_or(0);
+    let input = token_count_at(
+        value,
+        &[
+            &["tokenCount", "inputTokens"],
+            &["tokenCount", "input_tokens"],
+            &["usage", "inputTokens"],
+            &["inputTokens"],
+        ],
+    );
+    let output = token_count_at(
+        value,
+        &[
+            &["tokenCount", "outputTokens"],
+            &["tokenCount", "output_tokens"],
+            &["usage", "outputTokens"],
+            &["outputTokens"],
+        ],
+    );
 
     (input > 0 || output > 0).then_some((input, output))
 }
@@ -448,6 +464,44 @@ mod tests {
     }
 
     #[test]
+    fn entry_from_bubble_clamps_negative_token_counts() {
+        let value = json!({
+            "createdAt": "2026-02-06T10:00:00Z",
+            "tokenCount": {"inputTokens": -100, "outputTokens": 40}
+        });
+        let entry = entry_from_bubble(
+            "bubbleId:composer-1:bubble-1",
+            &value,
+            &HashMap::new(),
+            Path::new("/tmp/state.vscdb"),
+            tz(),
+        )
+        .unwrap();
+
+        assert_eq!(entry.input_tokens, 0);
+        assert_eq!(entry.output_tokens, 40);
+    }
+
+    #[test]
+    fn entry_from_bubble_skips_all_negative_token_counts() {
+        let value = json!({
+            "createdAt": "2026-02-06T10:00:00Z",
+            "tokenCount": {"inputTokens": -100, "outputTokens": -40}
+        });
+
+        assert!(
+            entry_from_bubble(
+                "bubbleId:composer-1:bubble-1",
+                &value,
+                &HashMap::new(),
+                Path::new("/tmp/state.vscdb"),
+                tz(),
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
     fn entry_from_bubble_uses_composer_model_fallback() {
         let mut composers = HashMap::new();
         composers.insert(
@@ -474,5 +528,33 @@ mod tests {
         assert_eq!(entry.model, "gpt-5");
         assert_eq!(entry.project_path, "/tmp/project");
         assert_eq!(entry.timestamp, "2026-02-06T10:00:00+00:00");
+    }
+
+    #[test]
+    fn entry_from_generation_clamps_negative_token_counts() {
+        let generation = json!({
+            "createdAt": "2026-02-06T10:00:00Z",
+            "inputTokens": 25,
+            "outputTokens": -5,
+            "generationUUID": "generation-1"
+        });
+        let entry =
+            entry_from_generation(&generation, Path::new("/tmp/state.vscdb"), tz()).unwrap();
+
+        assert_eq!(entry.session_id, "generation-1");
+        assert_eq!(entry.input_tokens, 25);
+        assert_eq!(entry.output_tokens, 0);
+    }
+
+    #[test]
+    fn entry_from_generation_skips_all_negative_token_counts() {
+        let generation = json!({
+            "createdAt": "2026-02-06T10:00:00Z",
+            "inputTokens": -25,
+            "outputTokens": -5,
+            "generationUUID": "generation-1"
+        });
+
+        assert!(entry_from_generation(&generation, Path::new("/tmp/state.vscdb"), tz()).is_none());
     }
 }

--- a/tests/negative_token_integration.rs
+++ b/tests/negative_token_integration.rs
@@ -1,0 +1,175 @@
+use rusqlite::Connection;
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("ccstats-{prefix}-{}-{nanos}", std::process::id()));
+    fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+fn write_file(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent dirs");
+    }
+    fs::write(path, content).expect("write test file");
+}
+
+fn resolve_ccstats_binary() -> PathBuf {
+    if let Some(bin) = std::env::var_os("CARGO_BIN_EXE_ccstats") {
+        return PathBuf::from(bin);
+    }
+
+    let bin_name = if cfg!(windows) {
+        "ccstats.exe"
+    } else {
+        "ccstats"
+    };
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let candidates = [
+        manifest_dir
+            .join("target")
+            .join("llvm-cov-target")
+            .join("debug")
+            .join(bin_name),
+        manifest_dir.join("target").join("debug").join(bin_name),
+    ];
+
+    candidates
+        .into_iter()
+        .find(|path| path.is_file())
+        .unwrap_or_else(|| panic!("unable to locate ccstats binary"))
+}
+
+fn run_ccstats(args: &[&str], envs: &[(&str, &Path)]) -> (bool, Vec<u8>, Vec<u8>) {
+    let mut cmd = Command::new(resolve_ccstats_binary());
+    cmd.args(args);
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    let output = cmd.output().expect("run ccstats");
+    (output.status.success(), output.stdout, output.stderr)
+}
+
+fn write_cursor_negative_state_db(path: &Path) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create cursor db parent");
+    }
+    let conn = Connection::open(path).expect("open cursor db");
+    conn.execute(
+        "CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value BLOB)",
+        [],
+    )
+    .expect("create cursorDiskKV");
+    conn.execute(
+        "CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value BLOB)",
+        [],
+    )
+    .expect("create ItemTable");
+    conn.execute(
+        "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+        (
+            "composerData:composer-1",
+            r#"{"composerId":"composer-1","modelConfig":{"modelName":"gpt-4o-mini"},"workspaceIdentifier":{"uri":{"fsPath":"/tmp/cursor-project"}}}"#,
+        ),
+    )
+    .expect("insert composer");
+    conn.execute(
+        "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+        (
+            "bubbleId:composer-1:bubble-1",
+            r#"{"createdAt":"2026-02-06T10:30:00Z","tokenCount":{"inputTokens":-25,"outputTokens":40}}"#,
+        ),
+    )
+    .expect("insert mixed bubble");
+    conn.execute(
+        "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+        (
+            "bubbleId:composer-1:bubble-negative",
+            r#"{"createdAt":"2026-02-06T10:31:00Z","tokenCount":{"inputTokens":-7,"outputTokens":-3}}"#,
+        ),
+    )
+    .expect("insert all-negative bubble");
+    conn.execute(
+        "INSERT INTO ItemTable (key, value) VALUES (?1, ?2)",
+        (
+            "aiService.generations",
+            r#"[{"createdAt":"2026-02-06T11:00:00Z","generationUUID":"generation-1","model":"gpt-4o-mini","inputTokens":25,"outputTokens":-5},{"createdAt":"2026-02-06T11:05:00Z","generationUUID":"generation-negative","model":"gpt-4o-mini","inputTokens":-11,"outputTokens":-2}]"#,
+        ),
+    )
+    .expect("insert generations");
+}
+
+#[test]
+fn all_sources_daily_json_clamps_negative_claude_and_cursor_tokens() {
+    let root = unique_temp_dir("negative-token-json");
+    let codex_home = root.join("codex-home");
+    let grok_home = root.join("grok-home");
+    let cursor_home = root.join("cursor-user");
+    let claude_file = root.join(".claude/projects/myapp/session-negative.jsonl");
+
+    write_file(
+        &claude_file,
+        r#"{"timestamp":"2026-02-06T10:00:00Z","message":{"id":"msg_mixed","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":-100,"output_tokens":50,"cache_creation_input_tokens":-30,"cache_read_input_tokens":20}}}
+{"timestamp":"2026-02-06T10:01:00Z","message":{"id":"msg_negative","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":-10,"output_tokens":-5,"cache_creation_input_tokens":-3,"cache_read_input_tokens":-2}}}
+"#,
+    );
+    write_cursor_negative_state_db(&cursor_home.join("globalStorage").join("state.vscdb"));
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "--source",
+            "all",
+            "-j",
+            "-O",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[
+            ("HOME", &root),
+            ("CODEX_HOME", &codex_home),
+            ("CURSOR_HOME", &cursor_home),
+            ("GROK_HOME", &grok_home),
+        ],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    let arr = json.as_array().expect("array output");
+    assert_eq!(arr.len(), 1);
+    let row = &arr[0];
+    assert_eq!(row["date"].as_str(), Some("2026-02-06"));
+    assert_eq!(row["input_tokens"].as_i64(), Some(25));
+    assert_eq!(row["output_tokens"].as_i64(), Some(90));
+    assert_eq!(row["cache_creation_tokens"].as_i64(), Some(0));
+    assert_eq!(row["cache_read_tokens"].as_i64(), Some(20));
+    assert_eq!(row["total_tokens"].as_i64(), Some(135));
+
+    for key in [
+        "input_tokens",
+        "output_tokens",
+        "cache_creation_tokens",
+        "cache_read_tokens",
+        "total_tokens",
+    ] {
+        assert!(
+            row[key].as_i64().expect("numeric token field") >= 0,
+            "{key} should be non-negative"
+        );
+    }
+
+    let _ = fs::remove_dir_all(root);
+}


### PR DESCRIPTION
## Summary
- Clamp negative Claude usage fields before constructing RawEntry
- Normalize Cursor bubble and generation token fields before filtering/constructing RawEntry
- Add parser tests for mixed and all-negative malformed records

## Verification
- cargo fmt --check
- cargo test claude
- cargo test cursor
- cargo check
- cargo test
- python3 checks/check_workflow.py --repo .
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH39
- git diff --check

Fixes #39