### PR TITLE
Respect CLAUDE_CONFIG_DIR for Claude source

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,14 @@ ccstats today -j
 ccstats today --debug
 ```
 
+By default, ccstats checks Claude Code logs under `~/.claude/projects/`.
+If Claude Code uses a moved config directory, set `CLAUDE_CONFIG_DIR` to the
+Claude config root:
+
+```bash
+CLAUDE_CONFIG_DIR="/path/to/claude-config" ccstats daily --source claude
+```
+
 ### OpenAI Codex
 
 ```bash
@@ -213,6 +221,13 @@ ccstats codex session
 
 # With model breakdown
 ccstats codex today -b
+```
+
+By default, ccstats checks Codex sessions under `~/.codex/sessions/`. You can
+override the Codex home directory with `CODEX_HOME`:
+
+```bash
+CODEX_HOME="/path/to/.codex" ccstats codex daily
 ```
 
 ### Cursor (Experimental)
@@ -354,13 +369,13 @@ Warning: ignored <N> malformed records
 
 ## Supported Data Sources
 
-| Source | Directory | Features |
-|--------|-----------|----------|
-| Claude Code | `~/.claude/projects/` | Projects, Billing Blocks, Deduplication |
-| OpenAI Codex | `~/.codex/sessions/` | Reasoning Tokens |
-| All Sources | Multiple | Combined daily/weekly/monthly/today/statusline summaries |
-| Cursor (experimental) | Cursor `User/globalStorage/state.vscdb` | Local SQLite `tokenCount` fields only |
-| Grok | `~/.grok/sessions/` | Context-token session summaries, Projects |
+| Source | Directory | Override | Features |
+|--------|-----------|----------|----------|
+| Claude Code | `~/.claude/projects/` | `CLAUDE_CONFIG_DIR` | Projects, Billing Blocks, Deduplication |
+| OpenAI Codex | `~/.codex/sessions/` | `CODEX_HOME` | Reasoning Tokens |
+| All Sources | Multiple | Source-specific env vars | Combined daily/weekly/monthly/today/statusline summaries |
+| Cursor (experimental) | Cursor `User/globalStorage/state.vscdb` | `CURSOR_HOME` | Local SQLite `tokenCount` fields only |
+| Grok | `~/.grok/sessions/` | `GROK_HOME` | Context-token session summaries, Projects |
 
 ## Architecture
 

--- a/docs/algorithm/authoritative-token-accounting.md
+++ b/docs/algorithm/authoritative-token-accounting.md
@@ -47,6 +47,12 @@ cost = input_tokens   × input_price
 ~/.claude/projects/<project>/subagents/*.jsonl
 ```
 
+可通过 `CLAUDE_CONFIG_DIR` 覆盖 Claude 配置根目录：
+
+```
+CLAUDE_CONFIG_DIR=/path/to/claude-config ccstats daily --source claude
+```
+
 ### 原始字段
 
 Anthropic API 的 `message.usage` 中，**每个字段独立、互不包含**：

--- a/src/source/claude/mod.rs
+++ b/src/source/claude/mod.rs
@@ -7,3 +7,4 @@ mod parser;
 pub(crate) mod tool_parser;
 
 pub(crate) use config::ClaudeSource;
+pub(crate) use parser::claude_projects_dir;

--- a/src/source/claude/parser.rs
+++ b/src/source/claude/parser.rs
@@ -1,9 +1,10 @@
 //! Claude Code JSONL parser
 //!
-//! Parses JSONL logs from ~/.claude/projects/ directory.
+//! Parses JSONL logs from the Claude config projects directory.
 
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
+use std::env;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -46,11 +47,26 @@ struct Usage {
 // File discovery
 // ============================================================================
 
+const CLAUDE_CONFIG_DIR_ENV: &str = "CLAUDE_CONFIG_DIR";
+const DEFAULT_CLAUDE_CONFIG_DIR: &str = ".claude";
+const PROJECTS_SUBDIR: &str = "projects";
+
+fn claude_config_root() -> Option<PathBuf> {
+    match env::var_os(CLAUDE_CONFIG_DIR_ENV) {
+        Some(path) if !path.is_empty() => Some(PathBuf::from(path)),
+        Some(_) => None,
+        None => dirs::home_dir().map(|home| home.join(DEFAULT_CLAUDE_CONFIG_DIR)),
+    }
+}
+
+pub(crate) fn claude_projects_dir() -> Option<PathBuf> {
+    claude_config_root().map(|root| root.join(PROJECTS_SUBDIR))
+}
+
 pub(super) fn find_claude_files() -> Vec<PathBuf> {
-    let Some(home) = dirs::home_dir() else {
+    let Some(claude_path) = claude_projects_dir() else {
         return Vec::new();
     };
-    let claude_path = home.join(".claude").join("projects");
 
     let mut files = Vec::new();
     if let Ok(entries) = glob::glob(&format!("{}/**/*.jsonl", claude_path.display())) {

--- a/src/source/loader.rs
+++ b/src/source/loader.rs
@@ -496,12 +496,12 @@ pub(crate) fn load_tool_calls(
     filter: &DateFilter,
     timezone: Timezone,
 ) -> Vec<crate::core::ToolCall> {
+    use crate::source::claude::claude_projects_dir;
     use crate::source::claude::tool_parser::parse_tool_calls;
 
-    let Some(home) = dirs::home_dir() else {
+    let Some(claude_path) = claude_projects_dir() else {
         return Vec::new();
     };
-    let claude_path = home.join(".claude").join("projects");
     let mut files = Vec::new();
     if let Ok(entries) = glob::glob(&format!("{}/**/*.jsonl", claude_path.display())) {
         for entry in entries.flatten() {

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1529,6 +1529,85 @@ fn claude_daily_json_reads_home_projects() {
 }
 
 #[test]
+fn claude_daily_json_reads_claude_config_dir_before_home() {
+    let root = unique_temp_dir("claude-config-dir");
+    let claude_config_dir = root.join("custom-claude");
+    let home_file = root.join(".claude/projects/home-project/session-a.jsonl");
+    let config_file = claude_config_dir.join("projects/config-project/session-a.jsonl");
+    write_file(
+        &home_file,
+        r#"{"timestamp":"2026-02-06T12:00:00Z","message":{"id":"msg_home","model":"anthropic.claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":900,"output_tokens":90,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+"#,
+    );
+    write_file(
+        &config_file,
+        r#"{"timestamp":"2026-02-06T12:00:00Z","message":{"id":"msg_config","model":"anthropic.claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":10,"cache_read_input_tokens":20}}}
+"#,
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "-j",
+            "-O",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("HOME", &root), ("CLAUDE_CONFIG_DIR", &claude_config_dir)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    let arr = json.as_array().expect("array output");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["date"].as_str(), Some("2026-02-06"));
+    assert_eq!(arr[0]["total_tokens"].as_i64(), Some(180));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn claude_daily_json_missing_claude_config_dir_returns_no_data() {
+    let root = unique_temp_dir("claude-config-dir-missing");
+    let missing_config_dir = root.join("missing-claude");
+    let home_file = root.join(".claude/projects/home-project/session-a.jsonl");
+    write_file(
+        &home_file,
+        r#"{"timestamp":"2026-02-06T12:00:00Z","message":{"id":"msg_home","model":"anthropic.claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":900,"output_tokens":90,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+"#,
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "-j",
+            "-O",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("HOME", &root), ("CLAUDE_CONFIG_DIR", &missing_config_dir)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    assert!(
+        String::from_utf8_lossy(&stdout).contains("No Claude Code usage data found"),
+        "stdout: {}",
+        String::from_utf8_lossy(&stdout)
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn claude_daily_ignores_sidechains_and_subagent_logs() {
     let root = unique_temp_dir("claude-ignore-sidechains");
     let claude_file = root.join(".claude/projects/myproject/session-a.jsonl");


### PR DESCRIPTION
## Summary
- resolves Claude project discovery through `CLAUDE_CONFIG_DIR` before the default home config path
- shares the same discovery helper with Claude tool-call loading so source data and tool-call data use the same root
- documents the environment override in README and authoritative accounting docs

Fixes #42

## Verification
- `cargo fmt --check`
- `cargo test claude_daily_json_reads_claude_config_dir_before_home`
- `cargo test claude_daily_json_missing_claude_config_dir_returns_no_data`
- `cargo test claude`
- `cargo check`
- `cargo test`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH42`
- `git diff --check`
