### PR TITLE
Make pricing model resolution conservative

### DIFF
--- a/src/pricing/resolver/resolve.rs
+++ b/src/pricing/resolver/resolve.rs
@@ -11,13 +11,64 @@ pub(crate) fn resolve_pricing_known(
         return None;
     }
 
-    for key in exact_candidate_keys(model, &model_lower) {
-        if let Some(pricing) = models.get(&key) {
-            return Some(pricing.clone());
-        }
+    match resolve_direct_exact(model, &model_lower, models) {
+        PricingResolution::Resolved(pricing) => return Some(pricing),
+        PricingResolution::Ambiguous => return None,
+        PricingResolution::NoMatch => {}
+    }
+
+    match resolve_normalized_exact(model, &model_lower, models) {
+        PricingResolution::Resolved(pricing) => return Some(pricing),
+        PricingResolution::Ambiguous => return None,
+        PricingResolution::NoMatch => {}
     }
 
     resolve_dated_claude_variant(&model_lower, models)
+}
+
+enum PricingResolution {
+    NoMatch,
+    Resolved(ModelPricing),
+    Ambiguous,
+}
+
+fn resolve_direct_exact(
+    model: &str,
+    model_lower: &str,
+    models: &HashMap<String, ModelPricing>,
+) -> PricingResolution {
+    let mut candidates = Vec::new();
+    let mut seen = HashSet::new();
+    for key in [model, model_lower] {
+        if seen.insert(key)
+            && let Some(pricing) = models.get(key)
+        {
+            candidates.push((key.to_lowercase(), pricing_signature(pricing), pricing));
+        }
+    }
+
+    resolve_unique_pricing(candidates)
+}
+
+fn resolve_normalized_exact(
+    model: &str,
+    model_lower: &str,
+    models: &HashMap<String, ModelPricing>,
+) -> PricingResolution {
+    let candidates = exact_candidate_keys(model, model_lower)
+        .into_iter()
+        .filter_map(|key| {
+            models.get(&key).map(|pricing| {
+                (
+                    canonical_lookup_key(&key),
+                    pricing_signature(pricing),
+                    pricing,
+                )
+            })
+        })
+        .collect();
+
+    resolve_unique_pricing(candidates)
 }
 
 fn exact_candidate_keys(model: &str, model_lower: &str) -> Vec<String> {
@@ -48,7 +99,7 @@ fn exact_candidate_keys(model: &str, model_lower: &str) -> Vec<String> {
 
     let base_keys = keys.clone();
     for key in base_keys {
-        if !key.as_bytes().iter().any(|character| *character == b'/')
+        if !key.as_bytes().contains(&b'/')
             && is_claude_family_alias(&key)
             && !key.starts_with("claude-")
         {
@@ -93,7 +144,7 @@ fn resolve_dated_claude_variant(
     for (key, pricing) in models {
         let key_lower = key.to_lowercase();
         let canonical = canonical_claude_key(&key_lower);
-        if strip_yyyymmdd_suffix(&canonical).is_some_and(|base| bases.get(base).is_some()) {
+        if strip_yyyymmdd_suffix(&canonical).is_some_and(|base| bases.contains(base)) {
             candidates.push((canonical, pricing_signature(pricing), pricing));
         }
     }
@@ -115,6 +166,17 @@ fn canonical_claude_key(key: &str) -> String {
     key.strip_prefix("claude-").unwrap_or(key).to_string()
 }
 
+fn canonical_lookup_key(key: &str) -> String {
+    let lower = key.to_lowercase();
+    let without_provider = lower
+        .strip_prefix("anthropic.")
+        .or_else(|| lower.strip_prefix("openai/"))
+        .or_else(|| lower.strip_prefix("xai/"))
+        .unwrap_or(&lower);
+
+    canonical_claude_key(without_provider)
+}
+
 fn is_claude_family_alias(key: &str) -> bool {
     key.split(['-', '.', '/', '_'])
         .any(|segment| matches!(segment, "sonnet" | "opus" | "haiku"))
@@ -129,11 +191,18 @@ fn strip_yyyymmdd_suffix(key: &str) -> Option<&str> {
 }
 
 fn unique_pricing(candidates: Vec<(String, [u64; 5], &ModelPricing)>) -> Option<ModelPricing> {
+    match resolve_unique_pricing(candidates) {
+        PricingResolution::Resolved(pricing) => Some(pricing),
+        PricingResolution::NoMatch | PricingResolution::Ambiguous => None,
+    }
+}
+
+fn resolve_unique_pricing(candidates: Vec<(String, [u64; 5], &ModelPricing)>) -> PricingResolution {
     let mut unique = HashMap::new();
     for (canonical, signature, pricing) in candidates {
         match unique.get(&canonical) {
             Some((existing_signature, _)) if *existing_signature != signature => {
-                return None;
+                return PricingResolution::Ambiguous;
             }
             Some(_) => {}
             None => {
@@ -142,11 +211,17 @@ fn unique_pricing(candidates: Vec<(String, [u64; 5], &ModelPricing)>) -> Option<
         }
     }
 
-    if unique.len() != 1 {
-        return None;
+    if unique.is_empty() {
+        return PricingResolution::NoMatch;
     }
-    let (_, pricing) = unique.into_values().next()?;
-    Some(pricing.clone())
+    if unique.len() != 1 {
+        return PricingResolution::Ambiguous;
+    }
+    let (_, pricing) = unique
+        .into_values()
+        .next()
+        .expect("unique pricing contains one value");
+    PricingResolution::Resolved(pricing.clone())
 }
 
 fn pricing_signature(pricing: &ModelPricing) -> [u64; 5] {
@@ -330,6 +405,28 @@ mod tests {
         let result = resolve_pricing_known("anthropic.claude-sonnet-4", &models);
         assert!(result.is_some());
         assert_eq!(result.unwrap().input, 3e-6);
+    }
+
+    #[test]
+    fn test_resolve_provider_normalized_ambiguity_returns_none() {
+        let mut models = HashMap::new();
+        models.insert(
+            "sonnet-4".to_string(),
+            ModelPricing {
+                input: 3e-6,
+                ..Default::default()
+            },
+        );
+        models.insert(
+            "claude-sonnet-4".to_string(),
+            ModelPricing {
+                input: 4e-6,
+                ..Default::default()
+            },
+        );
+
+        let result = resolve_pricing_known("anthropic.claude-sonnet-4", &models);
+        assert!(result.is_none());
     }
 
     #[test]

--- a/src/pricing/resolver/resolve.rs
+++ b/src/pricing/resolver/resolve.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use super::super::types::{dot_version_variant, ModelPricing};
+use super::super::types::{ModelPricing, dot_version_variant};
 
 pub(crate) fn resolve_pricing_known(
     model: &str,

--- a/src/pricing/resolver/resolve.rs
+++ b/src/pricing/resolver/resolve.rs
@@ -1,41 +1,162 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
-use super::super::types::ModelPricing;
+use super::super::types::{dot_version_variant, ModelPricing};
 
 pub(crate) fn resolve_pricing_known(
     model: &str,
     models: &HashMap<String, ModelPricing>,
 ) -> Option<ModelPricing> {
-    // Try exact match first
-    if let Some(pricing) = models.get(model) {
-        return Some(pricing.clone());
-    }
-
-    // Try with claude- prefix
-    let with_prefix = format!("claude-{model}");
-    if let Some(pricing) = models.get(&with_prefix) {
-        return Some(pricing.clone());
-    }
-
-    // Try partial matching
     let model_lower = model.to_lowercase();
     if model_lower.is_empty() {
         return None;
     }
-    let mut candidates: Vec<(&String, &ModelPricing)> = models
-        .iter()
-        .filter(|(name, _)| {
-            let name_lower = name.to_lowercase();
-            name_lower.contains(&model_lower) || model_lower.contains(&name_lower)
-        })
-        .collect();
-    candidates.sort_by(|(a, _), (b, _)| b.len().cmp(&a.len()).then_with(|| a.cmp(b)));
 
-    if let Some((_, pricing)) = candidates.first() {
-        return Some((*pricing).clone());
+    for key in exact_candidate_keys(model, &model_lower) {
+        if let Some(pricing) = models.get(&key) {
+            return Some(pricing.clone());
+        }
     }
 
-    None
+    resolve_dated_claude_variant(&model_lower, models)
+}
+
+fn exact_candidate_keys(model: &str, model_lower: &str) -> Vec<String> {
+    let mut keys = Vec::new();
+    let mut seen = HashSet::new();
+    push_candidate_key(&mut keys, &mut seen, model);
+    push_candidate_key(&mut keys, &mut seen, model_lower);
+
+    let base_keys = keys.clone();
+    for key in base_keys {
+        if let Some(stripped) = key.strip_prefix("anthropic.") {
+            push_candidate_key(&mut keys, &mut seen, stripped);
+        }
+        if let Some(stripped) = key.strip_prefix("openai/") {
+            push_candidate_key(&mut keys, &mut seen, stripped);
+        }
+        if let Some(stripped) = key.strip_prefix("xai/") {
+            push_candidate_key(&mut keys, &mut seen, stripped);
+        }
+    }
+
+    let base_keys = keys.clone();
+    for key in base_keys {
+        if let Some(stripped) = key.strip_prefix("claude-") {
+            push_candidate_key(&mut keys, &mut seen, stripped);
+        }
+    }
+
+    let base_keys = keys.clone();
+    for key in base_keys {
+        if !key.as_bytes().iter().any(|character| *character == b'/')
+            && is_claude_family_alias(&key)
+            && !key.starts_with("claude-")
+        {
+            push_candidate_key(&mut keys, &mut seen, format!("claude-{key}"));
+        }
+        if key.starts_with("gpt-") || key.starts_with("codex") {
+            push_candidate_key(&mut keys, &mut seen, format!("openai/{key}"));
+        }
+        if key.starts_with("grok-") {
+            push_candidate_key(&mut keys, &mut seen, format!("xai/{key}"));
+        }
+    }
+
+    keys
+}
+
+fn push_candidate_key(keys: &mut Vec<String>, seen: &mut HashSet<String>, key: impl AsRef<str>) {
+    let key = key.as_ref();
+    if key.is_empty() {
+        return;
+    }
+    if seen.insert(key.to_string()) {
+        keys.push(key.to_string());
+    }
+
+    let dotted = dot_version_variant(key);
+    if dotted != key && seen.insert(dotted.clone()) {
+        keys.push(dotted);
+    }
+}
+
+fn resolve_dated_claude_variant(
+    model_lower: &str,
+    models: &HashMap<String, ModelPricing>,
+) -> Option<ModelPricing> {
+    let bases = approved_dated_variant_bases(model_lower);
+    if bases.is_empty() {
+        return None;
+    }
+
+    let mut candidates = Vec::new();
+    for (key, pricing) in models {
+        let key_lower = key.to_lowercase();
+        let canonical = canonical_claude_key(&key_lower);
+        if strip_yyyymmdd_suffix(&canonical).is_some_and(|base| bases.get(base).is_some()) {
+            candidates.push((canonical, pricing_signature(pricing), pricing));
+        }
+    }
+
+    unique_pricing(candidates)
+}
+
+fn approved_dated_variant_bases(model_lower: &str) -> HashSet<String> {
+    exact_candidate_keys(model_lower, model_lower)
+        .into_iter()
+        .map(|key| canonical_claude_key(&key))
+        .filter(|key| is_claude_family_alias(key))
+        .filter(|key| strip_yyyymmdd_suffix(key).is_none())
+        .collect()
+}
+
+fn canonical_claude_key(key: &str) -> String {
+    let key = key.strip_prefix("anthropic.").unwrap_or(key);
+    key.strip_prefix("claude-").unwrap_or(key).to_string()
+}
+
+fn is_claude_family_alias(key: &str) -> bool {
+    key.split(['-', '.', '/', '_'])
+        .any(|segment| matches!(segment, "sonnet" | "opus" | "haiku"))
+}
+
+fn strip_yyyymmdd_suffix(key: &str) -> Option<&str> {
+    let (base, suffix) = key.rsplit_once('-')?;
+    (!base.is_empty()
+        && suffix.len() == 8
+        && suffix.chars().all(|character| character.is_ascii_digit()))
+    .then_some(base)
+}
+
+fn unique_pricing(candidates: Vec<(String, [u64; 5], &ModelPricing)>) -> Option<ModelPricing> {
+    let mut unique = HashMap::new();
+    for (canonical, signature, pricing) in candidates {
+        match unique.get(&canonical) {
+            Some((existing_signature, _)) if *existing_signature != signature => {
+                return None;
+            }
+            Some(_) => {}
+            None => {
+                unique.insert(canonical, (signature, pricing));
+            }
+        }
+    }
+
+    if unique.len() != 1 {
+        return None;
+    }
+    let (_, pricing) = unique.into_values().next()?;
+    Some(pricing.clone())
+}
+
+fn pricing_signature(pricing: &ModelPricing) -> [u64; 5] {
+    [
+        pricing.input.to_bits(),
+        pricing.output.to_bits(),
+        pricing.reasoning_output.to_bits(),
+        pricing.cache_read.to_bits(),
+        pricing.cache_create.to_bits(),
+    ]
 }
 
 #[cfg(test)]
@@ -80,7 +201,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_partial_match() {
+    fn test_resolve_approved_dated_claude_variant() {
         let mut models = HashMap::new();
         models.insert(
             "claude-sonnet-4-20250514".to_string(),
@@ -91,9 +212,9 @@ mod tests {
             },
         );
 
-        // Partial match: "sonnet-4" is contained in "claude-sonnet-4-20250514"
-        let result = resolve_pricing_known("claude-sonnet-4-20250514", &models);
+        let result = resolve_pricing_known("sonnet-4", &models);
         assert!(result.is_some());
+        assert_eq!(result.unwrap().input, 3e-6);
     }
 
     #[test]
@@ -104,7 +225,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_case_insensitive_partial() {
+    fn test_resolve_case_insensitive_exact() {
         let mut models = HashMap::new();
         models.insert(
             "claude-sonnet-4-20250514".to_string(),
@@ -114,7 +235,6 @@ mod tests {
             },
         );
 
-        // Mixed case query should still match via case-insensitive containment
         let result = resolve_pricing_known("Claude-Sonnet-4-20250514", &models);
         assert!(result.is_some());
         assert_eq!(result.unwrap().input, 3e-6);
@@ -131,13 +251,12 @@ mod tests {
             },
         );
 
-        // Query is a substring of a stored key
         let result = resolve_pricing_known("sonnet-4-20250514", &models);
         assert!(result.is_some());
     }
 
     #[test]
-    fn test_resolve_partial_model_name_in_query() {
+    fn test_resolve_substring_model_name_in_query_returns_none() {
         let mut models = HashMap::new();
         models.insert(
             "sonnet-4".to_string(),
@@ -147,34 +266,30 @@ mod tests {
             },
         );
 
-        // Stored key is a substring of the query (bidirectional containment)
         let result = resolve_pricing_known("claude-sonnet-4-20250514", &models);
-        assert!(result.is_some());
-        assert_eq!(result.unwrap().input, 3e-6);
+        assert!(result.is_none());
     }
 
     #[test]
-    fn test_resolve_longest_match_wins() {
+    fn test_resolve_ambiguous_dated_variants_return_none() {
         let mut models = HashMap::new();
         models.insert(
-            "sonnet".to_string(),
+            "claude-sonnet-4-20250514".to_string(),
             ModelPricing {
                 input: 1e-6,
                 ..Default::default()
             },
         );
         models.insert(
-            "claude-sonnet-4-20250514".to_string(),
+            "claude-sonnet-4-20260101".to_string(),
             ModelPricing {
                 input: 3e-6,
                 ..Default::default()
             },
         );
 
-        // Both match "sonnet-4-20250514", but the longer key should win
-        let result = resolve_pricing_known("sonnet-4-20250514", &models);
-        assert!(result.is_some());
-        assert_eq!(result.unwrap().input, 3e-6);
+        let result = resolve_pricing_known("sonnet-4", &models);
+        assert!(result.is_none());
     }
 
     #[test]
@@ -202,6 +317,22 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_provider_prefix_stripping() {
+        let mut models = HashMap::new();
+        models.insert(
+            "sonnet-4".to_string(),
+            ModelPricing {
+                input: 3e-6,
+                ..Default::default()
+            },
+        );
+
+        let result = resolve_pricing_known("anthropic.claude-sonnet-4", &models);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().input, 3e-6);
+    }
+
+    #[test]
     fn test_resolve_claude_prefix_fallback() {
         let mut models = HashMap::new();
         models.insert(
@@ -216,6 +347,21 @@ mod tests {
         let result = resolve_pricing_known("opus-4", &models);
         assert!(result.is_some());
         assert_eq!(result.unwrap().input, 15e-6);
+    }
+
+    #[test]
+    fn test_resolve_short_substring_returns_none() {
+        let mut models = HashMap::new();
+        models.insert(
+            "gpt-5.4-mini".to_string(),
+            ModelPricing {
+                input: 1e-6,
+                ..Default::default()
+            },
+        );
+
+        let result = resolve_pricing_known("mini", &models);
+        assert!(result.is_none());
     }
 
     #[test]

--- a/src/pricing/resolver/resolve.rs
+++ b/src/pricing/resolver/resolve.rs
@@ -23,6 +23,12 @@ pub(crate) fn resolve_pricing_known(
         PricingResolution::NoMatch => {}
     }
 
+    match resolve_dated_base_exact(model, &model_lower, models) {
+        PricingResolution::Resolved(pricing) => return Some(pricing),
+        PricingResolution::Ambiguous => return None,
+        PricingResolution::NoMatch => {}
+    }
+
     resolve_dated_claude_variant(&model_lower, models)
 }
 
@@ -71,6 +77,60 @@ fn resolve_normalized_exact(
     resolve_unique_pricing(candidates)
 }
 
+fn resolve_dated_base_exact(
+    model: &str,
+    model_lower: &str,
+    models: &HashMap<String, ModelPricing>,
+) -> PricingResolution {
+    let mut keys = Vec::new();
+    let mut seen = HashSet::new();
+    for key in dated_base_candidate_keys(model, model_lower) {
+        if let Some(base) = strip_known_date_suffix(&key) {
+            push_candidate_key(&mut keys, &mut seen, base);
+        }
+    }
+
+    let candidates = keys
+        .into_iter()
+        .filter_map(|key| {
+            models.get(&key).map(|pricing| {
+                (
+                    canonical_lookup_key(&key),
+                    pricing_signature(pricing),
+                    pricing,
+                )
+            })
+        })
+        .collect();
+
+    resolve_unique_pricing(candidates)
+}
+
+fn dated_base_candidate_keys(model: &str, model_lower: &str) -> Vec<String> {
+    let mut keys = Vec::new();
+    let mut seen = HashSet::new();
+    push_candidate_key(&mut keys, &mut seen, model);
+    push_candidate_key(&mut keys, &mut seen, model_lower);
+
+    let base_keys = keys.clone();
+    for key in base_keys {
+        if let Some(stripped) = key.strip_prefix("anthropic.") {
+            push_candidate_key(&mut keys, &mut seen, stripped);
+        }
+        if let Some(stripped) = key.strip_prefix("anthropic/") {
+            push_candidate_key(&mut keys, &mut seen, stripped);
+        }
+        if let Some(stripped) = key.strip_prefix("openai/") {
+            push_candidate_key(&mut keys, &mut seen, stripped);
+        }
+        if let Some(stripped) = key.strip_prefix("xai/") {
+            push_candidate_key(&mut keys, &mut seen, stripped);
+        }
+    }
+
+    keys
+}
+
 fn exact_candidate_keys(model: &str, model_lower: &str) -> Vec<String> {
     let mut keys = Vec::new();
     let mut seen = HashSet::new();
@@ -80,6 +140,9 @@ fn exact_candidate_keys(model: &str, model_lower: &str) -> Vec<String> {
     let base_keys = keys.clone();
     for key in base_keys {
         if let Some(stripped) = key.strip_prefix("anthropic.") {
+            push_candidate_key(&mut keys, &mut seen, stripped);
+        }
+        if let Some(stripped) = key.strip_prefix("anthropic/") {
             push_candidate_key(&mut keys, &mut seen, stripped);
         }
         if let Some(stripped) = key.strip_prefix("openai/") {
@@ -170,6 +233,7 @@ fn canonical_lookup_key(key: &str) -> String {
     let lower = key.to_lowercase();
     let without_provider = lower
         .strip_prefix("anthropic.")
+        .or_else(|| lower.strip_prefix("anthropic/"))
         .or_else(|| lower.strip_prefix("openai/"))
         .or_else(|| lower.strip_prefix("xai/"))
         .unwrap_or(&lower);
@@ -187,6 +251,30 @@ fn strip_yyyymmdd_suffix(key: &str) -> Option<&str> {
     (!base.is_empty()
         && suffix.len() == 8
         && suffix.chars().all(|character| character.is_ascii_digit()))
+    .then_some(base)
+}
+
+fn strip_known_date_suffix(key: &str) -> Option<&str> {
+    strip_yyyymmdd_suffix(key).or_else(|| strip_yyyy_mm_dd_suffix(key))
+}
+
+fn strip_yyyy_mm_dd_suffix(key: &str) -> Option<&str> {
+    let date_start = key.len().checked_sub(10)?;
+    let separator_index = date_start.checked_sub(1)?;
+    if key.as_bytes().get(separator_index) != Some(&b'-') {
+        return None;
+    }
+
+    let base = &key[..separator_index];
+    let suffix = &key[date_start..];
+    (!base.is_empty()
+        && suffix.len() == 10
+        && suffix.as_bytes().get(4) == Some(&b'-')
+        && suffix.as_bytes().get(7) == Some(&b'-')
+        && suffix
+            .bytes()
+            .enumerate()
+            .all(|(index, byte)| matches!(index, 4 | 7) || byte.is_ascii_digit()))
     .then_some(base)
 }
 
@@ -290,6 +378,51 @@ mod tests {
         let result = resolve_pricing_known("sonnet-4", &models);
         assert!(result.is_some());
         assert_eq!(result.unwrap().input, 3e-6);
+    }
+
+    #[test]
+    fn test_resolve_anthropic_slash_provider_prefix_stripping() {
+        let mut models = HashMap::new();
+        models.insert(
+            "claude-sonnet-4-20250514".to_string(),
+            ModelPricing {
+                input: 3e-6,
+                ..Default::default()
+            },
+        );
+
+        let result = resolve_pricing_known("anthropic/claude-sonnet-4-20250514", &models);
+        assert_eq!(result.map(|pricing| pricing.input), Some(3e-6));
+    }
+
+    #[test]
+    fn test_resolve_dated_openai_base_variant() {
+        let mut models = HashMap::new();
+        models.insert(
+            "gpt-4o-mini-audio-preview".to_string(),
+            ModelPricing {
+                input: 15e-8,
+                ..Default::default()
+            },
+        );
+
+        let result = resolve_pricing_known("gpt-4o-mini-audio-preview-2024-12-17", &models);
+        assert_eq!(result.map(|pricing| pricing.input), Some(15e-8));
+    }
+
+    #[test]
+    fn test_resolve_dated_claude_canonical_base_variant() {
+        let mut models = HashMap::new();
+        models.insert(
+            "claude-sonnet-4-5".to_string(),
+            ModelPricing {
+                input: 3e-6,
+                ..Default::default()
+            },
+        );
+
+        let result = resolve_pricing_known("claude-sonnet-4-5-20250929", &models);
+        assert_eq!(result.map(|pricing| pricing.input), Some(3e-6));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- removes unbounded bidirectional substring matching from pricing model resolution
- resolves only direct exact, explicit normalized/provider, and approved dated Claude variant candidates
- returns unknown when normalized/provider candidates or dated variants are ambiguous instead of silently selecting a price

Fixes #44

## Verification
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test pricing::resolver`
- `cargo test pricing`
- `cargo check`
- `cargo test`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH44`
- `git diff --check`
- `rg -n "contains\\(" src/pricing/resolver/resolve.rs` only reports byte-slice slash and `HashSet` membership checks, not string substring matching
