### PR TITLE
Use platform cache path for pricing cache

### DIFF
--- a/src/pricing/cache.rs
+++ b/src/pricing/cache.rs
@@ -1,42 +1,242 @@
 use std::collections::HashMap;
 use std::fs::File;
+use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 
+const APP_CACHE_DIR: &str = "ccstats";
+const PRICING_CACHE_FILE: &str = "pricing.json";
+
+#[derive(Debug)]
+struct CachePaths {
+    write_path: Option<PathBuf>,
+    read_paths: Vec<PathBuf>,
+}
+
+fn pricing_cache_file(root: PathBuf) -> PathBuf {
+    root.join(APP_CACHE_DIR).join(PRICING_CACHE_FILE)
+}
+
+fn legacy_cache_file(home_dir: PathBuf) -> PathBuf {
+    home_dir
+        .join(".cache")
+        .join(APP_CACHE_DIR)
+        .join(PRICING_CACHE_FILE)
+}
+
+fn select_cache_paths(
+    platform_cache_dir: Option<PathBuf>,
+    home_dir: Option<PathBuf>,
+) -> CachePaths {
+    let preferred_path = platform_cache_dir.map(pricing_cache_file);
+    let legacy_path = home_dir.map(legacy_cache_file);
+    let write_path = preferred_path.clone().or_else(|| legacy_path.clone());
+
+    let mut read_paths = Vec::new();
+    if let Some(path) = &write_path {
+        read_paths.push(path.clone());
+    }
+    if let Some(path) = legacy_path
+        && !read_paths.contains(&path)
+    {
+        read_paths.push(path);
+    }
+
+    CachePaths {
+        write_path,
+        read_paths,
+    }
+}
+
+fn cache_paths() -> CachePaths {
+    select_cache_paths(dirs::cache_dir(), dirs::home_dir())
+}
+
 pub(super) fn get_cache_path() -> Option<PathBuf> {
-    let home = dirs::home_dir()?;
-    Some(home.join(".cache").join("ccstats").join("pricing.json"))
+    cache_paths().write_path
+}
+
+fn open_cache_file(path: &PathBuf) -> Option<Option<File>> {
+    match File::open(path) {
+        Ok(file) => Some(Some(file)),
+        Err(error) if error.kind() == ErrorKind::NotFound => Some(None),
+        Err(_) => None,
+    }
+}
+
+fn load_raw_cache_from_paths(paths: &[PathBuf]) -> Option<HashMap<String, serde_json::Value>> {
+    for path in paths {
+        let Some(file) = open_cache_file(path)? else {
+            continue;
+        };
+        return serde_json::from_reader(file).ok();
+    }
+    None
+}
+
+fn load_raw_cache_if_fresh_from_paths(
+    paths: &[PathBuf],
+    ttl: Duration,
+) -> Option<(HashMap<String, serde_json::Value>, Duration)> {
+    for path in paths {
+        let meta = match std::fs::metadata(path) {
+            Ok(meta) => meta,
+            Err(error) if error.kind() == ErrorKind::NotFound => continue,
+            Err(_) => return None,
+        };
+        let modified = meta.modified().ok()?;
+        let age = SystemTime::now().duration_since(modified).ok()?;
+        if age > ttl {
+            return None;
+        }
+        let file = File::open(path).ok()?;
+        let data = serde_json::from_reader(file).ok()?;
+        return Some((data, age));
+    }
+    None
 }
 
 pub(super) fn load_raw_cache() -> Option<HashMap<String, serde_json::Value>> {
-    let path = get_cache_path()?;
-    let file = File::open(&path).ok()?;
-    serde_json::from_reader(file).ok()
+    let paths = cache_paths();
+    load_raw_cache_from_paths(&paths.read_paths)
 }
 
 pub(super) fn load_raw_cache_if_fresh(
     ttl: Duration,
 ) -> Option<(HashMap<String, serde_json::Value>, Duration)> {
-    let path = get_cache_path()?;
-    let meta = std::fs::metadata(&path).ok()?;
-    let modified = meta.modified().ok()?;
-    let age = SystemTime::now().duration_since(modified).ok()?;
-    if age > ttl {
-        return None;
-    }
-    let file = File::open(&path).ok()?;
-    let data = serde_json::from_reader(file).ok()?;
-    Some((data, age))
+    let paths = cache_paths();
+    load_raw_cache_if_fresh_from_paths(&paths.read_paths, ttl)
 }
 
 pub(super) fn save_raw_cache(raw_data: &HashMap<String, serde_json::Value>) {
     let Some(path) = get_cache_path() else {
         return;
     };
+    save_raw_cache_to_path(raw_data, &path);
+}
+
+fn save_raw_cache_to_path(raw_data: &HashMap<String, serde_json::Value>, path: &PathBuf) {
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    if let Ok(mut file) = File::create(&path) {
+    if let Ok(mut file) = File::create(path) {
         let _ = serde_json::to_writer(&mut file, raw_data);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    fn sample_raw_data(key: &str) -> HashMap<String, serde_json::Value> {
+        HashMap::from([(key.to_string(), json!({"input_cost_per_token": 1.0}))])
+    }
+
+    #[test]
+    fn cache_paths_prefer_platform_cache_dir() {
+        let platform = PathBuf::from("platform-cache");
+        let home = PathBuf::from("home-dir");
+        let paths = select_cache_paths(Some(platform.clone()), Some(home.clone()));
+
+        assert_eq!(
+            paths.write_path,
+            Some(platform.join(APP_CACHE_DIR).join(PRICING_CACHE_FILE))
+        );
+        assert_eq!(
+            paths.read_paths,
+            vec![
+                PathBuf::from("platform-cache")
+                    .join(APP_CACHE_DIR)
+                    .join(PRICING_CACHE_FILE),
+                PathBuf::from("home-dir")
+                    .join(".cache")
+                    .join(APP_CACHE_DIR)
+                    .join(PRICING_CACHE_FILE),
+            ]
+        );
+    }
+
+    #[test]
+    fn cache_paths_use_legacy_as_explicit_fallback() {
+        let home = PathBuf::from("home-dir");
+        let paths = select_cache_paths(None, Some(home.clone()));
+        let legacy_path = home
+            .join(".cache")
+            .join(APP_CACHE_DIR)
+            .join(PRICING_CACHE_FILE);
+
+        assert_eq!(paths.write_path, Some(legacy_path.clone()));
+        assert_eq!(paths.read_paths, vec![legacy_path]);
+    }
+
+    #[test]
+    fn load_raw_cache_reads_legacy_when_preferred_absent() {
+        let platform_root = TempDir::new().unwrap();
+        let home_root = TempDir::new().unwrap();
+        let paths = select_cache_paths(
+            Some(platform_root.path().to_path_buf()),
+            Some(home_root.path().to_path_buf()),
+        );
+        let legacy_path = legacy_cache_file(home_root.path().to_path_buf());
+        save_raw_cache_to_path(&sample_raw_data("legacy-model"), &legacy_path);
+
+        let data = load_raw_cache_from_paths(&paths.read_paths).unwrap();
+
+        assert!(data.contains_key("legacy-model"));
+    }
+
+    #[test]
+    fn load_raw_cache_prefers_current_when_both_exist() {
+        let platform_root = TempDir::new().unwrap();
+        let home_root = TempDir::new().unwrap();
+        let paths = select_cache_paths(
+            Some(platform_root.path().to_path_buf()),
+            Some(home_root.path().to_path_buf()),
+        );
+        let current_path = paths.write_path.as_ref().unwrap();
+        let legacy_path = legacy_cache_file(home_root.path().to_path_buf());
+        save_raw_cache_to_path(&sample_raw_data("current-model"), current_path);
+        save_raw_cache_to_path(&sample_raw_data("legacy-model"), &legacy_path);
+
+        let data = load_raw_cache_from_paths(&paths.read_paths).unwrap();
+
+        assert!(data.contains_key("current-model"));
+        assert!(!data.contains_key("legacy-model"));
+    }
+
+    #[test]
+    fn load_raw_cache_if_fresh_reads_legacy_when_preferred_absent() {
+        let platform_root = TempDir::new().unwrap();
+        let home_root = TempDir::new().unwrap();
+        let paths = select_cache_paths(
+            Some(platform_root.path().to_path_buf()),
+            Some(home_root.path().to_path_buf()),
+        );
+        let legacy_path = legacy_cache_file(home_root.path().to_path_buf());
+        save_raw_cache_to_path(&sample_raw_data("legacy-model"), &legacy_path);
+
+        let (data, _age) =
+            load_raw_cache_if_fresh_from_paths(&paths.read_paths, Duration::from_secs(60)).unwrap();
+
+        assert!(data.contains_key("legacy-model"));
+    }
+
+    #[test]
+    fn save_raw_cache_writes_current_path_not_legacy() {
+        let platform_root = TempDir::new().unwrap();
+        let home_root = TempDir::new().unwrap();
+        let paths = select_cache_paths(
+            Some(platform_root.path().to_path_buf()),
+            Some(home_root.path().to_path_buf()),
+        );
+        let current_path = paths.write_path.as_ref().unwrap();
+        let legacy_path = legacy_cache_file(home_root.path().to_path_buf());
+
+        save_raw_cache_to_path(&sample_raw_data("current-model"), current_path);
+
+        assert!(current_path.exists());
+        assert!(!legacy_path.exists());
     }
 }

--- a/src/pricing/cache.rs
+++ b/src/pricing/cache.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::ErrorKind;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
 const APP_CACHE_DIR: &str = "ccstats";
@@ -13,21 +13,18 @@ struct CachePaths {
     read_paths: Vec<PathBuf>,
 }
 
-fn pricing_cache_file(root: PathBuf) -> PathBuf {
+fn pricing_cache_file(root: &Path) -> PathBuf {
     root.join(APP_CACHE_DIR).join(PRICING_CACHE_FILE)
 }
 
-fn legacy_cache_file(home_dir: PathBuf) -> PathBuf {
+fn legacy_cache_file(home_dir: &Path) -> PathBuf {
     home_dir
         .join(".cache")
         .join(APP_CACHE_DIR)
         .join(PRICING_CACHE_FILE)
 }
 
-fn select_cache_paths(
-    platform_cache_dir: Option<PathBuf>,
-    home_dir: Option<PathBuf>,
-) -> CachePaths {
+fn select_cache_paths(platform_cache_dir: Option<&Path>, home_dir: Option<&Path>) -> CachePaths {
     let preferred_path = platform_cache_dir.map(pricing_cache_file);
     let legacy_path = home_dir.map(legacy_cache_file);
     let write_path = preferred_path.clone().or_else(|| legacy_path.clone());
@@ -49,25 +46,21 @@ fn select_cache_paths(
 }
 
 fn cache_paths() -> CachePaths {
-    select_cache_paths(dirs::cache_dir(), dirs::home_dir())
+    let platform_cache_dir = dirs::cache_dir();
+    let home_dir = dirs::home_dir();
+    select_cache_paths(platform_cache_dir.as_deref(), home_dir.as_deref())
 }
 
 pub(super) fn get_cache_path() -> Option<PathBuf> {
     cache_paths().write_path
 }
 
-fn open_cache_file(path: &PathBuf) -> Option<Option<File>> {
-    match File::open(path) {
-        Ok(file) => Some(Some(file)),
-        Err(error) if error.kind() == ErrorKind::NotFound => Some(None),
-        Err(_) => None,
-    }
-}
-
 fn load_raw_cache_from_paths(paths: &[PathBuf]) -> Option<HashMap<String, serde_json::Value>> {
     for path in paths {
-        let Some(file) = open_cache_file(path)? else {
-            continue;
+        let file = match File::open(path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == ErrorKind::NotFound => continue,
+            Err(_) => return None,
         };
         return serde_json::from_reader(file).ok();
     }
@@ -115,7 +108,7 @@ pub(super) fn save_raw_cache(raw_data: &HashMap<String, serde_json::Value>) {
     save_raw_cache_to_path(raw_data, &path);
 }
 
-fn save_raw_cache_to_path(raw_data: &HashMap<String, serde_json::Value>, path: &PathBuf) {
+fn save_raw_cache_to_path(raw_data: &HashMap<String, serde_json::Value>, path: &Path) {
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
@@ -138,7 +131,7 @@ mod tests {
     fn cache_paths_prefer_platform_cache_dir() {
         let platform = PathBuf::from("platform-cache");
         let home = PathBuf::from("home-dir");
-        let paths = select_cache_paths(Some(platform.clone()), Some(home.clone()));
+        let paths = select_cache_paths(Some(platform.as_path()), Some(home.as_path()));
 
         assert_eq!(
             paths.write_path,
@@ -161,7 +154,7 @@ mod tests {
     #[test]
     fn cache_paths_use_legacy_as_explicit_fallback() {
         let home = PathBuf::from("home-dir");
-        let paths = select_cache_paths(None, Some(home.clone()));
+        let paths = select_cache_paths(None, Some(home.as_path()));
         let legacy_path = home
             .join(".cache")
             .join(APP_CACHE_DIR)
@@ -175,11 +168,8 @@ mod tests {
     fn load_raw_cache_reads_legacy_when_preferred_absent() {
         let platform_root = TempDir::new().unwrap();
         let home_root = TempDir::new().unwrap();
-        let paths = select_cache_paths(
-            Some(platform_root.path().to_path_buf()),
-            Some(home_root.path().to_path_buf()),
-        );
-        let legacy_path = legacy_cache_file(home_root.path().to_path_buf());
+        let paths = select_cache_paths(Some(platform_root.path()), Some(home_root.path()));
+        let legacy_path = legacy_cache_file(home_root.path());
         save_raw_cache_to_path(&sample_raw_data("legacy-model"), &legacy_path);
 
         let data = load_raw_cache_from_paths(&paths.read_paths).unwrap();
@@ -191,12 +181,9 @@ mod tests {
     fn load_raw_cache_prefers_current_when_both_exist() {
         let platform_root = TempDir::new().unwrap();
         let home_root = TempDir::new().unwrap();
-        let paths = select_cache_paths(
-            Some(platform_root.path().to_path_buf()),
-            Some(home_root.path().to_path_buf()),
-        );
+        let paths = select_cache_paths(Some(platform_root.path()), Some(home_root.path()));
         let current_path = paths.write_path.as_ref().unwrap();
-        let legacy_path = legacy_cache_file(home_root.path().to_path_buf());
+        let legacy_path = legacy_cache_file(home_root.path());
         save_raw_cache_to_path(&sample_raw_data("current-model"), current_path);
         save_raw_cache_to_path(&sample_raw_data("legacy-model"), &legacy_path);
 
@@ -210,11 +197,8 @@ mod tests {
     fn load_raw_cache_if_fresh_reads_legacy_when_preferred_absent() {
         let platform_root = TempDir::new().unwrap();
         let home_root = TempDir::new().unwrap();
-        let paths = select_cache_paths(
-            Some(platform_root.path().to_path_buf()),
-            Some(home_root.path().to_path_buf()),
-        );
-        let legacy_path = legacy_cache_file(home_root.path().to_path_buf());
+        let paths = select_cache_paths(Some(platform_root.path()), Some(home_root.path()));
+        let legacy_path = legacy_cache_file(home_root.path());
         save_raw_cache_to_path(&sample_raw_data("legacy-model"), &legacy_path);
 
         let (data, _age) =
@@ -227,12 +211,9 @@ mod tests {
     fn save_raw_cache_writes_current_path_not_legacy() {
         let platform_root = TempDir::new().unwrap();
         let home_root = TempDir::new().unwrap();
-        let paths = select_cache_paths(
-            Some(platform_root.path().to_path_buf()),
-            Some(home_root.path().to_path_buf()),
-        );
+        let paths = select_cache_paths(Some(platform_root.path()), Some(home_root.path()));
         let current_path = paths.write_path.as_ref().unwrap();
-        let legacy_path = legacy_cache_file(home_root.path().to_path_buf());
+        let legacy_path = legacy_cache_file(home_root.path());
 
         save_raw_cache_to_path(&sample_raw_data("current-model"), current_path);
 


### PR DESCRIPTION
## Summary
- centralizes pricing cache path selection in `src/pricing/cache.rs`
- writes new pricing cache data to `dirs::cache_dir()/ccstats/pricing.json` when available
- keeps legacy `$HOME/.cache/ccstats/pricing.json` as a read fallback when the preferred cache is absent
- keeps the existing `PricingDb` caller API unchanged

Fixes #43

## Verification
- `cargo fmt --check`
- `cargo test pricing::cache`
- `cargo test pricing`
- `cargo check`
- `cargo test`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH43`
- `git diff --check`
- `rg -n "\\.cache.*pricing\\.json" src` (no production hardcoded pricing cache path matches)
