### PR TITLE
Fail fast on invalid config and document config paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,67 @@ ccstats today -c
 ccstats today --no-cost
 ```
 
+### Configuration
+
+ccstats reads an optional TOML config file before command execution. CLI flags
+override config values.
+
+Search order:
+
+1. `~/.config/ccstats/config.toml`
+2. Platform config directory: for example
+   `~/Library/Application Support/ccstats/config.toml` on macOS
+3. `~/.ccstats.toml`
+
+The first existing config file wins. If that file exists but cannot be read,
+has invalid TOML, or has a wrong field type, ccstats exits with an error. It
+does not fall back to defaults or lower-priority config paths. If no config file
+exists, defaults are used.
+
+Example `config.toml`:
+
+```toml
+source = "codex"
+timezone = "Asia/Shanghai"
+locale = "en"
+currency = "USD"
+offline = true
+strict_pricing = true
+compact = true
+breakdown = false
+order = "desc"
+color = "auto"
+cost = "show"
+```
+
+Supported keys:
+
+| Key | Type | Values |
+|-----|------|--------|
+| `offline` | boolean | `true` or `false` |
+| `compact` | boolean | `true` or `false` |
+| `no_cost` | boolean | `true` or `false` |
+| `no_color` | boolean | `true` or `false` |
+| `breakdown` | boolean | `true` or `false` |
+| `debug` | boolean | `true` or `false` |
+| `strict_pricing` | boolean | `true` or `false` |
+| `order` | string | `asc`, `desc` |
+| `color` | string | `auto`, `always`, `never` |
+| `cost` | string | `show`, `hide` |
+| `timezone` | string | IANA timezone such as `UTC` or `Asia/Shanghai` |
+| `locale` | string | Locale used for number formatting, such as `en` or `de` |
+| `currency` | string | Currency code such as `USD`, `CNY`, or `EUR` |
+| `source` | string | Source name or alias such as `claude`, `codex`, `cursor`, `grok`, or `all` |
+
+Source root env overrides are independent of config keys:
+
+| Source | Env var | Value | Default when unset |
+|--------|---------|-------|--------------------|
+| Claude Code | `CLAUDE_CONFIG_DIR` | Claude config root containing `projects/` | `~/.claude` |
+| OpenAI Codex | `CODEX_HOME` | Codex root containing `sessions/` | `~/.codex` |
+| Cursor | `CURSOR_HOME` | Cursor `User` directory | Cursor `User` under platform app/config data dirs |
+| Grok | `GROK_HOME` | Grok root containing `sessions/` | `~/.grok` |
+
 ### Session CSV Columns
 
 `ccstats session --csv` now includes:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -153,6 +153,51 @@ pub struct RawEntry {
 
 SDK 调用通过 `summarize_cost(SummaryOptions)` 复用同一套 source registry、loader、聚合和 pricing 逻辑，但返回结构化 `CostSummary`，不经过 table/JSON 输出层。需要和 CLI 持久化配置同口径时，SDK 使用 `summarize_cost_with_cli_config` 复用 timezone、offline pricing、strict pricing 和 currency 默认值。
 
+### CLI 配置加载
+
+CLI 启动时先读取可选的 TOML 配置，再合并命令行参数。命令行参数优先级高于配置文件。
+
+配置搜索顺序：
+
+1. `~/.config/ccstats/config.toml`
+2. 平台配置目录，例如 macOS 的 `~/Library/Application Support/ccstats/config.toml`
+3. `~/.ccstats.toml`
+
+第一个存在的配置文件是权威配置。如果它无法读取、TOML 语法错误或字段类型错误，CLI 直接返回错误；normal、quiet/statusline 路径都不能回落默认值继续输出。只有所有路径都不存在时才使用 `Config::default()`。
+
+配置键保持简单，且不定义 source 根目录路径：
+
+| 键 | 类型 | 取值 |
+|----|------|------|
+| `offline`, `compact`, `no_cost`, `no_color`, `breakdown`, `debug`, `strict_pricing` | boolean | `true` / `false` |
+| `order` | string | `asc` / `desc` |
+| `color` | string | `auto` / `always` / `never` |
+| `cost` | string | `show` / `hide` |
+| `timezone`, `locale`, `currency`, `source` | string | 对应 CLI 参数的字符串值 |
+
+示例：
+
+```toml
+source = "codex"
+timezone = "Asia/Shanghai"
+currency = "USD"
+offline = true
+strict_pricing = true
+compact = true
+order = "desc"
+color = "auto"
+cost = "show"
+```
+
+Source 根目录仍由环境变量覆盖：
+
+| Source | Env var | Value | Default |
+|--------|---------|-------|---------|
+| Claude Code | `CLAUDE_CONFIG_DIR` | Claude config root containing `projects/` | `~/.claude` |
+| OpenAI Codex | `CODEX_HOME` | Codex root containing `sessions/` | `~/.codex` |
+| Cursor | `CURSOR_HOME` | Cursor `User` directory | Platform Cursor `User` directory |
+| Grok | `GROK_HOME` | Grok root containing `sessions/` | `~/.grok` |
+
 ## 添加新数据源
 
 ### 1. 创建目录结构

--- a/docs/algorithm/authoritative-token-accounting.md
+++ b/docs/algorithm/authoritative-token-accounting.md
@@ -6,6 +6,59 @@ ccstats 从本地 JSONL 日志中统计 token 用量和费用。不同 AI 工具
 
 ---
 
+## 配置与数据源根目录
+
+ccstats 启动时先读取可选的 TOML 配置文件，再根据命令行参数和数据源环境变量寻找本地日志。配置文件搜索顺序：
+
+1. `~/.config/ccstats/config.toml`
+2. 平台配置目录，例如 macOS 的 `~/Library/Application Support/ccstats/config.toml`
+3. `~/.ccstats.toml`
+
+第一个存在的配置文件生效。如果该文件无法读取、TOML 语法错误或字段类型错误，命令直接报错退出，不会继续尝试低优先级配置，也不会回落默认值。没有配置文件时使用默认值。
+
+支持的配置键：
+
+| 键 | 类型 | 取值 |
+|----|------|------|
+| `offline` | boolean | `true` / `false` |
+| `compact` | boolean | `true` / `false` |
+| `no_cost` | boolean | `true` / `false` |
+| `no_color` | boolean | `true` / `false` |
+| `breakdown` | boolean | `true` / `false` |
+| `debug` | boolean | `true` / `false` |
+| `strict_pricing` | boolean | `true` / `false` |
+| `order` | string | `asc` / `desc` |
+| `color` | string | `auto` / `always` / `never` |
+| `cost` | string | `show` / `hide` |
+| `timezone` | string | IANA 时区，例如 `UTC` / `Asia/Shanghai` |
+| `locale` | string | 数字格式 locale，例如 `en` / `de` |
+| `currency` | string | 货币代码，例如 `USD` / `CNY` / `EUR` |
+| `source` | string | `claude` / `codex` / `cursor` / `grok` / `all` 或别名 |
+
+示例：
+
+```toml
+source = "codex"
+timezone = "Asia/Shanghai"
+currency = "USD"
+offline = true
+strict_pricing = true
+order = "desc"
+color = "auto"
+cost = "show"
+```
+
+数据源根目录由环境变量覆盖，不属于 TOML 配置键：
+
+| 数据源 | 环境变量 | 含义 | 默认值 |
+|--------|----------|------|--------|
+| Claude Code | `CLAUDE_CONFIG_DIR` | 包含 `projects/` 的 Claude 配置根目录 | `~/.claude` |
+| OpenAI Codex | `CODEX_HOME` | 包含 `sessions/` 的 Codex 根目录 | `~/.codex` |
+| Cursor | `CURSOR_HOME` | Cursor `User` 目录 | 平台 app/config data 目录下的 Cursor `User` |
+| Grok | `GROK_HOME` | 包含 `sessions/` 的 Grok 根目录 | `~/.grok` |
+
+---
+
 ## 统一数据模型
 
 所有数据源解析后输出统一的 `RawEntry`，其中 token 字段**互不重叠**：

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,10 +73,6 @@ pub(crate) struct Config {
 }
 
 impl Config {
-    pub(crate) fn load_quiet() -> Self {
-        Self::try_load_quiet().unwrap_or_default()
-    }
-
     pub(crate) fn try_load() -> Result<Self, ConfigError> {
         Self::try_load_internal(false)
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,21 @@
 use serde::Deserialize;
 use std::fs;
+use std::io;
 use std::path::PathBuf;
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub(crate) enum ConfigError {
+    #[error("failed to read config {}: {source}", path.display())]
+    Read { path: PathBuf, source: io::Error },
+
+    #[error("failed to parse config {}: {source}", path.display())]
+    Parse {
+        path: PathBuf,
+        source: toml::de::Error,
+    },
+}
 
 #[derive(Debug, Clone, Copy, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -58,40 +73,50 @@ pub(crate) struct Config {
 }
 
 impl Config {
-    pub(crate) fn load() -> Self {
-        Self::load_internal(false)
-    }
-
     pub(crate) fn load_quiet() -> Self {
-        Self::load_internal(true)
+        Self::try_load_quiet().unwrap_or_default()
     }
 
-    fn load_internal(quiet: bool) -> Self {
+    pub(crate) fn try_load() -> Result<Self, ConfigError> {
+        Self::try_load_internal(false)
+    }
+
+    pub(crate) fn try_load_quiet() -> Result<Self, ConfigError> {
+        Self::try_load_internal(true)
+    }
+
+    fn try_load_internal(quiet: bool) -> Result<Self, ConfigError> {
         Self::load_from_paths(&Self::get_config_paths(), quiet)
     }
 
-    fn load_from_paths(paths: &[PathBuf], quiet: bool) -> Self {
+    fn load_from_paths(paths: &[PathBuf], quiet: bool) -> Result<Self, ConfigError> {
         for path in paths {
-            if path.exists()
-                && let Ok(content) = fs::read_to_string(path)
-            {
-                match toml::from_str::<Config>(&content) {
+            match fs::read_to_string(path) {
+                Ok(content) => match toml::from_str::<Config>(&content) {
                     Ok(config) => {
                         if !quiet {
                             eprintln!("Loaded config from {}", path.display());
                         }
-                        return config;
+                        return Ok(config);
                     }
-                    Err(e) => {
-                        if !quiet {
-                            eprintln!("Warning: Failed to parse {}: {}", path.display(), e);
-                        }
+                    Err(source) => {
+                        return Err(ConfigError::Parse {
+                            path: path.clone(),
+                            source,
+                        });
                     }
+                },
+                Err(source) if source.kind() == io::ErrorKind::NotFound => {}
+                Err(source) => {
+                    return Err(ConfigError::Read {
+                        path: path.clone(),
+                        source,
+                    });
                 }
             }
         }
 
-        Self::default()
+        Ok(Self::default())
     }
 
     fn get_config_paths() -> Vec<PathBuf> {
@@ -311,7 +336,7 @@ source = "codex"
     #[test]
     fn test_load_from_valid_file() {
         let f = write_temp_config("compact = true\noffline = true");
-        let config = Config::load_from_paths(&[f.path().to_path_buf()], true);
+        let config = Config::load_from_paths(&[f.path().to_path_buf()], true).unwrap();
         assert!(config.compact);
         assert!(config.offline);
     }
@@ -319,14 +344,15 @@ source = "codex"
     #[test]
     fn test_load_from_nonexistent_path_returns_default() {
         let config =
-            Config::load_from_paths(&[PathBuf::from("/nonexistent/path/config.toml")], true);
+            Config::load_from_paths(&[PathBuf::from("/nonexistent/path/config.toml")], true)
+                .unwrap();
         assert!(!config.offline);
         assert!(!config.compact);
     }
 
     #[test]
     fn test_load_from_empty_paths_returns_default() {
-        let config = Config::load_from_paths(&[], true);
+        let config = Config::load_from_paths(&[], true).unwrap();
         assert!(!config.offline);
         assert!(config.order.is_none());
     }
@@ -336,7 +362,8 @@ source = "codex"
         let f1 = write_temp_config("compact = true");
         let f2 = write_temp_config("compact = false\noffline = true");
         let config =
-            Config::load_from_paths(&[f1.path().to_path_buf(), f2.path().to_path_buf()], true);
+            Config::load_from_paths(&[f1.path().to_path_buf(), f2.path().to_path_buf()], true)
+                .unwrap();
         // First file wins
         assert!(config.compact);
         // Second file's offline=true is NOT loaded
@@ -344,12 +371,10 @@ source = "codex"
     }
 
     #[test]
-    fn test_load_skips_invalid_toml_tries_next() {
+    fn test_load_invalid_toml_returns_error() {
         let bad = write_temp_config("this is not valid toml [[[");
-        let good = write_temp_config("debug = true");
-        let config =
-            Config::load_from_paths(&[bad.path().to_path_buf(), good.path().to_path_buf()], true);
-        assert!(config.debug);
+        let err = Config::load_from_paths(&[bad.path().to_path_buf()], true).unwrap_err();
+        assert!(err.to_string().contains("failed to parse config"));
     }
 
     #[test]
@@ -361,20 +386,27 @@ source = "codex"
                 good.path().to_path_buf(),
             ],
             true,
-        );
+        )
+        .unwrap();
         assert!(config.breakdown);
     }
 
     #[test]
-    fn test_load_all_invalid_returns_default() {
-        let bad1 = write_temp_config("not valid [[[");
-        let bad2 = write_temp_config("also bad {{{");
-        let config = Config::load_from_paths(
-            &[bad1.path().to_path_buf(), bad2.path().to_path_buf()],
-            true,
-        );
-        assert!(!config.offline);
-        assert!(!config.compact);
+    fn test_load_wrong_field_type_returns_error() {
+        let bad = write_temp_config("strict_pricing = \"yes\"");
+        let err = Config::load_from_paths(&[bad.path().to_path_buf()], true).unwrap_err();
+        assert!(err.to_string().contains("failed to parse config"));
+        assert!(err.to_string().contains("strict_pricing"));
+    }
+
+    #[test]
+    fn test_load_priority_invalid_config_does_not_fall_back() {
+        let bad = write_temp_config("offline = \"yes\"");
+        let good = write_temp_config("debug = true");
+        let err =
+            Config::load_from_paths(&[bad.path().to_path_buf(), good.path().to_path_buf()], true)
+                .unwrap_err();
+        assert!(err.to_string().contains("failed to parse config"));
     }
 
     // --- Default trait ---

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,10 +64,17 @@ pub fn run_cli() {
     let source_cmd = parsed_command.command;
     let is_statusline = source_cmd.is_statusline();
 
-    let config = if is_statusline {
-        Config::load_quiet()
+    let config_result = if is_statusline {
+        Config::try_load_quiet()
     } else {
-        Config::load()
+        Config::try_load()
+    };
+    let config = match config_result {
+        Ok(config) => config,
+        Err(err) => {
+            eprintln!("Error: {err}");
+            std::process::exit(1);
+        }
     };
 
     let cli = raw_cli.with_config(&config);

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -245,7 +245,12 @@ pub fn summarize_cost(options: SummaryOptions) -> Result<CostSummary, SdkError> 
 /// Returns an error when the resolved source or timezone is invalid, or when an
 /// explicit date range has `since` after `until`.
 pub fn summarize_cost_with_cli_config(options: SummaryOptions) -> Result<CostSummary, SdkError> {
-    summarize_cost(apply_cli_config(options, &Config::load_quiet()))
+    let config = load_cli_config()?;
+    summarize_cost(apply_cli_config(options, &config))
+}
+
+pub(super) fn load_cli_config() -> Result<Config, SdkError> {
+    Config::try_load_quiet().map_err(|err| SdkError::Configuration(err.to_string()))
 }
 
 fn apply_cli_config(mut options: SummaryOptions, config: &Config) -> SummaryOptions {

--- a/src/sdk/batch.rs
+++ b/src/sdk/batch.rs
@@ -5,7 +5,8 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    CostSummary, SdkError, UsageRange, UsageSource, build_cost_summary, load_requested_currency,
+    CostSummary, SdkError, UsageRange, UsageSource, build_cost_summary, load_cli_config,
+    load_requested_currency,
 };
 use crate::config::Config;
 use crate::consts::DATE_FORMAT;
@@ -147,7 +148,8 @@ pub fn summarize_cost_ranges(options: MultiSummaryOptions) -> Result<MultiCostSu
 pub fn summarize_cost_ranges_with_cli_config(
     options: MultiSummaryOptions,
 ) -> Result<MultiCostSummary, SdkError> {
-    summarize_cost_ranges(apply_cli_config_multi(options, &Config::load_quiet()))
+    let config = load_cli_config()?;
+    summarize_cost_ranges(apply_cli_config_multi(options, &config))
 }
 
 fn apply_cli_config_multi(

--- a/tests/config_cli_integration.rs
+++ b/tests/config_cli_integration.rs
@@ -1,8 +1,15 @@
+use ccstats::{
+    MultiSummaryOptions, SummaryOptions, UsageRange, summarize_cost_ranges_with_cli_config,
+    summarize_cost_with_cli_config,
+};
 use serde_json::Value;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 fn unique_temp_dir(prefix: &str) -> PathBuf {
     let nanos = SystemTime::now()
@@ -131,5 +138,38 @@ fn missing_config_uses_defaults_for_codex_daily() {
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0]["date"].as_str(), Some("2026-02-06"));
 
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn sdk_cli_config_helpers_fail_on_invalid_config() {
+    let _guard = ENV_LOCK.lock().expect("env lock");
+    let root = unique_temp_dir("sdk-invalid-config");
+    write_config(&root, "timezone = 123");
+
+    let previous_home = std::env::var_os("HOME");
+    unsafe {
+        std::env::set_var("HOME", &root);
+    }
+
+    let single = summarize_cost_with_cli_config(SummaryOptions::default())
+        .expect_err("single-range SDK helper should fail");
+    assert!(single.to_string().contains("failed to parse config"));
+
+    let multi = summarize_cost_ranges_with_cli_config(MultiSummaryOptions {
+        ranges: vec![UsageRange::Today],
+        ..MultiSummaryOptions::default()
+    })
+    .expect_err("multi-range SDK helper should fail");
+    assert!(multi.to_string().contains("failed to parse config"));
+
+    match previous_home {
+        Some(value) => unsafe {
+            std::env::set_var("HOME", value);
+        },
+        None => unsafe {
+            std::env::remove_var("HOME");
+        },
+    }
     let _ = fs::remove_dir_all(root);
 }

--- a/tests/config_cli_integration.rs
+++ b/tests/config_cli_integration.rs
@@ -1,0 +1,135 @@
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("ccstats-{prefix}-{}-{nanos}", std::process::id()));
+    fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+fn write_file(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent dirs");
+    }
+    fs::write(path, content).expect("write test file");
+}
+
+fn write_config(home: &Path, content: &str) {
+    write_file(&home.join(".config/ccstats/config.toml"), content);
+}
+
+fn write_codex_session(codex_home: &Path) {
+    write_file(
+        &codex_home.join("sessions/config-test.jsonl"),
+        r#"{"timestamp":"2026-02-06T10:00:00Z","type":"turn_context","payload":{"model":"gpt-5"}}
+{"timestamp":"2026-02-06T10:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"reasoning_output_tokens":10,"total_tokens":130},"last_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"reasoning_output_tokens":10,"total_tokens":130},"model":"gpt-5"}}}
+"#,
+    );
+}
+
+fn resolve_ccstats_binary() -> PathBuf {
+    if let Some(bin) = std::env::var_os("CARGO_BIN_EXE_ccstats") {
+        return PathBuf::from(bin);
+    }
+
+    let bin_name = if cfg!(windows) {
+        "ccstats.exe"
+    } else {
+        "ccstats"
+    };
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let candidates = [
+        manifest_dir
+            .join("target")
+            .join("llvm-cov-target")
+            .join("debug")
+            .join(bin_name),
+        manifest_dir.join("target").join("debug").join(bin_name),
+    ];
+
+    candidates
+        .into_iter()
+        .find(|path| path.is_file())
+        .unwrap_or_else(|| panic!("unable to locate ccstats binary"))
+}
+
+fn run_ccstats(args: &[&str], envs: &[(&str, &Path)]) -> (bool, Vec<u8>, Vec<u8>) {
+    let mut cmd = Command::new(resolve_ccstats_binary());
+    cmd.args(args);
+    for (key, value) in envs {
+        cmd.env(key, value);
+    }
+    let output = cmd.output().expect("run ccstats");
+    (output.status.success(), output.stdout, output.stderr)
+}
+
+#[test]
+fn invalid_config_toml_fails_daily_command() {
+    let root = unique_temp_dir("invalid-config-toml");
+    write_config(&root, "offline = true\nthis is not valid toml [[[");
+
+    let (ok, stdout, stderr) = run_ccstats(&["daily", "--no-cost"], &[("HOME", &root)]);
+
+    assert!(!ok);
+    assert!(stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&stderr);
+    assert!(stderr.contains("Error: failed to parse config"));
+    assert!(stderr.contains("config.toml"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn wrong_config_type_fails_statusline_command() {
+    let root = unique_temp_dir("wrong-config-type");
+    write_config(&root, "strict_pricing = \"yes\"");
+
+    let (ok, stdout, stderr) = run_ccstats(&["statusline"], &[("HOME", &root)]);
+
+    assert!(!ok);
+    assert!(stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&stderr);
+    assert!(stderr.contains("Error: failed to parse config"));
+    assert!(stderr.contains("strict_pricing"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn missing_config_uses_defaults_for_codex_daily() {
+    let root = unique_temp_dir("missing-config-defaults");
+    let codex_home = root.join("codex-home");
+    write_codex_session(&codex_home);
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "codex",
+            "daily",
+            "-j",
+            "-O",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("HOME", &root), ("CODEX_HOME", &codex_home)],
+    );
+
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    let rows = json.as_array().expect("array output");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["date"].as_str(), Some("2026-02-06"));
+
+    let _ = fs::remove_dir_all(root);
+}


### PR DESCRIPTION
## Summary
- makes CLI config loading distinguish missing config from invalid/unreadable existing config
- fails normal, quiet/statusline, and SDK `*_with_cli_config` paths on invalid config instead of silently using defaults
- adds focused config CLI/SDK integration tests without expanding `tests/cli_integration.rs`
- documents config search order, supported keys, example config, and source root env overrides including `CODEX_HOME`, `CURSOR_HOME`, `GROK_HOME`, and `CLAUDE_CONFIG_DIR`

Fixes #46

## Verification
- `cargo fmt --check`
- `cargo test config`
- `cargo test --test config_cli_integration`
- `cargo test sdk::tests::cli_config_fills_sdk_summary_defaults`
- `cargo test sdk::batch::tests::cli_config_fills_multi_summary_defaults`
- `cargo check`
- `cargo test`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH46`
- `git diff --check`
