### PR TITLE
Fix atomic pricing cache handling

### DIFF
--- a/src/pricing/cache.rs
+++ b/src/pricing/cache.rs
@@ -1,11 +1,15 @@
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::ErrorKind;
+use std::fs::{self, File, OpenOptions};
+use std::io::{BufWriter, ErrorKind, Write};
 use std::path::{Path, PathBuf};
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 const APP_CACHE_DIR: &str = "ccstats";
 const PRICING_CACHE_FILE: &str = "pricing.json";
+
+pub(super) type RawPricingCache = HashMap<String, serde_json::Value>;
+type FreshRawPricingCache = (RawPricingCache, Duration);
+type CacheReadResult<T> = Result<Option<T>, CacheReadError>;
 
 #[derive(Debug)]
 struct CachePaths {
@@ -51,76 +55,253 @@ fn cache_paths() -> CachePaths {
     select_cache_paths(platform_cache_dir.as_deref(), home_dir.as_deref())
 }
 
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum CacheReadError {
+    #[error("failed to inspect pricing cache at {path:?}: {source}")]
+    Metadata {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to read pricing cache timestamp at {path:?}: {source}")]
+    Modified {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to open pricing cache at {path:?}: {source}")]
+    Open {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("pricing cache at {path:?} is malformed: {source}")]
+    Malformed {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(super) enum CacheWriteError {
+    #[error("failed to create pricing cache directory {path:?}: {source}")]
+    CreateDirectory {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to create temporary pricing cache {path:?}: {source}")]
+    CreateTemp {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to serialize pricing cache to {path:?}: {source}")]
+    Serialize {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("failed to flush temporary pricing cache {path:?}: {source}")]
+    Flush {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to sync temporary pricing cache {path:?}: {source}")]
+    Sync {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to replace pricing cache {target:?} with {temp:?}: {source}")]
+    Rename {
+        temp: PathBuf,
+        target: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
 pub(super) fn get_cache_path() -> Option<PathBuf> {
     cache_paths().write_path
 }
 
-fn load_raw_cache_from_paths(paths: &[PathBuf]) -> Option<HashMap<String, serde_json::Value>> {
+pub(super) fn load_raw_cache_from_paths(paths: &[PathBuf]) -> CacheReadResult<RawPricingCache> {
     for path in paths {
         let file = match File::open(path) {
             Ok(file) => file,
             Err(error) if error.kind() == ErrorKind::NotFound => continue,
-            Err(_) => return None,
+            Err(source) => {
+                return Err(CacheReadError::Open {
+                    path: path.clone(),
+                    source,
+                });
+            }
         };
-        return serde_json::from_reader(file).ok();
+        let data = serde_json::from_reader(file).map_err(|source| CacheReadError::Malformed {
+            path: path.clone(),
+            source,
+        })?;
+        return Ok(Some(data));
     }
-    None
+    Ok(None)
 }
 
-fn load_raw_cache_if_fresh_from_paths(
+pub(super) fn load_raw_cache_if_fresh_from_paths(
     paths: &[PathBuf],
     ttl: Duration,
-) -> Option<(HashMap<String, serde_json::Value>, Duration)> {
+) -> CacheReadResult<FreshRawPricingCache> {
     for path in paths {
-        let meta = match std::fs::metadata(path) {
+        let meta = match fs::metadata(path) {
             Ok(meta) => meta,
             Err(error) if error.kind() == ErrorKind::NotFound => continue,
-            Err(_) => return None,
+            Err(source) => {
+                return Err(CacheReadError::Metadata {
+                    path: path.clone(),
+                    source,
+                });
+            }
         };
-        let modified = meta.modified().ok()?;
-        let age = SystemTime::now().duration_since(modified).ok()?;
+        let modified = meta.modified().map_err(|source| CacheReadError::Modified {
+            path: path.clone(),
+            source,
+        })?;
+        let age = SystemTime::now()
+            .duration_since(modified)
+            .unwrap_or(Duration::ZERO);
         if age > ttl {
-            return None;
+            return Ok(None);
         }
-        let file = File::open(path).ok()?;
-        let data = serde_json::from_reader(file).ok()?;
-        return Some((data, age));
+        let file = File::open(path).map_err(|source| CacheReadError::Open {
+            path: path.clone(),
+            source,
+        })?;
+        let data = serde_json::from_reader(file).map_err(|source| CacheReadError::Malformed {
+            path: path.clone(),
+            source,
+        })?;
+        return Ok(Some((data, age)));
     }
-    None
+    Ok(None)
 }
 
-pub(super) fn load_raw_cache() -> Option<HashMap<String, serde_json::Value>> {
+pub(super) fn load_raw_cache() -> CacheReadResult<RawPricingCache> {
     let paths = cache_paths();
     load_raw_cache_from_paths(&paths.read_paths)
 }
 
-pub(super) fn load_raw_cache_if_fresh(
-    ttl: Duration,
-) -> Option<(HashMap<String, serde_json::Value>, Duration)> {
+pub(super) fn load_raw_cache_if_fresh(ttl: Duration) -> CacheReadResult<FreshRawPricingCache> {
     let paths = cache_paths();
     load_raw_cache_if_fresh_from_paths(&paths.read_paths, ttl)
 }
 
-pub(super) fn save_raw_cache(raw_data: &HashMap<String, serde_json::Value>) {
+pub(super) fn save_raw_cache(
+    raw_data: &HashMap<String, serde_json::Value>,
+) -> Result<(), CacheWriteError> {
     let Some(path) = get_cache_path() else {
-        return;
+        return Ok(());
     };
-    save_raw_cache_to_path(raw_data, &path);
+    save_raw_cache_to_path(raw_data, &path)
 }
 
-fn save_raw_cache_to_path(raw_data: &HashMap<String, serde_json::Value>, path: &Path) {
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
+pub(super) fn save_raw_cache_to_path(
+    raw_data: &HashMap<String, serde_json::Value>,
+    path: &Path,
+) -> Result<(), CacheWriteError> {
+    let parent = path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent).map_err(|source| CacheWriteError::CreateDirectory {
+        path: parent.to_path_buf(),
+        source,
+    })?;
+
+    let (temp_path, temp_file) = create_temp_file(parent)?;
+    let write_result = write_cache_file(raw_data, &temp_path, temp_file);
+    if let Err(error) = write_result {
+        let _ = fs::remove_file(&temp_path);
+        return Err(error);
     }
-    if let Ok(mut file) = File::create(path) {
-        let _ = serde_json::to_writer(&mut file, raw_data);
+
+    fs::rename(&temp_path, path).map_err(|source| {
+        let error = CacheWriteError::Rename {
+            temp: temp_path.clone(),
+            target: path.to_path_buf(),
+            source,
+        };
+        let _ = fs::remove_file(&temp_path);
+        error
+    })
+}
+
+fn create_temp_file(parent: &Path) -> Result<(PathBuf, File), CacheWriteError> {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_nanos();
+    let process_id = std::process::id();
+
+    for attempt in 0..32 {
+        let temp_path = parent.join(format!(
+            ".{PRICING_CACHE_FILE}.{process_id}.{nanos}.{attempt}.tmp"
+        ));
+        match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp_path)
+        {
+            Ok(file) => return Ok((temp_path, file)),
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => {}
+            Err(source) => {
+                return Err(CacheWriteError::CreateTemp {
+                    path: temp_path,
+                    source,
+                });
+            }
+        }
     }
+
+    let temp_path = parent.join(format!(".{PRICING_CACHE_FILE}.{process_id}.{nanos}.tmp"));
+    Err(CacheWriteError::CreateTemp {
+        path: temp_path,
+        source: std::io::Error::new(
+            ErrorKind::AlreadyExists,
+            "unable to allocate unique pricing cache temporary file",
+        ),
+    })
+}
+
+fn write_cache_file(
+    raw_data: &HashMap<String, serde_json::Value>,
+    temp_path: &Path,
+    temp_file: File,
+) -> Result<(), CacheWriteError> {
+    let mut writer = BufWriter::new(temp_file);
+    serde_json::to_writer(&mut writer, raw_data).map_err(|source| CacheWriteError::Serialize {
+        path: temp_path.to_path_buf(),
+        source,
+    })?;
+    writer.flush().map_err(|source| CacheWriteError::Flush {
+        path: temp_path.to_path_buf(),
+        source,
+    })?;
+    writer
+        .get_ref()
+        .sync_all()
+        .map_err(|source| CacheWriteError::Sync {
+            path: temp_path.to_path_buf(),
+            source,
+        })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::fs;
     use tempfile::TempDir;
 
     fn sample_raw_data(key: &str) -> HashMap<String, serde_json::Value> {
@@ -170,9 +351,11 @@ mod tests {
         let home_root = TempDir::new().unwrap();
         let paths = select_cache_paths(Some(platform_root.path()), Some(home_root.path()));
         let legacy_path = legacy_cache_file(home_root.path());
-        save_raw_cache_to_path(&sample_raw_data("legacy-model"), &legacy_path);
+        save_raw_cache_to_path(&sample_raw_data("legacy-model"), &legacy_path).unwrap();
 
-        let data = load_raw_cache_from_paths(&paths.read_paths).unwrap();
+        let data = load_raw_cache_from_paths(&paths.read_paths)
+            .unwrap()
+            .unwrap();
 
         assert!(data.contains_key("legacy-model"));
     }
@@ -184,10 +367,12 @@ mod tests {
         let paths = select_cache_paths(Some(platform_root.path()), Some(home_root.path()));
         let current_path = paths.write_path.as_ref().unwrap();
         let legacy_path = legacy_cache_file(home_root.path());
-        save_raw_cache_to_path(&sample_raw_data("current-model"), current_path);
-        save_raw_cache_to_path(&sample_raw_data("legacy-model"), &legacy_path);
+        save_raw_cache_to_path(&sample_raw_data("current-model"), current_path).unwrap();
+        save_raw_cache_to_path(&sample_raw_data("legacy-model"), &legacy_path).unwrap();
 
-        let data = load_raw_cache_from_paths(&paths.read_paths).unwrap();
+        let data = load_raw_cache_from_paths(&paths.read_paths)
+            .unwrap()
+            .unwrap();
 
         assert!(data.contains_key("current-model"));
         assert!(!data.contains_key("legacy-model"));
@@ -199,10 +384,12 @@ mod tests {
         let home_root = TempDir::new().unwrap();
         let paths = select_cache_paths(Some(platform_root.path()), Some(home_root.path()));
         let legacy_path = legacy_cache_file(home_root.path());
-        save_raw_cache_to_path(&sample_raw_data("legacy-model"), &legacy_path);
+        save_raw_cache_to_path(&sample_raw_data("legacy-model"), &legacy_path).unwrap();
 
         let (data, _age) =
-            load_raw_cache_if_fresh_from_paths(&paths.read_paths, Duration::from_secs(60)).unwrap();
+            load_raw_cache_if_fresh_from_paths(&paths.read_paths, Duration::from_secs(60))
+                .unwrap()
+                .unwrap();
 
         assert!(data.contains_key("legacy-model"));
     }
@@ -215,9 +402,79 @@ mod tests {
         let current_path = paths.write_path.as_ref().unwrap();
         let legacy_path = legacy_cache_file(home_root.path());
 
-        save_raw_cache_to_path(&sample_raw_data("current-model"), current_path);
+        save_raw_cache_to_path(&sample_raw_data("current-model"), current_path).unwrap();
 
         assert!(current_path.exists());
         assert!(!legacy_path.exists());
+    }
+
+    #[test]
+    fn load_raw_cache_returns_missing_for_absent_cache() {
+        let root = TempDir::new().unwrap();
+        let missing = root.path().join("pricing.json");
+
+        let result = load_raw_cache_from_paths(&[missing]).unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn load_raw_cache_reports_malformed_cache() {
+        let root = TempDir::new().unwrap();
+        let cache_path = root.path().join("pricing.json");
+        fs::write(&cache_path, "{not json").unwrap();
+
+        let error = load_raw_cache_from_paths(&[cache_path]).unwrap_err();
+
+        assert!(matches!(error, CacheReadError::Malformed { .. }));
+    }
+
+    #[test]
+    fn load_raw_cache_if_fresh_reports_malformed_cache() {
+        let root = TempDir::new().unwrap();
+        let cache_path = root.path().join("pricing.json");
+        fs::write(&cache_path, "{not json").unwrap();
+
+        let error =
+            load_raw_cache_if_fresh_from_paths(&[cache_path], Duration::from_secs(60)).unwrap_err();
+
+        assert!(matches!(error, CacheReadError::Malformed { .. }));
+    }
+
+    #[test]
+    fn save_raw_cache_atomically_replaces_existing_cache() {
+        let root = TempDir::new().unwrap();
+        let cache_path = root.path().join("pricing.json");
+        save_raw_cache_to_path(&sample_raw_data("old-model"), &cache_path).unwrap();
+
+        save_raw_cache_to_path(&sample_raw_data("new-model"), &cache_path).unwrap();
+        let data = load_raw_cache_from_paths(&[cache_path]).unwrap().unwrap();
+
+        assert!(data.contains_key("new-model"));
+        assert!(!data.contains_key("old-model"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_raw_cache_failure_keeps_existing_cache() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = TempDir::new().unwrap();
+        let cache_path = root.path().join("pricing.json");
+        save_raw_cache_to_path(&sample_raw_data("old-model"), &cache_path).unwrap();
+        let old_contents = fs::read_to_string(&cache_path).unwrap();
+
+        let mut permissions = fs::metadata(root.path()).unwrap().permissions();
+        permissions.set_mode(0o555);
+        fs::set_permissions(root.path(), permissions).unwrap();
+
+        let save_result = save_raw_cache_to_path(&sample_raw_data("new-model"), &cache_path);
+
+        let mut permissions = fs::metadata(root.path()).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(root.path(), permissions).unwrap();
+
+        assert!(save_result.is_err());
+        assert_eq!(fs::read_to_string(&cache_path).unwrap(), old_contents);
     }
 }

--- a/src/pricing/db.rs
+++ b/src/pricing/db.rs
@@ -4,7 +4,9 @@ use std::time::{Duration, Instant};
 
 use crate::core::Stats;
 
-use super::cache::{load_raw_cache, load_raw_cache_if_fresh, save_raw_cache};
+use super::cache::{
+    CacheReadError, CacheWriteError, load_raw_cache, load_raw_cache_if_fresh, save_raw_cache,
+};
 use super::provider::fetch_litellm_raw;
 use super::resolver::{fallback_pricing, parse_litellm_data, resolve_pricing_known};
 use super::types::ModelPricing;
@@ -13,6 +15,12 @@ use super::types::ModelPricing;
 enum ResolvedPricing {
     Known(ModelPricing),
     Unknown,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum PricingLoadError {
+    #[error("failed to load pricing cache: {0}")]
+    Cache(#[from] CacheReadError),
 }
 
 /// Pricing database loaded from `LiteLLM` or cache
@@ -26,6 +34,14 @@ pub(crate) struct PricingDb {
 const PRICING_CACHE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
 
 impl PricingDb {
+    fn empty(strict_unknown: bool) -> Self {
+        Self {
+            models: HashMap::new(),
+            resolved: RefCell::new(HashMap::new()),
+            strict_unknown,
+        }
+    }
+
     fn from_raw_data(data: HashMap<String, serde_json::Value>, strict_unknown: bool) -> Self {
         Self {
             models: parse_litellm_data(data),
@@ -34,58 +50,73 @@ impl PricingDb {
         }
     }
 
-    fn load_from_cache(strict_unknown: bool) -> Option<Self> {
-        let raw_data = load_raw_cache()?;
-        Some(Self::from_raw_data(raw_data, strict_unknown))
+    fn load_from_cache(strict_unknown: bool) -> Result<Option<Self>, CacheReadError> {
+        Ok(load_raw_cache()?.map(|raw_data| Self::from_raw_data(raw_data, strict_unknown)))
     }
 
-    fn load_from_cache_if_fresh(ttl: Duration, strict_unknown: bool) -> Option<(Self, Duration)> {
-        let (raw_data, age) = load_raw_cache_if_fresh(ttl)?;
-        Some((Self::from_raw_data(raw_data, strict_unknown), age))
+    fn load_from_cache_if_fresh(
+        ttl: Duration,
+        strict_unknown: bool,
+    ) -> Result<Option<(Self, Duration)>, CacheReadError> {
+        Ok(load_raw_cache_if_fresh(ttl)?
+            .map(|(raw_data, age)| (Self::from_raw_data(raw_data, strict_unknown), age)))
     }
 
     pub(crate) fn load(offline: bool, strict_unknown: bool) -> Self {
-        Self::load_internal(offline, strict_unknown, false)
+        Self::try_load(offline, strict_unknown).unwrap_or_else(|error| {
+            eprintln!("Error: {error}");
+            std::process::exit(1);
+        })
     }
 
     pub(crate) fn load_quiet(offline: bool, strict_unknown: bool) -> Self {
+        Self::try_load_quiet(offline, strict_unknown).unwrap_or_else(|error| {
+            eprintln!("Error: {error}");
+            std::process::exit(1);
+        })
+    }
+
+    pub(crate) fn try_load(offline: bool, strict_unknown: bool) -> Result<Self, PricingLoadError> {
+        Self::load_internal(offline, strict_unknown, false)
+    }
+
+    pub(crate) fn try_load_quiet(
+        offline: bool,
+        strict_unknown: bool,
+    ) -> Result<Self, PricingLoadError> {
         Self::load_internal(offline, strict_unknown, true)
     }
 
-    fn load_internal(offline: bool, strict_unknown: bool, quiet: bool) -> Self {
+    fn load_internal(
+        offline: bool,
+        strict_unknown: bool,
+        quiet: bool,
+    ) -> Result<Self, PricingLoadError> {
         let start = Instant::now();
 
         if offline {
-            if let Some(db) = Self::load_from_cache(strict_unknown) {
-                if !quiet {
-                    eprintln!(
-                        "Using cached pricing ({:.2}ms)",
-                        start.elapsed().as_secs_f64() * 1000.0
-                    );
-                }
-                return db;
-            }
-            if !quiet {
-                eprintln!(
-                    "No cached pricing, using defaults ({:.2}ms)",
-                    start.elapsed().as_secs_f64() * 1000.0
-                );
-            }
-            return Self {
-                models: HashMap::new(),
-                resolved: RefCell::new(HashMap::new()),
+            return Self::finish_offline_cache_load(
+                Self::load_from_cache(strict_unknown),
                 strict_unknown,
-            };
+                quiet,
+                start,
+            );
         }
 
-        if let Some((db, age)) = Self::load_from_cache_if_fresh(PRICING_CACHE_TTL, strict_unknown) {
-            if !quiet {
-                eprintln!(
-                    "Using cached pricing ({:.1}h old)",
-                    age.as_secs_f64() / 3600.0
-                );
+        match Self::load_from_cache_if_fresh(PRICING_CACHE_TTL, strict_unknown) {
+            Ok(Some((db, age))) => {
+                if !quiet {
+                    eprintln!(
+                        "Using cached pricing ({:.1}h old)",
+                        age.as_secs_f64() / 3600.0
+                    );
+                }
+                return Ok(db);
             }
-            return db;
+            Ok(None) => {}
+            Err(error) => {
+                eprintln!("Warning: ignoring invalid pricing cache before refresh: {error}");
+            }
         }
 
         if !quiet {
@@ -93,7 +124,7 @@ impl PricingDb {
         }
         if let Some(raw_data) = fetch_litellm_raw() {
             let fetch_time = start.elapsed();
-            save_raw_cache(&raw_data);
+            let save_result = save_raw_cache(&raw_data);
             let db = Self::from_raw_data(raw_data, strict_unknown);
             if !quiet {
                 eprintln!(
@@ -102,20 +133,25 @@ impl PricingDb {
                     fetch_time.as_secs_f64() * 1000.0
                 );
             }
-            return db;
+            warn_cache_write_error(save_result);
+            return Ok(db);
         }
 
         if !quiet {
             eprintln!(" failed, trying cache...");
         }
-        if let Some(db) = Self::load_from_cache(strict_unknown) {
-            if !quiet {
-                eprintln!(
-                    "Using cached pricing ({:.2}ms)",
-                    start.elapsed().as_secs_f64() * 1000.0
-                );
+        match Self::load_from_cache(strict_unknown) {
+            Ok(Some(db)) => {
+                if !quiet {
+                    eprintln!(
+                        "Using cached pricing ({:.2}ms)",
+                        start.elapsed().as_secs_f64() * 1000.0
+                    );
+                }
+                return Ok(db);
             }
-            return db;
+            Ok(None) => {}
+            Err(error) => return Err(error.into()),
         }
 
         if !quiet {
@@ -124,10 +160,35 @@ impl PricingDb {
                 start.elapsed().as_secs_f64() * 1000.0
             );
         }
-        Self {
-            models: HashMap::new(),
-            resolved: RefCell::new(HashMap::new()),
-            strict_unknown,
+        Ok(Self::empty(strict_unknown))
+    }
+
+    fn finish_offline_cache_load(
+        cache_result: Result<Option<Self>, CacheReadError>,
+        strict_unknown: bool,
+        quiet: bool,
+        start: Instant,
+    ) -> Result<Self, PricingLoadError> {
+        match cache_result {
+            Ok(Some(db)) => {
+                if !quiet {
+                    eprintln!(
+                        "Using cached pricing ({:.2}ms)",
+                        start.elapsed().as_secs_f64() * 1000.0
+                    );
+                }
+                Ok(db)
+            }
+            Ok(None) => {
+                if !quiet {
+                    eprintln!(
+                        "No cached pricing, using defaults ({:.2}ms)",
+                        start.elapsed().as_secs_f64() * 1000.0
+                    );
+                }
+                Ok(Self::empty(strict_unknown))
+            }
+            Err(error) => Err(error.into()),
         }
     }
 
@@ -153,6 +214,12 @@ impl PricingDb {
         };
         self.resolved.borrow_mut().insert(model.to_string(), cached);
         pricing
+    }
+}
+
+fn warn_cache_write_error(result: Result<(), CacheWriteError>) {
+    if let Err(error) = result {
+        eprintln!("Warning: failed to save pricing cache: {error}");
     }
 }
 
@@ -232,6 +299,83 @@ where
 #[allow(clippy::float_cmp)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use std::fs;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn sample_raw_pricing(model: &str) -> HashMap<String, serde_json::Value> {
+        HashMap::from([(
+            model.to_string(),
+            json!({
+                "input_cost_per_token": 1e-6,
+                "output_cost_per_token": 2e-6,
+            }),
+        )])
+    }
+
+    fn malformed_cache_error() -> CacheReadError {
+        let source =
+            serde_json::from_str::<HashMap<String, serde_json::Value>>("{not json").unwrap_err();
+        CacheReadError::Malformed {
+            path: PathBuf::from("pricing.json"),
+            source,
+        }
+    }
+
+    #[test]
+    fn offline_missing_cache_keeps_default_pricing_behavior() {
+        let db = PricingDb::finish_offline_cache_load(Ok(None), true, true, Instant::now())
+            .expect("missing cache should use defaults");
+
+        assert!(db.models.is_empty());
+        assert!(db.strict_unknown);
+    }
+
+    #[test]
+    fn offline_malformed_cache_fails_closed() {
+        let error = PricingDb::finish_offline_cache_load(
+            Err(malformed_cache_error()),
+            false,
+            true,
+            Instant::now(),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("malformed"));
+    }
+
+    #[test]
+    fn cache_read_distinguishes_missing_from_malformed_for_db_load() {
+        let root = TempDir::new().unwrap();
+        let missing_path = root.path().join("missing-pricing.json");
+        assert!(
+            super::super::cache::load_raw_cache_from_paths(&[missing_path])
+                .unwrap()
+                .is_none()
+        );
+
+        let malformed_path = root.path().join("pricing.json");
+        fs::write(&malformed_path, "{not json").unwrap();
+        let error = super::super::cache::load_raw_cache_from_paths(&[malformed_path]).unwrap_err();
+
+        assert!(matches!(error, CacheReadError::Malformed { .. }));
+    }
+
+    #[test]
+    fn fetched_pricing_remains_usable_after_cache_save_failure() {
+        let root = TempDir::new().unwrap();
+        let blocker = root.path().join("not-a-directory");
+        fs::write(&blocker, "file").unwrap();
+        let cache_path = blocker.join("pricing.json");
+        let raw_data = sample_raw_pricing("gpt-5");
+
+        let save_result = super::super::cache::save_raw_cache_to_path(&raw_data, &cache_path);
+        let db = PricingDb::from_raw_data(raw_data, false);
+
+        assert!(save_result.is_err());
+        assert!(db.get_pricing("gpt-5").is_some());
+    }
 
     #[test]
     fn calculate_cost_basic() {

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -212,7 +212,8 @@ pub fn summarize_cost(options: SummaryOptions) -> Result<CostSummary, SdkError> 
     let source = get_source(options.source.as_str()).ok_or_else(|| SdkError::InvalidSource {
         name: options.source.as_str().to_string(),
     })?;
-    let pricing_db = PricingDb::load_quiet(options.offline, options.strict_pricing);
+    let pricing_db = PricingDb::try_load_quiet(options.offline, options.strict_pricing)
+        .map_err(|err| SdkError::Configuration(err.to_string()))?;
     let currency = load_requested_currency(options.currency.as_deref(), options.offline)?;
     let currency_code = currency.as_ref().map_or_else(
         || "USD".to_string(),

--- a/src/sdk/batch.rs
+++ b/src/sdk/batch.rs
@@ -98,7 +98,8 @@ pub fn summarize_cost_ranges(options: MultiSummaryOptions) -> Result<MultiCostSu
     let source = get_source(usage_source.as_str()).ok_or_else(|| SdkError::InvalidSource {
         name: usage_source.as_str().to_string(),
     })?;
-    let pricing_db = PricingDb::load_quiet(offline, strict_pricing);
+    let pricing_db = PricingDb::try_load_quiet(offline, strict_pricing)
+        .map_err(|err| SdkError::Configuration(err.to_string()))?;
     let currency = load_requested_currency(requested_currency.as_deref(), offline)?;
     let currency_code = currency.as_ref().map_or_else(
         || "USD".to_string(),

--- a/tests/sdk_integration.rs
+++ b/tests/sdk_integration.rs
@@ -17,6 +17,12 @@ fn write_file(path: &Path, content: &str) {
     fs::write(path, content).expect("write test file");
 }
 
+fn write_pricing_cache(home: &Path, xdg_cache: &Path, contents: &str) {
+    write_file(&xdg_cache.join("ccstats/pricing.json"), contents);
+    write_file(&home.join("Library/Caches/ccstats/pricing.json"), contents);
+    write_file(&home.join(".cache/ccstats/pricing.json"), contents);
+}
+
 fn assert_stable_summary_eq(actual: &CostSummary, expected: &CostSummary) {
     assert_eq!(actual.source, expected.source);
     assert_eq!(actual.source_name, expected.source_name);
@@ -32,6 +38,60 @@ fn assert_stable_summary_eq(actual: &CostSummary, expected: &CostSummary) {
     assert_eq!(actual.valid_entries, expected.valid_entries);
     assert_eq!(actual.skipped_entries, expected.skipped_entries);
     assert!(actual.elapsed_ms.is_finite());
+}
+
+#[test]
+fn sdk_offline_corrupt_pricing_cache_returns_error() {
+    let _guard = ENV_LOCK.lock().expect("env lock");
+    let root = tempfile::tempdir().expect("temp dir");
+    let xdg_cache = root.path().join("xdg-cache");
+    let codex_home = root.path().join("codex-home");
+    write_pricing_cache(root.path(), &xdg_cache, "{not json");
+
+    let previous_home = std::env::var_os("HOME");
+    let previous_xdg_cache = std::env::var_os("XDG_CACHE_HOME");
+    let previous_codex_home = std::env::var_os("CODEX_HOME");
+    unsafe {
+        std::env::set_var("HOME", root.path());
+        std::env::set_var("XDG_CACHE_HOME", &xdg_cache);
+        std::env::set_var("CODEX_HOME", &codex_home);
+    }
+
+    let error = summarize_cost(SummaryOptions {
+        source: UsageSource::Codex,
+        offline: true,
+        ..SummaryOptions::default()
+    })
+    .expect_err("corrupt offline pricing cache should return SDK error");
+
+    match previous_home {
+        Some(value) => unsafe {
+            std::env::set_var("HOME", value);
+        },
+        None => unsafe {
+            std::env::remove_var("HOME");
+        },
+    }
+    match previous_xdg_cache {
+        Some(value) => unsafe {
+            std::env::set_var("XDG_CACHE_HOME", value);
+        },
+        None => unsafe {
+            std::env::remove_var("XDG_CACHE_HOME");
+        },
+    }
+    match previous_codex_home {
+        Some(value) => unsafe {
+            std::env::set_var("CODEX_HOME", value);
+        },
+        None => unsafe {
+            std::env::remove_var("CODEX_HOME");
+        },
+    }
+
+    let message = error.to_string();
+    assert!(message.contains("pricing cache"), "{message}");
+    assert!(message.contains("malformed"), "{message}");
 }
 
 #[test]

--- a/tests/statusline_pricing_cache_integration.rs
+++ b/tests/statusline_pricing_cache_integration.rs
@@ -1,0 +1,97 @@
+use chrono::Utc;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("ccstats-{prefix}-{}-{nanos}", std::process::id()));
+    fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+fn write_file(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent dirs");
+    }
+    fs::write(path, content).expect("write test file");
+}
+
+fn write_pricing_cache(home: &Path, xdg_cache: &Path, contents: &str) {
+    write_file(&xdg_cache.join("ccstats/pricing.json"), contents);
+    write_file(&home.join("Library/Caches/ccstats/pricing.json"), contents);
+    write_file(&home.join(".cache/ccstats/pricing.json"), contents);
+}
+
+fn resolve_ccstats_binary() -> PathBuf {
+    if let Some(bin) = std::env::var_os("CARGO_BIN_EXE_ccstats") {
+        return PathBuf::from(bin);
+    }
+
+    let bin_name = if cfg!(windows) {
+        "ccstats.exe"
+    } else {
+        "ccstats"
+    };
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let candidates = [
+        manifest_dir
+            .join("target")
+            .join("llvm-cov-target")
+            .join("debug")
+            .join(bin_name),
+        manifest_dir.join("target").join("debug").join(bin_name),
+    ];
+
+    candidates
+        .into_iter()
+        .find(|path| path.is_file())
+        .unwrap_or_else(|| panic!("unable to locate ccstats binary"))
+}
+
+fn run_ccstats(args: &[&str], envs: &[(&str, &Path)]) -> (bool, Vec<u8>, Vec<u8>) {
+    let mut cmd = Command::new(resolve_ccstats_binary());
+    cmd.args(args);
+    for (key, value) in envs {
+        cmd.env(key, value);
+    }
+    let output = cmd.output().expect("run ccstats");
+    (output.status.success(), output.stdout, output.stderr)
+}
+
+#[test]
+fn statusline_offline_corrupt_pricing_cache_fails_closed() {
+    let root = unique_temp_dir("statusline-corrupt-pricing");
+    let xdg_cache = root.join("xdg-cache");
+    write_pricing_cache(&root, &xdg_cache, "{not json");
+    let today = Utc::now().format("%Y-%m-%dT12:00:00Z").to_string();
+    let claude_file = root.join(".claude/projects/myproject/session-a.jsonl");
+    write_file(
+        &claude_file,
+        &format!(
+            r#"{{"timestamp":"{today}","message":{{"id":"msg_1","model":"mystery-model","stop_reason":"end_turn","usage":{{"input_tokens":100,"output_tokens":50}}}}}}
+"#
+        ),
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &["statusline", "-j", "-O", "--strict-pricing"],
+        &[("HOME", &root), ("XDG_CACHE_HOME", &xdg_cache)],
+    );
+
+    assert!(!ok, "expected corrupt pricing cache failure");
+    assert!(
+        stdout.is_empty(),
+        "stdout should not contain all-N/A statusline output: {}",
+        String::from_utf8_lossy(&stdout)
+    );
+    let stderr = String::from_utf8_lossy(&stderr);
+    assert!(stderr.contains("pricing cache"), "stderr: {stderr}");
+    assert!(stderr.contains("malformed"), "stderr: {stderr}");
+
+    let _ = fs::remove_dir_all(root);
+}


### PR DESCRIPTION
## Summary

- write pricing cache through a same-directory temp file, flush/sync, then atomic rename
- distinguish missing cache from malformed/unreadable cache and fail closed for corrupt offline cache
- keep online pricing usable after cache-save failures while surfacing a warning
- return SDK errors instead of exiting embedding processes on corrupt offline pricing cache

Fixes #32

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test pricing::db`
- `cargo test --test statusline_pricing_cache_integration`
- `cargo test --test sdk_integration sdk_offline_corrupt_pricing_cache_returns_error`
- `cargo test`
- `cargo check`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH32`
- `git diff --check`

## Review

- Native reviewer found and verified the SDK no-process-exit blocker fix on head `90e93d0`.
