### PR TITLE
Align source registry capabilities and SDK parsing

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -247,8 +247,8 @@ fn validate_top_limit(limit: usize) -> Result<usize, String> {
     }
 }
 
-fn handle_tools(ctx: &CommandContext<'_>) {
-    let calls = load_tool_calls(ctx.filter, ctx.timezone);
+fn handle_tools(source: &dyn Source, ctx: &CommandContext<'_>) {
+    let calls = load_tool_calls(source, ctx.filter, ctx.timezone);
     let summary = aggregate_tools(&calls);
     if ctx.cli.csv {
         let csv = output_tools_csv(&summary);
@@ -524,13 +524,13 @@ pub(crate) fn handle_source_command(
         }
         SourceCommand::Statusline => return handle_statusline(source, ctx),
         SourceCommand::Tools => {
-            if source.name() != "claude" {
+            if !caps.has_tool_calls {
                 println!(
                     "Tool usage analysis is only supported for Claude source.\nHint: switch with `--source claude` (or alias `--source cc`)."
                 );
                 return;
             }
-            return handle_tools(ctx);
+            return handle_tools(source, ctx);
         }
         SourceCommand::Top { dim, limit } => {
             let limit = match validate_top_limit(limit) {
@@ -561,6 +561,7 @@ fn all_sources_capabilities() -> Capabilities {
         combined.has_reasoning_tokens |= caps.has_reasoning_tokens;
         combined.has_cache_creation |= caps.has_cache_creation;
         combined.needs_dedup |= caps.needs_dedup;
+        combined.has_tool_calls |= caps.has_tool_calls;
     }
     combined
 }
@@ -577,6 +578,7 @@ fn load_all_daily(ctx: &CommandContext<'_>, quiet: bool) -> (LoadResult, Capabil
         caps.has_reasoning_tokens |= source_caps.has_reasoning_tokens;
         caps.has_cache_creation |= source_caps.has_cache_creation;
         caps.needs_dedup |= source_caps.needs_dedup;
+        caps.has_tool_calls |= source_caps.has_tool_calls;
 
         let result = load_daily(source, ctx.filter, ctx.timezone, quiet, ctx.cli.debug);
         combined.skipped += result.skipped;

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -23,6 +23,7 @@ pub use batch::{
 
 /// Supported local usage sources.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum UsageSource {
     /// Claude Code logs under `~/.claude/projects`.
@@ -36,6 +37,14 @@ pub enum UsageSource {
 }
 
 impl UsageSource {
+    #[cfg(test)]
+    pub(crate) const VARIANTS: [Self; 4] = [
+        UsageSource::Claude,
+        UsageSource::Codex,
+        UsageSource::Cursor,
+        UsageSource::Grok,
+    ];
+
     #[must_use]
     pub fn as_str(self) -> &'static str {
         match self {
@@ -45,21 +54,30 @@ impl UsageSource {
             UsageSource::Grok => "grok",
         }
     }
+
+    fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "claude" => Some(UsageSource::Claude),
+            "codex" => Some(UsageSource::Codex),
+            "cursor" => Some(UsageSource::Cursor),
+            "grok" => Some(UsageSource::Grok),
+            _ => None,
+        }
+    }
 }
 
 impl FromStr for UsageSource {
     type Err = SdkError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value.trim().to_ascii_lowercase().as_str() {
-            "claude" | "cc" => Ok(UsageSource::Claude),
-            "codex" | "cx" => Ok(UsageSource::Codex),
-            "cursor" | "cur" => Ok(UsageSource::Cursor),
-            "grok" | "gx" => Ok(UsageSource::Grok),
-            source => Err(SdkError::InvalidSource {
-                name: source.to_string(),
-            }),
-        }
+        let source_name = value.trim().to_ascii_lowercase();
+        let Some(source) = get_source(&source_name) else {
+            return Err(SdkError::InvalidSource { name: source_name });
+        };
+
+        Self::from_name(source.name()).ok_or_else(|| SdkError::InvalidSource {
+            name: source.name().to_string(),
+        })
     }
 }
 
@@ -397,19 +415,63 @@ fn summarize_models(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeSet;
 
     #[test]
-    fn usage_source_accepts_names_and_aliases() {
-        assert_eq!(
-            "claude".parse::<UsageSource>().unwrap(),
-            UsageSource::Claude
-        );
-        assert_eq!("cc".parse::<UsageSource>().unwrap(), UsageSource::Claude);
-        assert_eq!("codex".parse::<UsageSource>().unwrap(), UsageSource::Codex);
-        assert_eq!("cx".parse::<UsageSource>().unwrap(), UsageSource::Codex);
-        assert_eq!("grok".parse::<UsageSource>().unwrap(), UsageSource::Grok);
-        assert_eq!("gx".parse::<UsageSource>().unwrap(), UsageSource::Grok);
-        assert!("unknown".parse::<UsageSource>().is_err());
+    fn usage_source_accepts_registry_names_and_aliases() {
+        for source in crate::source::all_sources() {
+            let expected = UsageSource::from_name(source.name()).expect("SDK source variant");
+            assert_eq!(source.name().parse::<UsageSource>().unwrap(), expected);
+            assert_eq!(
+                source
+                    .name()
+                    .to_ascii_uppercase()
+                    .parse::<UsageSource>()
+                    .unwrap(),
+                expected
+            );
+            assert_eq!(
+                format!(" {} ", source.name())
+                    .parse::<UsageSource>()
+                    .unwrap(),
+                expected
+            );
+
+            for alias in source.aliases() {
+                assert_eq!(alias.parse::<UsageSource>().unwrap(), expected);
+            }
+        }
+
+        let err = " unknown ".parse::<UsageSource>().unwrap_err();
+        assert!(matches!(err, SdkError::InvalidSource { name } if name == "unknown"));
+    }
+
+    #[test]
+    fn registry_concrete_sources_match_sdk_usage_sources() {
+        let registry_sources = crate::source::all_sources()
+            .map(Source::name)
+            .collect::<BTreeSet<_>>();
+        let sdk_sources = UsageSource::VARIANTS
+            .iter()
+            .map(|source| source.as_str())
+            .collect::<BTreeSet<_>>();
+
+        assert_eq!(registry_sources, sdk_sources);
+        assert!(crate::source::source_choices().contains(&crate::source::ALL_SOURCES));
+        assert!(crate::source::ALL_SOURCES.parse::<UsageSource>().is_err());
+
+        for source in crate::source::all_sources() {
+            assert_eq!(
+                source.name().parse::<UsageSource>().unwrap().as_str(),
+                source.name()
+            );
+            for alias in source.aliases() {
+                assert_eq!(
+                    alias.parse::<UsageSource>().unwrap().as_str(),
+                    source.name()
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/source/claude/config.rs
+++ b/src/source/claude/config.rs
@@ -8,6 +8,7 @@ use crate::source::{Capabilities, ParseOutput, Source};
 use crate::utils::Timezone;
 
 use super::parser::{find_claude_files, parse_claude_file_with_debug};
+use super::tool_parser::parse_tool_calls;
 
 /// Claude data source
 pub(crate) struct ClaudeSource;
@@ -44,6 +45,7 @@ impl Source for ClaudeSource {
             has_reasoning_tokens: false,
             has_cache_creation: true,
             needs_dedup: true,
+            has_tool_calls: true,
         }
     }
 
@@ -53,5 +55,13 @@ impl Source for ClaudeSource {
 
     fn parse_file(&self, path: &Path, timezone: Timezone, debug: bool) -> ParseOutput {
         parse_claude_file_with_debug(path, timezone, debug)
+    }
+
+    fn find_tool_call_files(&self) -> Vec<PathBuf> {
+        find_claude_files()
+    }
+
+    fn parse_tool_call_file(&self, path: &Path, timezone: Timezone) -> Vec<crate::core::ToolCall> {
+        parse_tool_calls(path, timezone)
     }
 }

--- a/src/source/claude/mod.rs
+++ b/src/source/claude/mod.rs
@@ -7,4 +7,3 @@ mod parser;
 pub(crate) mod tool_parser;
 
 pub(crate) use config::ClaudeSource;
-pub(crate) use parser::claude_projects_dir;

--- a/src/source/codex/config.rs
+++ b/src/source/codex/config.rs
@@ -44,6 +44,7 @@ impl Source for CodexSource {
             has_reasoning_tokens: true,
             has_cache_creation: false,
             needs_dedup: true,
+            has_tool_calls: false,
         }
     }
 

--- a/src/source/cursor/config.rs
+++ b/src/source/cursor/config.rs
@@ -44,6 +44,7 @@ impl Source for CursorSource {
             has_reasoning_tokens: false,
             has_cache_creation: false,
             needs_dedup: false,
+            has_tool_calls: false,
         }
     }
 

--- a/src/source/grok/config.rs
+++ b/src/source/grok/config.rs
@@ -44,6 +44,7 @@ impl Source for GrokSource {
             has_reasoning_tokens: false,
             has_cache_creation: false,
             needs_dedup: false,
+            has_tool_calls: false,
         }
     }
 

--- a/src/source/loader.rs
+++ b/src/source/loader.rs
@@ -491,24 +491,17 @@ pub(crate) fn load_blocks(
     loader.load_blocks(filter, timezone)
 }
 
-/// Convenience function to load tool calls from Claude source
+/// Convenience function to load tool calls for a source with tool-call support.
 pub(crate) fn load_tool_calls(
+    source: &dyn Source,
     filter: &DateFilter,
     timezone: Timezone,
 ) -> Vec<crate::core::ToolCall> {
-    use crate::source::claude::claude_projects_dir;
-    use crate::source::claude::tool_parser::parse_tool_calls;
-
-    let Some(claude_path) = claude_projects_dir() else {
+    if !source.capabilities().has_tool_calls {
         return Vec::new();
-    };
-    let mut files = Vec::new();
-    if let Ok(entries) = glob::glob(&format!("{}/**/*.jsonl", claude_path.display())) {
-        for entry in entries.flatten() {
-            files.push(entry);
-        }
     }
 
+    let files = source.find_tool_call_files();
     if files.is_empty() {
         return Vec::new();
     }
@@ -518,7 +511,7 @@ pub(crate) fn load_tool_calls(
     let all_calls: Vec<crate::core::ToolCall> = files
         .par_iter()
         .flat_map(|path| {
-            let calls = parse_tool_calls(path, timezone);
+            let calls = source.parse_tool_call_file(path, timezone);
             calls
                 .into_iter()
                 .filter(|c| {
@@ -764,3 +757,7 @@ mod tests {
         assert_eq!(target.models["other-model"].input_tokens, 200);
     }
 }
+
+#[cfg(test)]
+#[path = "loader_tool_tests.rs"]
+mod loader_tool_tests;

--- a/src/source/loader_tool_tests.rs
+++ b/src/source/loader_tool_tests.rs
@@ -1,0 +1,78 @@
+use std::path::{Path, PathBuf};
+
+use chrono::NaiveDate;
+
+use crate::core::{DateFilter, ToolCall};
+use crate::source::{Capabilities, ParseOutput, Source};
+use crate::utils::Timezone;
+
+use super::load_tool_calls;
+
+struct TestToolSource {
+    has_tool_calls: bool,
+}
+
+impl Source for TestToolSource {
+    fn name(&self) -> &'static str {
+        "test"
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            has_tool_calls: self.has_tool_calls,
+            ..Capabilities::default()
+        }
+    }
+
+    fn find_files(&self) -> Vec<PathBuf> {
+        Vec::new()
+    }
+
+    fn parse_file(&self, _path: &Path, _timezone: Timezone, _debug: bool) -> ParseOutput {
+        ParseOutput::default()
+    }
+
+    fn find_tool_call_files(&self) -> Vec<PathBuf> {
+        vec![PathBuf::from("tool-calls.jsonl")]
+    }
+
+    fn parse_tool_call_file(&self, _path: &Path, _timezone: Timezone) -> Vec<ToolCall> {
+        vec![ToolCall {
+            name: "Read".to_string(),
+            date_str: "2026-02-06".to_string(),
+            identity: None,
+        }]
+    }
+}
+
+fn tz() -> Timezone {
+    Timezone::parse(None).unwrap()
+}
+
+#[test]
+fn load_tool_calls_dispatches_through_source_trait() {
+    let source = TestToolSource {
+        has_tool_calls: true,
+    };
+    let filter = DateFilter::new(
+        NaiveDate::from_ymd_opt(2026, 2, 6),
+        NaiveDate::from_ymd_opt(2026, 2, 6),
+    );
+
+    let calls = load_tool_calls(&source, &filter, tz());
+
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].name, "Read");
+}
+
+#[test]
+fn load_tool_calls_returns_empty_without_capability() {
+    let source = TestToolSource {
+        has_tool_calls: false,
+    };
+    let filter = DateFilter::new(None, None);
+
+    let calls = load_tool_calls(&source, &filter, tz());
+
+    assert!(calls.is_empty());
+}

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -12,7 +12,7 @@ mod registry;
 
 use std::path::{Path, PathBuf};
 
-use crate::core::RawEntry;
+use crate::core::{RawEntry, ToolCall};
 use crate::utils::Timezone;
 
 /// Parse result for a single source file.
@@ -36,6 +36,8 @@ pub(crate) struct Capabilities {
     pub(crate) has_cache_creation: bool,
     /// Requires deduplication (streaming creates duplicate entries)
     pub(crate) needs_dedup: bool,
+    /// Supports tool-call discovery and parsing
+    pub(crate) has_tool_calls: bool,
 }
 
 /// Data source trait - implemented by each CLI tool
@@ -48,7 +50,7 @@ pub(crate) trait Source: Send + Sync {
         self.name()
     }
 
-    /// Short aliases for CLI (e.g., "cc" for "claude")
+    /// Short aliases for CLI.
     fn aliases(&self) -> &'static [&'static str] {
         &[]
     }
@@ -61,6 +63,16 @@ pub(crate) trait Source: Send + Sync {
 
     /// Parse a single file into raw entries and diagnostics.
     fn parse_file(&self, path: &Path, timezone: Timezone, debug: bool) -> ParseOutput;
+
+    /// Find files that may contain tool-call records for this source.
+    fn find_tool_call_files(&self) -> Vec<PathBuf> {
+        Vec::new()
+    }
+
+    /// Parse tool-call records from one source-owned file.
+    fn parse_tool_call_file(&self, _path: &Path, _timezone: Timezone) -> Vec<ToolCall> {
+        Vec::new()
+    }
 }
 
 /// Box type for dynamic dispatch

--- a/src/source/registry.rs
+++ b/src/source/registry.rs
@@ -132,10 +132,11 @@ mod tests {
 
     #[test]
     fn test_get_source_by_alias() {
-        assert!(get_source("cc").is_some());
-        assert!(get_source("cx").is_some());
-        assert!(get_source("cur").is_some());
-        assert!(get_source("gx").is_some());
+        for source in all_sources() {
+            for alias in source.aliases() {
+                assert!(get_source(alias).is_some());
+            }
+        }
     }
 
     #[test]
@@ -153,7 +154,7 @@ mod tests {
         let source = get_source("claude").unwrap();
         assert_eq!(source.name(), "claude");
         assert_eq!(source.display_name(), "Claude Code");
-        assert!(source.aliases().contains(&"cc"));
+        assert!(!source.aliases().is_empty());
     }
 
     #[test]
@@ -161,7 +162,7 @@ mod tests {
         let source = get_source("codex").unwrap();
         assert_eq!(source.name(), "codex");
         assert_eq!(source.display_name(), "OpenAI Codex");
-        assert!(source.aliases().contains(&"cx"));
+        assert!(!source.aliases().is_empty());
     }
 
     #[test]
@@ -169,7 +170,7 @@ mod tests {
         let source = get_source("cursor").unwrap();
         assert_eq!(source.name(), "cursor");
         assert_eq!(source.display_name(), "Cursor");
-        assert!(source.aliases().contains(&"cur"));
+        assert!(!source.aliases().is_empty());
     }
 
     #[test]
@@ -177,7 +178,7 @@ mod tests {
         let source = get_source("grok").unwrap();
         assert_eq!(source.name(), "grok");
         assert_eq!(source.display_name(), "Grok");
-        assert!(source.aliases().contains(&"gx"));
+        assert!(!source.aliases().is_empty());
     }
 
     #[test]
@@ -188,6 +189,7 @@ mod tests {
         assert!(caps.has_billing_blocks);
         assert!(caps.has_cache_creation);
         assert!(caps.needs_dedup);
+        assert!(caps.has_tool_calls);
         assert!(!caps.has_reasoning_tokens);
     }
 
@@ -200,6 +202,7 @@ mod tests {
         assert!(!caps.has_cache_creation);
         assert!(caps.needs_dedup);
         assert!(caps.has_reasoning_tokens);
+        assert!(!caps.has_tool_calls);
     }
 
     #[test]
@@ -211,6 +214,7 @@ mod tests {
         assert!(!caps.has_cache_creation);
         assert!(!caps.needs_dedup);
         assert!(!caps.has_reasoning_tokens);
+        assert!(!caps.has_tool_calls);
     }
 
     #[test]
@@ -222,6 +226,7 @@ mod tests {
         assert!(!caps.has_cache_creation);
         assert!(!caps.needs_dedup);
         assert!(!caps.has_reasoning_tokens);
+        assert!(!caps.has_tool_calls);
     }
 
     #[test]
@@ -232,35 +237,25 @@ mod tests {
 
     #[test]
     fn test_alias_resolves_to_correct_source() {
-        let by_name = get_source("claude").unwrap();
-        let by_alias = get_source("cc").unwrap();
-        assert_eq!(by_name.name(), by_alias.name());
-
-        let by_name = get_source("codex").unwrap();
-        let by_alias = get_source("cx").unwrap();
-        assert_eq!(by_name.name(), by_alias.name());
-
-        let by_name = get_source("cursor").unwrap();
-        let by_alias = get_source("cur").unwrap();
-        assert_eq!(by_name.name(), by_alias.name());
-
-        let by_name = get_source("grok").unwrap();
-        let by_alias = get_source("gx").unwrap();
-        assert_eq!(by_name.name(), by_alias.name());
+        for source in all_sources() {
+            let by_name = get_source(source.name()).unwrap();
+            for alias in source.aliases() {
+                let by_alias = get_source(alias).unwrap();
+                assert_eq!(by_name.name(), by_alias.name());
+            }
+        }
     }
 
     #[test]
     fn test_source_choices_include_names_and_aliases() {
         let choices = source_choices();
         assert!(choices.contains(&"all"));
-        assert!(choices.contains(&"claude"));
-        assert!(choices.contains(&"codex"));
-        assert!(choices.contains(&"cursor"));
-        assert!(choices.contains(&"grok"));
-        assert!(choices.contains(&"cc"));
-        assert!(choices.contains(&"cx"));
-        assert!(choices.contains(&"cur"));
-        assert!(choices.contains(&"gx"));
+        for source in all_sources() {
+            assert!(choices.contains(&source.name()));
+            for alias in source.aliases() {
+                assert!(choices.contains(alias));
+            }
+        }
     }
 
     #[test]
@@ -271,7 +266,8 @@ mod tests {
         assert_eq!(suggest_source("gro"), Some("grok"));
         assert_eq!(suggest_source("claud"), Some("claude"));
         assert_eq!(suggest_source("al"), Some("all"));
-        assert_eq!(suggest_source("cx"), Some("cx"));
+        let codex_alias = get_source("codex").unwrap().aliases()[0];
+        assert_eq!(suggest_source(codex_alias), Some(codex_alias));
     }
 
     #[test]

--- a/tests/tools_integration.rs
+++ b/tests/tools_integration.rs
@@ -1,0 +1,119 @@
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("ccstats-{prefix}-{}-{nanos}", std::process::id()));
+    fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+fn write_file(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent dirs");
+    }
+    fs::write(path, content).expect("write test file");
+}
+
+fn resolve_ccstats_binary() -> PathBuf {
+    if let Some(bin) = std::env::var_os("CARGO_BIN_EXE_ccstats") {
+        return PathBuf::from(bin);
+    }
+
+    let bin_name = if cfg!(windows) {
+        "ccstats.exe"
+    } else {
+        "ccstats"
+    };
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let candidates = [
+        manifest_dir
+            .join("target")
+            .join("llvm-cov-target")
+            .join("debug")
+            .join(bin_name),
+        manifest_dir.join("target").join("debug").join(bin_name),
+    ];
+
+    candidates
+        .into_iter()
+        .find(|path| path.is_file())
+        .unwrap_or_else(|| panic!("unable to locate ccstats binary"))
+}
+
+fn run_ccstats(args: &[&str], envs: &[(&str, &Path)]) -> (bool, Vec<u8>, Vec<u8>) {
+    let mut cmd = Command::new(resolve_ccstats_binary());
+    cmd.args(args);
+    for (key, value) in envs {
+        cmd.env(key, value);
+    }
+    let output = cmd.output().expect("run ccstats");
+    (output.status.success(), output.stdout, output.stderr)
+}
+
+#[test]
+fn tools_command_reads_claude_config_dir_tool_calls() {
+    let root = unique_temp_dir("tools-claude-config-dir");
+    let claude_config_dir = root.join("custom-claude");
+    let home_file = root.join(".claude/projects/home-project/session-a.jsonl");
+    let config_file = claude_config_dir.join("projects/config-project/session-a.jsonl");
+    write_file(
+        &home_file,
+        r#"{"type":"assistant","timestamp":"2026-02-06T12:00:00Z","message":{"id":"msg_home","content":[{"type":"tool_use","name":"HomeOnly","id":"tool_home","input":{}}]}}
+"#,
+    );
+    write_file(
+        &config_file,
+        r#"{"type":"assistant","timestamp":"2026-02-06T12:00:00Z","message":{"id":"msg_config","content":[{"type":"tool_use","name":"Read","id":"tool_config","input":{}}]}}
+"#,
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "tools",
+            "-j",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("HOME", &root), ("CLAUDE_CONFIG_DIR", &claude_config_dir)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    assert_eq!(json["total"].as_u64(), Some(1));
+    let tools = json["tools"].as_array().expect("tools");
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0]["name"].as_str(), Some("Read"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn tools_command_rejects_source_without_tool_call_capability() {
+    let root = unique_temp_dir("tools-capability-gate");
+    let codex_home = root.join("codex-home");
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &["tools", "--source", "codex"],
+        &[("HOME", &root), ("CODEX_HOME", &codex_home)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    assert!(
+        String::from_utf8_lossy(&stdout)
+            .contains("Tool usage analysis is only supported for Claude source."),
+        "stdout: {}",
+        String::from_utf8_lossy(&stdout)
+    );
+
+    let _ = fs::remove_dir_all(root);
+}


### PR DESCRIPTION
## Summary

- route SDK `UsageSource::from_str` source names and aliases through the source registry
- add a registry/SDK consistency test that excludes pseudo-source `all`
- add `Capabilities.has_tool_calls` and gate `ccstats tools` by capability instead of a source-name string check
- move tool-call discovery/parsing behind the `Source` trait while preserving `CLAUDE_CONFIG_DIR`

Fixes #45

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test sdk`
- `cargo test source`
- `cargo test --test tools_integration`
- `cargo check`
- `cargo test`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH45`
- `rg '"claude"' src/app.rs` returned no matches
- `git diff --check`

## Review

- Native reviewer reported no findings on head `b833118`.
- Rebased onto `origin/main` after #72; coordinator reran full local gate on head `ef84347`.
