### PR TITLE
Refactor long CLI and Codex parser flows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub use sdk::{
     summarize_cost_ranges_with_cli_config, summarize_cost_with_cli_config,
 };
 
-use chrono::Utc;
+use chrono::{NaiveDate, Utc};
 use clap::Parser;
 
 use app::{CommandContext, handle_all_sources_command, handle_source_command};
@@ -51,43 +51,31 @@ enum TimezoneSource {
     Config,
 }
 
-/// Run the `ccstats` CLI using process arguments.
-///
-/// This is intended for the binary target. SDK consumers should prefer
-/// [`summarize_cost`], [`summarize_cost_ranges`], or their CLI-config variants
-/// so they receive structured data instead of rendered CLI output.
-#[allow(clippy::too_many_lines)] // CLI setup intentionally stays in one dispatch function.
-pub fn run_cli() {
-    let raw_cli = Cli::parse();
-    let raw_timezone = raw_cli.timezone.clone();
-    let parsed_command = parse_command(raw_cli.command.as_ref());
-    let source_cmd = parsed_command.command;
-    let is_statusline = source_cmd.is_statusline();
-
+fn load_config(is_statusline: bool) -> Config {
     let config_result = if is_statusline {
         Config::try_load_quiet()
     } else {
         Config::try_load()
     };
-    let config = match config_result {
+    match config_result {
         Ok(config) => config,
         Err(err) => {
             eprintln!("Error: {err}");
             std::process::exit(1);
         }
-    };
+    }
+}
 
-    let cli = raw_cli.with_config(&config);
-
-    let timezone_source = if raw_timezone.is_some() {
+fn resolve_timezone(timezone: Option<&str>, cli_timezone_was_set: bool) -> Timezone {
+    let timezone_source = if cli_timezone_was_set {
         Some(TimezoneSource::Cli)
-    } else if cli.timezone.is_some() {
+    } else if timezone.is_some() {
         Some(TimezoneSource::Config)
     } else {
         None
     };
 
-    let timezone = match Timezone::parse(cli.timezone.as_deref()) {
+    match Timezone::parse(timezone) {
         Ok(tz) => tz,
         Err(err) => {
             if let Some(TimezoneSource::Config) = timezone_source {
@@ -98,148 +86,157 @@ pub fn run_cli() {
                 std::process::exit(1);
             }
         }
-    };
+    }
+}
 
-    let number_format = match NumberFormat::from_locale(cli.locale.as_deref()) {
+fn resolve_number_format(locale: Option<&str>) -> NumberFormat {
+    match NumberFormat::from_locale(locale) {
         Ok(format) => format,
         Err(err) => {
             eprintln!("Warning: {err}. Using default locale.");
             NumberFormat::default()
         }
-    };
+    }
+}
 
-    let jq_filter = cli.jq.as_deref();
+fn parse_date_flag(value: Option<&str>, flag: &str) -> Option<NaiveDate> {
+    value.map(|s| match parse_date(s) {
+        Ok(date) => date,
+        Err(err) => {
+            eprintln!("{flag}: {err}");
+            std::process::exit(1);
+        }
+    })
+}
 
-    let parse_date_flag = |value: &Option<String>, flag: &str| {
-        value.as_ref().map(|s| match parse_date(s) {
-            Ok(date) => date,
-            Err(err) => {
-                eprintln!("{flag}: {err}");
-                std::process::exit(1);
-            }
-        })
-    };
-    let since = parse_date_flag(&cli.since, "--since");
-    let until = parse_date_flag(&cli.until, "--until");
-
+fn validate_date_range(since: Option<NaiveDate>, until: Option<NaiveDate>) {
     if let (Some(s), Some(u)) = (since, until)
         && s > u
     {
         eprintln!("Error: --since ({s}) is after --until ({u})");
         std::process::exit(1);
     }
+}
 
-    if let Some(monthly_budget) = cli.monthly_budget {
-        if !monthly_budget.is_finite() || monthly_budget <= 0.0 {
-            eprintln!("Error: --monthly-budget must be a positive number");
-            std::process::exit(1);
-        }
-        if source_cmd != SourceCommand::Monthly {
-            eprintln!("Error: --monthly-budget only supports the monthly command");
-            std::process::exit(1);
-        }
-        if !cli.show_cost() {
-            eprintln!(
-                "Error: --monthly-budget requires cost display; remove --no-cost or --cost hide"
-            );
-            std::process::exit(1);
-        }
+fn validate_monthly_budget(cli: &Cli, source_cmd: SourceCommand) {
+    let Some(monthly_budget) = cli.monthly_budget else {
+        return;
+    };
+    if !monthly_budget.is_finite() || monthly_budget <= 0.0 {
+        eprintln!("Error: --monthly-budget must be a positive number");
+        std::process::exit(1);
     }
+    if source_cmd != SourceCommand::Monthly {
+        eprintln!("Error: --monthly-budget only supports the monthly command");
+        std::process::exit(1);
+    }
+    if !cli.show_cost() {
+        eprintln!("Error: --monthly-budget requires cost display; remove --no-cost or --cost hide");
+        std::process::exit(1);
+    }
+}
 
-    let today = timezone.to_fixed_offset(Utc::now()).date_naive();
-    let budget_as_of = until.map_or(today, |end| end.min(today));
-
-    let filter = if source_cmd.needs_today_filter() {
+fn build_date_filter(
+    source_cmd: SourceCommand,
+    today: NaiveDate,
+    since: Option<NaiveDate>,
+    until: Option<NaiveDate>,
+) -> DateFilter {
+    if source_cmd.needs_today_filter() {
         DateFilter::new(Some(today), Some(today))
     } else {
         DateFilter::new(since, until)
-    };
+    }
+}
 
-    let show_cost = cli.show_cost();
-    let needs_pricing = is_statusline || show_cost;
-
-    let pricing_db = if !needs_pricing {
+fn load_pricing_db(cli: &Cli, needs_pricing: bool, is_statusline: bool) -> PricingDb {
+    if !needs_pricing {
         PricingDb::default()
     } else if is_statusline {
         PricingDb::load_quiet(cli.offline, cli.strict_pricing)
     } else {
         PricingDb::load(cli.offline, cli.strict_pricing)
-    };
+    }
+}
 
-    let unknown_source_message = |input: &str| {
-        let available = source_choices().join(", ");
-        if let Some(suggested) = suggest_source(input) {
-            format!(
-                "Error: unknown source '{input}'. Did you mean '{suggested}'? Available: {available}"
-            )
-        } else {
-            format!("Error: unknown source '{input}'. Available: {available}")
-        }
-    };
-
-    let source_name = if source_cmd == SourceCommand::Sources {
-        "claude"
+fn unknown_source_message(input: &str) -> String {
+    let available = source_choices().join(", ");
+    if let Some(suggested) = suggest_source(input) {
+        format!(
+            "Error: unknown source '{input}'. Did you mean '{suggested}'? Available: {available}"
+        )
     } else {
-        match (parsed_command.source_hint, cli.source.as_deref()) {
-            (Some(hint), Some(override_name)) => {
-                if override_name.eq_ignore_ascii_case(ALL_SOURCES) {
-                    eprintln!("Error: command source '{hint}' conflicts with --source all");
-                    std::process::exit(1);
-                }
-                let Some(override_source) = get_source(override_name) else {
-                    eprintln!("{}", unknown_source_message(override_name));
-                    std::process::exit(1);
-                };
-                if override_source.name() != hint {
-                    eprintln!(
-                        "Error: command source '{hint}' conflicts with --source '{}'",
-                        override_source.name()
-                    );
-                    std::process::exit(1);
-                }
-                override_source.name()
-            }
-            (Some(hint), None) => hint,
-            (None, Some(name)) => name,
-            (None, None) => "claude",
-        }
-    };
+        format!("Error: unknown source '{input}'. Available: {available}")
+    }
+}
 
-    let currency_converter = if needs_pricing {
-        cli.currency.as_ref().map(|code| {
-            let Some(conv) = CurrencyConverter::load(code, cli.offline) else {
-                eprintln!(
-                    "Error: failed to load exchange rate for '{code}'. Use a supported currency with cached rates, refresh rates without --offline, or omit --currency."
-                );
-                std::process::exit(1);
-            };
-            if !is_statusline && conv.currency_code() != "USD" {
-                eprintln!(
-                    "Converting costs to {} (rate: displayed as {})",
-                    conv.currency_code(),
-                    conv.format(1.0)
-                );
-            }
-            conv
-        })
-    } else {
-        None
-    };
+fn resolve_source_name<'a>(
+    source_hint: Option<&'static str>,
+    source_override: Option<&'a str>,
+    source_cmd: SourceCommand,
+) -> &'a str {
+    if source_cmd == SourceCommand::Sources {
+        return "claude";
+    }
 
-    if source_name.eq_ignore_ascii_case(ALL_SOURCES) {
-        return handle_all_sources_command(
-            source_cmd,
-            &CommandContext {
-                filter: &filter,
-                cli: &cli,
-                pricing_db: &pricing_db,
-                timezone,
-                number_format,
-                jq_filter,
-                currency: currency_converter.as_ref(),
-                budget_as_of,
-            },
+    match (source_hint, source_override) {
+        (Some(hint), Some(override_name)) => resolve_overridden_command_source(hint, override_name),
+        (Some(hint), None) => hint,
+        (None, Some(name)) => name,
+        (None, None) => "claude",
+    }
+}
+
+fn resolve_overridden_command_source(hint: &'static str, override_name: &str) -> &'static str {
+    if override_name.eq_ignore_ascii_case(ALL_SOURCES) {
+        eprintln!("Error: command source '{hint}' conflicts with --source all");
+        std::process::exit(1);
+    }
+
+    let Some(override_source) = get_source(override_name) else {
+        eprintln!("{}", unknown_source_message(override_name));
+        std::process::exit(1);
+    };
+    if override_source.name() != hint {
+        eprintln!(
+            "Error: command source '{hint}' conflicts with --source '{}'",
+            override_source.name()
         );
+        std::process::exit(1);
+    }
+    override_source.name()
+}
+
+fn load_currency_converter(
+    cli: &Cli,
+    needs_pricing: bool,
+    is_statusline: bool,
+) -> Option<CurrencyConverter> {
+    if !needs_pricing {
+        return None;
+    }
+
+    cli.currency.as_ref().map(|code| {
+        let Some(converter) = CurrencyConverter::load(code, cli.offline) else {
+            eprintln!(
+                "Error: failed to load exchange rate for '{code}'. Use a supported currency with cached rates, refresh rates without --offline, or omit --currency."
+            );
+            std::process::exit(1);
+        };
+        if !is_statusline && converter.currency_code() != "USD" {
+            eprintln!(
+                "Converting costs to {} (rate: displayed as {})",
+                converter.currency_code(),
+                converter.format(1.0)
+            );
+        }
+        converter
+    })
+}
+
+fn dispatch_command(source_name: &str, source_cmd: SourceCommand, context: &CommandContext<'_>) {
+    if source_name.eq_ignore_ascii_case(ALL_SOURCES) {
+        return handle_all_sources_command(source_cmd, context);
     }
 
     let Some(source) = get_source(source_name) else {
@@ -247,8 +244,47 @@ pub fn run_cli() {
         std::process::exit(1);
     };
 
-    handle_source_command(
-        source,
+    handle_source_command(source, source_cmd, context);
+}
+
+/// Run the `ccstats` CLI using process arguments.
+///
+/// This is intended for the binary target. SDK consumers should prefer
+/// [`summarize_cost`], [`summarize_cost_ranges`], or their CLI-config variants
+/// so they receive structured data instead of rendered CLI output.
+pub fn run_cli() {
+    let raw_cli = Cli::parse();
+    let cli_timezone_was_set = raw_cli.timezone.is_some();
+    let parsed_command = parse_command(raw_cli.command.as_ref());
+    let source_cmd = parsed_command.command;
+    let is_statusline = source_cmd.is_statusline();
+
+    let config = load_config(is_statusline);
+    let cli = raw_cli.with_config(&config);
+    let timezone = resolve_timezone(cli.timezone.as_deref(), cli_timezone_was_set);
+    let number_format = resolve_number_format(cli.locale.as_deref());
+
+    let jq_filter = cli.jq.as_deref();
+    let since = parse_date_flag(cli.since.as_deref(), "--since");
+    let until = parse_date_flag(cli.until.as_deref(), "--until");
+    validate_date_range(since, until);
+    validate_monthly_budget(&cli, source_cmd);
+
+    let today = timezone.to_fixed_offset(Utc::now()).date_naive();
+    let budget_as_of = until.map_or(today, |end| end.min(today));
+    let filter = build_date_filter(source_cmd, today, since, until);
+    let show_cost = cli.show_cost();
+    let needs_pricing = is_statusline || show_cost;
+    let pricing_db = load_pricing_db(&cli, needs_pricing, is_statusline);
+    let source_name = resolve_source_name(
+        parsed_command.source_hint,
+        cli.source.as_deref(),
+        source_cmd,
+    );
+    let currency_converter = load_currency_converter(&cli, needs_pricing, is_statusline);
+
+    dispatch_command(
+        source_name,
         source_cmd,
         &CommandContext {
             filter: &filter,

--- a/src/source/codex/parser.rs
+++ b/src/source/codex/parser.rs
@@ -245,57 +245,115 @@ fn extract_model(payload: &Payload<'_>) -> Option<String> {
     extract_model_ref(payload).map(std::string::ToString::to_string)
 }
 
-#[allow(clippy::too_many_lines)]
+struct CodexFileIdentity {
+    session_key: String,
+    session_id: String,
+}
+
+impl CodexFileIdentity {
+    fn from_path(path: &Path) -> Self {
+        Self {
+            session_key: path.display().to_string(),
+            session_id: path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or(UNKNOWN)
+                .to_string(),
+        }
+    }
+}
+
+struct CodexParseContext<'a> {
+    path: &'a Path,
+    timezone: Timezone,
+    debug: bool,
+    identity: CodexFileIdentity,
+}
+
+struct CodexParseState {
+    entries: Vec<RawEntry>,
+    parse_errors: usize,
+    previous_totals: Option<UsageTotals>,
+    current_model: Option<String>,
+    logical_session_key: String,
+}
+
+impl CodexParseState {
+    fn new(capacity: usize, session_key: String) -> Self {
+        Self {
+            entries: Vec::with_capacity(capacity),
+            parse_errors: 0,
+            previous_totals: None,
+            current_model: None,
+            logical_session_key: session_key,
+        }
+    }
+
+    fn finish(self) -> ParseOutput {
+        ParseOutput {
+            entries: self.entries,
+            errors: self.parse_errors,
+        }
+    }
+}
+
 pub(super) fn parse_codex_file_with_debug(
     path: &Path,
     timezone: Timezone,
     debug: bool,
 ) -> ParseOutput {
-    let session_key = path.display().to_string();
-    let session_id = path
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or(UNKNOWN)
-        .to_string();
-
-    let file = match File::open(path) {
-        Ok(f) => f,
-        Err(err) => {
-            if debug {
-                eprintln!("Failed to open {}: {}", path.display(), err);
-            }
-            return ParseOutput {
-                entries: Vec::new(),
-                errors: 1,
-            };
-        }
+    let identity = CodexFileIdentity::from_path(path);
+    let context = CodexParseContext {
+        path,
+        timezone,
+        debug,
+        identity,
+    };
+    let file = match open_codex_file(&context) {
+        Ok(file) => file,
+        Err(output) => return output,
     };
     let estimated_capacity = estimate_entry_capacity(&file, 260);
-    let reader = BufReader::new(file);
+    let mut state = CodexParseState::new(estimated_capacity, context.identity.session_key.clone());
 
-    let mut entries = Vec::with_capacity(estimated_capacity);
-    let mut parse_errors = 0usize;
-    let mut previous_totals: Option<UsageTotals> = None;
-    let mut current_model: Option<String> = None;
-    let mut logical_session_key = session_key.clone();
+    parse_codex_reader(BufReader::new(file), &context, &mut state);
+    state.finish()
+}
+
+fn open_codex_file(context: &CodexParseContext<'_>) -> Result<File, ParseOutput> {
+    File::open(context.path).map_err(|err| {
+        if context.debug {
+            eprintln!("Failed to open {}: {}", context.path.display(), err);
+        }
+        ParseOutput {
+            entries: Vec::new(),
+            errors: 1,
+        }
+    })
+}
+
+fn parse_codex_reader<R: BufRead>(
+    mut reader: R,
+    context: &CodexParseContext<'_>,
+    state: &mut CodexParseState,
+) {
     let mut line = String::new();
     let mut line_no = 0usize;
-    let mut reader = reader;
     loop {
         line.clear();
         let bytes_read = match reader.read_line(&mut line) {
             Ok(n) => n,
             Err(err) => {
                 line_no += 1;
-                if debug {
+                if context.debug {
                     eprintln!(
                         "Failed to read line {} in {}: {}",
                         line_no,
-                        path.display(),
+                        context.path.display(),
                         err
                     );
                 }
-                parse_errors += 1;
+                state.parse_errors += 1;
                 continue;
             }
         };
@@ -309,450 +367,198 @@ pub(super) fn parse_codex_file_with_debug(
             continue;
         }
 
-        let raw_entry: RawJsonEntry<'_> = match serde_json::from_str(line) {
-            Ok(e) => e,
-            Err(err) => {
-                if debug {
-                    eprintln!("Invalid JSON at {}:{}: {}", path.display(), line_no, err);
-                }
-                parse_errors += 1;
-                continue;
+        process_codex_line(line, line_no, context, state);
+    }
+}
+
+fn process_codex_line(
+    line: &str,
+    line_no: usize,
+    context: &CodexParseContext<'_>,
+    state: &mut CodexParseState,
+) {
+    let raw_entry: RawJsonEntry<'_> = match serde_json::from_str(line) {
+        Ok(entry) => entry,
+        Err(err) => {
+            if context.debug {
+                eprintln!(
+                    "Invalid JSON at {}:{}: {}",
+                    context.path.display(),
+                    line_no,
+                    err
+                );
             }
-        };
-
-        let Some(entry_type) = raw_entry.entry_type else {
-            continue;
-        };
-
-        if entry_type == "session_meta" {
-            if let Some(payload) = &raw_entry.payload
-                && let Some(id) = non_empty_model(payload.id)
-            {
-                logical_session_key = format!("codex-session:{id}");
-            }
-            continue;
+            state.parse_errors += 1;
+            return;
         }
+    };
 
-        // Handle turn_context to get model info
-        if entry_type == "turn_context" {
-            if let Some(payload) = &raw_entry.payload
-                && let Some(model) = extract_model_ref(payload)
-            {
-                current_model = Some(model.to_string());
-            }
-            continue;
-        }
+    match raw_entry.entry_type {
+        Some("session_meta") => update_logical_session_key(raw_entry.payload.as_ref(), state),
+        Some("turn_context") => update_current_model(raw_entry.payload.as_ref(), state),
+        Some("event_msg") => process_event_message(&raw_entry, line_no, context, state),
+        _ => {}
+    }
+}
 
-        // Only process event_msg with token_count
-        if entry_type != "event_msg" {
-            continue;
-        }
+fn update_logical_session_key(payload: Option<&Payload<'_>>, state: &mut CodexParseState) {
+    if let Some(payload) = payload
+        && let Some(id) = non_empty_model(payload.id)
+    {
+        state.logical_session_key = format!("codex-session:{id}");
+    }
+}
 
-        let Some(payload) = &raw_entry.payload else {
-            continue;
-        };
+fn update_current_model(payload: Option<&Payload<'_>>, state: &mut CodexParseState) {
+    if let Some(payload) = payload
+        && let Some(model) = extract_model_ref(payload)
+    {
+        state.current_model = Some(model.to_string());
+    }
+}
 
-        let Some(payload_type) = payload.payload_type else {
-            continue;
-        };
+fn process_event_message(
+    raw_entry: &RawJsonEntry<'_>,
+    line_no: usize,
+    context: &CodexParseContext<'_>,
+    state: &mut CodexParseState,
+) {
+    let Some(payload) = &raw_entry.payload else {
+        return;
+    };
+    let Some("token_count") = payload.payload_type else {
+        return;
+    };
+    let Some(timestamp) = raw_entry.timestamp else {
+        return;
+    };
+    let Some(info) = &payload.info else { return };
+    let Some((total, delta)) = next_usage_delta(info, state) else {
+        return;
+    };
+    let Some(utc_dt) = parse_entry_timestamp(timestamp, line_no, context, state) else {
+        return;
+    };
 
-        if payload_type != "token_count" {
-            continue;
-        }
+    let model = resolve_entry_model(payload, state);
+    push_codex_entry(timestamp, utc_dt, total, delta, model, context, state);
+}
 
-        let Some(timestamp) = &raw_entry.timestamp else {
-            continue;
-        };
+fn next_usage_delta(
+    info: &TokenInfo<'_>,
+    state: &mut CodexParseState,
+) -> Option<(UsageTotals, UsageTotals)> {
+    let total = UsageTotals::from_usage(info.total_token_usage.as_ref()?);
 
-        let Some(info) = &payload.info else { continue };
-
-        // Get delta usage
-        let Some(total) = &info.total_token_usage else {
-            continue;
-        };
-        let total = UsageTotals::from_usage(total);
-
-        // Skip only when the complete normalized cumulative usage vector is unchanged.
-        if let Some(prev) = &previous_totals
-            && total.is_duplicate_of(prev)
-        {
-            continue;
-        }
-
-        // Use last_token_usage if available, otherwise compute delta
-        let delta = if let Some(last) = &info.last_token_usage {
-            UsageTotals::from_usage(last)
-        } else {
-            previous_totals.map_or(total, |prev| total.subtract(prev))
-        };
-
-        previous_totals = Some(total);
-
-        if delta.is_empty() {
-            continue;
-        }
-
-        // Parse timestamp
-        let utc_dt = match timestamp.parse::<DateTime<Utc>>() {
-            Ok(dt) => dt,
-            Err(err) => {
-                if debug {
-                    eprintln!(
-                        "Invalid timestamp at {}:{}: {} ({})",
-                        path.display(),
-                        line_no,
-                        timestamp,
-                        err
-                    );
-                }
-                parse_errors += 1;
-                continue;
-            }
-        };
-        let local_dt = timezone.to_fixed_offset(utc_dt);
-        let date = local_dt.date_naive();
-
-        // Get model name
-        let model = if let Some(parsed_model) = extract_model_ref(payload) {
-            let parsed_model = parsed_model.to_string();
-            current_model = Some(parsed_model.clone());
-            parsed_model
-        } else {
-            current_model.clone().unwrap_or_else(|| "gpt-5".to_string())
-        };
-
-        // Codex's input_tokens INCLUDES cached_input_tokens
-        let raw_input = delta.input_tokens;
-        let cached = delta.cached_input_tokens;
-        let non_cached_input = (raw_input - cached).max(0);
-
-        // OpenAI's output_tokens INCLUDES reasoning_output_tokens as a subset.
-        // Separate them so total_tokens() and calculate_cost() don't double-count.
-        let raw_output = delta.output_tokens;
-        let reasoning = delta.reasoning_output_tokens;
-        let non_reasoning_output = (raw_output - reasoning).max(0);
-        let message_id = usage_message_id(&model, &logical_session_key, total, delta);
-
-        entries.push(RawEntry {
-            timestamp: timestamp.to_string(),
-            timestamp_ms: utc_dt.timestamp_millis(),
-            date_str: date.format(DATE_FORMAT).to_string(),
-            message_id: Some(message_id),
-            session_key: session_key.clone(),
-            session_id: session_id.clone(),
-            project_path: String::new(), // Codex doesn't track projects
-            model,
-            input_tokens: non_cached_input,
-            output_tokens: non_reasoning_output,
-            cache_creation: 0, // Codex doesn't have cache creation
-            cache_read: cached,
-            reasoning_tokens: reasoning,
-            stop_reason: Some("complete".to_string()), // Codex events are always complete
-        });
+    // Skip only when the complete normalized cumulative usage vector is unchanged.
+    if let Some(prev) = &state.previous_totals
+        && total.is_duplicate_of(prev)
+    {
+        return None;
     }
 
-    ParseOutput {
-        entries,
-        errors: parse_errors,
+    // Use last_token_usage if available, otherwise compute delta.
+    let delta = if let Some(last) = &info.last_token_usage {
+        UsageTotals::from_usage(last)
+    } else {
+        state
+            .previous_totals
+            .map_or(total, |prev| total.subtract(prev))
+    };
+
+    state.previous_totals = Some(total);
+    if delta.is_empty() {
+        return None;
     }
+
+    Some((total, delta))
+}
+
+fn parse_entry_timestamp(
+    timestamp: &str,
+    line_no: usize,
+    context: &CodexParseContext<'_>,
+    state: &mut CodexParseState,
+) -> Option<DateTime<Utc>> {
+    match timestamp.parse::<DateTime<Utc>>() {
+        Ok(dt) => Some(dt),
+        Err(err) => {
+            if context.debug {
+                eprintln!(
+                    "Invalid timestamp at {}:{}: {} ({})",
+                    context.path.display(),
+                    line_no,
+                    timestamp,
+                    err
+                );
+            }
+            state.parse_errors += 1;
+            None
+        }
+    }
+}
+
+fn resolve_entry_model(payload: &Payload<'_>, state: &mut CodexParseState) -> String {
+    if let Some(parsed_model) = extract_model_ref(payload) {
+        let parsed_model = parsed_model.to_string();
+        state.current_model = Some(parsed_model.clone());
+        parsed_model
+    } else {
+        state
+            .current_model
+            .clone()
+            .unwrap_or_else(|| "gpt-5".to_string())
+    }
+}
+
+fn push_codex_entry(
+    timestamp: &str,
+    utc_dt: DateTime<Utc>,
+    total: UsageTotals,
+    delta: UsageTotals,
+    model: String,
+    context: &CodexParseContext<'_>,
+    state: &mut CodexParseState,
+) {
+    let local_dt = context.timezone.to_fixed_offset(utc_dt);
+    let date = local_dt.date_naive();
+    let (input_tokens, output_tokens, cache_read, reasoning_tokens) = split_codex_usage(delta);
+    let message_id = usage_message_id(&model, &state.logical_session_key, total, delta);
+
+    state.entries.push(RawEntry {
+        timestamp: timestamp.to_string(),
+        timestamp_ms: utc_dt.timestamp_millis(),
+        date_str: date.format(DATE_FORMAT).to_string(),
+        message_id: Some(message_id),
+        session_key: context.identity.session_key.clone(),
+        session_id: context.identity.session_id.clone(),
+        project_path: String::new(), // Codex doesn't track projects
+        model,
+        input_tokens,
+        output_tokens,
+        cache_creation: 0, // Codex doesn't have cache creation
+        cache_read,
+        reasoning_tokens,
+        stop_reason: Some("complete".to_string()), // Codex events are always complete
+    });
+}
+
+fn split_codex_usage(delta: UsageTotals) -> (i64, i64, i64, i64) {
+    // Codex's input_tokens includes cached_input_tokens.
+    let input_tokens = (delta.input_tokens - delta.cached_input_tokens).max(0);
+
+    // OpenAI's output_tokens includes reasoning_output_tokens as a subset.
+    // Separate them so total_tokens() and calculate_cost() don't double-count.
+    let output_tokens = (delta.output_tokens - delta.reasoning_output_tokens).max(0);
+
+    (
+        input_tokens,
+        output_tokens,
+        delta.cached_input_tokens,
+        delta.reasoning_output_tokens,
+    )
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    // ========================================================================
-    // TokenUsage::subtract
-    // ========================================================================
-
-    #[test]
-    fn test_subtract_normal() {
-        let total = TokenUsage {
-            input_tokens: Some(1000),
-            cached_input_tokens: Some(200),
-            alt_cache_read_input_tokens: None,
-            output_tokens: Some(500),
-            reasoning_output_tokens: Some(100),
-            total_tokens: Some(1500),
-        };
-        let prev = TokenUsage {
-            input_tokens: Some(400),
-            cached_input_tokens: Some(100),
-            alt_cache_read_input_tokens: None,
-            output_tokens: Some(200),
-            reasoning_output_tokens: Some(50),
-            total_tokens: Some(600),
-        };
-        let delta = total.subtract(&prev);
-        assert_eq!(delta.input_tokens, Some(600));
-        assert_eq!(delta.cached_input_tokens, Some(100));
-        assert_eq!(delta.output_tokens, Some(300));
-        assert_eq!(delta.reasoning_output_tokens, Some(50));
-        assert_eq!(delta.total_tokens, Some(900));
-    }
-
-    #[test]
-    fn test_subtract_clamps_negative_to_zero() {
-        let total = TokenUsage {
-            input_tokens: Some(100),
-            cached_input_tokens: Some(50),
-            alt_cache_read_input_tokens: None,
-            output_tokens: Some(10),
-            reasoning_output_tokens: Some(0),
-            total_tokens: Some(110),
-        };
-        let prev = TokenUsage {
-            input_tokens: Some(500),
-            cached_input_tokens: Some(200),
-            alt_cache_read_input_tokens: None,
-            output_tokens: Some(300),
-            reasoning_output_tokens: Some(100),
-            total_tokens: Some(800),
-        };
-        let delta = total.subtract(&prev);
-        assert_eq!(delta.input_tokens, Some(0));
-        assert_eq!(delta.cached_input_tokens, Some(0));
-        assert_eq!(delta.output_tokens, Some(0));
-        assert_eq!(delta.reasoning_output_tokens, Some(0));
-        assert_eq!(delta.total_tokens, Some(0));
-    }
-
-    #[test]
-    fn test_subtract_none_fields_treated_as_zero() {
-        let total = TokenUsage {
-            input_tokens: Some(100),
-            ..Default::default()
-        };
-        let prev = TokenUsage::default();
-        let delta = total.subtract(&prev);
-        assert_eq!(delta.input_tokens, Some(100));
-        assert_eq!(delta.output_tokens, Some(0));
-        assert_eq!(delta.reasoning_output_tokens, Some(0));
-    }
-
-    // ========================================================================
-    // UsageTotals::is_duplicate_of
-    // ========================================================================
-
-    #[test]
-    fn test_usage_totals_duplicate_when_complete_vector_matches() {
-        let prev = UsageTotals {
-            input_tokens: 100,
-            cached_input_tokens: 20,
-            output_tokens: 30,
-            reasoning_output_tokens: 10,
-            total_tokens: 0,
-        };
-        let total = UsageTotals {
-            input_tokens: 100,
-            cached_input_tokens: 20,
-            output_tokens: 30,
-            reasoning_output_tokens: 10,
-            total_tokens: 0,
-        };
-
-        assert!(total.is_duplicate_of(&prev));
-    }
-
-    #[test]
-    fn test_usage_totals_not_duplicate_when_component_grows_with_zero_total() {
-        let prev = UsageTotals {
-            input_tokens: 100,
-            cached_input_tokens: 20,
-            output_tokens: 30,
-            reasoning_output_tokens: 10,
-            total_tokens: 0,
-        };
-        let total = UsageTotals {
-            input_tokens: 150,
-            cached_input_tokens: 20,
-            output_tokens: 30,
-            reasoning_output_tokens: 10,
-            total_tokens: 0,
-        };
-
-        assert!(!total.is_duplicate_of(&prev));
-        assert_eq!(total.subtract(prev).input_tokens, 50);
-    }
-
-    // ========================================================================
-    // TokenUsage::is_empty
-    // ========================================================================
-
-    #[test]
-    fn test_is_empty_default() {
-        assert!(TokenUsage::default().is_empty());
-    }
-
-    #[test]
-    fn test_is_empty_with_input() {
-        let usage = TokenUsage {
-            input_tokens: Some(1),
-            ..Default::default()
-        };
-        assert!(!usage.is_empty());
-    }
-
-    #[test]
-    fn test_is_empty_with_cached_only() {
-        let usage = TokenUsage {
-            cached_input_tokens: Some(50),
-            ..Default::default()
-        };
-        assert!(!usage.is_empty());
-    }
-
-    #[test]
-    fn test_is_empty_with_reasoning_only() {
-        let usage = TokenUsage {
-            reasoning_output_tokens: Some(10),
-            ..Default::default()
-        };
-        assert!(!usage.is_empty());
-    }
-
-    // ========================================================================
-    // TokenUsage::cached_input (fallback logic)
-    // ========================================================================
-
-    #[test]
-    fn test_cached_input_prefers_cached_input_tokens() {
-        let usage = TokenUsage {
-            cached_input_tokens: Some(100),
-            alt_cache_read_input_tokens: Some(50),
-            ..Default::default()
-        };
-        assert_eq!(usage.cached_input(), 100);
-    }
-
-    #[test]
-    fn test_cached_input_falls_back_to_cache_read() {
-        let usage = TokenUsage {
-            cached_input_tokens: None,
-            alt_cache_read_input_tokens: Some(75),
-            ..Default::default()
-        };
-        assert_eq!(usage.cached_input(), 75);
-    }
-
-    #[test]
-    fn test_cached_input_both_none_returns_zero() {
-        let usage = TokenUsage::default();
-        assert_eq!(usage.cached_input(), 0);
-    }
-
-    // ========================================================================
-    // extract_model (priority chain)
-    // ========================================================================
-
-    #[test]
-    fn test_extract_model_from_info_model() {
-        let payload = Payload {
-            payload_type: None,
-            id: None,
-            model: Some("fallback-model"),
-            info: Some(TokenInfo {
-                total_token_usage: None,
-                last_token_usage: None,
-                model: Some("info-model"),
-                model_name: Some("info-model-name"),
-                metadata: Some(Metadata {
-                    model: Some("meta-model"),
-                }),
-            }),
-        };
-        assert_eq!(extract_model(&payload), Some("info-model".to_string()));
-    }
-
-    #[test]
-    fn test_extract_model_falls_back_to_model_name() {
-        let payload = Payload {
-            payload_type: None,
-            id: None,
-            model: Some("fallback"),
-            info: Some(TokenInfo {
-                total_token_usage: None,
-                last_token_usage: None,
-                model: None,
-                model_name: Some("model-name"),
-                metadata: None,
-            }),
-        };
-        assert_eq!(extract_model(&payload), Some("model-name".to_string()));
-    }
-
-    #[test]
-    fn test_extract_model_falls_back_to_metadata() {
-        let payload = Payload {
-            payload_type: None,
-            id: None,
-            model: Some("fallback"),
-            info: Some(TokenInfo {
-                total_token_usage: None,
-                last_token_usage: None,
-                model: None,
-                model_name: None,
-                metadata: Some(Metadata {
-                    model: Some("meta-model"),
-                }),
-            }),
-        };
-        assert_eq!(extract_model(&payload), Some("meta-model".to_string()));
-    }
-
-    #[test]
-    fn test_extract_model_falls_back_to_payload_model() {
-        let payload = Payload {
-            payload_type: None,
-            id: None,
-            model: Some("payload-model"),
-            info: Some(TokenInfo {
-                total_token_usage: None,
-                last_token_usage: None,
-                model: None,
-                model_name: None,
-                metadata: None,
-            }),
-        };
-        assert_eq!(extract_model(&payload), Some("payload-model".to_string()));
-    }
-
-    #[test]
-    fn test_extract_model_no_info_uses_payload() {
-        let payload = Payload {
-            payload_type: None,
-            id: None,
-            model: Some("payload-only"),
-            info: None,
-        };
-        assert_eq!(extract_model(&payload), Some("payload-only".to_string()));
-    }
-
-    #[test]
-    fn test_extract_model_all_none_returns_none() {
-        let payload = Payload {
-            payload_type: None,
-            id: None,
-            model: None,
-            info: None,
-        };
-        assert_eq!(extract_model(&payload), None);
-    }
-
-    #[test]
-    fn test_extract_model_empty_strings_skipped() {
-        let payload = Payload {
-            payload_type: None,
-            id: None,
-            model: Some("real-model"),
-            info: Some(TokenInfo {
-                total_token_usage: None,
-                last_token_usage: None,
-                model: Some("  "),
-                model_name: Some(""),
-                metadata: None,
-            }),
-        };
-        assert_eq!(extract_model(&payload), Some("real-model".to_string()));
-    }
-}
+#[path = "parser_tests.rs"]
+mod parser_tests;

--- a/src/source/codex/parser_tests.rs
+++ b/src/source/codex/parser_tests.rs
@@ -1,0 +1,276 @@
+use super::*;
+
+#[test]
+fn test_subtract_normal() {
+    let total = TokenUsage {
+        input_tokens: Some(1000),
+        cached_input_tokens: Some(200),
+        alt_cache_read_input_tokens: None,
+        output_tokens: Some(500),
+        reasoning_output_tokens: Some(100),
+        total_tokens: Some(1500),
+    };
+    let prev = TokenUsage {
+        input_tokens: Some(400),
+        cached_input_tokens: Some(100),
+        alt_cache_read_input_tokens: None,
+        output_tokens: Some(200),
+        reasoning_output_tokens: Some(50),
+        total_tokens: Some(600),
+    };
+    let delta = total.subtract(&prev);
+    assert_eq!(delta.input_tokens, Some(600));
+    assert_eq!(delta.cached_input_tokens, Some(100));
+    assert_eq!(delta.output_tokens, Some(300));
+    assert_eq!(delta.reasoning_output_tokens, Some(50));
+    assert_eq!(delta.total_tokens, Some(900));
+}
+
+#[test]
+fn test_subtract_clamps_negative_to_zero() {
+    let total = TokenUsage {
+        input_tokens: Some(100),
+        cached_input_tokens: Some(50),
+        alt_cache_read_input_tokens: None,
+        output_tokens: Some(10),
+        reasoning_output_tokens: Some(0),
+        total_tokens: Some(110),
+    };
+    let prev = TokenUsage {
+        input_tokens: Some(500),
+        cached_input_tokens: Some(200),
+        alt_cache_read_input_tokens: None,
+        output_tokens: Some(300),
+        reasoning_output_tokens: Some(100),
+        total_tokens: Some(800),
+    };
+    let delta = total.subtract(&prev);
+    assert_eq!(delta.input_tokens, Some(0));
+    assert_eq!(delta.cached_input_tokens, Some(0));
+    assert_eq!(delta.output_tokens, Some(0));
+    assert_eq!(delta.reasoning_output_tokens, Some(0));
+    assert_eq!(delta.total_tokens, Some(0));
+}
+
+#[test]
+fn test_subtract_none_fields_treated_as_zero() {
+    let total = TokenUsage {
+        input_tokens: Some(100),
+        ..Default::default()
+    };
+    let prev = TokenUsage::default();
+    let delta = total.subtract(&prev);
+    assert_eq!(delta.input_tokens, Some(100));
+    assert_eq!(delta.output_tokens, Some(0));
+    assert_eq!(delta.reasoning_output_tokens, Some(0));
+}
+
+#[test]
+fn test_usage_totals_duplicate_when_complete_vector_matches() {
+    let prev = UsageTotals {
+        input_tokens: 100,
+        cached_input_tokens: 20,
+        output_tokens: 30,
+        reasoning_output_tokens: 10,
+        total_tokens: 0,
+    };
+    let total = UsageTotals {
+        input_tokens: 100,
+        cached_input_tokens: 20,
+        output_tokens: 30,
+        reasoning_output_tokens: 10,
+        total_tokens: 0,
+    };
+
+    assert!(total.is_duplicate_of(&prev));
+}
+
+#[test]
+fn test_usage_totals_not_duplicate_when_component_grows_with_zero_total() {
+    let prev = UsageTotals {
+        input_tokens: 100,
+        cached_input_tokens: 20,
+        output_tokens: 30,
+        reasoning_output_tokens: 10,
+        total_tokens: 0,
+    };
+    let total = UsageTotals {
+        input_tokens: 150,
+        cached_input_tokens: 20,
+        output_tokens: 30,
+        reasoning_output_tokens: 10,
+        total_tokens: 0,
+    };
+
+    assert!(!total.is_duplicate_of(&prev));
+    assert_eq!(total.subtract(prev).input_tokens, 50);
+}
+
+#[test]
+fn test_is_empty_default() {
+    assert!(TokenUsage::default().is_empty());
+}
+
+#[test]
+fn test_is_empty_with_input() {
+    let usage = TokenUsage {
+        input_tokens: Some(1),
+        ..Default::default()
+    };
+    assert!(!usage.is_empty());
+}
+
+#[test]
+fn test_is_empty_with_cached_only() {
+    let usage = TokenUsage {
+        cached_input_tokens: Some(50),
+        ..Default::default()
+    };
+    assert!(!usage.is_empty());
+}
+
+#[test]
+fn test_is_empty_with_reasoning_only() {
+    let usage = TokenUsage {
+        reasoning_output_tokens: Some(10),
+        ..Default::default()
+    };
+    assert!(!usage.is_empty());
+}
+
+#[test]
+fn test_cached_input_prefers_cached_input_tokens() {
+    let usage = TokenUsage {
+        cached_input_tokens: Some(100),
+        alt_cache_read_input_tokens: Some(50),
+        ..Default::default()
+    };
+    assert_eq!(usage.cached_input(), 100);
+}
+
+#[test]
+fn test_cached_input_falls_back_to_cache_read() {
+    let usage = TokenUsage {
+        cached_input_tokens: None,
+        alt_cache_read_input_tokens: Some(75),
+        ..Default::default()
+    };
+    assert_eq!(usage.cached_input(), 75);
+}
+
+#[test]
+fn test_cached_input_both_none_returns_zero() {
+    let usage = TokenUsage::default();
+    assert_eq!(usage.cached_input(), 0);
+}
+
+#[test]
+fn test_extract_model_from_info_model() {
+    let payload = Payload {
+        payload_type: None,
+        id: None,
+        model: Some("fallback-model"),
+        info: Some(TokenInfo {
+            total_token_usage: None,
+            last_token_usage: None,
+            model: Some("info-model"),
+            model_name: Some("info-model-name"),
+            metadata: Some(Metadata {
+                model: Some("meta-model"),
+            }),
+        }),
+    };
+    assert_eq!(extract_model(&payload), Some("info-model".to_string()));
+}
+
+#[test]
+fn test_extract_model_falls_back_to_model_name() {
+    let payload = Payload {
+        payload_type: None,
+        id: None,
+        model: Some("fallback"),
+        info: Some(TokenInfo {
+            total_token_usage: None,
+            last_token_usage: None,
+            model: None,
+            model_name: Some("model-name"),
+            metadata: None,
+        }),
+    };
+    assert_eq!(extract_model(&payload), Some("model-name".to_string()));
+}
+
+#[test]
+fn test_extract_model_falls_back_to_metadata() {
+    let payload = Payload {
+        payload_type: None,
+        id: None,
+        model: Some("fallback"),
+        info: Some(TokenInfo {
+            total_token_usage: None,
+            last_token_usage: None,
+            model: None,
+            model_name: None,
+            metadata: Some(Metadata {
+                model: Some("meta-model"),
+            }),
+        }),
+    };
+    assert_eq!(extract_model(&payload), Some("meta-model".to_string()));
+}
+
+#[test]
+fn test_extract_model_falls_back_to_payload_model() {
+    let payload = Payload {
+        payload_type: None,
+        id: None,
+        model: Some("payload-model"),
+        info: Some(TokenInfo {
+            total_token_usage: None,
+            last_token_usage: None,
+            model: None,
+            model_name: None,
+            metadata: None,
+        }),
+    };
+    assert_eq!(extract_model(&payload), Some("payload-model".to_string()));
+}
+
+#[test]
+fn test_extract_model_no_info_uses_payload() {
+    let payload = Payload {
+        payload_type: None,
+        id: None,
+        model: Some("payload-only"),
+        info: None,
+    };
+    assert_eq!(extract_model(&payload), Some("payload-only".to_string()));
+}
+
+#[test]
+fn test_extract_model_all_none_returns_none() {
+    let payload = Payload {
+        payload_type: None,
+        id: None,
+        model: None,
+        info: None,
+    };
+    assert_eq!(extract_model(&payload), None);
+}
+
+#[test]
+fn test_extract_model_empty_strings_skipped() {
+    let payload = Payload {
+        payload_type: None,
+        id: None,
+        model: Some("real-model"),
+        info: Some(TokenInfo {
+            total_token_usage: None,
+            last_token_usage: None,
+            model: Some("  "),
+            model_name: Some(""),
+            metadata: None,
+        }),
+    };
+    assert_eq!(extract_model(&payload), Some("real-model".to_string()));
+}


### PR DESCRIPTION
## Summary
- remove the too_many_lines exceptions from run_cli and the Codex parser by extracting private helper flows
- move Codex parser unit tests into src/source/codex/parser_tests.rs
- preserve CLI exit behavior and Codex cumulative token parsing semantics

Refs #47

## Verification
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test source::codex
- cargo test cli
- cargo check
- cargo test
- python3 checks/check_workflow.py --repo .
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH47
- git diff --check