### PR TITLE
Rename period summary footer options

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -7,8 +7,8 @@ use crate::core::{
 };
 use crate::output::NumberFormat;
 use crate::output::{
-    BlockTableOptions, MonthlyBudgetOptions, OutputFormat, Period, ProjectTableOptions,
-    SessionTableOptions, SummaryOptions, TokenTableOptions, TopRow, TopTableOptions,
+    BlockTableOptions, MonthlyBudgetOptions, OutputFormat, Period, PeriodSummaryFooter,
+    ProjectTableOptions, SessionTableOptions, TokenTableOptions, TopRow, TopTableOptions,
     add_monthly_budget_to_json, monthly_budget_reports, output_block_csv, output_block_json,
     output_monthly_budget_csv, output_period_csv, output_period_json, output_project_csv,
     output_project_json, output_session_csv, output_session_json, output_tools_csv,
@@ -507,7 +507,7 @@ fn render_period_result(
                 &result.day_stats,
                 period,
                 ctx.cli.breakdown,
-                SummaryOptions {
+                PeriodSummaryFooter {
                     skipped: result.skipped,
                     valid: result.valid,
                     elapsed_ms: Some(result.elapsed_ms),

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -38,7 +38,7 @@ pub(crate) use period::Period;
 pub(crate) use project::{ProjectTableOptions, output_project_json, print_project_table};
 pub(crate) use session::{SessionTableOptions, output_session_json, print_session_table};
 pub(crate) use statusline::{print_statusline, print_statusline_json};
-pub(crate) use table::{SummaryOptions, TokenTableOptions, print_period_table};
+pub(crate) use table::{PeriodSummaryFooter, TokenTableOptions, print_period_table};
 pub(crate) use tools::{output_tools_csv, output_tools_json, print_tools_table};
 pub(crate) use top::{
     TopRow, TopTableOptions, output_top_csv, output_top_json, print_top_table, rank_by_model,

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -24,7 +24,7 @@ pub(crate) struct TokenTableOptions<'a> {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct SummaryOptions {
+pub(crate) struct PeriodSummaryFooter {
     pub(crate) skipped: i64,
     pub(crate) valid: i64,
     pub(crate) elapsed_ms: Option<f64>,
@@ -396,7 +396,7 @@ pub(crate) fn print_period_table(
     day_stats: &HashMap<String, DayStats>,
     period: Period,
     breakdown: bool,
-    summary: SummaryOptions,
+    summary: PeriodSummaryFooter,
     pricing_db: &PricingDb,
     options: TokenTableOptions<'_>,
 ) {


### PR DESCRIPTION
## Summary
- rename the internal output SummaryOptions type to PeriodSummaryFooter
- update the output re-export and period table call site
- keep the public SDK SummaryOptions name and behavior unchanged

Refs #47

## Verification
- cargo fmt --check
- cargo check
- cargo test output::table
- cargo test sdk::tests::cli_config_fills_sdk_summary_defaults
- cargo clippy --all-targets --all-features -- -D warnings
- python3 checks/check_workflow.py --repo .
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH47
- git diff --check