### PR TITLE
Deduplicate Claude messages across files

### DIFF
--- a/src/core/dedup.rs
+++ b/src/core/dedup.rs
@@ -8,6 +8,10 @@ use std::collections::HashMap;
 
 const SOURCE_WIDE_DEDUP_PREFIX: &str = "source-wide:";
 
+pub(crate) fn source_wide_message_id(source: &str, message_id: &str) -> String {
+    format!("{SOURCE_WIDE_DEDUP_PREFIX}{source}:{message_id}")
+}
+
 /// Trait for entries that can be deduplicated
 pub(crate) trait Deduplicatable {
     fn timestamp_ms(&self) -> i64;
@@ -240,6 +244,33 @@ mod tests {
         }
         fn message_id(&self) -> Option<&str> {
             self.id.as_deref()
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct ScopedTestEntry {
+        id: String,
+        scope: String,
+        ts: i64,
+        value: i32,
+    }
+
+    impl Deduplicatable for ScopedTestEntry {
+        fn timestamp_ms(&self) -> i64 {
+            self.ts
+        }
+        fn has_stop_reason(&self) -> bool {
+            true
+        }
+        fn message_id(&self) -> Option<&str> {
+            Some(&self.id)
+        }
+        fn dedup_scope(&self) -> Option<&str> {
+            if self.id.starts_with(SOURCE_WIDE_DEDUP_PREFIX) {
+                None
+            } else {
+                Some(&self.scope)
+            }
         }
     }
 
@@ -523,5 +554,30 @@ mod tests {
         assert_eq!(result[0].value, 2); // msg1 chooses completed entry from right chunk
         assert_eq!(result[1].value, 10); // msg2 keeps completed entry from left chunk
         assert_eq!(skipped, 2);
+    }
+
+    #[test]
+    fn source_wide_message_ids_ignore_session_scope() {
+        let id = source_wide_message_id("claude", "msg_1");
+        let entries = vec![
+            ScopedTestEntry {
+                id: id.clone(),
+                scope: "file-a".to_string(),
+                ts: 100,
+                value: 1,
+            },
+            ScopedTestEntry {
+                id,
+                scope: "file-b".to_string(),
+                ts: 200,
+                value: 2,
+            },
+        ];
+
+        let (result, skipped) = deduplicate(entries);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].value, 2);
+        assert_eq!(skipped, 1);
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use aggregator::{
     aggregate_blocks, aggregate_daily, aggregate_projects, aggregate_sessions,
     aggregate_sessions_map, format_project_name, merge_day_stats,
 };
-pub(crate) use dedup::DedupAccumulator;
+pub(crate) use dedup::{DedupAccumulator, source_wide_message_id};
 pub(crate) use tool_aggregator::aggregate_tools;
 #[cfg(test)]
 pub(crate) use tool_types::ToolStats;

--- a/src/source/claude/parser.rs
+++ b/src/source/claude/parser.rs
@@ -10,7 +10,7 @@ use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
 use crate::consts::{DATE_FORMAT, UNKNOWN};
-use crate::core::RawEntry;
+use crate::core::{RawEntry, source_wide_message_id};
 use crate::source::ParseOutput;
 use crate::utils::Timezone;
 
@@ -304,7 +304,7 @@ fn parse_entry_with_debug(
         timestamp: ts,
         timestamp_ms: utc_dt.timestamp_millis(),
         date_str: date.format(DATE_FORMAT).to_string(),
-        message_id: msg.id,
+        message_id: msg.id.map(|id| source_wide_message_id("claude", &id)),
         session_key: session_key.to_string(),
         session_id: session_id.to_string(),
         project_path: project_path.to_string(),

--- a/tests/cli_claude.rs
+++ b/tests/cli_claude.rs
@@ -310,7 +310,12 @@ fn claude_dedup_keeps_same_message_id_from_different_files() {
     let json: Value = serde_json::from_slice(&stdout).expect("json");
     let arr = json.as_array().expect("array output");
     assert_eq!(arr.len(), 1);
-    assert_eq!(arr[0]["total_tokens"].as_i64(), Some(430));
+    assert_eq!(arr[0]["total_tokens"].as_i64(), Some(280));
+    assert!(
+        String::from_utf8_lossy(&stderr).contains("Deduplicated 1 entries"),
+        "stderr: {}",
+        String::from_utf8_lossy(&stderr)
+    );
 
     let _ = fs::remove_dir_all(root);
 }


### PR DESCRIPTION
## Summary
- add a shared source-wide message id helper for dedup keys
- mark Claude message ids as source-wide so duplicate message ids across JSONL files count once
- update the Claude cross-file duplicate fixture to assert the completed/latest entry wins and skipped count increments

Fixes #34

## Investigation Evidence
- scanned local `~/.claude/projects/**/*.jsonl`: 79 files, 21,196 lines, 3,803 message ids
- observed cross-file duplicate ids: 0; estimated duplicate token impact in current local data: 0
- no observed counterexample where the same message id represents different requests
- kept a synthetic integration fixture because the existing code path could double-count if such duplicate files appear

## Verification
- `cargo fmt --check`
- `cargo test source_wide_message_ids_ignore_session_scope`
- `cargo test --test cli_claude claude_dedup_keeps_same_message_id_from_different_files`
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH34`
- `git diff --check`
- `cargo test`