### PR TITLE
Harden Cursor DB parsing

### DIFF
--- a/src/source/cursor/config.rs
+++ b/src/source/cursor/config.rs
@@ -39,6 +39,9 @@ impl Source for CursorSource {
 
     fn capabilities(&self) -> Capabilities {
         Capabilities {
+            // Cursor project metadata is only present in some experimental rows.
+            // Keep project aggregation disabled until every parsed table can
+            // provide a trustworthy project path.
             has_projects: false,
             has_billing_blocks: false,
             has_reasoning_tokens: false,

--- a/src/source/cursor/parser.rs
+++ b/src/source/cursor/parser.rs
@@ -3,9 +3,10 @@
 //! Cursor's schema is not a public API. This parser intentionally only trusts
 //! explicit token count fields and skips records that would require estimation.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use chrono::{DateTime, TimeZone, Utc};
 use rusqlite::types::ValueRef;
@@ -19,11 +20,31 @@ use crate::utils::Timezone;
 
 const CURSOR_HOME_ENV: &str = "CURSOR_HOME";
 const CURSOR_MODEL: &str = "cursor";
+const CURSOR_BUSY_TIMEOUT_MS: u64 = 1_000;
 
 #[derive(Debug, Clone, Default)]
 struct ComposerMeta {
     model: Option<String>,
-    project_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum CursorTable {
+    CursorDiskKv,
+    ItemTable,
+}
+
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+struct CursorOverlapSignature {
+    timestamp_ms: i64,
+    model: String,
+    input_tokens: i64,
+    output_tokens: i64,
+}
+
+#[derive(Debug, Default)]
+struct CursorDedupState {
+    message_ids: HashSet<String>,
+    signatures: HashMap<CursorOverlapSignature, CursorTable>,
 }
 
 fn cursor_user_dirs() -> Vec<PathBuf> {
@@ -73,10 +94,12 @@ pub(super) fn find_cursor_files() -> Vec<PathBuf> {
 }
 
 fn open_readonly(path: &Path) -> rusqlite::Result<Connection> {
-    Connection::open_with_flags(
+    let conn = Connection::open_with_flags(
         path,
         OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    )
+    )?;
+    conn.busy_timeout(Duration::from_millis(CURSOR_BUSY_TIMEOUT_MS))?;
+    Ok(conn)
 }
 
 fn table_exists(conn: &Connection, table: &str) -> bool {
@@ -193,14 +216,6 @@ fn composer_meta_from_value(value: &Value) -> ComposerMeta {
                 &["model"],
             ],
         ),
-        project_path: first_string(
-            value,
-            &[
-                &["workspaceIdentifier", "uri", "fsPath"],
-                &["workspaceIdentifier", "uri", "path"],
-                &["workspaceIdentifier", "path"],
-            ],
-        ),
     }
 }
 
@@ -234,9 +249,7 @@ fn entry_from_bubble(
         message_id: Some(bubble_id.to_string()),
         session_key: format!("{}:{composer_id}", path.display()),
         session_id: composer_id.to_string(),
-        project_path: meta
-            .and_then(|m| m.project_path.clone())
-            .unwrap_or_default(),
+        project_path: String::new(),
         model,
         input_tokens,
         output_tokens,
@@ -293,6 +306,48 @@ fn entry_from_generation(generation: &Value, path: &Path, timezone: Timezone) ->
         reasoning_tokens: 0,
         stop_reason: Some("complete".to_string()),
     })
+}
+
+fn cursor_overlap_signature(entry: &RawEntry) -> CursorOverlapSignature {
+    CursorOverlapSignature {
+        timestamp_ms: entry.timestamp_ms,
+        model: entry.model.clone(),
+        input_tokens: entry.input_tokens,
+        output_tokens: entry.output_tokens,
+    }
+}
+
+fn append_cursor_entries(
+    entries: &mut Vec<RawEntry>,
+    dedup: &mut CursorDedupState,
+    parsed: Vec<RawEntry>,
+    table: CursorTable,
+) {
+    for entry in parsed {
+        // Cursor can store the same completed interaction in cursorDiskKV and
+        // ItemTable. Stable IDs win when they match; otherwise exact
+        // timestamp/model/token signatures protect against cross-table
+        // double-counting without collapsing same-table records.
+        let duplicate_message_id = entry
+            .message_id
+            .as_ref()
+            .is_some_and(|message_id| !dedup.message_ids.insert(message_id.clone()));
+        if duplicate_message_id {
+            continue;
+        }
+
+        let signature = cursor_overlap_signature(&entry);
+        let duplicate_cross_table = dedup
+            .signatures
+            .get(&signature)
+            .is_some_and(|seen_table| *seen_table != table);
+        if duplicate_cross_table {
+            continue;
+        }
+
+        dedup.signatures.entry(signature).or_insert(table);
+        entries.push(entry);
+    }
 }
 
 fn parse_cursor_disk_kv(
@@ -385,12 +440,13 @@ pub(super) fn parse_cursor_db_with_debug(
     };
 
     let mut entries = Vec::new();
+    let mut dedup = CursorDedupState::default();
     let mut errors = 0usize;
 
     if table_exists(&conn, "cursorDiskKV") {
         match parse_cursor_disk_kv(&conn, path, timezone) {
-            Ok((mut parsed, parse_errors)) => {
-                entries.append(&mut parsed);
+            Ok((parsed, parse_errors)) => {
+                append_cursor_entries(&mut entries, &mut dedup, parsed, CursorTable::CursorDiskKv);
                 errors += parse_errors;
             }
             Err(err) => {
@@ -408,8 +464,8 @@ pub(super) fn parse_cursor_db_with_debug(
 
     if table_exists(&conn, "ItemTable") {
         match parse_item_table(&conn, path, timezone) {
-            Ok((mut parsed, parse_errors)) => {
-                entries.append(&mut parsed);
+            Ok((parsed, parse_errors)) => {
+                append_cursor_entries(&mut entries, &mut dedup, parsed, CursorTable::ItemTable);
                 errors += parse_errors;
             }
             Err(err) => {
@@ -431,6 +487,147 @@ mod tests {
 
     fn tz() -> Timezone {
         Timezone::parse(Some("UTC")).unwrap()
+    }
+
+    fn create_cursor_disk_kv(conn: &Connection) {
+        conn.execute(
+            "CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value BLOB)",
+            [],
+        )
+        .expect("create cursorDiskKV");
+    }
+
+    fn create_item_table(conn: &Connection) {
+        conn.execute(
+            "CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value BLOB)",
+            [],
+        )
+        .expect("create ItemTable");
+    }
+
+    fn insert_cursor_composer(conn: &Connection) {
+        conn.execute(
+            "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+            (
+                "composerData:composer-1",
+                r#"{"composerId":"composer-1","modelConfig":{"modelName":"claude-4-sonnet"},"workspaceIdentifier":{"uri":{"fsPath":"/tmp/cursor-project"}}}"#,
+            ),
+        )
+        .expect("insert composer");
+    }
+
+    fn insert_cursor_bubble(conn: &Connection, bubble_id: &str, created_at: &str) {
+        conn.execute(
+            "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+            (
+                format!("bubbleId:composer-1:{bubble_id}"),
+                format!(
+                    r#"{{"createdAt":"{created_at}","tokenCount":{{"inputTokens":100,"outputTokens":40}}}}"#
+                ),
+            ),
+        )
+        .expect("insert bubble");
+    }
+
+    fn insert_item_generations(conn: &Connection, value: &str) {
+        conn.execute(
+            "INSERT INTO ItemTable (key, value) VALUES (?1, ?2)",
+            ("aiService.generations", value),
+        )
+        .expect("insert generations");
+    }
+
+    #[test]
+    fn open_readonly_sets_busy_timeout() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db_path = temp.path().join("state.vscdb");
+        {
+            let conn = Connection::open(&db_path).expect("create db");
+            create_cursor_disk_kv(&conn);
+        }
+
+        let conn = open_readonly(&db_path).expect("open readonly");
+        let timeout_ms: i64 = conn
+            .query_row("PRAGMA busy_timeout", [], |row| row.get(0))
+            .expect("read busy_timeout");
+
+        assert_eq!(timeout_ms, CURSOR_BUSY_TIMEOUT_MS as i64);
+    }
+
+    #[test]
+    fn parse_cursor_db_deduplicates_cross_table_overlap_fixture() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db_path = temp.path().join("state.vscdb");
+        {
+            let conn = Connection::open(&db_path).expect("create db");
+            create_cursor_disk_kv(&conn);
+            create_item_table(&conn);
+            insert_cursor_composer(&conn);
+            insert_cursor_bubble(&conn, "bubble-1", "2026-02-06T10:00:00Z");
+            insert_item_generations(
+                &conn,
+                r#"[{"createdAt":"2026-02-06T10:00:00Z","inputTokens":100,"outputTokens":40,"generationUUID":"generation-1","model":"claude-4-sonnet"}]"#,
+            );
+        }
+
+        let parsed = parse_cursor_db_with_debug(&db_path, tz(), false);
+
+        assert_eq!(parsed.errors, 0);
+        assert_eq!(parsed.entries.len(), 1);
+        assert_eq!(parsed.entries[0].session_id, "composer-1");
+        assert_eq!(parsed.entries[0].message_id.as_deref(), Some("bubble-1"));
+        assert_eq!(parsed.entries[0].input_tokens, 100);
+        assert_eq!(parsed.entries[0].output_tokens, 40);
+    }
+
+    #[test]
+    fn parse_cursor_db_keeps_distinct_cross_table_records() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db_path = temp.path().join("state.vscdb");
+        {
+            let conn = Connection::open(&db_path).expect("create db");
+            create_cursor_disk_kv(&conn);
+            create_item_table(&conn);
+            insert_cursor_composer(&conn);
+            insert_cursor_bubble(&conn, "bubble-1", "2026-02-06T10:00:00Z");
+            insert_item_generations(
+                &conn,
+                r#"[{"createdAt":"2026-02-06T11:00:00Z","inputTokens":25,"outputTokens":10,"generationUUID":"generation-1","model":"claude-4-sonnet"}]"#,
+            );
+        }
+
+        let parsed = parse_cursor_db_with_debug(&db_path, tz(), false);
+
+        assert_eq!(parsed.errors, 0);
+        assert_eq!(parsed.entries.len(), 2);
+        assert_eq!(
+            parsed
+                .entries
+                .iter()
+                .map(|entry| entry.input_tokens + entry.output_tokens)
+                .sum::<i64>(),
+            175
+        );
+    }
+
+    #[test]
+    fn parse_cursor_db_counts_malformed_json_errors() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db_path = temp.path().join("state.vscdb");
+        {
+            let conn = Connection::open(&db_path).expect("create db");
+            create_cursor_disk_kv(&conn);
+            conn.execute(
+                "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+                ("bubbleId:composer-1:bad-json", "{not-json"),
+            )
+            .expect("insert malformed row");
+        }
+
+        let parsed = parse_cursor_db_with_debug(&db_path, tz(), false);
+
+        assert_eq!(parsed.errors, 1);
+        assert!(parsed.entries.is_empty());
     }
 
     #[test]
@@ -508,7 +705,6 @@ mod tests {
             "composer-1".to_string(),
             ComposerMeta {
                 model: Some("gpt-5".to_string()),
-                project_path: Some("/tmp/project".to_string()),
             },
         );
         let value = json!({
@@ -526,7 +722,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(entry.model, "gpt-5");
-        assert_eq!(entry.project_path, "/tmp/project");
+        assert_eq!(entry.project_path, "");
         assert_eq!(entry.timestamp, "2026-02-06T10:00:00+00:00");
     }
 


### PR DESCRIPTION
## Summary
- set a 1000ms busy timeout on readonly Cursor SQLite connections
- deduplicate possible cursorDiskKV/ItemTable cross-table overlaps by stable id or exact timestamp/model/token signature
- keep Cursor project aggregation disabled and stop emitting unsupported project paths from partial experimental metadata

Fixes #41

## Investigation Evidence
- `CURSOR_HOME` is unset on this machine
- default Cursor User locations currently contain 0 `state.vscdb` files
- no private Cursor DB data was committed
- added reproducible SQLite fixtures: overlapping two-table rows count once; distinct two-table rows remain separate; malformed rows still increment errors

## Verification
- `cargo test cursor`
- `cargo fmt --check`
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH41`
- `git diff --check`
- `cargo test`

## Notes
- `src/source/cursor/parser.rs` is 756 lines after this change, under the 800-line hard ceiling.