### PR TITLE
Expose data quality metadata

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -9,13 +9,13 @@ use crate::output::NumberFormat;
 use crate::output::{
     BlockTableOptions, MonthlyBudgetOptions, OutputFormat, Period, PeriodSummaryFooter,
     ProjectTableOptions, SessionTableOptions, TokenTableOptions, TopRow, TopTableOptions,
-    add_monthly_budget_to_json, monthly_budget_reports, output_block_csv, output_block_json,
-    output_monthly_budget_csv, output_period_csv, output_period_json, output_project_csv,
-    output_project_json, output_session_csv, output_session_json, output_tools_csv,
-    output_tools_json, output_top_csv, output_top_json, print_block_table,
-    print_monthly_budget_table, print_period_table, print_project_table, print_session_table,
-    print_statusline, print_statusline_json, print_tools_table, print_top_table, rank_by_model,
-    rank_by_project,
+    add_monthly_budget_to_json, append_data_quality_csv_comment, monthly_budget_reports,
+    output_block_csv, output_block_json, output_monthly_budget_csv, output_period_csv_with_quality,
+    output_period_json_with_quality, output_project_csv, output_project_json, output_session_csv,
+    output_session_json, output_tools_csv, output_tools_json, output_top_csv, output_top_json,
+    print_block_table, print_monthly_budget_table, print_period_table, print_project_table,
+    print_session_table, print_statusline, print_statusline_json_with_quality, print_tools_table,
+    print_top_table, rank_by_model, rank_by_project,
 };
 use crate::pricing::PricingDb;
 use crate::source::{
@@ -54,6 +54,15 @@ fn print_no_data_hint(source_name: &str, category: &str) {
     println!(
         "No {source_name} {category} data found in the selected date range.\nHint: widen --since/--until, try `today`, or run `ccstats sources` to pick a different --source."
     );
+}
+
+fn should_render_empty_structured_result(result: &LoadResult, ctx: &CommandContext<'_>) -> bool {
+    result.day_stats.is_empty()
+        && result.data_quality().has_warnings()
+        && matches!(
+            ctx.cli.output_format(),
+            OutputFormat::Json | OutputFormat::Csv
+        )
 }
 
 fn handle_session(source: &dyn Source, ctx: &CommandContext<'_>) {
@@ -422,12 +431,13 @@ fn print_sources_table(sources: &[&dyn Source], all_caps: &Capabilities) {
 fn handle_statusline(source: &dyn Source, ctx: &CommandContext<'_>) {
     let result = load_daily(source, ctx.filter, ctx.timezone, true, false);
     if ctx.cli.json {
-        let json = print_statusline_json(
+        let json = print_statusline_json_with_quality(
             &result.day_stats,
             ctx.pricing_db,
             source.display_name(),
             ctx.number_format,
             ctx.currency,
+            Some(result.data_quality()),
         );
         print_json(&json, ctx.jq_filter);
     } else {
@@ -454,7 +464,7 @@ fn render_period_result(
     match ctx.cli.output_format() {
         OutputFormat::Csv => {
             let csv = if let Some(budget) = monthly_budget {
-                output_monthly_budget_csv(
+                let mut csv = output_monthly_budget_csv(
                     &result.day_stats,
                     ctx.pricing_db,
                     MonthlyBudgetOptions {
@@ -465,9 +475,11 @@ fn render_period_result(
                         as_of: ctx.budget_as_of,
                         currency: ctx.currency,
                     },
-                )
+                );
+                append_data_quality_csv_comment(&mut csv, Some(result.data_quality()));
+                csv
             } else {
-                output_period_csv(
+                output_period_csv_with_quality(
                     &result.day_stats,
                     period,
                     ctx.pricing_db,
@@ -475,12 +487,13 @@ fn render_period_result(
                     ctx.cli.breakdown,
                     ctx.cli.show_cost(),
                     ctx.currency,
+                    Some(result.data_quality()),
                 )
             };
             print!("{csv}");
         }
         OutputFormat::Json => {
-            let mut json = output_period_json(
+            let mut json = output_period_json_with_quality(
                 &result.day_stats,
                 period,
                 ctx.pricing_db,
@@ -488,6 +501,7 @@ fn render_period_result(
                 ctx.cli.breakdown,
                 ctx.cli.show_cost(),
                 ctx.currency,
+                Some(result.data_quality()),
             );
             if let Some(budget) = monthly_budget {
                 let reports = monthly_budget_reports(
@@ -553,7 +567,7 @@ fn handle_period(
     };
 
     let result = load_daily(source, ctx.filter, ctx.timezone, false, ctx.cli.debug);
-    if result.day_stats.is_empty() {
+    if result.day_stats.is_empty() && !should_render_empty_structured_result(&result, ctx) {
         print_no_data_hint(source.display_name(), "usage");
         return;
     }
@@ -653,6 +667,7 @@ fn load_all_daily(ctx: &CommandContext<'_>, quiet: bool) -> (LoadResult, Capabil
         let result = load_daily(source, ctx.filter, ctx.timezone, quiet, ctx.cli.debug);
         combined.skipped += result.skipped;
         combined.valid += result.valid;
+        combined.parse_errors += result.parse_errors;
         merge_day_stats(&mut combined.day_stats, result.day_stats);
     }
 
@@ -667,12 +682,13 @@ pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandCo
         SourceCommand::Statusline => {
             let (result, _) = load_all_daily(ctx, true);
             if ctx.cli.json {
-                let json = print_statusline_json(
+                let json = print_statusline_json_with_quality(
                     &result.day_stats,
                     ctx.pricing_db,
                     "All Sources",
                     ctx.number_format,
                     ctx.currency,
+                    Some(result.data_quality()),
                 );
                 print_json(&json, ctx.jq_filter);
             } else {
@@ -731,7 +747,7 @@ pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandCo
     };
 
     let (result, caps) = load_all_daily(ctx, false);
-    if result.day_stats.is_empty() {
+    if result.day_stats.is_empty() && !should_render_empty_structured_result(&result, ctx) {
         print_no_data_hint("All Sources", "usage");
         return;
     }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -16,5 +16,6 @@ pub(crate) use tool_aggregator::aggregate_tools;
 pub(crate) use tool_types::ToolStats;
 pub(crate) use tool_types::{ToolCall, ToolCallIdentity, ToolSummary};
 pub(crate) use types::{
-    BlockStats, DateFilter, DayStats, LoadResult, ProjectStats, RawEntry, SessionStats, Stats,
+    BlockStats, DataQuality, DateFilter, DayStats, LoadResult, ProjectStats, RawEntry,
+    SessionStats, Stats,
 };

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -162,8 +162,33 @@ pub(crate) struct LoadResult {
     pub(crate) day_stats: HashMap<String, DayStats>,
     pub(crate) skipped: i64,
     pub(crate) valid: i64,
+    pub(crate) parse_errors: usize,
     /// Processing time in milliseconds (excluding cache save)
     pub(crate) elapsed_ms: f64,
+}
+
+/// Machine-readable data quality metadata for structured consumers.
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub(crate) struct DataQuality {
+    pub(crate) valid_entries: i64,
+    pub(crate) dedup_skipped_entries: i64,
+    pub(crate) parse_errors: usize,
+}
+
+impl DataQuality {
+    pub(crate) fn has_warnings(self) -> bool {
+        self.dedup_skipped_entries > 0 || self.parse_errors > 0
+    }
+}
+
+impl LoadResult {
+    pub(crate) fn data_quality(&self) -> DataQuality {
+        DataQuality {
+            valid_entries: self.valid,
+            dedup_skipped_entries: self.skipped,
+            parse_errors: self.parse_errors,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/output/csv.rs
+++ b/src/output/csv.rs
@@ -3,12 +3,13 @@ use std::fmt::Write;
 
 use super::session::compare_session_last_timestamp;
 use crate::cli::SortOrder;
-use crate::core::{BlockStats, DayStats, ProjectStats, SessionStats};
+use crate::core::{BlockStats, DataQuality, DayStats, ProjectStats, SessionStats};
 use crate::output::budget::{MonthlyBudgetOptions, MonthlyBudgetReport, monthly_budget_reports};
 use crate::output::format::{compare_cost, csv_escape};
 use crate::output::period::{Period, aggregate_day_stats_by_period};
 use crate::pricing::{CurrencyConverter, PricingDb, calculate_cost, sum_model_costs};
 
+#[cfg(test)]
 pub(crate) fn output_period_csv(
     day_stats: &HashMap<String, DayStats>,
     period: Period,
@@ -17,6 +18,22 @@ pub(crate) fn output_period_csv(
     breakdown: bool,
     show_cost: bool,
     currency: Option<&CurrencyConverter>,
+) -> String {
+    output_period_csv_with_quality(
+        day_stats, period, pricing_db, order, breakdown, show_cost, currency, None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn output_period_csv_with_quality(
+    day_stats: &HashMap<String, DayStats>,
+    period: Period,
+    pricing_db: &PricingDb,
+    order: SortOrder,
+    breakdown: bool,
+    show_cost: bool,
+    currency: Option<&CurrencyConverter>,
+    data_quality: Option<DataQuality>,
 ) -> String {
     let aggregated;
     let stats_ref = if period == Period::Day {
@@ -99,7 +116,27 @@ pub(crate) fn output_period_csv(
         }
     }
 
+    append_data_quality_csv_comment(&mut out, data_quality);
     out
+}
+
+pub(crate) fn append_data_quality_csv_comment(out: &mut String, data_quality: Option<DataQuality>) {
+    let Some(data_quality) = data_quality else {
+        return;
+    };
+    if !data_quality.has_warnings() {
+        return;
+    }
+
+    let _ = writeln!(
+        out,
+        "# data_quality,valid_entries,dedup_skipped_entries,parse_errors"
+    );
+    let _ = writeln!(
+        out,
+        "# data_quality,{},{},{}",
+        data_quality.valid_entries, data_quality.dedup_skipped_entries, data_quality.parse_errors
+    );
 }
 
 fn csv_float(value: f64) -> String {

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 
 use crate::cli::SortOrder;
-use crate::core::DayStats;
+use crate::core::{DataQuality, DayStats};
 use crate::output::format::cost_json_value;
 use crate::output::period::{Period, aggregate_day_stats_by_period};
 use crate::pricing::CurrencyConverter;
@@ -117,6 +117,15 @@ fn build_period_entry(
     }
 }
 
+fn data_quality_json(data_quality: DataQuality) -> serde_json::Value {
+    serde_json::json!({
+        "valid_entries": data_quality.valid_entries,
+        "dedup_skipped_entries": data_quality.dedup_skipped_entries,
+        "parse_errors": data_quality.parse_errors,
+    })
+}
+
+#[cfg(test)]
 pub(crate) fn output_period_json(
     day_stats: &HashMap<String, DayStats>,
     period: Period,
@@ -125,6 +134,22 @@ pub(crate) fn output_period_json(
     breakdown: bool,
     show_cost: bool,
     currency: Option<&CurrencyConverter>,
+) -> String {
+    output_period_json_with_quality(
+        day_stats, period, pricing_db, order, breakdown, show_cost, currency, None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn output_period_json_with_quality(
+    day_stats: &HashMap<String, DayStats>,
+    period: Period,
+    pricing_db: &PricingDb,
+    order: SortOrder,
+    breakdown: bool,
+    show_cost: bool,
+    currency: Option<&CurrencyConverter>,
+    data_quality: Option<DataQuality>,
 ) -> String {
     let label = period.label();
     let aggregated;
@@ -135,14 +160,25 @@ pub(crate) fn output_period_json(
         &aggregated
     };
 
+    let data_quality = data_quality.map(data_quality_json);
     let mut output: Vec<serde_json::Value> = stats_ref
         .iter()
         .map(|(key, stats)| {
-            build_period_entry(
+            let mut entry = build_period_entry(
                 label, key, stats, pricing_db, breakdown, show_cost, currency,
-            )
+            );
+            if let Some(data_quality) = &data_quality {
+                entry["data_quality"] = data_quality.clone();
+            }
+            entry
         })
         .collect();
+
+    if output.is_empty()
+        && let Some(data_quality) = data_quality
+    {
+        output.push(serde_json::json!({ "data_quality": data_quality }));
+    }
 
     sort_output(&mut output, label, order);
     serde_json::to_string(&output).unwrap_or_else(|e| {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -29,15 +29,15 @@ pub(crate) use budget::{
     print_monthly_budget_table,
 };
 pub(crate) use csv::{
-    output_block_csv, output_monthly_budget_csv, output_period_csv, output_project_csv,
-    output_session_csv,
+    append_data_quality_csv_comment, output_block_csv, output_monthly_budget_csv,
+    output_period_csv_with_quality, output_project_csv, output_session_csv,
 };
 pub(crate) use format::NumberFormat;
-pub(crate) use json::output_period_json;
+pub(crate) use json::output_period_json_with_quality;
 pub(crate) use period::Period;
 pub(crate) use project::{ProjectTableOptions, output_project_json, print_project_table};
 pub(crate) use session::{SessionTableOptions, output_session_json, print_session_table};
-pub(crate) use statusline::{print_statusline, print_statusline_json};
+pub(crate) use statusline::{print_statusline, print_statusline_json_with_quality};
 pub(crate) use table::{PeriodSummaryFooter, TokenTableOptions, print_period_table};
 pub(crate) use tools::{output_tools_csv, output_tools_json, print_tools_table};
 pub(crate) use top::{

--- a/src/output/statusline.rs
+++ b/src/output/statusline.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::core::{DayStats, Stats};
+use crate::core::{DataQuality, DayStats, Stats};
 use crate::output::format::{NumberFormat, cost_json_value, format_compact, format_cost};
 use crate::pricing::{CurrencyConverter, PricingDb, sum_model_costs};
 
@@ -48,6 +48,7 @@ pub(crate) fn print_statusline(
 }
 
 /// Output statusline as JSON for programmatic consumption
+#[cfg(test)]
 pub(crate) fn print_statusline_json(
     day_stats: &HashMap<String, DayStats>,
     pricing_db: &PricingDb,
@@ -55,9 +56,27 @@ pub(crate) fn print_statusline_json(
     number_format: NumberFormat,
     currency: Option<&CurrencyConverter>,
 ) -> String {
+    print_statusline_json_with_quality(
+        day_stats,
+        pricing_db,
+        source_label,
+        number_format,
+        currency,
+        None,
+    )
+}
+
+pub(crate) fn print_statusline_json_with_quality(
+    day_stats: &HashMap<String, DayStats>,
+    pricing_db: &PricingDb,
+    source_label: &str,
+    number_format: NumberFormat,
+    currency: Option<&CurrencyConverter>,
+    data_quality: Option<DataQuality>,
+) -> String {
     let t = aggregate_totals(day_stats, pricing_db);
 
-    let output = serde_json::json!({
+    let mut output = serde_json::json!({
         "source": source_label,
         "input_tokens": t.stats.input_tokens,
         "output_tokens": t.stats.output_tokens,
@@ -73,6 +92,13 @@ pub(crate) fn print_statusline_json(
             "reasoning": format_compact(t.stats.reasoning_tokens, number_format),
         }
     });
+    if let Some(data_quality) = data_quality {
+        output["data_quality"] = serde_json::json!({
+            "valid_entries": data_quality.valid_entries,
+            "dedup_skipped_entries": data_quality.dedup_skipped_entries,
+            "parse_errors": data_quality.parse_errors,
+        });
+    }
 
     serde_json::to_string(&output).unwrap_or_else(|e| {
         eprintln!("Failed to serialize JSON output: {e}");

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -198,6 +198,7 @@ pub struct CostSummary {
     pub models: Vec<ModelCostSummary>,
     pub valid_entries: i64,
     pub skipped_entries: i64,
+    pub parse_error_entries: usize,
     pub elapsed_ms: f64,
 }
 
@@ -331,6 +332,7 @@ pub(in crate::sdk) fn build_cost_summary(
         models: summarize_models(&models, pricing_db, currency),
         valid_entries: result.valid,
         skipped_entries: result.skipped,
+        parse_error_entries: result.parse_errors,
         elapsed_ms: result.elapsed_ms,
     }
 }

--- a/src/sdk/batch.rs
+++ b/src/sdk/batch.rs
@@ -209,20 +209,27 @@ fn load_daily_ranges(
         return ranges.iter().map(|_| LoadResult::default()).collect();
     }
 
-    let entries: Vec<RawEntry> = files
+    let (entries, parse_errors) = files
         .par_iter()
-        .flat_map(|path| {
-            source
-                .parse_file(path, timezone, false)
+        .map(|path| {
+            let parsed = source.parse_file(path, timezone, false);
+            let entries = parsed
                 .entries
                 .into_iter()
                 .filter_map(|mut entry| {
                     let date = normalize_entry_date(&mut entry, timezone)?;
                     contains_any_range(date, ranges).then_some(entry)
                 })
-                .collect::<Vec<_>>()
+                .collect::<Vec<_>>();
+            (entries, parsed.errors)
         })
-        .collect();
+        .reduce(
+            || (Vec::new(), 0usize),
+            |(mut entries, errors), (partial_entries, partial_errors)| {
+                entries.extend(partial_entries);
+                (entries, errors + partial_errors)
+            },
+        );
 
     let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
     ranges
@@ -233,6 +240,7 @@ fn load_daily_ranges(
                 &range.filter,
                 source.capabilities().needs_dedup,
             );
+            result.parse_errors = parse_errors;
             result.elapsed_ms = elapsed_ms;
             result
         })
@@ -285,6 +293,7 @@ fn load_result_from_entries(entries: Vec<RawEntry>, skipped: i64) -> LoadResult 
         day_stats: aggregate_daily(entries),
         skipped,
         valid,
+        parse_errors: 0,
         elapsed_ms: 0.0,
     }
 }

--- a/src/source/loader.rs
+++ b/src/source/loader.rs
@@ -188,7 +188,7 @@ impl<'a> DataLoader<'a> {
             }
         }
 
-        Some((result, file_count))
+        Some((result, parse_errors))
     }
 
     /// Load and deduplicate entries incrementally to avoid buffering all raw records in memory.
@@ -196,7 +196,7 @@ impl<'a> DataLoader<'a> {
         &self,
         filter: &DateFilter,
         timezone: Timezone,
-    ) -> (Vec<RawEntry>, i64) {
+    ) -> (Vec<RawEntry>, i64, usize) {
         let result = self.par_process(
             filter,
             timezone,
@@ -213,8 +213,11 @@ impl<'a> DataLoader<'a> {
         );
 
         match result {
-            Some((accumulator, _)) => accumulator.finalize(),
-            None => (Vec::new(), 0),
+            Some((accumulator, parse_errors)) => {
+                let (entries, skipped) = accumulator.finalize();
+                (entries, skipped, parse_errors)
+            }
+            None => (Vec::new(), 0, 0),
         }
     }
 
@@ -232,7 +235,7 @@ impl<'a> DataLoader<'a> {
             },
         );
 
-        let Some((day_stats, _)) = result else {
+        let Some((day_stats, parse_errors)) = result else {
             return LoadResult::default();
         };
 
@@ -247,6 +250,7 @@ impl<'a> DataLoader<'a> {
             day_stats,
             skipped: 0,
             valid,
+            parse_errors,
             elapsed_ms,
         }
     }
@@ -315,9 +319,15 @@ impl<'a> DataLoader<'a> {
         }
 
         let load_start = Instant::now();
-        let (final_entries, skipped) = self.load_deduped_entries_incremental(filter, timezone);
+        let (final_entries, skipped, parse_errors) =
+            self.load_deduped_entries_incremental(filter, timezone);
         if final_entries.is_empty() {
-            return LoadResult::default();
+            return LoadResult {
+                parse_errors,
+                skipped,
+                elapsed_ms: load_start.elapsed().as_secs_f64() * 1000.0,
+                ..LoadResult::default()
+            };
         }
 
         let agg_start = Instant::now();
@@ -344,6 +354,7 @@ impl<'a> DataLoader<'a> {
             day_stats,
             skipped,
             valid,
+            parse_errors,
             elapsed_ms,
         }
     }
@@ -354,7 +365,7 @@ impl<'a> DataLoader<'a> {
             return self.load_sessions_incremental(filter, timezone);
         }
 
-        let (final_entries, skipped) = self.load_deduped_entries_incremental(filter, timezone);
+        let (final_entries, skipped, _) = self.load_deduped_entries_incremental(filter, timezone);
         if final_entries.is_empty() {
             return Vec::new();
         }
@@ -399,7 +410,8 @@ impl<'a> DataLoader<'a> {
         }
 
         let (final_entries, skipped) = if self.source.capabilities().needs_dedup {
-            self.load_deduped_entries_incremental(filter, timezone)
+            let (entries, skipped, _) = self.load_deduped_entries_incremental(filter, timezone);
+            (entries, skipped)
         } else {
             match self.par_process(
                 filter,
@@ -761,3 +773,7 @@ mod tests {
 #[cfg(test)]
 #[path = "loader_tool_tests.rs"]
 mod loader_tool_tests;
+
+#[cfg(test)]
+#[path = "loader_quality_tests.rs"]
+mod loader_quality_tests;

--- a/src/source/loader_quality_tests.rs
+++ b/src/source/loader_quality_tests.rs
@@ -1,0 +1,106 @@
+use std::path::{Path, PathBuf};
+
+use chrono::NaiveDate;
+
+use crate::core::{DateFilter, RawEntry};
+use crate::source::{Capabilities, ParseOutput, Source};
+use crate::utils::Timezone;
+
+use super::load_daily;
+
+struct TestSource {
+    needs_dedup: bool,
+    files: Vec<(PathBuf, Vec<RawEntry>, usize)>,
+}
+
+impl Source for TestSource {
+    fn name(&self) -> &'static str {
+        "test"
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            needs_dedup: self.needs_dedup,
+            ..Capabilities::default()
+        }
+    }
+
+    fn find_files(&self) -> Vec<PathBuf> {
+        self.files.iter().map(|(path, _, _)| path.clone()).collect()
+    }
+
+    fn parse_file(&self, path: &Path, _timezone: Timezone, _debug: bool) -> ParseOutput {
+        let (_, entries, errors) = self
+            .files
+            .iter()
+            .find(|(candidate, _, _)| candidate == path)
+            .expect("known test path");
+        ParseOutput {
+            entries: entries.clone(),
+            errors: *errors,
+        }
+    }
+}
+
+fn entry(id: &str, input_tokens: i64) -> RawEntry {
+    RawEntry {
+        timestamp: "2026-02-06T12:00:00Z".to_string(),
+        timestamp_ms: 1_770_379_200_000,
+        date_str: "2026-02-06".to_string(),
+        message_id: Some(id.to_string()),
+        session_key: "session".to_string(),
+        session_id: "session".to_string(),
+        project_path: String::new(),
+        model: "model".to_string(),
+        input_tokens,
+        output_tokens: 0,
+        cache_creation: 0,
+        cache_read: 0,
+        reasoning_tokens: 0,
+        stop_reason: Some("end_turn".to_string()),
+    }
+}
+
+fn filter() -> DateFilter {
+    DateFilter::new(
+        NaiveDate::from_ymd_opt(2026, 2, 6),
+        NaiveDate::from_ymd_opt(2026, 2, 6),
+    )
+}
+
+fn tz() -> Timezone {
+    Timezone::parse(Some("UTC")).unwrap()
+}
+
+#[test]
+fn load_daily_reports_parse_errors_not_file_count() {
+    let source = TestSource {
+        needs_dedup: false,
+        files: vec![
+            (PathBuf::from("a.jsonl"), vec![entry("a", 10)], 0),
+            (PathBuf::from("b.jsonl"), vec![entry("b", 20)], 0),
+        ],
+    };
+
+    let result = load_daily(&source, &filter(), tz(), true, false);
+
+    assert_eq!(result.valid, 2);
+    assert_eq!(result.parse_errors, 0);
+}
+
+#[test]
+fn load_daily_dedup_reports_skipped_and_parse_errors() {
+    let source = TestSource {
+        needs_dedup: true,
+        files: vec![
+            (PathBuf::from("a.jsonl"), vec![entry("dup", 10)], 1),
+            (PathBuf::from("b.jsonl"), vec![entry("dup", 20)], 2),
+        ],
+    };
+
+    let result = load_daily(&source, &filter(), tz(), true, false);
+
+    assert_eq!(result.valid, 1);
+    assert_eq!(result.skipped, 1);
+    assert_eq!(result.parse_errors, 3);
+}

--- a/tests/cli_budget_currency_statusline.rs
+++ b/tests/cli_budget_currency_statusline.rs
@@ -253,3 +253,44 @@ fn statusline_json_uses_requested_currency() {
 
     let _ = fs::remove_dir_all(root);
 }
+
+#[test]
+fn statusline_json_includes_data_quality_metadata() {
+    let root = unique_temp_dir("statusline-quality");
+    let codex_home = root.join("codex-home");
+    let session_file = codex_home.join("sessions").join("statusline.jsonl");
+    let today = Utc::now().format("%Y-%m-%dT12:00:00Z").to_string();
+    write_file(
+        &session_file,
+        &format!(
+            r#"{{"timestamp":"{today}","type":"event_msg","payload":{{"type":"token_count","info":{{"total_token_usage":{{"input_tokens":10,"cached_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":0,"total_tokens":15}},"last_token_usage":{{"input_tokens":10,"cached_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":0,"total_tokens":15}},"model":"gpt-5"}}}}}}
+{{"timestamp":"not-json"
+"#
+        ),
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "statusline",
+            "--source",
+            "codex",
+            "-j",
+            "-O",
+            "--timezone",
+            "UTC",
+        ],
+        &[("CODEX_HOME", &codex_home)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    assert_eq!(json["source"].as_str(), Some("OpenAI Codex"));
+    assert_eq!(json["data_quality"]["valid_entries"].as_i64(), Some(1));
+    assert_eq!(
+        json["data_quality"]["dedup_skipped_entries"].as_i64(),
+        Some(0)
+    );
+    assert_eq!(json["data_quality"]["parse_errors"].as_u64(), Some(1));
+
+    let _ = fs::remove_dir_all(root);
+}

--- a/tests/cli_claude.rs
+++ b/tests/cli_claude.rs
@@ -311,6 +311,12 @@ fn claude_dedup_keeps_same_message_id_from_different_files() {
     let arr = json.as_array().expect("array output");
     assert_eq!(arr.len(), 1);
     assert_eq!(arr[0]["total_tokens"].as_i64(), Some(280));
+    assert_eq!(arr[0]["data_quality"]["valid_entries"].as_i64(), Some(1));
+    assert_eq!(
+        arr[0]["data_quality"]["dedup_skipped_entries"].as_i64(),
+        Some(1)
+    );
+    assert_eq!(arr[0]["data_quality"]["parse_errors"].as_u64(), Some(0));
     assert!(
         String::from_utf8_lossy(&stderr).contains("Deduplicated 1 entries"),
         "stderr: {}",

--- a/tests/cli_codex_source_routing.rs
+++ b/tests/cli_codex_source_routing.rs
@@ -355,7 +355,7 @@ fn malformed_records_are_reported_without_debug_flag() {
 "#,
     );
 
-    let (ok, _stdout, stderr) = run_ccstats(
+    let (ok, stdout, stderr) = run_ccstats(
         &[
             "daily",
             "--source",
@@ -375,6 +375,91 @@ fn malformed_records_are_reported_without_debug_flag() {
     assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
     let stderr = String::from_utf8_lossy(&stderr);
     assert!(stderr.contains("malformed records"), "stderr: {stderr}");
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    let arr = json.as_array().expect("array output");
+    assert_eq!(arr[0]["data_quality"]["valid_entries"].as_i64(), Some(1));
+    assert_eq!(
+        arr[0]["data_quality"]["dedup_skipped_entries"].as_i64(),
+        Some(0)
+    );
+    assert_eq!(arr[0]["data_quality"]["parse_errors"].as_u64(), Some(1));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn malformed_records_are_reported_in_csv_metadata() {
+    let root = unique_temp_dir("malformed-record-csv-metadata");
+    let codex_home = root.join("codex-home");
+    let session_file = codex_home.join("sessions").join("malformed.jsonl");
+    write_file(
+        &session_file,
+        r#"{"timestamp":"2026-02-06T10:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":0,"total_tokens":15},"last_token_usage":{"input_tokens":10,"cached_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":0,"total_tokens":15},"model":"gpt-5"}}}
+{"timestamp":"not-json"
+"#,
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "--source",
+            "codex",
+            "--csv",
+            "-O",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("CODEX_HOME", &codex_home)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let output = String::from_utf8(stdout).expect("utf8 stdout");
+    assert!(output.contains("# data_quality,1,0,1"), "stdout: {output}");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn all_malformed_json_outputs_metadata_only_row() {
+    let root = unique_temp_dir("all-malformed-json-metadata");
+    let codex_home = root.join("codex-home");
+    let session_file = codex_home.join("sessions").join("malformed.jsonl");
+    write_file(
+        &session_file,
+        r#"{"timestamp":"not-json"
+"#,
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "--source",
+            "codex",
+            "-j",
+            "-O",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("CODEX_HOME", &codex_home)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    let arr = json.as_array().expect("array output");
+    assert_eq!(arr.len(), 1);
+    assert!(arr[0].get("date").is_none());
+    assert_eq!(arr[0]["data_quality"]["valid_entries"].as_i64(), Some(0));
+    assert_eq!(arr[0]["data_quality"]["parse_errors"].as_u64(), Some(1));
 
     let _ = fs::remove_dir_all(root);
 }

--- a/tests/sdk_integration.rs
+++ b/tests/sdk_integration.rs
@@ -37,6 +37,7 @@ fn assert_stable_summary_eq(actual: &CostSummary, expected: &CostSummary) {
     assert_eq!(actual.models, expected.models);
     assert_eq!(actual.valid_entries, expected.valid_entries);
     assert_eq!(actual.skipped_entries, expected.skipped_entries);
+    assert_eq!(actual.parse_error_entries, expected.parse_error_entries);
     assert!(actual.elapsed_ms.is_finite());
 }
 


### PR DESCRIPTION
Fixes #40

## Summary
- Adds `DataQuality` metadata to structured daily JSON, CSV footers, statusline JSON, and SDK summaries.
- Propagates parser error counts through loader and all-source aggregation instead of relying on stderr-only warnings.
- Keeps dedup skipped accounting explicit and adds metadata-only JSON output for all-malformed structured runs.
- Adds loader and CLI coverage for parse errors, dedup skipped counts, CSV metadata, statusline JSON, SDK summaries, and all-malformed fixtures.

## Verification
- cargo fmt --check
- cargo check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- python3 checks/check_workflow.py --repo .
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH40
- git diff --check

## Notes
- `src/source/loader.rs` is 779 lines, below the AGENTS hard ceiling of 800; new loader metadata tests live in `src/source/loader_quality_tests.rs` to avoid growing the main test module further.
