### PR TITLE
Separate real and estimated proxy costs

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -15,9 +15,9 @@ use crate::output::{
     output_session_json, output_tools_csv, output_tools_json, output_top_csv, output_top_json,
     print_block_table, print_monthly_budget_table, print_period_table, print_project_table,
     print_session_table, print_statusline, print_statusline_json_with_quality, print_tools_table,
-    print_top_table, rank_by_model, rank_by_project,
+    print_top_table, rank_by_model, rank_by_model_with_cost_mode, rank_by_project,
 };
-use crate::pricing::PricingDb;
+use crate::pricing::{CostDisplayMode, PricingDb};
 use crate::source::{
     ALL_SOURCES, Capabilities, Source, all_sources, load_blocks, load_daily, load_projects,
     load_sessions, load_tool_calls,
@@ -216,13 +216,14 @@ fn handle_top(
     limit: usize,
     source_label: &str,
     ctx: &CommandContext<'_>,
+    cost_mode: CostDisplayMode,
 ) {
     if rows.is_empty() {
         print_no_data_hint(source_label, "usage");
         return;
     }
 
-    render_top(rows, dim, limit, source_label, ctx);
+    render_top(rows, dim, limit, source_label, ctx, cost_mode);
 }
 
 fn render_top(
@@ -231,6 +232,7 @@ fn render_top(
     limit: usize,
     source_label: &str,
     ctx: &CommandContext<'_>,
+    cost_mode: CostDisplayMode,
 ) {
     match ctx.cli.output_format() {
         OutputFormat::Csv => {
@@ -252,6 +254,7 @@ fn render_top(
                 currency: ctx.currency,
                 dim,
                 limit,
+                cost_mode,
             },
         ),
     }
@@ -267,7 +270,14 @@ fn handle_top_for_source(
         TopDimension::Model => {
             let result = load_daily(source, ctx.filter, ctx.timezone, false, ctx.cli.debug);
             let rows = rank_by_model(&result.day_stats, ctx.pricing_db);
-            handle_top(&rows, dim, limit, source.display_name(), ctx);
+            handle_top(
+                &rows,
+                dim,
+                limit,
+                source.display_name(),
+                ctx,
+                CostDisplayMode::Total,
+            );
         }
         TopDimension::Project => {
             if !source.capabilities().has_projects {
@@ -279,7 +289,14 @@ fn handle_top_for_source(
             }
             let projects = load_projects(source, ctx.filter, ctx.timezone, false);
             let rows = rank_by_project(&projects, ctx.pricing_db);
-            handle_top(&rows, dim, limit, source.display_name(), ctx);
+            handle_top(
+                &rows,
+                dim,
+                limit,
+                source.display_name(),
+                ctx,
+                CostDisplayMode::Total,
+            );
         }
     }
 }
@@ -438,6 +455,7 @@ fn handle_statusline(source: &dyn Source, ctx: &CommandContext<'_>) {
             ctx.number_format,
             ctx.currency,
             Some(result.data_quality()),
+            CostDisplayMode::Total,
         );
         print_json(&json, ctx.jq_filter);
     } else {
@@ -447,6 +465,7 @@ fn handle_statusline(source: &dyn Source, ctx: &CommandContext<'_>) {
             source.display_name(),
             ctx.number_format,
             ctx.currency,
+            CostDisplayMode::Total,
         );
     }
 }
@@ -456,6 +475,7 @@ fn render_period_result(
     period: Period,
     caps: &Capabilities,
     ctx: &CommandContext<'_>,
+    cost_mode: CostDisplayMode,
 ) {
     let monthly_budget = (period == Period::Month)
         .then_some(ctx.cli.monthly_budget)
@@ -474,6 +494,7 @@ fn render_period_result(
                         limit: budget,
                         as_of: ctx.budget_as_of,
                         currency: ctx.currency,
+                        cost_mode,
                     },
                 );
                 append_data_quality_csv_comment(&mut csv, Some(result.data_quality()));
@@ -488,6 +509,7 @@ fn render_period_result(
                     ctx.cli.show_cost(),
                     ctx.currency,
                     Some(result.data_quality()),
+                    cost_mode,
                 )
             };
             print!("{csv}");
@@ -502,6 +524,7 @@ fn render_period_result(
                 ctx.cli.show_cost(),
                 ctx.currency,
                 Some(result.data_quality()),
+                cost_mode,
             );
             if let Some(budget) = monthly_budget {
                 let reports = monthly_budget_reports(
@@ -511,6 +534,7 @@ fn render_period_result(
                     budget,
                     ctx.budget_as_of,
                     ctx.currency,
+                    cost_mode,
                 );
                 json = add_monthly_budget_to_json(&json, &reports);
             }
@@ -536,6 +560,7 @@ fn render_period_result(
                     show_reasoning: caps.has_reasoning_tokens,
                     show_cache_creation: caps.has_cache_creation,
                     currency: ctx.currency,
+                    cost_mode,
                 },
             );
             if let Some(budget) = monthly_budget {
@@ -546,6 +571,7 @@ fn render_period_result(
                     budget,
                     ctx.budget_as_of,
                     ctx.currency,
+                    cost_mode,
                 );
                 print_monthly_budget_table(&reports, ctx.cli.use_color(), ctx.currency);
             }
@@ -571,7 +597,7 @@ fn handle_period(
         print_no_data_hint(source.display_name(), "usage");
         return;
     }
-    render_period_result(&result, period, caps, ctx);
+    render_period_result(&result, period, caps, ctx, CostDisplayMode::Total);
 }
 
 /// Handle commands for a specific data source
@@ -689,6 +715,7 @@ pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandCo
                     ctx.number_format,
                     ctx.currency,
                     Some(result.data_quality()),
+                    CostDisplayMode::RealOnly,
                 );
                 print_json(&json, ctx.jq_filter);
             } else {
@@ -698,6 +725,7 @@ pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandCo
                     "All Sources",
                     ctx.number_format,
                     ctx.currency,
+                    CostDisplayMode::RealOnly,
                 );
             }
             return;
@@ -720,8 +748,19 @@ pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandCo
                 return;
             }
             let (result, _) = load_all_daily(ctx, false);
-            let rows = rank_by_model(&result.day_stats, ctx.pricing_db);
-            handle_top(&rows, dim, limit, "All Sources", ctx);
+            let rows = rank_by_model_with_cost_mode(
+                &result.day_stats,
+                ctx.pricing_db,
+                CostDisplayMode::RealOnly,
+            );
+            handle_top(
+                &rows,
+                dim,
+                limit,
+                "All Sources",
+                ctx,
+                CostDisplayMode::RealOnly,
+            );
             return;
         }
         SourceCommand::Session
@@ -751,5 +790,5 @@ pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandCo
         print_no_data_hint("All Sources", "usage");
         return;
     }
-    render_period_result(&result, period, &caps, ctx);
+    render_period_result(&result, period, &caps, ctx, CostDisplayMode::RealOnly);
 }

--- a/src/core/aggregator.rs
+++ b/src/core/aggregator.rs
@@ -68,28 +68,11 @@ impl SessionAccumulator {
         }
     }
 
-    fn add_entry(&mut self, entry: RawEntry) {
-        let RawEntry {
-            timestamp,
-            timestamp_ms,
-            model,
-            input_tokens,
-            output_tokens,
-            cache_creation,
-            cache_read,
-            reasoning_tokens,
-            ..
-        } = entry;
-
-        let stats = Stats {
-            input_tokens,
-            output_tokens,
-            cache_creation,
-            cache_read,
-            reasoning_tokens,
-            count: 1,
-            skipped_chunks: 0,
-        };
+    fn add_entry(&mut self, entry: &RawEntry) {
+        let timestamp = entry.timestamp.clone();
+        let timestamp_ms = entry.timestamp_ms;
+        let model = entry.model.clone();
+        let stats = entry.to_stats();
         self.stats.add(&stats);
         self.models.entry(model).or_default().add(&stats);
         self.update_timestamps(timestamp, timestamp_ms);
@@ -147,7 +130,7 @@ pub(crate) fn aggregate_sessions_map(entries: Vec<RawEntry>) -> HashMap<String, 
                 entry.timestamp_ms,
             )
         });
-        session.add_entry(entry);
+        session.add_entry(&entry);
     }
 
     sessions
@@ -274,6 +257,7 @@ mod tests {
             cache_read: 0,
             reasoning_tokens: 0,
             stop_reason: Some("end_turn".to_string()),
+            cost_kind: crate::core::CostKind::Real,
         }
     }
 
@@ -499,6 +483,7 @@ mod tests {
                 cache_read: 0,
                 reasoning_tokens: 0,
                 stop_reason: None,
+                cost_kind: crate::core::CostKind::Real,
             },
             RawEntry {
                 timestamp: "2025-01-01T08:00:00Z".to_string(),
@@ -515,6 +500,7 @@ mod tests {
                 cache_read: 0,
                 reasoning_tokens: 0,
                 stop_reason: None,
+                cost_kind: crate::core::CostKind::Real,
             },
             RawEntry {
                 timestamp: "2025-01-01T20:00:00Z".to_string(),
@@ -531,6 +517,7 @@ mod tests {
                 cache_read: 0,
                 reasoning_tokens: 0,
                 stop_reason: None,
+                cost_kind: crate::core::CostKind::Real,
             },
         ];
         let result = aggregate_sessions(entries);

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -16,6 +16,6 @@ pub(crate) use tool_aggregator::aggregate_tools;
 pub(crate) use tool_types::ToolStats;
 pub(crate) use tool_types::{ToolCall, ToolCallIdentity, ToolSummary};
 pub(crate) use types::{
-    BlockStats, DataQuality, DateFilter, DayStats, LoadResult, ProjectStats, RawEntry,
-    SessionStats, Stats,
+    BlockStats, CostKind, CostTokens, DataQuality, DateFilter, DayStats, LoadResult, ProjectStats,
+    RawEntry, SessionStats, Stats,
 };

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -16,6 +16,7 @@ pub(crate) struct Stats {
     pub(crate) reasoning_tokens: i64,
     pub(crate) count: i64,
     pub(crate) skipped_chunks: i64,
+    pub(crate) estimated_proxy: CostTokens,
 }
 
 impl Stats {
@@ -27,6 +28,7 @@ impl Stats {
         self.reasoning_tokens += other.reasoning_tokens;
         self.count += other.count;
         self.skipped_chunks += other.skipped_chunks;
+        self.estimated_proxy.add(&other.estimated_proxy);
     }
 
     /// Total tokens for display purposes
@@ -36,6 +38,93 @@ impl Stats {
             + self.reasoning_tokens
             + self.cache_creation
             + self.cache_read
+    }
+
+    pub(crate) fn cost_tokens(&self) -> CostTokens {
+        CostTokens {
+            input_tokens: self.input_tokens,
+            output_tokens: self.output_tokens,
+            cache_creation: self.cache_creation,
+            cache_read: self.cache_read,
+            reasoning_tokens: self.reasoning_tokens,
+            count: self.count,
+        }
+    }
+
+    pub(crate) fn real_cost_tokens(&self) -> CostTokens {
+        self.cost_tokens().saturating_sub(&self.estimated_proxy)
+    }
+
+    pub(crate) fn cost_kind(&self) -> CostKind {
+        let estimated_count = self.estimated_proxy.count.max(0);
+        if estimated_count == 0 {
+            CostKind::Real
+        } else if estimated_count >= self.count.max(0) {
+            CostKind::EstimatedProxy
+        } else {
+            CostKind::Mixed
+        }
+    }
+}
+
+/// Cost provenance for token records.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum CostKind {
+    #[default]
+    Real,
+    EstimatedProxy,
+    Mixed,
+}
+
+impl CostKind {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            CostKind::Real => "real",
+            CostKind::EstimatedProxy => "estimated_proxy",
+            CostKind::Mixed => "mixed",
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct CostTokens {
+    pub(crate) input_tokens: i64,
+    pub(crate) output_tokens: i64,
+    pub(crate) cache_creation: i64,
+    pub(crate) cache_read: i64,
+    pub(crate) reasoning_tokens: i64,
+    pub(crate) count: i64,
+}
+
+impl CostTokens {
+    pub(crate) fn add(&mut self, other: &Self) {
+        self.input_tokens += other.input_tokens;
+        self.output_tokens += other.output_tokens;
+        self.cache_creation += other.cache_creation;
+        self.cache_read += other.cache_read;
+        self.reasoning_tokens += other.reasoning_tokens;
+        self.count += other.count;
+    }
+
+    fn saturating_sub(self, other: &Self) -> Self {
+        Self {
+            input_tokens: (self.input_tokens - other.input_tokens).max(0),
+            output_tokens: (self.output_tokens - other.output_tokens).max(0),
+            cache_creation: (self.cache_creation - other.cache_creation).max(0),
+            cache_read: (self.cache_read - other.cache_read).max(0),
+            reasoning_tokens: (self.reasoning_tokens - other.reasoning_tokens).max(0),
+            count: (self.count - other.count).max(0),
+        }
+    }
+
+    pub(crate) fn has_entries(self) -> bool {
+        self.count > 0
+            || self.input_tokens > 0
+            || self.output_tokens > 0
+            || self.cache_creation > 0
+            || self.cache_read > 0
+            || self.reasoning_tokens > 0
     }
 }
 
@@ -113,11 +202,13 @@ pub(crate) struct RawEntry {
     pub(crate) reasoning_tokens: i64,
     /// Stop reason for completion detection
     pub(crate) stop_reason: Option<String>,
+    #[serde(default)]
+    pub(crate) cost_kind: CostKind,
 }
 
 impl RawEntry {
     pub(crate) fn to_stats(&self) -> Stats {
-        Stats {
+        let mut stats = Stats {
             input_tokens: self.input_tokens,
             output_tokens: self.output_tokens,
             cache_creation: self.cache_creation,
@@ -125,7 +216,12 @@ impl RawEntry {
             reasoning_tokens: self.reasoning_tokens,
             count: 1,
             skipped_chunks: 0,
+            estimated_proxy: CostTokens::default(),
+        };
+        if self.cost_kind == CostKind::EstimatedProxy {
+            stats.estimated_proxy = stats.cost_tokens();
         }
+        stats
     }
 }
 
@@ -205,6 +301,7 @@ mod tests {
             reasoning_tokens: reason,
             count: 1,
             skipped_chunks: 0,
+            estimated_proxy: CostTokens::default(),
         }
     }
 
@@ -238,6 +335,7 @@ mod tests {
             reasoning_tokens: 0,
             count: 999,
             skipped_chunks: 42,
+            estimated_proxy: CostTokens::default(),
         };
         assert_eq!(s.total_tokens(), 15);
     }
@@ -259,6 +357,7 @@ mod tests {
             reasoning_tokens: 10,
             count: 3,
             skipped_chunks: 5,
+            estimated_proxy: CostTokens::default(),
         };
         a.add(&b);
         assert_eq!(a.input_tokens, 110);
@@ -335,6 +434,7 @@ mod tests {
             cache_read: 30,
             reasoning_tokens: 10,
             stop_reason: None,
+            cost_kind: CostKind::Real,
         };
         let s = entry.to_stats();
         assert_eq!(s.input_tokens, 100);

--- a/src/output/blocks.rs
+++ b/src/output/blocks.rs
@@ -6,7 +6,9 @@ use crate::output::format::{
     NumberFormat, cost_json_value, create_styled_table, format_compact, format_cost, format_number,
     header_cell, right_cell, styled_cell,
 };
-use crate::pricing::{CurrencyConverter, PricingDb, sum_model_costs};
+use crate::pricing::{
+    CurrencyConverter, PricingDb, model_cost_kind, sum_estimated_proxy_model_costs, sum_model_costs,
+};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct BlockTableOptions<'a> {
@@ -69,10 +71,17 @@ pub(crate) fn print_block_table(
 
     let mut total_stats = Stats::default();
     let mut total_cost = 0.0;
+    let mut total_estimated_cost = 0.0;
+    let mut has_estimated_cost = false;
 
     for block in &sorted_blocks {
         let block_cost = sum_model_costs(&block.models, pricing_db);
         total_cost += block_cost;
+        let estimated_cost = sum_estimated_proxy_model_costs(&block.models, pricing_db);
+        if estimated_cost > 0.0 {
+            total_estimated_cost += estimated_cost;
+            has_estimated_cost = true;
+        }
         total_stats.add(&block.stats);
 
         let block_label = format!("{} - {}", block.block_start, block.block_end);
@@ -196,6 +205,12 @@ pub(crate) fn print_block_table(
 
     println!("\n  {source_label} 5-Hour Billing Blocks\n");
     println!("{table}");
+    if show_cost && has_estimated_cost {
+        println!(
+            "\n  Cost includes estimated proxy values: {}",
+            format_cost(total_estimated_cost, options.currency)
+        );
+    }
     println!(
         "\n  {} blocks\n",
         format_number(sorted_blocks.len() as i64, number_format)
@@ -235,6 +250,11 @@ pub(crate) fn output_block_json(
             });
             if show_cost {
                 obj["cost"] = cost_json_value(block_cost, currency);
+                let estimated_cost = sum_estimated_proxy_model_costs(&block.models, pricing_db);
+                if estimated_cost > 0.0 {
+                    obj["cost_kind"] = serde_json::json!(model_cost_kind(&block.models).as_str());
+                    obj["estimated_cost"] = cost_json_value(estimated_cost, currency);
+                }
             }
             obj
         })

--- a/src/output/budget.rs
+++ b/src/output/budget.rs
@@ -8,7 +8,7 @@ use crate::cli::SortOrder;
 use crate::core::DayStats;
 use crate::output::format::{create_styled_table, header_cell, right_cell, styled_cell};
 use crate::output::period::{Period, aggregate_day_stats_by_period};
-use crate::pricing::{CurrencyConverter, PricingDb, sum_model_costs};
+use crate::pricing::{CostDisplayMode, CurrencyConverter, PricingDb, sum_display_model_costs};
 
 #[derive(Debug, Clone)]
 pub(crate) struct MonthlyBudgetReport {
@@ -32,6 +32,7 @@ pub(crate) struct MonthlyBudgetOptions<'a> {
     pub(crate) limit: f64,
     pub(crate) as_of: NaiveDate,
     pub(crate) currency: Option<&'a CurrencyConverter>,
+    pub(crate) cost_mode: CostDisplayMode,
 }
 
 fn display_cost(usd: f64, currency: Option<&CurrencyConverter>) -> f64 {
@@ -126,6 +127,7 @@ pub(crate) fn monthly_budget_reports(
     monthly_budget: f64,
     as_of: NaiveDate,
     currency: Option<&CurrencyConverter>,
+    cost_mode: CostDisplayMode,
 ) -> Vec<MonthlyBudgetReport> {
     let monthly = aggregate_day_stats_by_period(day_stats, Period::Month);
     let mut months: Vec<_> = monthly.keys().collect();
@@ -138,7 +140,10 @@ pub(crate) fn monthly_budget_reports(
         .into_iter()
         .filter_map(|month| {
             monthly.get(month).map(|stats| {
-                let spent = display_cost(sum_model_costs(&stats.models, pricing_db), currency);
+                let spent = display_cost(
+                    sum_display_model_costs(&stats.models, pricing_db, cost_mode),
+                    currency,
+                );
                 budget_report(month.clone(), spent, monthly_budget, as_of)
             })
         })
@@ -298,6 +303,7 @@ mod tests {
             10.0,
             NaiveDate::from_ymd_opt(2026, 2, 10).unwrap(),
             None,
+            CostDisplayMode::Total,
         );
 
         assert_eq!(reports.len(), 1);

--- a/src/output/csv.rs
+++ b/src/output/csv.rs
@@ -7,7 +7,11 @@ use crate::core::{BlockStats, DataQuality, DayStats, ProjectStats, SessionStats}
 use crate::output::budget::{MonthlyBudgetOptions, MonthlyBudgetReport, monthly_budget_reports};
 use crate::output::format::{compare_cost, csv_escape};
 use crate::output::period::{Period, aggregate_day_stats_by_period};
-use crate::pricing::{CurrencyConverter, PricingDb, calculate_cost, sum_model_costs};
+use crate::pricing::{
+    CostDisplayMode, CurrencyConverter, PricingDb, calculate_display_cost,
+    calculate_estimated_proxy_cost, model_cost_kind, sum_display_model_costs,
+    sum_estimated_proxy_model_costs, sum_model_costs,
+};
 
 #[cfg(test)]
 pub(crate) fn output_period_csv(
@@ -20,7 +24,15 @@ pub(crate) fn output_period_csv(
     currency: Option<&CurrencyConverter>,
 ) -> String {
     output_period_csv_with_quality(
-        day_stats, period, pricing_db, order, breakdown, show_cost, currency, None,
+        day_stats,
+        period,
+        pricing_db,
+        order,
+        breakdown,
+        show_cost,
+        currency,
+        None,
+        CostDisplayMode::Total,
     )
 }
 
@@ -34,6 +46,7 @@ pub(crate) fn output_period_csv_with_quality(
     show_cost: bool,
     currency: Option<&CurrencyConverter>,
     data_quality: Option<DataQuality>,
+    cost_mode: CostDisplayMode,
 ) -> String {
     let aggregated;
     let stats_ref = if period == Period::Day {
@@ -50,74 +63,148 @@ pub(crate) fn output_period_csv_with_quality(
     }
     let label = period.label();
     let mut out = String::new();
-
+    let ctx = PeriodCsvContext {
+        label,
+        pricing_db,
+        show_cost,
+        currency,
+        include_cost_kind: period_csv_includes_cost_kind(&rows, breakdown, show_cost),
+        cost_mode,
+    };
     if breakdown {
-        // Breakdown: one row per model per period
-        let _ = write!(
-            out,
-            "{label},model,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,total_tokens"
-        );
-        if show_cost {
-            let _ = write!(out, ",cost");
-        }
-        out.push('\n');
-
-        for (key, stats) in &rows {
-            let mut models: Vec<_> = stats.models.iter().collect();
-            models.sort_by_key(|(name, _)| name.as_str());
-            for (model, model_stats) in &models {
-                let _ = write!(
-                    out,
-                    "{},{},{},{},{},{},{},{}",
-                    csv_escape(key),
-                    csv_escape(model),
-                    model_stats.input_tokens,
-                    model_stats.output_tokens,
-                    model_stats.reasoning_tokens,
-                    model_stats.cache_creation,
-                    model_stats.cache_read,
-                    model_stats.total_tokens(),
-                );
-                if show_cost {
-                    let cost = calculate_cost(model_stats, model, pricing_db);
-                    let _ = write!(out, ",{}", csv_cost(cost, currency));
-                }
-                out.push('\n');
-            }
-        }
+        write_period_csv_breakdown(&mut out, &rows, &ctx);
     } else {
-        // Standard: one row per period
-        let _ = write!(
-            out,
-            "{label},input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,total_tokens"
-        );
-        if show_cost {
-            let _ = write!(out, ",cost");
-        }
-        out.push('\n');
-
-        for (key, stats) in &rows {
-            let _ = write!(
-                out,
-                "{},{},{},{},{},{},{}",
-                csv_escape(key),
-                stats.stats.input_tokens,
-                stats.stats.output_tokens,
-                stats.stats.reasoning_tokens,
-                stats.stats.cache_creation,
-                stats.stats.cache_read,
-                stats.stats.total_tokens(),
-            );
-            if show_cost {
-                let cost = sum_model_costs(&stats.models, pricing_db);
-                let _ = write!(out, ",{}", csv_cost(cost, currency));
-            }
-            out.push('\n');
-        }
+        write_period_csv_standard(&mut out, &rows, &ctx);
     }
 
     append_data_quality_csv_comment(&mut out, data_quality);
     out
+}
+
+struct PeriodCsvContext<'a> {
+    label: &'a str,
+    pricing_db: &'a PricingDb,
+    show_cost: bool,
+    currency: Option<&'a CurrencyConverter>,
+    include_cost_kind: bool,
+    cost_mode: CostDisplayMode,
+}
+
+fn period_csv_includes_cost_kind(
+    rows: &[(&String, &DayStats)],
+    breakdown: bool,
+    show_cost: bool,
+) -> bool {
+    show_cost
+        && rows.iter().any(|(_, stats)| {
+            if breakdown {
+                stats
+                    .models
+                    .values()
+                    .any(|model| model.cost_kind().as_str() != "real")
+            } else {
+                model_cost_kind(&stats.models).as_str() != "real"
+            }
+        })
+}
+
+fn write_period_cost_header(out: &mut String, ctx: &PeriodCsvContext<'_>) {
+    if ctx.show_cost {
+        let _ = write!(out, ",cost");
+        if ctx.include_cost_kind {
+            let _ = write!(out, ",cost_kind,estimated_cost");
+        }
+    }
+    out.push('\n');
+}
+
+fn write_period_csv_breakdown(
+    out: &mut String,
+    rows: &[(&String, &DayStats)],
+    ctx: &PeriodCsvContext<'_>,
+) {
+    let _ = write!(
+        out,
+        "{},model,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,total_tokens",
+        ctx.label
+    );
+    write_period_cost_header(out, ctx);
+
+    for &(key, stats) in rows {
+        let mut models: Vec<_> = stats.models.iter().collect();
+        models.sort_by_key(|(name, _)| name.as_str());
+        for (model, model_stats) in &models {
+            let _ = write!(
+                out,
+                "{},{},{},{},{},{},{},{}",
+                csv_escape(key),
+                csv_escape(model),
+                model_stats.input_tokens,
+                model_stats.output_tokens,
+                model_stats.reasoning_tokens,
+                model_stats.cache_creation,
+                model_stats.cache_read,
+                model_stats.total_tokens(),
+            );
+            if ctx.show_cost {
+                let cost =
+                    calculate_display_cost(model_stats, model, ctx.pricing_db, ctx.cost_mode);
+                let _ = write!(out, ",{}", csv_cost(cost, ctx.currency));
+                if ctx.include_cost_kind {
+                    let estimated_cost =
+                        calculate_estimated_proxy_cost(model_stats, model, ctx.pricing_db);
+                    let _ = write!(
+                        out,
+                        ",{},{}",
+                        model_stats.cost_kind().as_str(),
+                        csv_cost(estimated_cost, ctx.currency)
+                    );
+                }
+            }
+            out.push('\n');
+        }
+    }
+}
+
+fn write_period_csv_standard(
+    out: &mut String,
+    rows: &[(&String, &DayStats)],
+    ctx: &PeriodCsvContext<'_>,
+) {
+    let _ = write!(
+        out,
+        "{},input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,total_tokens",
+        ctx.label
+    );
+    write_period_cost_header(out, ctx);
+
+    for &(key, stats) in rows {
+        let _ = write!(
+            out,
+            "{},{},{},{},{},{},{}",
+            csv_escape(key),
+            stats.stats.input_tokens,
+            stats.stats.output_tokens,
+            stats.stats.reasoning_tokens,
+            stats.stats.cache_creation,
+            stats.stats.cache_read,
+            stats.stats.total_tokens(),
+        );
+        if ctx.show_cost {
+            let cost = sum_display_model_costs(&stats.models, ctx.pricing_db, ctx.cost_mode);
+            let _ = write!(out, ",{}", csv_cost(cost, ctx.currency));
+            if ctx.include_cost_kind {
+                let estimated_cost = sum_estimated_proxy_model_costs(&stats.models, ctx.pricing_db);
+                let _ = write!(
+                    out,
+                    ",{},{}",
+                    model_cost_kind(&stats.models).as_str(),
+                    csv_cost(estimated_cost, ctx.currency)
+                );
+            }
+        }
+        out.push('\n');
+    }
 }
 
 pub(crate) fn append_data_quality_csv_comment(out: &mut String, data_quality: Option<DataQuality>) {
@@ -188,6 +275,7 @@ pub(crate) fn output_monthly_budget_csv(
         options.limit,
         options.as_of,
         options.currency,
+        options.cost_mode,
     );
     let mut out = String::new();
 
@@ -222,7 +310,8 @@ pub(crate) fn output_monthly_budget_csv(
                     model_stats.total_tokens(),
                 );
                 if options.show_cost {
-                    let cost = calculate_cost(model_stats, model, pricing_db);
+                    let cost =
+                        calculate_display_cost(model_stats, model, pricing_db, options.cost_mode);
                     let _ = write!(out, ",{}", csv_cost(cost, options.currency));
                 }
                 write_budget_fields(&mut out, report);
@@ -256,7 +345,7 @@ pub(crate) fn output_monthly_budget_csv(
                 stats.stats.total_tokens(),
             );
             if options.show_cost {
-                let cost = sum_model_costs(&stats.models, pricing_db);
+                let cost = sum_display_model_costs(&stats.models, pricing_db, options.cost_mode);
                 let _ = write!(out, ",{}", csv_cost(cost, options.currency));
             }
             write_budget_fields(&mut out, report);
@@ -281,12 +370,19 @@ pub(crate) fn output_session_csv(
     }
 
     let mut out = String::new();
+    let include_cost_kind = show_cost
+        && sorted
+            .iter()
+            .any(|session| sum_estimated_proxy_model_costs(&session.models, pricing_db) > 0.0);
     let _ = write!(
         out,
         "session_id,project_path,first_timestamp,last_timestamp,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,total_tokens"
     );
     if show_cost {
         let _ = write!(out, ",cost");
+        if include_cost_kind {
+            let _ = write!(out, ",cost_kind,estimated_cost");
+        }
     }
     out.push('\n');
 
@@ -308,6 +404,15 @@ pub(crate) fn output_session_csv(
         if show_cost {
             let cost = sum_model_costs(&s.models, pricing_db);
             let _ = write!(out, ",{}", csv_cost(cost, currency));
+            if include_cost_kind {
+                let estimated_cost = sum_estimated_proxy_model_costs(&s.models, pricing_db);
+                let _ = write!(
+                    out,
+                    ",{},{}",
+                    model_cost_kind(&s.models).as_str(),
+                    csv_cost(estimated_cost, currency)
+                );
+            }
         }
         out.push('\n');
     }
@@ -338,12 +443,19 @@ pub(crate) fn output_project_csv(
     }
 
     let mut out = String::new();
+    let include_cost_kind = show_cost
+        && sorted
+            .iter()
+            .any(|project| sum_estimated_proxy_model_costs(&project.models, pricing_db) > 0.0);
     let _ = write!(
         out,
         "project_name,project_path,sessions,input_tokens,output_tokens,total_tokens"
     );
     if show_cost {
         let _ = write!(out, ",cost");
+        if include_cost_kind {
+            let _ = write!(out, ",cost_kind,estimated_cost");
+        }
     }
     out.push('\n');
 
@@ -361,6 +473,15 @@ pub(crate) fn output_project_csv(
         if show_cost {
             let cost = sum_model_costs(&p.models, pricing_db);
             let _ = write!(out, ",{}", csv_cost(cost, currency));
+            if include_cost_kind {
+                let estimated_cost = sum_estimated_proxy_model_costs(&p.models, pricing_db);
+                let _ = write!(
+                    out,
+                    ",{},{}",
+                    model_cost_kind(&p.models).as_str(),
+                    csv_cost(estimated_cost, currency)
+                );
+            }
         }
         out.push('\n');
     }
@@ -382,12 +503,19 @@ pub(crate) fn output_block_csv(
     }
 
     let mut out = String::new();
+    let include_cost_kind = show_cost
+        && sorted
+            .iter()
+            .any(|block| sum_estimated_proxy_model_costs(&block.models, pricing_db) > 0.0);
     let _ = write!(
         out,
         "block_start,block_end,input_tokens,output_tokens,cache_creation_tokens,cache_read_tokens,total_tokens"
     );
     if show_cost {
         let _ = write!(out, ",cost");
+        if include_cost_kind {
+            let _ = write!(out, ",cost_kind,estimated_cost");
+        }
     }
     out.push('\n');
 
@@ -406,6 +534,15 @@ pub(crate) fn output_block_csv(
         if show_cost {
             let cost = sum_model_costs(&b.models, pricing_db);
             let _ = write!(out, ",{}", csv_cost(cost, currency));
+            if include_cost_kind {
+                let estimated_cost = sum_estimated_proxy_model_costs(&b.models, pricing_db);
+                let _ = write!(
+                    out,
+                    ",{},{}",
+                    model_cost_kind(&b.models).as_str(),
+                    csv_cost(estimated_cost, currency)
+                );
+            }
         }
         out.push('\n');
     }

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -5,8 +5,11 @@ use crate::cli::SortOrder;
 use crate::core::{DataQuality, DayStats};
 use crate::output::format::cost_json_value;
 use crate::output::period::{Period, aggregate_day_stats_by_period};
-use crate::pricing::CurrencyConverter;
-use crate::pricing::{PricingDb, calculate_cost, sum_model_costs};
+use crate::pricing::{
+    CostDisplayMode, CurrencyConverter, PricingDb, calculate_display_cost,
+    calculate_estimated_proxy_cost, model_cost_kind, sum_display_model_costs,
+    sum_estimated_proxy_model_costs,
+};
 
 fn sort_output(output: &mut [serde_json::Value], key: &str, order: SortOrder) {
     match order {
@@ -49,12 +52,9 @@ fn build_period_entry(
     label: &str,
     key: &str,
     stats: &DayStats,
-    pricing_db: &PricingDb,
-    breakdown: bool,
-    show_cost: bool,
-    currency: Option<&CurrencyConverter>,
+    options: &PeriodJsonOptions<'_>,
 ) -> serde_json::Value {
-    if breakdown {
+    if options.breakdown {
         let mut models_breakdown: Vec<serde_json::Value> = Vec::new();
         let mut period_cost = 0.0;
 
@@ -68,15 +68,26 @@ fn build_period_entry(
                 "cache_read_tokens": model_stats.cache_read,
                 "total_tokens": model_stats.total_tokens(),
             });
-            if show_cost {
-                let cost = calculate_cost(model_stats, model, pricing_db);
+            if options.show_cost {
+                let cost = calculate_display_cost(
+                    model_stats,
+                    model,
+                    options.pricing_db,
+                    options.cost_mode,
+                );
                 period_cost += cost;
-                model_obj["cost"] = cost_json_value(cost, currency);
+                model_obj["cost"] = cost_json_value(cost, options.currency);
+                let estimated_cost =
+                    calculate_estimated_proxy_cost(model_stats, model, options.pricing_db);
+                if estimated_cost > 0.0 {
+                    model_obj["cost_kind"] = serde_json::json!(model_stats.cost_kind().as_str());
+                    model_obj["estimated_cost"] = cost_json_value(estimated_cost, options.currency);
+                }
             }
             models_breakdown.push(model_obj);
         }
 
-        sort_models_breakdown(&mut models_breakdown, show_cost);
+        sort_models_breakdown(&mut models_breakdown, options.show_cost);
 
         let mut obj = serde_json::json!({
             (label): key,
@@ -88,13 +99,22 @@ fn build_period_entry(
             "total_tokens": stats.stats.total_tokens(),
             "breakdown": models_breakdown,
         });
-        if show_cost {
-            obj["cost"] = cost_json_value(period_cost, currency);
+        if options.show_cost {
+            obj["cost"] = cost_json_value(period_cost, options.currency);
+            let estimated_cost = sum_estimated_proxy_model_costs(&stats.models, options.pricing_db);
+            if estimated_cost > 0.0 {
+                obj["cost_kind"] = serde_json::json!(model_cost_kind(&stats.models).as_str());
+                obj["estimated_cost"] = cost_json_value(estimated_cost, options.currency);
+            }
         }
         obj
     } else {
-        let period_cost = if show_cost {
-            Some(sum_model_costs(&stats.models, pricing_db))
+        let period_cost = if options.show_cost {
+            Some(sum_display_model_costs(
+                &stats.models,
+                options.pricing_db,
+                options.cost_mode,
+            ))
         } else {
             None
         };
@@ -110,11 +130,24 @@ fn build_period_entry(
             "total_tokens": stats.stats.total_tokens(),
             "models": models,
         });
-        if show_cost {
-            obj["cost"] = cost_json_value(period_cost.unwrap_or(0.0), currency);
+        if options.show_cost {
+            obj["cost"] = cost_json_value(period_cost.unwrap_or(0.0), options.currency);
+            let estimated_cost = sum_estimated_proxy_model_costs(&stats.models, options.pricing_db);
+            if estimated_cost > 0.0 {
+                obj["cost_kind"] = serde_json::json!(model_cost_kind(&stats.models).as_str());
+                obj["estimated_cost"] = cost_json_value(estimated_cost, options.currency);
+            }
         }
         obj
     }
+}
+
+struct PeriodJsonOptions<'a> {
+    pricing_db: &'a PricingDb,
+    breakdown: bool,
+    show_cost: bool,
+    currency: Option<&'a CurrencyConverter>,
+    cost_mode: CostDisplayMode,
 }
 
 fn data_quality_json(data_quality: DataQuality) -> serde_json::Value {
@@ -136,7 +169,15 @@ pub(crate) fn output_period_json(
     currency: Option<&CurrencyConverter>,
 ) -> String {
     output_period_json_with_quality(
-        day_stats, period, pricing_db, order, breakdown, show_cost, currency, None,
+        day_stats,
+        period,
+        pricing_db,
+        order,
+        breakdown,
+        show_cost,
+        currency,
+        None,
+        CostDisplayMode::Total,
     )
 }
 
@@ -150,6 +191,7 @@ pub(crate) fn output_period_json_with_quality(
     show_cost: bool,
     currency: Option<&CurrencyConverter>,
     data_quality: Option<DataQuality>,
+    cost_mode: CostDisplayMode,
 ) -> String {
     let label = period.label();
     let aggregated;
@@ -161,12 +203,17 @@ pub(crate) fn output_period_json_with_quality(
     };
 
     let data_quality = data_quality.map(data_quality_json);
+    let options = PeriodJsonOptions {
+        pricing_db,
+        breakdown,
+        show_cost,
+        currency,
+        cost_mode,
+    };
     let mut output: Vec<serde_json::Value> = stats_ref
         .iter()
         .map(|(key, stats)| {
-            let mut entry = build_period_entry(
-                label, key, stats, pricing_db, breakdown, show_cost, currency,
-            );
+            let mut entry = build_period_entry(label, key, stats, &options);
             if let Some(data_quality) = &data_quality {
                 entry["data_quality"] = data_quality.clone();
             }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -42,5 +42,5 @@ pub(crate) use table::{PeriodSummaryFooter, TokenTableOptions, print_period_tabl
 pub(crate) use tools::{output_tools_csv, output_tools_json, print_tools_table};
 pub(crate) use top::{
     TopRow, TopTableOptions, output_top_csv, output_top_json, print_top_table, rank_by_model,
-    rank_by_project,
+    rank_by_model_with_cost_mode, rank_by_project,
 };

--- a/src/output/period.rs
+++ b/src/output/period.rs
@@ -259,6 +259,7 @@ mod tests {
             reasoning_tokens: 5,
             count: 1,
             skipped_chunks: 0,
+            estimated_proxy: crate::core::CostTokens::default(),
         };
         ds.add_stats("model-a".to_string(), &stats);
         day_stats.insert("2025-03-01".to_string(), ds);
@@ -272,6 +273,7 @@ mod tests {
             reasoning_tokens: 15,
             count: 2,
             skipped_chunks: 1,
+            estimated_proxy: crate::core::CostTokens::default(),
         };
         ds2.add_stats("model-a".to_string(), &stats2);
         day_stats.insert("2025-03-10".to_string(), ds2);

--- a/src/output/project.rs
+++ b/src/output/project.rs
@@ -6,7 +6,9 @@ use crate::output::format::{
     NumberFormat, compare_cost, cost_json_value, create_styled_table, format_compact, format_cost,
     format_number, header_cell, right_cell, styled_cell,
 };
-use crate::pricing::{CurrencyConverter, PricingDb, attach_costs};
+use crate::pricing::{
+    CurrencyConverter, PricingDb, attach_costs, model_cost_kind, sum_estimated_proxy_model_costs,
+};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ProjectTableOptions<'a> {
@@ -70,12 +72,19 @@ pub(crate) fn print_project_table(
 
     let mut total_stats = Stats::default();
     let mut total_cost = 0.0;
+    let mut total_estimated_cost = 0.0;
+    let mut has_estimated_cost = false;
     let mut total_sessions = 0usize;
 
     for costed in &sorted_projects {
         let project = costed.item;
         let project_cost = costed.cost;
         total_cost += project_cost;
+        let estimated_cost = sum_estimated_proxy_model_costs(&project.models, pricing_db);
+        if estimated_cost > 0.0 {
+            total_estimated_cost += estimated_cost;
+            has_estimated_cost = true;
+        }
         total_stats.add(&project.stats);
         total_sessions += project.session_count;
 
@@ -198,6 +207,12 @@ pub(crate) fn print_project_table(
 
     println!("\n  {source_label} Project Usage\n");
     println!("{table}");
+    if show_cost && has_estimated_cost {
+        println!(
+            "\n  Cost includes estimated proxy values: {}",
+            format_cost(total_estimated_cost, options.currency)
+        );
+    }
     println!(
         "\n  {} projects, {} sessions\n",
         format_number(sorted_projects.len() as i64, number_format),
@@ -240,6 +255,11 @@ pub(crate) fn output_project_json(
             });
             if show_cost {
                 obj["cost"] = cost_json_value(project_cost, currency);
+                let estimated_cost = sum_estimated_proxy_model_costs(&project.models, pricing_db);
+                if estimated_cost > 0.0 {
+                    obj["cost_kind"] = serde_json::json!(model_cost_kind(&project.models).as_str());
+                    obj["estimated_cost"] = cost_json_value(estimated_cost, currency);
+                }
             }
             obj
         })

--- a/src/output/session.rs
+++ b/src/output/session.rs
@@ -9,7 +9,9 @@ use crate::output::format::{
     NumberFormat, cost_json_value, create_styled_table, format_compact, format_cost, format_number,
     header_cell, right_cell, styled_cell,
 };
-use crate::pricing::{CurrencyConverter, PricingDb, sum_model_costs};
+use crate::pricing::{
+    CurrencyConverter, PricingDb, model_cost_kind, sum_estimated_proxy_model_costs, sum_model_costs,
+};
 use crate::utils::Timezone;
 
 /// Truncate session ID for display
@@ -119,11 +121,18 @@ pub(crate) fn print_session_table(
 
     let mut total_stats = Stats::default();
     let mut total_cost = 0.0;
+    let mut total_estimated_cost = 0.0;
+    let mut has_estimated_cost = false;
 
     for session in &sorted_sessions {
         let session_cost = if show_cost {
             let cost = sum_model_costs(&session.models, pricing_db);
             total_cost += cost;
+            let estimated_cost = sum_estimated_proxy_model_costs(&session.models, pricing_db);
+            if estimated_cost > 0.0 {
+                total_estimated_cost += estimated_cost;
+                has_estimated_cost = true;
+            }
             Some(cost)
         } else {
             None
@@ -241,6 +250,12 @@ pub(crate) fn print_session_table(
 
     println!("\n  {source_label} Session Usage\n");
     println!("{table}");
+    if show_cost && has_estimated_cost {
+        println!(
+            "\n  Cost includes estimated proxy values: {}",
+            format_cost(total_estimated_cost, options.currency)
+        );
+    }
     println!(
         "\n  {} sessions\n",
         format_number(sorted_sessions.len() as i64, number_format)
@@ -288,6 +303,11 @@ pub(crate) fn output_session_json(
             });
             if show_cost {
                 obj["cost"] = cost_json_value(session_cost.unwrap_or(0.0), currency);
+                let estimated_cost = sum_estimated_proxy_model_costs(&session.models, pricing_db);
+                if estimated_cost > 0.0 {
+                    obj["cost_kind"] = serde_json::json!(model_cost_kind(&session.models).as_str());
+                    obj["estimated_cost"] = cost_json_value(estimated_cost, currency);
+                }
             }
             obj
         })

--- a/src/output/statusline.rs
+++ b/src/output/statusline.rs
@@ -2,21 +2,35 @@ use std::collections::HashMap;
 
 use crate::core::{DataQuality, DayStats, Stats};
 use crate::output::format::{NumberFormat, cost_json_value, format_compact, format_cost};
-use crate::pricing::{CurrencyConverter, PricingDb, sum_model_costs};
+use crate::pricing::{
+    CostDisplayMode, CurrencyConverter, PricingDb, sum_display_model_costs,
+    sum_estimated_proxy_model_costs,
+};
 
 struct Totals {
     stats: Stats,
     cost: f64,
+    estimated_proxy_cost: f64,
 }
 
-fn aggregate_totals(day_stats: &HashMap<String, DayStats>, pricing_db: &PricingDb) -> Totals {
+fn aggregate_totals(
+    day_stats: &HashMap<String, DayStats>,
+    pricing_db: &PricingDb,
+    cost_mode: CostDisplayMode,
+) -> Totals {
     let mut stats = Stats::default();
     let mut cost = 0.0;
+    let mut estimated_proxy_cost = 0.0;
     for day in day_stats.values() {
         stats.add(&day.stats);
-        cost += sum_model_costs(&day.models, pricing_db);
+        cost += sum_display_model_costs(&day.models, pricing_db, cost_mode);
+        estimated_proxy_cost += sum_estimated_proxy_model_costs(&day.models, pricing_db);
     }
-    Totals { stats, cost }
+    Totals {
+        stats,
+        cost,
+        estimated_proxy_cost,
+    }
 }
 
 /// Output a single line suitable for statusline/tmux integration
@@ -27,8 +41,9 @@ pub(crate) fn print_statusline(
     source_label: &str,
     number_format: NumberFormat,
     currency: Option<&CurrencyConverter>,
+    cost_mode: CostDisplayMode,
 ) {
-    let t = aggregate_totals(day_stats, pricing_db);
+    let t = aggregate_totals(day_stats, pricing_db, cost_mode);
 
     let mut parts = vec![
         format!("{}: {}", source_label, format_cost(t.cost, currency)),
@@ -63,6 +78,7 @@ pub(crate) fn print_statusline_json(
         number_format,
         currency,
         None,
+        CostDisplayMode::Total,
     )
 }
 
@@ -73,8 +89,9 @@ pub(crate) fn print_statusline_json_with_quality(
     number_format: NumberFormat,
     currency: Option<&CurrencyConverter>,
     data_quality: Option<DataQuality>,
+    cost_mode: CostDisplayMode,
 ) -> String {
-    let t = aggregate_totals(day_stats, pricing_db);
+    let t = aggregate_totals(day_stats, pricing_db, cost_mode);
 
     let mut output = serde_json::json!({
         "source": source_label,
@@ -99,6 +116,10 @@ pub(crate) fn print_statusline_json_with_quality(
             "parse_errors": data_quality.parse_errors,
         });
     }
+    if t.estimated_proxy_cost > 0.0 {
+        output["cost_kind"] = serde_json::json!(t.stats.cost_kind().as_str());
+        output["estimated_cost"] = cost_json_value(t.estimated_proxy_cost, currency);
+    }
 
     serde_json::to_string(&output).unwrap_or_else(|e| {
         eprintln!("Failed to serialize JSON output: {e}");
@@ -119,6 +140,7 @@ mod tests {
             cache_read: cache_r,
             count: 1,
             skipped_chunks: 0,
+            estimated_proxy: crate::core::CostTokens::default(),
         };
         let mut day = DayStats {
             stats: stats.clone(),
@@ -143,6 +165,7 @@ mod tests {
                 cache_read: 20,
                 count: 1,
                 skipped_chunks: 0,
+                estimated_proxy: crate::core::CostTokens::default(),
             },
             ..Default::default()
         };

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -8,7 +8,10 @@ use crate::output::format::{
     right_cell, styled_cell,
 };
 use crate::output::period::{Period, aggregate_day_stats_by_period};
-use crate::pricing::{CurrencyConverter, PricingDb, calculate_cost, sum_model_costs};
+use crate::pricing::{
+    CostDisplayMode, CurrencyConverter, PricingDb, calculate_display_cost, model_cost_kind,
+    sum_display_model_costs, sum_estimated_proxy_model_costs,
+};
 
 #[derive(Debug, Clone, Copy)]
 #[allow(clippy::struct_excessive_bools)]
@@ -21,6 +24,7 @@ pub(crate) struct TokenTableOptions<'a> {
     pub(crate) show_reasoning: bool,
     pub(crate) show_cache_creation: bool,
     pub(crate) currency: Option<&'a CurrencyConverter>,
+    pub(crate) cost_mode: CostDisplayMode,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -150,7 +154,7 @@ fn add_compact_rows(
     cost_color: Option<Color>,
     pricing_db: &PricingDb,
 ) -> f64 {
-    let cost = sum_model_costs(&data.models, pricing_db);
+    let cost = sum_display_model_costs(&data.models, pricing_db, opts.cost_mode);
     let nf = opts.number_format;
     let mut row = vec![Cell::new(key)];
     if cfg.show_calls {
@@ -192,7 +196,7 @@ fn add_breakdown_rows(
 
     for (i, model) in models.iter().enumerate() {
         let stats = &data.models[*model];
-        let cost = calculate_cost(stats, model, pricing_db);
+        let cost = calculate_display_cost(stats, model, pricing_db, opts.cost_mode);
         period_cost += cost;
 
         let mut row = vec![Cell::new(if i == 0 { key } else { "" }), Cell::new(*model)];
@@ -250,7 +254,7 @@ fn add_standard_rows(
         .map(|s| s.as_str())
         .collect::<Vec<_>>()
         .join(", ");
-    let cost = sum_model_costs(&data.models, pricing_db);
+    let cost = sum_display_model_costs(&data.models, pricing_db, opts.cost_mode);
     let nf = opts.number_format;
 
     let mut row = vec![Cell::new(key), Cell::new(&models_str)];
@@ -422,9 +426,19 @@ pub(crate) fn print_period_table(
     };
     let mut total_stats = Stats::default();
     let mut total_cost = 0.0;
+    let mut estimated_proxy_cost = 0.0;
+    let mut has_estimated_proxy = false;
 
     for key in &keys {
         let data = &stats_ref[*key];
+        let row_estimated_cost = sum_estimated_proxy_model_costs(&data.models, pricing_db);
+        if row_estimated_cost > 0.0 {
+            has_estimated_proxy = true;
+            estimated_proxy_cost += row_estimated_cost;
+        }
+        if model_cost_kind(&data.models).as_str() != "real" {
+            has_estimated_proxy = true;
+        }
         let cost = if options.compact {
             add_compact_rows(
                 &mut table, key, data, &cfg, &options, cost_color, pricing_db,
@@ -453,6 +467,18 @@ pub(crate) fn print_period_table(
 
     println!("\n  {}\n", cfg.title);
     println!("{table}");
+    if options.show_cost && has_estimated_proxy {
+        match options.cost_mode {
+            CostDisplayMode::RealOnly => println!(
+                "\n  Estimated proxy cost excluded from Cost total: {}",
+                format_cost(estimated_proxy_cost, options.currency)
+            ),
+            CostDisplayMode::Total => println!(
+                "\n  Cost includes estimated proxy values: {}",
+                format_cost(estimated_proxy_cost, options.currency)
+            ),
+        }
+    }
     print_summary_line(
         summary.valid,
         summary.skipped,

--- a/src/output/table_tests.rs
+++ b/src/output/table_tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::cli::SortOrder;
 use crate::output::format::NumberFormat;
 use crate::output::period::Period;
+use crate::pricing::CostDisplayMode;
 
 fn default_opts() -> TokenTableOptions<'static> {
     TokenTableOptions {
@@ -13,6 +14,7 @@ fn default_opts() -> TokenTableOptions<'static> {
         show_reasoning: false,
         show_cache_creation: false,
         currency: None,
+        cost_mode: CostDisplayMode::Total,
     }
 }
 
@@ -137,6 +139,7 @@ fn make_day_stats() -> DayStats {
         cache_read: 200,
         count: 3,
         skipped_chunks: 0,
+        estimated_proxy: crate::core::CostTokens::default(),
     };
     day.stats = stats.clone();
     day.models.insert("claude-sonnet".to_string(), stats);

--- a/src/output/top.rs
+++ b/src/output/top.rs
@@ -12,12 +12,15 @@ use comfy_table::{Attribute, Cell, CellAlignment, Color};
 use serde_json::json;
 
 use crate::cli::TopDimension;
-use crate::core::{DayStats, ProjectStats, Stats};
+use crate::core::{CostKind, DayStats, ProjectStats, Stats};
 use crate::output::format::{
     NumberFormat, create_styled_table, csv_escape, format_compact, format_cost, format_number,
     header_cell, right_cell, styled_cell,
 };
-use crate::pricing::{CurrencyConverter, PricingDb, calculate_cost, sum_model_costs};
+use crate::pricing::{
+    CostDisplayMode, CurrencyConverter, PricingDb, calculate_display_cost, model_cost_kind,
+    sum_display_model_costs, sum_estimated_proxy_model_costs,
+};
 
 /// One row in the leaderboard.
 #[derive(Debug, Clone)]
@@ -26,6 +29,8 @@ pub(crate) struct TopRow {
     pub(crate) count: i64,
     pub(crate) stats: Stats,
     pub(crate) cost: f64,
+    pub(crate) estimated_cost: f64,
+    pub(crate) cost_kind: CostKind,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -38,12 +43,21 @@ pub(crate) struct TopTableOptions<'a> {
     pub(crate) currency: Option<&'a CurrencyConverter>,
     pub(crate) dim: TopDimension,
     pub(crate) limit: usize,
+    pub(crate) cost_mode: CostDisplayMode,
 }
 
 /// Aggregate per-model rows from a daily-stats map.
 pub(crate) fn rank_by_model(
     day_stats: &HashMap<String, DayStats>,
     pricing_db: &PricingDb,
+) -> Vec<TopRow> {
+    rank_by_model_with_cost_mode(day_stats, pricing_db, CostDisplayMode::Total)
+}
+
+pub(crate) fn rank_by_model_with_cost_mode(
+    day_stats: &HashMap<String, DayStats>,
+    pricing_db: &PricingDb,
+    cost_mode: CostDisplayMode,
 ) -> Vec<TopRow> {
     let mut totals: HashMap<String, Stats> = HashMap::new();
     for day in day_stats.values() {
@@ -55,12 +69,18 @@ pub(crate) fn rank_by_model(
     let mut rows: Vec<TopRow> = totals
         .into_iter()
         .map(|(model, stats)| {
-            let cost = calculate_cost(&stats, &model, pricing_db);
+            let cost = calculate_display_cost(&stats, &model, pricing_db, cost_mode);
+            let estimated_cost =
+                calculate_display_cost(&stats, &model, pricing_db, CostDisplayMode::Total)
+                    - calculate_display_cost(&stats, &model, pricing_db, CostDisplayMode::RealOnly);
+            let cost_kind = stats.cost_kind();
             TopRow {
                 name: model,
                 count: stats.count,
                 stats,
                 cost,
+                estimated_cost,
+                cost_kind,
             }
         })
         .collect();
@@ -74,7 +94,9 @@ pub(crate) fn rank_by_project(projects: &[ProjectStats], pricing_db: &PricingDb)
     let mut rows: Vec<TopRow> = projects
         .iter()
         .map(|project| {
-            let cost = sum_model_costs(&project.models, pricing_db);
+            let cost = sum_display_model_costs(&project.models, pricing_db, CostDisplayMode::Total);
+            let estimated_cost = sum_estimated_proxy_model_costs(&project.models, pricing_db);
+            let cost_kind = model_cost_kind(&project.models);
             TopRow {
                 name: if project.project_name.is_empty() {
                     project.project_path.clone()
@@ -84,6 +106,8 @@ pub(crate) fn rank_by_project(projects: &[ProjectStats], pricing_db: &PricingDb)
                 count: project.session_count as i64,
                 stats: project.stats.clone(),
                 cost,
+                estimated_cost,
+                cost_kind,
             }
         })
         .collect();
@@ -284,6 +308,11 @@ pub(crate) fn print_top_table(rows: &[TopRow], options: TopTableOptions<'_>) {
         ));
     }
     table.add_row(total_row);
+    let estimated_proxy_cost: f64 = limited
+        .iter()
+        .filter(|row| row.estimated_cost.is_finite())
+        .map(|row| row.estimated_cost)
+        .sum();
 
     if rows.len() > limited.len() {
         println!(
@@ -312,6 +341,18 @@ pub(crate) fn print_top_table(rows: &[TopRow], options: TopTableOptions<'_>) {
         );
     }
     println!("{table}");
+    if options.show_cost && estimated_proxy_cost > 0.0 {
+        match options.cost_mode {
+            CostDisplayMode::RealOnly => println!(
+                "\nEstimated proxy cost excluded from Cost ranking: {}",
+                format_cost(estimated_proxy_cost, options.currency)
+            ),
+            CostDisplayMode::Total => println!(
+                "\nCost includes estimated proxy values: {}",
+                format_cost(estimated_proxy_cost, options.currency)
+            ),
+        }
+    }
 }
 
 /// JSON output. Always includes share, basis, and full stats so downstream
@@ -327,6 +368,7 @@ pub(crate) fn output_top_json(
     let total_cost = sum_cost(&limited);
     let total_tokens = sum_tokens(&limited);
     let basis = share_basis(&limited);
+    let include_estimated = show_cost && limited.iter().any(|row| row.estimated_cost > 0.0);
 
     let entries: Vec<serde_json::Value> = limited
         .iter()
@@ -355,6 +397,19 @@ pub(crate) fn output_top_json(
                     && !row.cost.is_nan()
                 {
                     obj["cost_local"] = json!(conv.format(row.cost));
+                }
+                if include_estimated {
+                    obj["cost_kind"] = json!(row.cost_kind.as_str());
+                    obj["estimated_cost_usd"] = if row.estimated_cost.is_nan() {
+                        serde_json::Value::Null
+                    } else {
+                        json!((row.estimated_cost * 100_000.0).round() / 100_000.0)
+                    };
+                    if let Some(conv) = currency
+                        && !row.estimated_cost.is_nan()
+                    {
+                        obj["estimated_cost_local"] = json!(conv.format(row.estimated_cost));
+                    }
                 }
             }
             obj
@@ -405,8 +460,15 @@ pub(crate) fn output_top_csv(
         if currency.is_some() {
             out.push_str(",cost_local");
         }
+        if limited.iter().any(|row| row.estimated_cost > 0.0) {
+            out.push_str(",cost_kind,estimated_cost_usd");
+            if currency.is_some() {
+                out.push_str(",estimated_cost_local");
+            }
+        }
     }
     out.push('\n');
+    let include_estimated = show_cost && limited.iter().any(|row| row.estimated_cost > 0.0);
 
     for (idx, row) in limited.iter().enumerate() {
         let share = share_of(row, total_cost, total_tokens, basis);
@@ -434,6 +496,21 @@ pub(crate) fn output_top_csv(
                 let _ = write!(out, ",{:.6}", row.cost);
                 if let Some(conv) = currency {
                     let _ = write!(out, ",{}", csv_escape(&conv.format(row.cost)));
+                }
+            }
+            if include_estimated {
+                let _ = write!(out, ",{}", row.cost_kind.as_str());
+                if row.estimated_cost.is_nan() {
+                    out.push(',');
+                } else {
+                    let _ = write!(out, ",{:.6}", row.estimated_cost);
+                }
+                if let Some(conv) = currency {
+                    if row.estimated_cost.is_nan() {
+                        out.push(',');
+                    } else {
+                        let _ = write!(out, ",{}", csv_escape(&conv.format(row.estimated_cost)));
+                    }
                 }
             }
         }
@@ -476,6 +553,7 @@ mod tests {
             reasoning_tokens: 0,
             count,
             skipped_chunks: 0,
+            estimated_proxy: crate::core::CostTokens::default(),
         }
     }
 
@@ -530,12 +608,16 @@ mod tests {
                 count: 1,
                 stats: stats_of(100, 0, 1),
                 cost: f64::NAN,
+                estimated_cost: 0.0,
+                cost_kind: CostKind::Real,
             },
             TopRow {
                 name: "b".into(),
                 count: 1,
                 stats: stats_of(300, 0, 1),
                 cost: f64::NAN,
+                estimated_cost: 0.0,
+                cost_kind: CostKind::Real,
             },
         ];
         assert_eq!(share_basis(&rows), ShareBasis::Tokens);
@@ -551,12 +633,16 @@ mod tests {
                 count: 1,
                 stats: stats_of(100, 0, 1),
                 cost: 0.25,
+                estimated_cost: 0.0,
+                cost_kind: CostKind::Real,
             },
             TopRow {
                 name: "b".into(),
                 count: 1,
                 stats: stats_of(100, 0, 1),
                 cost: 0.75,
+                estimated_cost: 0.0,
+                cost_kind: CostKind::Real,
             },
         ];
         assert_eq!(share_basis(&rows), ShareBasis::Cost);
@@ -573,18 +659,24 @@ mod tests {
                 count: 1,
                 stats: stats_of(100, 0, 1),
                 cost: f64::NAN,
+                estimated_cost: 0.0,
+                cost_kind: CostKind::Real,
             },
             TopRow {
                 name: "high-cost".into(),
                 count: 1,
                 stats: stats_of(10, 0, 1),
                 cost: 5.0,
+                estimated_cost: 0.0,
+                cost_kind: CostKind::Real,
             },
             TopRow {
                 name: "low-cost".into(),
                 count: 1,
                 stats: stats_of(10, 0, 1),
                 cost: 1.0,
+                estimated_cost: 0.0,
+                cost_kind: CostKind::Real,
             },
         ];
         sort_rows(&mut rows);
@@ -601,6 +693,8 @@ mod tests {
                 count: 1,
                 stats: stats_of(100 - i, 0, 1),
                 cost: f64::NAN,
+                estimated_cost: 0.0,
+                cost_kind: CostKind::Real,
             })
             .collect();
         let csv = output_top_csv(&rows, TopDimension::Model, 5, false, None);
@@ -615,6 +709,8 @@ mod tests {
             count: 1,
             stats: stats_of(100, 50, 1),
             cost: 1.5,
+            estimated_cost: 0.0,
+            cost_kind: CostKind::Real,
         }];
         let json = output_top_json(&rows, TopDimension::Model, 10, true, None);
         let val: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -634,12 +730,16 @@ mod tests {
                 count: 1,
                 stats: stats_of(100, 0, 1),
                 cost: f64::NAN,
+                estimated_cost: 0.0,
+                cost_kind: CostKind::Real,
             },
             TopRow {
                 name: "b".into(),
                 count: 1,
                 stats: stats_of(300, 0, 1),
                 cost: f64::NAN,
+                estimated_cost: 0.0,
+                cost_kind: CostKind::Real,
             },
         ];
         let json = output_top_json(&rows, TopDimension::Model, 10, true, None);
@@ -656,6 +756,8 @@ mod tests {
             count: 1,
             stats: stats_of(10, 0, 1),
             cost: f64::NAN,
+            estimated_cost: 0.0,
+            cost_kind: CostKind::Real,
         }];
         let csv = output_top_csv(&rows, TopDimension::Project, 1, false, None);
         let lines: Vec<&str> = csv.lines().collect();
@@ -669,6 +771,8 @@ mod tests {
             count: 1,
             stats: stats_of(10, 0, 1),
             cost: 1.5,
+            estimated_cost: 0.0,
+            cost_kind: CostKind::Real,
         }];
         let converter = CurrencyConverter::from_rate_for_test("CNY", 7.0, "CNY ");
 

--- a/src/pricing/cost.rs
+++ b/src/pricing/cost.rs
@@ -1,0 +1,165 @@
+use std::collections::HashMap;
+
+use crate::core::{CostKind, CostTokens, Stats};
+
+use super::db::PricingDb;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CostDisplayMode {
+    Total,
+    RealOnly,
+}
+
+fn calculate_token_cost(tokens: CostTokens, model: &str, pricing_db: &PricingDb) -> f64 {
+    if !tokens.has_entries() {
+        return 0.0;
+    }
+    match pricing_db.get_pricing(model) {
+        Some(pricing) => {
+            tokens.input_tokens as f64 * pricing.input
+                + tokens.output_tokens as f64 * pricing.output
+                + tokens.reasoning_tokens as f64 * pricing.reasoning_output
+                + tokens.cache_creation as f64 * pricing.cache_create
+                + tokens.cache_read as f64 * pricing.cache_read
+        }
+        None => f64::NAN,
+    }
+}
+
+pub(crate) fn calculate_cost(stats: &Stats, model: &str, pricing_db: &PricingDb) -> f64 {
+    calculate_token_cost(stats.cost_tokens(), model, pricing_db)
+}
+
+pub(crate) fn calculate_real_cost(stats: &Stats, model: &str, pricing_db: &PricingDb) -> f64 {
+    calculate_token_cost(stats.real_cost_tokens(), model, pricing_db)
+}
+
+pub(crate) fn calculate_estimated_proxy_cost(
+    stats: &Stats,
+    model: &str,
+    pricing_db: &PricingDb,
+) -> f64 {
+    calculate_token_cost(stats.estimated_proxy, model, pricing_db)
+}
+
+pub(crate) fn calculate_display_cost(
+    stats: &Stats,
+    model: &str,
+    pricing_db: &PricingDb,
+    mode: CostDisplayMode,
+) -> f64 {
+    match mode {
+        CostDisplayMode::Total => calculate_cost(stats, model, pricing_db),
+        CostDisplayMode::RealOnly => calculate_real_cost(stats, model, pricing_db),
+    }
+}
+
+/// Sum total cost across model breakdown map.
+///
+/// Unknown models are skipped, so a single unpriced model does not erase the
+/// total of every other model in the same row. An empty map returns 0.0; a map
+/// where every selected cost bucket is unknown returns NaN so callers surface
+/// N/A instead of a misleading $0.00.
+pub(crate) fn sum_model_costs(models: &HashMap<String, Stats>, pricing_db: &PricingDb) -> f64 {
+    sum_model_costs_by(models, pricing_db, Stats::cost_tokens)
+}
+
+pub(crate) fn sum_real_model_costs(models: &HashMap<String, Stats>, pricing_db: &PricingDb) -> f64 {
+    sum_model_costs_by(models, pricing_db, Stats::real_cost_tokens)
+}
+
+pub(crate) fn sum_estimated_proxy_model_costs(
+    models: &HashMap<String, Stats>,
+    pricing_db: &PricingDb,
+) -> f64 {
+    sum_model_costs_by(models, pricing_db, |stats| stats.estimated_proxy)
+}
+
+pub(crate) fn sum_display_model_costs(
+    models: &HashMap<String, Stats>,
+    pricing_db: &PricingDb,
+    mode: CostDisplayMode,
+) -> f64 {
+    match mode {
+        CostDisplayMode::Total => sum_model_costs(models, pricing_db),
+        CostDisplayMode::RealOnly => sum_real_model_costs(models, pricing_db),
+    }
+}
+
+fn sum_model_costs_by(
+    models: &HashMap<String, Stats>,
+    pricing_db: &PricingDb,
+    tokens_of: impl Fn(&Stats) -> CostTokens,
+) -> f64 {
+    if models.is_empty() {
+        return 0.0;
+    }
+    let mut total = 0.0;
+    let mut any_entries = false;
+    let mut any_known = false;
+    for (model, stats) in models {
+        let tokens = tokens_of(stats);
+        if !tokens.has_entries() {
+            continue;
+        }
+        any_entries = true;
+        let cost = calculate_token_cost(tokens, model, pricing_db);
+        if cost.is_nan() {
+            continue;
+        }
+        total += cost;
+        any_known = true;
+    }
+    if !any_entries {
+        0.0
+    } else if any_known {
+        total
+    } else {
+        f64::NAN
+    }
+}
+
+pub(crate) fn model_cost_kind(models: &HashMap<String, Stats>) -> CostKind {
+    let mut has_real = false;
+    let mut has_estimated = false;
+    for stats in models.values() {
+        match stats.cost_kind() {
+            CostKind::Real => has_real = true,
+            CostKind::EstimatedProxy => has_estimated = true,
+            CostKind::Mixed => {
+                has_real = true;
+                has_estimated = true;
+            }
+        }
+    }
+    match (has_real, has_estimated) {
+        (true, true) => CostKind::Mixed,
+        (false, true) => CostKind::EstimatedProxy,
+        _ => CostKind::Real,
+    }
+}
+
+/// Borrowed item with precomputed total cost.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CostedRef<'a, T> {
+    pub(crate) item: &'a T,
+    pub(crate) cost: f64,
+}
+
+/// Attach precomputed costs to a slice of items.
+pub(crate) fn attach_costs<'a, T, F>(
+    items: &'a [T],
+    mut models_of: F,
+    pricing_db: &PricingDb,
+) -> Vec<CostedRef<'a, T>>
+where
+    F: FnMut(&T) -> &HashMap<String, Stats>,
+{
+    items
+        .iter()
+        .map(|item| CostedRef {
+            item,
+            cost: sum_model_costs(models_of(item), pricing_db),
+        })
+        .collect()
+}

--- a/src/pricing/db.rs
+++ b/src/pricing/db.rs
@@ -2,8 +2,6 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
-use crate::core::Stats;
-
 use super::cache::{
     CacheReadError, CacheWriteError, load_raw_cache, load_raw_cache_if_fresh, save_raw_cache,
 };
@@ -192,7 +190,7 @@ impl PricingDb {
         }
     }
 
-    fn get_pricing(&self, model: &str) -> Option<ModelPricing> {
+    pub(super) fn get_pricing(&self, model: &str) -> Option<ModelPricing> {
         if let Some(cached) = self.resolved.borrow().get(model) {
             return match cached {
                 ResolvedPricing::Known(pricing) => Some(pricing.clone()),
@@ -233,72 +231,12 @@ impl Default for PricingDb {
     }
 }
 
-pub(crate) fn calculate_cost(stats: &Stats, model: &str, pricing_db: &PricingDb) -> f64 {
-    match pricing_db.get_pricing(model) {
-        Some(pricing) => {
-            stats.input_tokens as f64 * pricing.input
-                + stats.output_tokens as f64 * pricing.output
-                + stats.reasoning_tokens as f64 * pricing.reasoning_output
-                + stats.cache_creation as f64 * pricing.cache_create
-                + stats.cache_read as f64 * pricing.cache_read
-        }
-        None => f64::NAN,
-    }
-}
-
-/// Sum total cost across model breakdown map.
-///
-/// Unknown models (`calculate_cost` returns NaN because pricing did not
-/// resolve) are skipped, so a single unpriced model does not erase the total
-/// of every other model in the same row. An empty map returns 0.0; a map where
-/// every model is unknown returns NaN so the caller surfaces N/A instead of a
-/// misleading $0.00.
-pub(crate) fn sum_model_costs(models: &HashMap<String, Stats>, pricing_db: &PricingDb) -> f64 {
-    if models.is_empty() {
-        return 0.0;
-    }
-    let mut total = 0.0;
-    let mut any_known = false;
-    for (model, stats) in models {
-        let cost = calculate_cost(stats, model, pricing_db);
-        if cost.is_nan() {
-            continue;
-        }
-        total += cost;
-        any_known = true;
-    }
-    if any_known { total } else { f64::NAN }
-}
-
-/// Borrowed item with precomputed total cost.
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct CostedRef<'a, T> {
-    pub(crate) item: &'a T,
-    pub(crate) cost: f64,
-}
-
-/// Attach precomputed costs to a slice of items.
-pub(crate) fn attach_costs<'a, T, F>(
-    items: &'a [T],
-    mut models_of: F,
-    pricing_db: &PricingDb,
-) -> Vec<CostedRef<'a, T>>
-where
-    F: FnMut(&T) -> &HashMap<String, Stats>,
-{
-    items
-        .iter()
-        .map(|item| CostedRef {
-            item,
-            cost: sum_model_costs(models_of(item), pricing_db),
-        })
-        .collect()
-}
-
 #[cfg(test)]
 #[allow(clippy::float_cmp)]
 mod tests {
     use super::*;
+    use crate::core::Stats;
+    use crate::pricing::{attach_costs, calculate_cost, sum_model_costs};
     use serde_json::json;
     use std::fs;
     use std::path::PathBuf;
@@ -399,6 +337,7 @@ mod tests {
             reasoning_tokens: 0,
             count: 1,
             skipped_chunks: 0,
+            estimated_proxy: crate::core::CostTokens::default(),
         };
 
         let cost = calculate_cost(&stats, "sonnet-4", &db);
@@ -428,6 +367,7 @@ mod tests {
             reasoning_tokens: 0,
             count: 1,
             skipped_chunks: 0,
+            estimated_proxy: crate::core::CostTokens::default(),
         };
 
         let cost = calculate_cost(&stats, "sonnet-4", &db);

--- a/src/pricing/mod.rs
+++ b/src/pricing/mod.rs
@@ -1,9 +1,15 @@
 mod cache;
+mod cost;
 pub(crate) mod currency;
 mod db;
 mod provider;
 mod resolver;
 mod types;
 
+pub(crate) use cost::{
+    CostDisplayMode, attach_costs, calculate_cost, calculate_display_cost,
+    calculate_estimated_proxy_cost, model_cost_kind, sum_display_model_costs,
+    sum_estimated_proxy_model_costs, sum_model_costs,
+};
 pub(crate) use currency::CurrencyConverter;
-pub(crate) use db::{PricingDb, attach_costs, calculate_cost, sum_model_costs};
+pub(crate) use db::PricingDb;

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -12,7 +12,10 @@ use thiserror::Error;
 
 use crate::config::Config;
 use crate::core::{DateFilter, DayStats, LoadResult, Stats};
-use crate::pricing::{CurrencyConverter, PricingDb, calculate_cost, sum_model_costs};
+use crate::pricing::{
+    CurrencyConverter, PricingDb, calculate_cost, calculate_estimated_proxy_cost, model_cost_kind,
+    sum_estimated_proxy_model_costs, sum_model_costs,
+};
 use crate::source::{Source, get_source, load_daily};
 use crate::utils::Timezone;
 
@@ -179,6 +182,9 @@ pub struct ModelCostSummary {
     pub model: String,
     pub cost: Option<f64>,
     pub cost_usd: Option<f64>,
+    pub estimated_cost: Option<f64>,
+    pub estimated_cost_usd: Option<f64>,
+    pub cost_kind: String,
     pub tokens: TokenBreakdown,
 }
 
@@ -194,6 +200,9 @@ pub struct CostSummary {
     pub currency: String,
     pub cost: Option<f64>,
     pub cost_usd: Option<f64>,
+    pub estimated_cost: Option<f64>,
+    pub estimated_cost_usd: Option<f64>,
+    pub cost_kind: String,
     pub tokens: TokenBreakdown,
     pub models: Vec<ModelCostSummary>,
     pub valid_entries: i64,
@@ -317,6 +326,8 @@ pub(in crate::sdk) fn build_cost_summary(
 ) -> CostSummary {
     let (stats, models) = merge_days(&result.day_stats);
     let cost_usd = finite_cost(sum_model_costs(&models, pricing_db));
+    let estimated_cost_usd =
+        finite_positive_cost(sum_estimated_proxy_model_costs(&models, pricing_db));
 
     CostSummary {
         source: usage_source,
@@ -328,6 +339,9 @@ pub(in crate::sdk) fn build_cost_summary(
         currency: currency_code.to_string(),
         cost: convert_cost(cost_usd, currency),
         cost_usd,
+        estimated_cost: convert_cost(estimated_cost_usd, currency),
+        estimated_cost_usd,
+        cost_kind: model_cost_kind(&models).as_str().to_string(),
         tokens: TokenBreakdown::from_stats(&stats),
         models: summarize_models(&models, pricing_db, currency),
         valid_entries: result.valid,
@@ -356,6 +370,10 @@ fn merge_days(day_stats: &HashMap<String, DayStats>) -> (Stats, HashMap<String, 
 
 fn finite_cost(cost: f64) -> Option<f64> {
     cost.is_finite().then_some(cost)
+}
+
+fn finite_positive_cost(cost: f64) -> Option<f64> {
+    (cost.is_finite() && cost > 0.0).then_some(cost)
 }
 
 fn convert_cost(cost_usd: Option<f64>, currency: Option<&CurrencyConverter>) -> Option<f64> {
@@ -389,10 +407,15 @@ fn summarize_models(
         .iter()
         .map(|(model, stats)| {
             let cost_usd = finite_cost(calculate_cost(stats, model, pricing_db));
+            let estimated_cost_usd =
+                finite_positive_cost(calculate_estimated_proxy_cost(stats, model, pricing_db));
             ModelCostSummary {
                 model: model.clone(),
                 cost: convert_cost(cost_usd, currency),
                 cost_usd,
+                estimated_cost: convert_cost(estimated_cost_usd, currency),
+                estimated_cost_usd,
+                cost_kind: stats.cost_kind().as_str().to_string(),
                 tokens: TokenBreakdown::from_stats(stats),
             }
         })

--- a/src/sdk/batch.rs
+++ b/src/sdk/batch.rs
@@ -359,6 +359,7 @@ mod tests {
                     cache_read: 0,
                     reasoning_tokens: 0,
                     stop_reason: Some("complete".to_string()),
+                    cost_kind: crate::core::CostKind::Real,
                 }],
                 errors: 0,
             }

--- a/src/source/claude/parser.rs
+++ b/src/source/claude/parser.rs
@@ -315,6 +315,7 @@ fn parse_entry_with_debug(
         cache_read: non_negative_tokens(usage.cache_read_input_tokens),
         reasoning_tokens: 0, // Claude doesn't have reasoning tokens
         stop_reason: msg.stop_reason,
+        cost_kind: crate::core::CostKind::Real,
     })
 }
 

--- a/src/source/codex/parser.rs
+++ b/src/source/codex/parser.rs
@@ -540,6 +540,7 @@ fn push_codex_entry(
         cache_read,
         reasoning_tokens,
         stop_reason: Some("complete".to_string()), // Codex events are always complete
+        cost_kind: crate::core::CostKind::Real,
     });
 }
 

--- a/src/source/cursor/parser.rs
+++ b/src/source/cursor/parser.rs
@@ -257,6 +257,7 @@ fn entry_from_bubble(
         cache_read: 0,
         reasoning_tokens: 0,
         stop_reason: Some("complete".to_string()),
+        cost_kind: crate::core::CostKind::Real,
     })
 }
 
@@ -305,6 +306,7 @@ fn entry_from_generation(generation: &Value, path: &Path, timezone: Timezone) ->
         cache_read: 0,
         reasoning_tokens: 0,
         stop_reason: Some("complete".to_string()),
+        cost_kind: crate::core::CostKind::Real,
     })
 }
 

--- a/src/source/grok/parser.rs
+++ b/src/source/grok/parser.rs
@@ -14,7 +14,7 @@ use chrono::{DateTime, Utc};
 use serde::Deserialize;
 
 use crate::consts::{DATE_FORMAT, UNKNOWN};
-use crate::core::RawEntry;
+use crate::core::{CostKind, RawEntry};
 use crate::source::ParseOutput;
 use crate::utils::Timezone;
 
@@ -356,6 +356,7 @@ pub(super) fn parse_grok_signal_file_with_debug(
             cache_read: 0,
             reasoning_tokens: 0,
             stop_reason: Some("context_snapshot".to_string()),
+            cost_kind: CostKind::EstimatedProxy,
         }],
         errors,
     }

--- a/src/source/loader.rs
+++ b/src/source/loader.rs
@@ -560,6 +560,7 @@ mod tests {
             cache_read: 0,
             reasoning_tokens: 0,
             stop_reason: Some("end_turn".to_string()),
+            cost_kind: crate::core::CostKind::Real,
         }
     }
 

--- a/src/source/loader_quality_tests.rs
+++ b/src/source/loader_quality_tests.rs
@@ -58,6 +58,7 @@ fn entry(id: &str, input_tokens: i64) -> RawEntry {
         cache_read: 0,
         reasoning_tokens: 0,
         stop_reason: Some("end_turn".to_string()),
+        cost_kind: crate::core::CostKind::Real,
     }
 }
 

--- a/tests/cli_grok_cursor.rs
+++ b/tests/cli_grok_cursor.rs
@@ -1,5 +1,6 @@
 mod common;
 
+use chrono::Utc;
 use common::{run_ccstats, unique_temp_dir, write_file};
 use rusqlite::Connection;
 use serde_json::Value;
@@ -35,6 +36,10 @@ fn write_cursor_state_db(path: &Path) {
 }
 
 fn write_grok_session(grok_home: &Path) {
+    write_grok_session_at(grok_home, "2026-02-06T09:00:00Z", "2026-02-06T10:00:00Z");
+}
+
+fn write_grok_session_at(grok_home: &Path, created_at: &str, updated_at: &str) {
     let session_dir = grok_home
         .join("sessions")
         .join("%2Ftmp%2Fgrok-project")
@@ -50,12 +55,14 @@ fn write_grok_session(grok_home: &Path) {
     );
     write_file(
         &session_dir.join("summary.json"),
-        r#"{
-  "created_at": "2026-02-06T09:00:00Z",
-  "updated_at": "2026-02-06T10:00:00Z",
+        &format!(
+            r#"{{
+  "created_at": "{created_at}",
+  "updated_at": "{updated_at}",
   "current_model_id": "grok-build",
   "git_root_dir": "/tmp/grok-project/"
-}"#,
+}}"#
+        ),
     );
 }
 
@@ -78,6 +85,27 @@ fn write_grok_update_only_session(grok_home: &Path) {
         r#"{"timestamp":1779096277,"params":{"sessionId":"grok-update-only","_meta":{"updateType":"AvailableCommandsUpdate","totalTokens":100}}}
 {"timestamp":1779096277,"params":{"sessionId":"grok-update-only","_meta":{"updateType":"AvailableCommandsUpdate","totalTokens":250}}}
 "#,
+    );
+}
+
+fn write_claude_session(root: &Path) {
+    write_claude_session_at(root, "2026-02-06T10:00:00Z");
+}
+
+fn write_claude_session_at(root: &Path, timestamp: &str) {
+    write_file(
+        &root.join(".claude/projects/mixed/session.jsonl"),
+        &format!(
+            r#"{{"timestamp":"{timestamp}","message":{{"id":"msg_real","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{{"input_tokens":1000000,"output_tokens":100000,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}}}}
+"#
+        ),
+    );
+}
+
+fn assert_close(actual: f64, expected: f64) {
+    assert!(
+        (actual - expected).abs() < 0.000_001,
+        "expected {expected}, got {actual}"
     );
 }
 
@@ -157,6 +185,212 @@ fn source_flag_can_select_grok_without_subcommand() {
         arr[0]["models"].as_array().unwrap()[0].as_str(),
         Some("grok-build")
     );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn grok_daily_json_marks_estimated_proxy_cost() {
+    let root = unique_temp_dir("grok-estimated-json");
+    let grok_home = root.join("grok-home");
+    write_grok_session(&grok_home);
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "grok",
+            "daily",
+            "-j",
+            "-O",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("GROK_HOME", &grok_home)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    let arr = json.as_array().expect("array output");
+    assert_eq!(arr[0]["cost_kind"].as_str(), Some("estimated_proxy"));
+    assert_close(arr[0]["cost"].as_f64().unwrap(), 0.0015);
+    assert_close(arr[0]["estimated_cost"].as_f64().unwrap(), 0.0015);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn grok_daily_csv_marks_estimated_proxy_cost() {
+    let root = unique_temp_dir("grok-estimated-csv");
+    let grok_home = root.join("grok-home");
+    write_grok_session(&grok_home);
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "grok",
+            "daily",
+            "--csv",
+            "-O",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("GROK_HOME", &grok_home)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let output = String::from_utf8(stdout).expect("utf8 stdout");
+    let lines: Vec<&str> = output.lines().collect();
+    assert!(lines[0].ends_with(",cost,cost_kind,estimated_cost"));
+    assert!(
+        lines[1].ends_with(",0.001500,estimated_proxy,0.001500"),
+        "stdout: {output}"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn all_sources_json_separates_real_and_grok_estimated_cost() {
+    let root = unique_temp_dir("all-sources-grok-estimated");
+    let grok_home = root.join("grok-home");
+    write_claude_session(&root);
+    write_grok_session(&grok_home);
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "--source",
+            "all",
+            "-j",
+            "-O",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("HOME", &root), ("GROK_HOME", &grok_home)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    let arr = json.as_array().expect("array output");
+    assert_eq!(arr[0]["cost_kind"].as_str(), Some("mixed"));
+    assert_close(arr[0]["cost"].as_f64().unwrap(), 4.5);
+    assert_close(arr[0]["estimated_cost"].as_f64().unwrap(), 0.0015);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn all_sources_statusline_json_excludes_grok_estimated_cost() {
+    let root = unique_temp_dir("all-statusline-grok-estimated");
+    let grok_home = root.join("grok-home");
+    let today = Utc::now().format("%Y-%m-%dT12:00:00Z").to_string();
+    write_claude_session_at(&root, &today);
+    write_grok_session_at(&grok_home, &today, &today);
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "statusline",
+            "--source",
+            "all",
+            "-j",
+            "-O",
+            "--timezone",
+            "UTC",
+        ],
+        &[("HOME", &root), ("GROK_HOME", &grok_home)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    assert_eq!(json["cost_kind"].as_str(), Some("mixed"));
+    assert_close(json["cost"].as_f64().unwrap(), 4.5);
+    assert_close(json["estimated_cost"].as_f64().unwrap(), 0.0015);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn all_sources_top_json_exposes_grok_estimate_without_real_cost() {
+    let root = unique_temp_dir("all-top-grok-estimated");
+    let grok_home = root.join("grok-home");
+    write_claude_session(&root);
+    write_grok_session(&grok_home);
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "top",
+            "--source",
+            "all",
+            "--dim",
+            "model",
+            "-j",
+            "-O",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("HOME", &root), ("GROK_HOME", &grok_home)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    let entries = json["entries"].as_array().expect("entries");
+    let grok = entries
+        .iter()
+        .find(|entry| entry["name"].as_str() == Some("grok-build"))
+        .expect("grok row");
+    assert_eq!(grok["cost_kind"].as_str(), Some("estimated_proxy"));
+    assert_close(grok["cost_usd"].as_f64().unwrap(), 0.0);
+    assert_close(grok["estimated_cost_usd"].as_f64().unwrap(), 0.0015);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn all_sources_monthly_budget_uses_real_cost_only() {
+    let root = unique_temp_dir("all-budget-grok-estimated");
+    let grok_home = root.join("grok-home");
+    write_claude_session(&root);
+    write_grok_session(&grok_home);
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "monthly",
+            "--source",
+            "all",
+            "-j",
+            "-O",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-01",
+            "--until",
+            "2026-02-28",
+            "--monthly-budget",
+            "10",
+        ],
+        &[("HOME", &root), ("GROK_HOME", &grok_home)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    let arr = json.as_array().expect("array output");
+    assert_close(arr[0]["cost"].as_f64().unwrap(), 4.5);
+    assert_close(arr[0]["estimated_cost"].as_f64().unwrap(), 0.0015);
+    assert_close(arr[0]["budget"]["spent"].as_f64().unwrap(), 4.5);
 
     let _ = fs::remove_dir_all(root);
 }

--- a/tests/sdk_integration.rs
+++ b/tests/sdk_integration.rs
@@ -33,6 +33,9 @@ fn assert_stable_summary_eq(actual: &CostSummary, expected: &CostSummary) {
     assert_eq!(actual.currency, expected.currency);
     assert_eq!(actual.cost, expected.cost);
     assert_eq!(actual.cost_usd, expected.cost_usd);
+    assert_eq!(actual.estimated_cost, expected.estimated_cost);
+    assert_eq!(actual.estimated_cost_usd, expected.estimated_cost_usd);
+    assert_eq!(actual.cost_kind, expected.cost_kind);
     assert_eq!(actual.tokens, expected.tokens);
     assert_eq!(actual.models, expected.models);
     assert_eq!(actual.valid_entries, expected.valid_entries);
@@ -399,4 +402,11 @@ fn sdk_summarizes_grok_context_tokens_without_running_cli() {
     assert_eq!(summary.models.len(), 1);
     assert_eq!(summary.models[0].model, "grok-build");
     assert!(summary.cost_usd.is_some_and(|cost| cost > 0.0));
+    assert_eq!(summary.cost_kind, "estimated_proxy");
+    assert_eq!(summary.estimated_cost_usd, summary.cost_usd);
+    assert_eq!(summary.models[0].cost_kind, "estimated_proxy");
+    assert_eq!(
+        summary.models[0].estimated_cost_usd,
+        summary.models[0].cost_usd
+    );
 }


### PR DESCRIPTION
## Summary

Fixes #35.

- add per-entry and aggregate cost provenance (`real`, `estimated_proxy`, `mixed`) so Grok context proxy costs do not masquerade as real spend
- use real-only display mode for `--source all` period totals, statusline, top ranking, and monthly-budget spending while exposing estimated proxy cost separately
- add JSON/CSV/table/statusline/top/SDK fields or footnotes that preserve existing shapes and make estimated costs machine-distinguishable

## Verification

- `cargo fmt --check`
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH35`
- `git diff --check`
- `python3 checks/route_gate.py --repo . --route implement --issue 35 --evidence /tmp/ccstats-gh35-evidence-fresh.json --json`

## SpecRail

- Route: `implement`
- Issue state: `ready_to_implement`
- Spec packet: `specs/GH35/{product.md,tech.md,tasks.md}`
