### PR TITLE
Expose pricing source metadata

### DIFF
--- a/src/output/blocks.rs
+++ b/src/output/blocks.rs
@@ -6,6 +6,7 @@ use crate::output::format::{
     NumberFormat, cost_json_value, create_styled_table, format_compact, format_cost, format_number,
     header_cell, right_cell, styled_cell,
 };
+use crate::output::pricing_meta;
 use crate::pricing::{
     CurrencyConverter, PricingDb, model_cost_kind, sum_estimated_proxy_model_costs, sum_model_costs,
 };
@@ -211,6 +212,12 @@ pub(crate) fn print_block_table(
             format_cost(total_estimated_cost, options.currency)
         );
     }
+    if show_cost
+        && let Some(note) =
+            pricing_meta::note_for_maps(sorted_blocks.iter().map(|block| &block.models), pricing_db)
+    {
+        println!("\n  {note}");
+    }
     println!(
         "\n  {} blocks\n",
         format_number(sorted_blocks.len() as i64, number_format)
@@ -250,6 +257,7 @@ pub(crate) fn output_block_json(
             });
             if show_cost {
                 obj["cost"] = cost_json_value(block_cost, currency);
+                pricing_meta::add_json(&mut obj, &block.models, pricing_db);
                 let estimated_cost = sum_estimated_proxy_model_costs(&block.models, pricing_db);
                 if estimated_cost > 0.0 {
                     obj["cost_kind"] = serde_json::json!(model_cost_kind(&block.models).as_str());

--- a/src/output/budget.rs
+++ b/src/output/budget.rs
@@ -8,7 +8,10 @@ use crate::cli::SortOrder;
 use crate::core::DayStats;
 use crate::output::format::{create_styled_table, header_cell, right_cell, styled_cell};
 use crate::output::period::{Period, aggregate_day_stats_by_period};
-use crate::pricing::{CostDisplayMode, CurrencyConverter, PricingDb, sum_display_model_costs};
+use crate::pricing::{
+    CostDisplayMode, CurrencyConverter, PricingDb, PricingSource, pricing_source_for_models,
+    sum_display_model_costs,
+};
 
 #[derive(Debug, Clone)]
 pub(crate) struct MonthlyBudgetReport {
@@ -22,6 +25,9 @@ pub(crate) struct MonthlyBudgetReport {
     pub(crate) days_elapsed: u32,
     pub(crate) days_in_month: u32,
     pub(crate) status: &'static str,
+    pub(crate) pricing_source: PricingSource,
+    pub(crate) pricing_cache_age_seconds: Option<u64>,
+    pub(crate) pricing_cache_mtime_epoch_seconds: Option<u64>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -90,7 +96,14 @@ fn budget_status(spent: f64, projected: f64, projected_pct: f64, limit: f64) -> 
     }
 }
 
-fn budget_report(month: String, spent: f64, limit: f64, as_of: NaiveDate) -> MonthlyBudgetReport {
+fn budget_report(
+    month: String,
+    spent: f64,
+    limit: f64,
+    as_of: NaiveDate,
+    pricing_source: PricingSource,
+    pricing_db: &PricingDb,
+) -> MonthlyBudgetReport {
     let (days_elapsed, days_in_month) = budget_days(&month, as_of);
     let projected = if spent.is_nan() || days_elapsed >= days_in_month {
         spent
@@ -117,6 +130,9 @@ fn budget_report(month: String, spent: f64, limit: f64, as_of: NaiveDate) -> Mon
         days_elapsed,
         days_in_month,
         status,
+        pricing_source,
+        pricing_cache_age_seconds: pricing_db.cache_age_seconds(),
+        pricing_cache_mtime_epoch_seconds: pricing_db.cache_modified_epoch_seconds(),
     }
 }
 
@@ -144,7 +160,15 @@ pub(crate) fn monthly_budget_reports(
                     sum_display_model_costs(&stats.models, pricing_db, cost_mode),
                     currency,
                 );
-                budget_report(month.clone(), spent, monthly_budget, as_of)
+                let pricing_source = pricing_source_for_models(&stats.models, pricing_db);
+                budget_report(
+                    month.clone(),
+                    spent,
+                    monthly_budget,
+                    as_of,
+                    pricing_source,
+                    pricing_db,
+                )
             })
         })
         .collect()
@@ -178,6 +202,27 @@ fn report_json(report: &MonthlyBudgetReport) -> Value {
         serde_json::json!(report.days_in_month),
     );
     obj.insert("status".to_string(), serde_json::json!(report.status));
+    obj.insert(
+        "pricing_source".to_string(),
+        serde_json::json!(report.pricing_source.as_str()),
+    );
+    if matches!(
+        report.pricing_source,
+        PricingSource::Cache | PricingSource::CacheStale | PricingSource::Mixed
+    ) {
+        if let Some(age) = report.pricing_cache_age_seconds {
+            obj.insert(
+                "pricing_cache_age_seconds".to_string(),
+                serde_json::json!(age),
+            );
+        }
+        if let Some(mtime) = report.pricing_cache_mtime_epoch_seconds {
+            obj.insert(
+                "pricing_cache_mtime_epoch_seconds".to_string(),
+                serde_json::json!(mtime),
+            );
+        }
+    }
     Value::Object(obj)
 }
 
@@ -270,6 +315,49 @@ pub(crate) fn print_monthly_budget_table(
 
     println!("\n  Monthly Budget Forecast\n");
     println!("{table}");
+    if let Some(note) = budget_pricing_note(reports) {
+        println!("\n  {note}");
+    }
+}
+
+fn budget_pricing_note(reports: &[MonthlyBudgetReport]) -> Option<String> {
+    let source = reports
+        .iter()
+        .map(|report| report.pricing_source)
+        .reduce(PricingSource::combine)?;
+    match source {
+        PricingSource::Live => None,
+        PricingSource::Cache => Some(format!(
+            "Pricing source: cache{}.",
+            report_cache_suffix(reports)
+        )),
+        PricingSource::CacheStale => Some(format!(
+            "Pricing source: stale cache{}.",
+            report_cache_suffix(reports)
+        )),
+        PricingSource::Fallback => Some("Pricing source: fallback estimates.".to_string()),
+        PricingSource::Mixed => Some(format!(
+            "Pricing source: mixed{}.",
+            report_cache_suffix(reports)
+        )),
+    }
+}
+
+fn report_cache_suffix(reports: &[MonthlyBudgetReport]) -> String {
+    let Some(age) = reports
+        .iter()
+        .find_map(|report| report.pricing_cache_age_seconds)
+    else {
+        return String::new();
+    };
+    let hours = age as f64 / 3600.0;
+    match reports
+        .iter()
+        .find_map(|report| report.pricing_cache_mtime_epoch_seconds)
+    {
+        Some(mtime) => format!(" ({hours:.1}h old, mtime {mtime})"),
+        None => format!(" ({hours:.1}h old)"),
+    }
 }
 
 #[cfg(test)]
@@ -323,6 +411,8 @@ mod tests {
             4.5,
             10.0,
             NaiveDate::from_ymd_opt(2026, 2, 10).unwrap(),
+            PricingSource::Fallback,
+            &PricingDb::default(),
         );
         let json = r#"[{"month":"2026-02","cost":4.5}]"#;
         let output = add_monthly_budget_to_json(json, &[report]);

--- a/src/output/budget.rs
+++ b/src/output/budget.rs
@@ -336,6 +336,7 @@ fn budget_pricing_note(reports: &[MonthlyBudgetReport]) -> Option<String> {
             report_cache_suffix(reports)
         )),
         PricingSource::Fallback => Some("Pricing source: fallback estimates.".to_string()),
+        PricingSource::Unknown => Some("Pricing source: unknown unpriced models.".to_string()),
         PricingSource::Mixed => Some(format!(
             "Pricing source: mixed{}.",
             report_cache_suffix(reports)

--- a/src/output/csv.rs
+++ b/src/output/csv.rs
@@ -7,10 +7,11 @@ use crate::core::{BlockStats, DataQuality, DayStats, ProjectStats, SessionStats}
 use crate::output::budget::{MonthlyBudgetOptions, MonthlyBudgetReport, monthly_budget_reports};
 use crate::output::format::{compare_cost, csv_escape};
 use crate::output::period::{Period, aggregate_day_stats_by_period};
+use crate::output::pricing_meta;
 use crate::pricing::{
-    CostDisplayMode, CurrencyConverter, PricingDb, calculate_display_cost,
-    calculate_estimated_proxy_cost, model_cost_kind, sum_display_model_costs,
-    sum_estimated_proxy_model_costs, sum_model_costs,
+    CostDisplayMode, CurrencyConverter, PricingDb, PricingSource, calculate_display_cost,
+    calculate_estimated_proxy_cost, model_cost_kind, pricing_source_for_model_maps,
+    sum_display_model_costs, sum_estimated_proxy_model_costs, sum_model_costs,
 };
 
 #[cfg(test)]
@@ -69,6 +70,10 @@ pub(crate) fn output_period_csv_with_quality(
         show_cost,
         currency,
         include_cost_kind: period_csv_includes_cost_kind(&rows, breakdown, show_cost),
+        pricing_source: pricing_source_for_model_maps(
+            rows.iter().map(|(_, stats)| &stats.models),
+            pricing_db,
+        ),
         cost_mode,
     };
     if breakdown {
@@ -87,6 +92,7 @@ struct PeriodCsvContext<'a> {
     show_cost: bool,
     currency: Option<&'a CurrencyConverter>,
     include_cost_kind: bool,
+    pricing_source: crate::pricing::PricingSource,
     cost_mode: CostDisplayMode,
 }
 
@@ -114,6 +120,7 @@ fn write_period_cost_header(out: &mut String, ctx: &PeriodCsvContext<'_>) {
         if ctx.include_cost_kind {
             let _ = write!(out, ",cost_kind,estimated_cost");
         }
+        pricing_meta::append_source_csv_header(out, ctx.pricing_source, ctx.pricing_db);
     }
     out.push('\n');
 }
@@ -160,6 +167,12 @@ fn write_period_csv_breakdown(
                         csv_cost(estimated_cost, ctx.currency)
                     );
                 }
+                pricing_meta::append_model_csv_fields(
+                    out,
+                    model,
+                    ctx.pricing_db,
+                    pricing_meta::csv_has_cache_fields(ctx.pricing_source, ctx.pricing_db),
+                );
             }
             out.push('\n');
         }
@@ -202,6 +215,12 @@ fn write_period_csv_standard(
                     csv_cost(estimated_cost, ctx.currency)
                 );
             }
+            pricing_meta::append_csv_fields(
+                out,
+                &stats.models,
+                ctx.pricing_db,
+                pricing_meta::csv_has_cache_fields(ctx.pricing_source, ctx.pricing_db),
+            );
         }
         out.push('\n');
     }
@@ -262,6 +281,17 @@ fn write_budget_fields(out: &mut String, report: &MonthlyBudgetReport) {
     );
 }
 
+fn budget_csv_pricing_source(
+    reports: &[MonthlyBudgetReport],
+    pricing_db: &PricingDb,
+) -> PricingSource {
+    reports
+        .iter()
+        .map(|report| report.pricing_source)
+        .reduce(PricingSource::combine)
+        .unwrap_or_else(|| pricing_db.source())
+}
+
 pub(crate) fn output_monthly_budget_csv(
     day_stats: &HashMap<String, DayStats>,
     pricing_db: &PricingDb,
@@ -278,6 +308,9 @@ pub(crate) fn output_monthly_budget_csv(
         options.cost_mode,
     );
     let mut out = String::new();
+    let pricing_source = budget_csv_pricing_source(&reports, pricing_db);
+    let include_pricing_cache_fields =
+        pricing_meta::csv_has_cache_fields(pricing_source, pricing_db);
 
     if options.breakdown {
         let _ = write!(
@@ -286,6 +319,7 @@ pub(crate) fn output_monthly_budget_csv(
         );
         if options.show_cost {
             let _ = write!(out, ",cost");
+            pricing_meta::append_source_csv_header(&mut out, pricing_source, pricing_db);
         }
         write_budget_header(&mut out);
         out.push('\n');
@@ -313,6 +347,12 @@ pub(crate) fn output_monthly_budget_csv(
                     let cost =
                         calculate_display_cost(model_stats, model, pricing_db, options.cost_mode);
                     let _ = write!(out, ",{}", csv_cost(cost, options.currency));
+                    pricing_meta::append_model_csv_fields(
+                        &mut out,
+                        model,
+                        pricing_db,
+                        include_pricing_cache_fields,
+                    );
                 }
                 write_budget_fields(&mut out, report);
                 out.push('\n');
@@ -325,6 +365,7 @@ pub(crate) fn output_monthly_budget_csv(
         );
         if options.show_cost {
             let _ = write!(out, ",cost");
+            pricing_meta::append_source_csv_header(&mut out, pricing_source, pricing_db);
         }
         write_budget_header(&mut out);
         out.push('\n');
@@ -347,6 +388,12 @@ pub(crate) fn output_monthly_budget_csv(
             if options.show_cost {
                 let cost = sum_display_model_costs(&stats.models, pricing_db, options.cost_mode);
                 let _ = write!(out, ",{}", csv_cost(cost, options.currency));
+                pricing_meta::append_csv_fields(
+                    &mut out,
+                    &stats.models,
+                    pricing_db,
+                    include_pricing_cache_fields,
+                );
             }
             write_budget_fields(&mut out, report);
             out.push('\n');
@@ -374,6 +421,10 @@ pub(crate) fn output_session_csv(
         && sorted
             .iter()
             .any(|session| sum_estimated_proxy_model_costs(&session.models, pricing_db) > 0.0);
+    let pricing_source =
+        pricing_source_for_model_maps(sorted.iter().map(|session| &session.models), pricing_db);
+    let include_pricing_cache_fields =
+        pricing_meta::csv_has_cache_fields(pricing_source, pricing_db);
     let _ = write!(
         out,
         "session_id,project_path,first_timestamp,last_timestamp,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,total_tokens"
@@ -383,6 +434,7 @@ pub(crate) fn output_session_csv(
         if include_cost_kind {
             let _ = write!(out, ",cost_kind,estimated_cost");
         }
+        pricing_meta::append_source_csv_header(&mut out, pricing_source, pricing_db);
     }
     out.push('\n');
 
@@ -413,6 +465,12 @@ pub(crate) fn output_session_csv(
                     csv_cost(estimated_cost, currency)
                 );
             }
+            pricing_meta::append_csv_fields(
+                &mut out,
+                &s.models,
+                pricing_db,
+                include_pricing_cache_fields,
+            );
         }
         out.push('\n');
     }
@@ -447,6 +505,10 @@ pub(crate) fn output_project_csv(
         && sorted
             .iter()
             .any(|project| sum_estimated_proxy_model_costs(&project.models, pricing_db) > 0.0);
+    let pricing_source =
+        pricing_source_for_model_maps(sorted.iter().map(|project| &project.models), pricing_db);
+    let include_pricing_cache_fields =
+        pricing_meta::csv_has_cache_fields(pricing_source, pricing_db);
     let _ = write!(
         out,
         "project_name,project_path,sessions,input_tokens,output_tokens,total_tokens"
@@ -456,6 +518,7 @@ pub(crate) fn output_project_csv(
         if include_cost_kind {
             let _ = write!(out, ",cost_kind,estimated_cost");
         }
+        pricing_meta::append_source_csv_header(&mut out, pricing_source, pricing_db);
     }
     out.push('\n');
 
@@ -482,6 +545,12 @@ pub(crate) fn output_project_csv(
                     csv_cost(estimated_cost, currency)
                 );
             }
+            pricing_meta::append_csv_fields(
+                &mut out,
+                &p.models,
+                pricing_db,
+                include_pricing_cache_fields,
+            );
         }
         out.push('\n');
     }
@@ -507,6 +576,10 @@ pub(crate) fn output_block_csv(
         && sorted
             .iter()
             .any(|block| sum_estimated_proxy_model_costs(&block.models, pricing_db) > 0.0);
+    let pricing_source =
+        pricing_source_for_model_maps(sorted.iter().map(|block| &block.models), pricing_db);
+    let include_pricing_cache_fields =
+        pricing_meta::csv_has_cache_fields(pricing_source, pricing_db);
     let _ = write!(
         out,
         "block_start,block_end,input_tokens,output_tokens,cache_creation_tokens,cache_read_tokens,total_tokens"
@@ -516,6 +589,7 @@ pub(crate) fn output_block_csv(
         if include_cost_kind {
             let _ = write!(out, ",cost_kind,estimated_cost");
         }
+        pricing_meta::append_source_csv_header(&mut out, pricing_source, pricing_db);
     }
     out.push('\n');
 
@@ -543,6 +617,12 @@ pub(crate) fn output_block_csv(
                     csv_cost(estimated_cost, currency)
                 );
             }
+            pricing_meta::append_csv_fields(
+                &mut out,
+                &b.models,
+                pricing_db,
+                include_pricing_cache_fields,
+            );
         }
         out.push('\n');
     }

--- a/src/output/csv_tests.rs
+++ b/src/output/csv_tests.rs
@@ -80,8 +80,9 @@ fn period_csv_daily_with_cost() {
     );
 
     let lines: Vec<&str> = csv.lines().collect();
-    assert!(lines[0].ends_with(",cost"));
+    assert!(lines[0].ends_with(",cost,pricing_source"));
     assert_eq!(lines.len(), 2);
+    assert!(lines[1].ends_with(",fallback"));
 }
 
 #[test]
@@ -107,7 +108,7 @@ fn period_csv_converts_cost_when_currency_is_set() {
     let lines: Vec<&str> = csv.lines().collect();
     assert_eq!(
         lines[1],
-        "2025-01-01,1000000,500000,0,0,0,1500000,73.500000"
+        "2025-01-01,1000000,500000,0,0,0,1500000,73.500000,fallback"
     );
 }
 
@@ -210,8 +211,9 @@ fn project_csv_structure() {
     let csv = output_project_csv(&projects, &db, SortOrder::Asc, true, None);
 
     let lines: Vec<&str> = csv.lines().collect();
-    assert!(lines[0].ends_with(",cost"));
+    assert!(lines[0].ends_with(",cost,pricing_source"));
     assert!(lines[1].starts_with("proj,"));
+    assert!(lines[1].ends_with(",fallback"));
 }
 
 #[test]
@@ -327,9 +329,10 @@ fn breakdown_csv_with_cost() {
     );
 
     let lines: Vec<&str> = csv.lines().collect();
-    assert!(lines[0].ends_with(",cost"));
+    assert!(lines[0].ends_with(",cost,pricing_source"));
     let fields: Vec<&str> = lines[1].split(',').collect();
-    assert_eq!(fields.len(), 9);
+    assert_eq!(fields.len(), 10);
+    assert_eq!(fields[9], "fallback");
 }
 
 #[test]

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -5,6 +5,7 @@ use crate::cli::SortOrder;
 use crate::core::{DataQuality, DayStats};
 use crate::output::format::cost_json_value;
 use crate::output::period::{Period, aggregate_day_stats_by_period};
+use crate::output::pricing_meta;
 use crate::pricing::{
     CostDisplayMode, CurrencyConverter, PricingDb, calculate_display_cost,
     calculate_estimated_proxy_cost, model_cost_kind, sum_display_model_costs,
@@ -77,6 +78,7 @@ fn build_period_entry(
                 );
                 period_cost += cost;
                 model_obj["cost"] = cost_json_value(cost, options.currency);
+                pricing_meta::add_model_json(&mut model_obj, model, options.pricing_db);
                 let estimated_cost =
                     calculate_estimated_proxy_cost(model_stats, model, options.pricing_db);
                 if estimated_cost > 0.0 {
@@ -101,6 +103,7 @@ fn build_period_entry(
         });
         if options.show_cost {
             obj["cost"] = cost_json_value(period_cost, options.currency);
+            pricing_meta::add_json(&mut obj, &stats.models, options.pricing_db);
             let estimated_cost = sum_estimated_proxy_model_costs(&stats.models, options.pricing_db);
             if estimated_cost > 0.0 {
                 obj["cost_kind"] = serde_json::json!(model_cost_kind(&stats.models).as_str());
@@ -132,6 +135,7 @@ fn build_period_entry(
         });
         if options.show_cost {
             obj["cost"] = cost_json_value(period_cost.unwrap_or(0.0), options.currency);
+            pricing_meta::add_json(&mut obj, &stats.models, options.pricing_db);
             let estimated_cost = sum_estimated_proxy_model_costs(&stats.models, options.pricing_db);
             if estimated_cost > 0.0 {
                 obj["cost_kind"] = serde_json::json!(model_cost_kind(&stats.models).as_str());

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -4,12 +4,14 @@ mod csv;
 mod format;
 mod json;
 mod period;
+mod pricing_meta;
 mod project;
 mod session;
 mod statusline;
 mod table;
 mod tools;
 mod top;
+mod top_structured;
 
 /// Central selector for supported CLI output modes.
 ///
@@ -41,6 +43,7 @@ pub(crate) use statusline::{print_statusline, print_statusline_json_with_quality
 pub(crate) use table::{PeriodSummaryFooter, TokenTableOptions, print_period_table};
 pub(crate) use tools::{output_tools_csv, output_tools_json, print_tools_table};
 pub(crate) use top::{
-    TopRow, TopTableOptions, output_top_csv, output_top_json, print_top_table, rank_by_model,
-    rank_by_model_with_cost_mode, rank_by_project,
+    TopRow, TopTableOptions, print_top_table, rank_by_model, rank_by_model_with_cost_mode,
+    rank_by_project,
 };
+pub(crate) use top_structured::{output_top_csv, output_top_json};

--- a/src/output/pricing_meta.rs
+++ b/src/output/pricing_meta.rs
@@ -27,7 +27,7 @@ pub(super) fn add_json(
 pub(super) fn add_model_json(obj: &mut serde_json::Value, model: &str, pricing_db: &PricingDb) {
     let source = pricing_db
         .pricing_source_for_model(model)
-        .unwrap_or_else(|| pricing_db.source());
+        .unwrap_or(PricingSource::Unknown);
     add_source_json(obj, source, pricing_db);
 }
 
@@ -96,7 +96,7 @@ pub(super) fn append_model_csv_fields(
 ) {
     let source = pricing_db
         .pricing_source_for_model(model)
-        .unwrap_or_else(|| pricing_db.source());
+        .unwrap_or(PricingSource::Unknown);
     append_source_csv_fields(out, source, pricing_db, include_cache_fields);
 }
 
@@ -134,6 +134,7 @@ pub(super) fn note(source: PricingSource, pricing_db: &PricingDb) -> Option<Stri
             cache_age_suffix(pricing_db)
         )),
         PricingSource::Fallback => Some("Pricing source: fallback estimates.".to_string()),
+        PricingSource::Unknown => Some("Pricing source: unknown unpriced models.".to_string()),
         PricingSource::Mixed => Some(format!(
             "Pricing source: mixed{}.",
             cache_age_suffix(pricing_db)

--- a/src/output/pricing_meta.rs
+++ b/src/output/pricing_meta.rs
@@ -1,0 +1,160 @@
+use std::{collections::HashMap, fmt::Write};
+
+use crate::core::Stats;
+use crate::pricing::{
+    PricingDb, PricingSource, pricing_source_for_model_maps, pricing_source_for_models,
+};
+
+fn needs_cache_fields(source: PricingSource, pricing_db: &PricingDb) -> bool {
+    matches!(
+        source,
+        PricingSource::Cache | PricingSource::CacheStale | PricingSource::Mixed
+    ) && pricing_db.cache_age_seconds().is_some()
+}
+
+pub(super) fn add_json(
+    obj: &mut serde_json::Value,
+    models: &HashMap<String, Stats>,
+    pricing_db: &PricingDb,
+) {
+    add_source_json(
+        obj,
+        pricing_source_for_models(models, pricing_db),
+        pricing_db,
+    );
+}
+
+pub(super) fn add_model_json(obj: &mut serde_json::Value, model: &str, pricing_db: &PricingDb) {
+    let source = pricing_db
+        .pricing_source_for_model(model)
+        .unwrap_or_else(|| pricing_db.source());
+    add_source_json(obj, source, pricing_db);
+}
+
+pub(super) fn add_json_for_maps<'a>(
+    obj: &mut serde_json::Value,
+    maps: impl IntoIterator<Item = &'a HashMap<String, Stats>>,
+    pricing_db: &PricingDb,
+) {
+    add_source_json(
+        obj,
+        pricing_source_for_model_maps(maps, pricing_db),
+        pricing_db,
+    );
+}
+
+pub(super) fn add_source_json(
+    obj: &mut serde_json::Value,
+    source: PricingSource,
+    pricing_db: &PricingDb,
+) {
+    obj["pricing_source"] = serde_json::json!(source.as_str());
+    if needs_cache_fields(source, pricing_db) {
+        if let Some(age) = pricing_db.cache_age_seconds() {
+            obj["pricing_cache_age_seconds"] = serde_json::json!(age);
+        }
+        if let Some(mtime) = pricing_db.cache_modified_epoch_seconds() {
+            obj["pricing_cache_mtime_epoch_seconds"] = serde_json::json!(mtime);
+        }
+    }
+}
+
+pub(super) fn csv_has_cache_fields(source: PricingSource, pricing_db: &PricingDb) -> bool {
+    needs_cache_fields(source, pricing_db)
+}
+
+pub(super) fn append_source_csv_header(
+    out: &mut String,
+    source: PricingSource,
+    pricing_db: &PricingDb,
+) {
+    out.push_str(",pricing_source");
+    if csv_has_cache_fields(source, pricing_db) {
+        out.push_str(",pricing_cache_age_seconds,pricing_cache_mtime_epoch_seconds");
+    }
+}
+
+pub(super) fn append_csv_fields(
+    out: &mut String,
+    models: &HashMap<String, Stats>,
+    pricing_db: &PricingDb,
+    include_cache_fields: bool,
+) {
+    append_source_csv_fields(
+        out,
+        pricing_source_for_models(models, pricing_db),
+        pricing_db,
+        include_cache_fields,
+    );
+}
+
+pub(super) fn append_model_csv_fields(
+    out: &mut String,
+    model: &str,
+    pricing_db: &PricingDb,
+    include_cache_fields: bool,
+) {
+    let source = pricing_db
+        .pricing_source_for_model(model)
+        .unwrap_or_else(|| pricing_db.source());
+    append_source_csv_fields(out, source, pricing_db, include_cache_fields);
+}
+
+pub(super) fn append_source_csv_fields(
+    out: &mut String,
+    source: PricingSource,
+    pricing_db: &PricingDb,
+    include_cache_fields: bool,
+) {
+    out.push(',');
+    out.push_str(source.as_str());
+    if !include_cache_fields {
+        return;
+    }
+    if needs_cache_fields(source, pricing_db) {
+        let age = pricing_db.cache_age_seconds().unwrap_or_default();
+        let mtime = pricing_db
+            .cache_modified_epoch_seconds()
+            .unwrap_or_default();
+        let _ = write!(out, ",{age},{mtime}");
+    } else {
+        out.push_str(",,");
+    }
+}
+
+pub(super) fn note(source: PricingSource, pricing_db: &PricingDb) -> Option<String> {
+    match source {
+        PricingSource::Live => None,
+        PricingSource::Cache => Some(format!(
+            "Pricing source: cache{}.",
+            cache_age_suffix(pricing_db)
+        )),
+        PricingSource::CacheStale => Some(format!(
+            "Pricing source: stale cache{}.",
+            cache_age_suffix(pricing_db)
+        )),
+        PricingSource::Fallback => Some("Pricing source: fallback estimates.".to_string()),
+        PricingSource::Mixed => Some(format!(
+            "Pricing source: mixed{}.",
+            cache_age_suffix(pricing_db)
+        )),
+    }
+}
+
+pub(super) fn note_for_maps<'a>(
+    maps: impl IntoIterator<Item = &'a HashMap<String, Stats>>,
+    pricing_db: &PricingDb,
+) -> Option<String> {
+    note(pricing_source_for_model_maps(maps, pricing_db), pricing_db)
+}
+
+fn cache_age_suffix(pricing_db: &PricingDb) -> String {
+    let Some(age) = pricing_db.cache_age_seconds() else {
+        return String::new();
+    };
+    let hours = age as f64 / 3600.0;
+    match pricing_db.cache_modified_epoch_seconds() {
+        Some(mtime) => format!(" ({hours:.1}h old, mtime {mtime})"),
+        None => format!(" ({hours:.1}h old)"),
+    }
+}

--- a/src/output/project.rs
+++ b/src/output/project.rs
@@ -6,6 +6,7 @@ use crate::output::format::{
     NumberFormat, compare_cost, cost_json_value, create_styled_table, format_compact, format_cost,
     format_number, header_cell, right_cell, styled_cell,
 };
+use crate::output::pricing_meta;
 use crate::pricing::{
     CurrencyConverter, PricingDb, attach_costs, model_cost_kind, sum_estimated_proxy_model_costs,
 };
@@ -213,6 +214,14 @@ pub(crate) fn print_project_table(
             format_cost(total_estimated_cost, options.currency)
         );
     }
+    if show_cost
+        && let Some(note) = pricing_meta::note_for_maps(
+            sorted_projects.iter().map(|costed| &costed.item.models),
+            pricing_db,
+        )
+    {
+        println!("\n  {note}");
+    }
     println!(
         "\n  {} projects, {} sessions\n",
         format_number(sorted_projects.len() as i64, number_format),
@@ -255,6 +264,7 @@ pub(crate) fn output_project_json(
             });
             if show_cost {
                 obj["cost"] = cost_json_value(project_cost, currency);
+                pricing_meta::add_json(&mut obj, &project.models, pricing_db);
                 let estimated_cost = sum_estimated_proxy_model_costs(&project.models, pricing_db);
                 if estimated_cost > 0.0 {
                     obj["cost_kind"] = serde_json::json!(model_cost_kind(&project.models).as_str());

--- a/src/output/session.rs
+++ b/src/output/session.rs
@@ -9,6 +9,7 @@ use crate::output::format::{
     NumberFormat, cost_json_value, create_styled_table, format_compact, format_cost, format_number,
     header_cell, right_cell, styled_cell,
 };
+use crate::output::pricing_meta;
 use crate::pricing::{
     CurrencyConverter, PricingDb, model_cost_kind, sum_estimated_proxy_model_costs, sum_model_costs,
 };
@@ -256,6 +257,14 @@ pub(crate) fn print_session_table(
             format_cost(total_estimated_cost, options.currency)
         );
     }
+    if show_cost
+        && let Some(note) = pricing_meta::note_for_maps(
+            sorted_sessions.iter().map(|session| &session.models),
+            pricing_db,
+        )
+    {
+        println!("\n  {note}");
+    }
     println!(
         "\n  {} sessions\n",
         format_number(sorted_sessions.len() as i64, number_format)
@@ -303,6 +312,7 @@ pub(crate) fn output_session_json(
             });
             if show_cost {
                 obj["cost"] = cost_json_value(session_cost.unwrap_or(0.0), currency);
+                pricing_meta::add_json(&mut obj, &session.models, pricing_db);
                 let estimated_cost = sum_estimated_proxy_model_costs(&session.models, pricing_db);
                 if estimated_cost > 0.0 {
                     obj["cost_kind"] = serde_json::json!(model_cost_kind(&session.models).as_str());

--- a/src/output/statusline.rs
+++ b/src/output/statusline.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use crate::core::{DataQuality, DayStats, Stats};
 use crate::output::format::{NumberFormat, cost_json_value, format_compact, format_cost};
+use crate::output::pricing_meta;
 use crate::pricing::{
     CostDisplayMode, CurrencyConverter, PricingDb, sum_display_model_costs,
     sum_estimated_proxy_model_costs,
@@ -116,6 +117,11 @@ pub(crate) fn print_statusline_json_with_quality(
             "parse_errors": data_quality.parse_errors,
         });
     }
+    pricing_meta::add_json_for_maps(
+        &mut output,
+        day_stats.values().map(|day| &day.models),
+        pricing_db,
+    );
     if t.estimated_proxy_cost > 0.0 {
         output["cost_kind"] = serde_json::json!(t.stats.cost_kind().as_str());
         output["estimated_cost"] = cost_json_value(t.estimated_proxy_cost, currency);

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -8,6 +8,7 @@ use crate::output::format::{
     right_cell, styled_cell,
 };
 use crate::output::period::{Period, aggregate_day_stats_by_period};
+use crate::output::pricing_meta;
 use crate::pricing::{
     CostDisplayMode, CurrencyConverter, PricingDb, calculate_display_cost, model_cost_kind,
     sum_display_model_costs, sum_estimated_proxy_model_costs,
@@ -478,6 +479,12 @@ pub(crate) fn print_period_table(
                 format_cost(estimated_proxy_cost, options.currency)
             ),
         }
+    }
+    if options.show_cost
+        && let Some(note) =
+            pricing_meta::note_for_maps(stats_ref.values().map(|data| &data.models), pricing_db)
+    {
+        println!("\n  {note}");
     }
     print_summary_line(
         summary.valid,

--- a/src/output/top.rs
+++ b/src/output/top.rs
@@ -6,20 +6,18 @@
 //! consumer is dominating spend or token volume.
 
 use std::collections::HashMap;
-use std::fmt::Write;
 
 use comfy_table::{Attribute, Cell, CellAlignment, Color};
-use serde_json::json;
 
 use crate::cli::TopDimension;
 use crate::core::{CostKind, DayStats, ProjectStats, Stats};
 use crate::output::format::{
-    NumberFormat, create_styled_table, csv_escape, format_compact, format_cost, format_number,
-    header_cell, right_cell, styled_cell,
+    NumberFormat, create_styled_table, format_compact, format_cost, format_number, header_cell,
+    right_cell, styled_cell,
 };
 use crate::pricing::{
     CostDisplayMode, CurrencyConverter, PricingDb, calculate_display_cost, model_cost_kind,
-    sum_display_model_costs, sum_estimated_proxy_model_costs,
+    pricing_source_for_models, sum_display_model_costs, sum_estimated_proxy_model_costs,
 };
 
 /// One row in the leaderboard.
@@ -31,6 +29,9 @@ pub(crate) struct TopRow {
     pub(crate) cost: f64,
     pub(crate) estimated_cost: f64,
     pub(crate) cost_kind: CostKind,
+    pub(crate) pricing_source: crate::pricing::PricingSource,
+    pub(crate) pricing_cache_age_seconds: Option<u64>,
+    pub(crate) pricing_cache_mtime_epoch_seconds: Option<u64>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -74,6 +75,11 @@ pub(crate) fn rank_by_model_with_cost_mode(
                 calculate_display_cost(&stats, &model, pricing_db, CostDisplayMode::Total)
                     - calculate_display_cost(&stats, &model, pricing_db, CostDisplayMode::RealOnly);
             let cost_kind = stats.cost_kind();
+            let pricing_source = pricing_db
+                .pricing_source_for_model(&model)
+                .unwrap_or_else(|| pricing_db.source());
+            let (pricing_cache_age_seconds, pricing_cache_mtime_epoch_seconds) =
+                top_cache_metadata(pricing_source, pricing_db);
             TopRow {
                 name: model,
                 count: stats.count,
@@ -81,6 +87,9 @@ pub(crate) fn rank_by_model_with_cost_mode(
                 cost,
                 estimated_cost,
                 cost_kind,
+                pricing_source,
+                pricing_cache_age_seconds,
+                pricing_cache_mtime_epoch_seconds,
             }
         })
         .collect();
@@ -97,6 +106,9 @@ pub(crate) fn rank_by_project(projects: &[ProjectStats], pricing_db: &PricingDb)
             let cost = sum_display_model_costs(&project.models, pricing_db, CostDisplayMode::Total);
             let estimated_cost = sum_estimated_proxy_model_costs(&project.models, pricing_db);
             let cost_kind = model_cost_kind(&project.models);
+            let pricing_source = pricing_source_for_models(&project.models, pricing_db);
+            let (pricing_cache_age_seconds, pricing_cache_mtime_epoch_seconds) =
+                top_cache_metadata(pricing_source, pricing_db);
             TopRow {
                 name: if project.project_name.is_empty() {
                     project.project_path.clone()
@@ -108,12 +120,34 @@ pub(crate) fn rank_by_project(projects: &[ProjectStats], pricing_db: &PricingDb)
                 cost,
                 estimated_cost,
                 cost_kind,
+                pricing_source,
+                pricing_cache_age_seconds,
+                pricing_cache_mtime_epoch_seconds,
             }
         })
         .collect();
 
     sort_rows(&mut rows);
     rows
+}
+
+fn top_cache_metadata(
+    source: crate::pricing::PricingSource,
+    pricing_db: &PricingDb,
+) -> (Option<u64>, Option<u64>) {
+    if matches!(
+        source,
+        crate::pricing::PricingSource::Cache
+            | crate::pricing::PricingSource::CacheStale
+            | crate::pricing::PricingSource::Mixed
+    ) {
+        (
+            pricing_db.cache_age_seconds(),
+            pricing_db.cache_modified_epoch_seconds(),
+        )
+    } else {
+        (None, None)
+    }
 }
 
 /// Sort rows by cost desc, falling back to token total when cost is unknown
@@ -141,7 +175,7 @@ fn sort_rows(rows: &mut [TopRow]) {
 /// Decide how to compute share-of-total. Use cost when every row has a
 /// numeric cost so percentages stay consistent with the sort order; fall
 /// back to token totals otherwise.
-fn share_basis(rows: &[TopRow]) -> ShareBasis {
+pub(super) fn share_basis(rows: &[TopRow]) -> ShareBasis {
     if !rows.is_empty() && rows.iter().all(|r| !r.cost.is_nan() && r.cost > 0.0) {
         ShareBasis::Cost
     } else {
@@ -150,12 +184,12 @@ fn share_basis(rows: &[TopRow]) -> ShareBasis {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ShareBasis {
+pub(super) enum ShareBasis {
     Cost,
     Tokens,
 }
 
-fn share_of(row: &TopRow, total_cost: f64, total_tokens: i64, basis: ShareBasis) -> f64 {
+pub(super) fn share_of(row: &TopRow, total_cost: f64, total_tokens: i64, basis: ShareBasis) -> f64 {
     match basis {
         ShareBasis::Cost if total_cost > 0.0 => (row.cost / total_cost) * 100.0,
         ShareBasis::Tokens if total_tokens > 0 => {
@@ -353,178 +387,56 @@ pub(crate) fn print_top_table(rows: &[TopRow], options: TopTableOptions<'_>) {
             ),
         }
     }
+    if options.show_cost
+        && let Some(note) = top_pricing_note(&limited)
+    {
+        println!("\n{note}");
+    }
 }
 
-/// JSON output. Always includes share, basis, and full stats so downstream
-/// tooling does not have to recompute them.
-pub(crate) fn output_top_json(
-    rows: &[TopRow],
-    dim: TopDimension,
-    limit: usize,
-    show_cost: bool,
-    currency: Option<&CurrencyConverter>,
-) -> String {
-    let limited = take_top(rows, limit);
-    let total_cost = sum_cost(&limited);
-    let total_tokens = sum_tokens(&limited);
-    let basis = share_basis(&limited);
-    let include_estimated = show_cost && limited.iter().any(|row| row.estimated_cost > 0.0);
-
-    let entries: Vec<serde_json::Value> = limited
+fn top_pricing_note(rows: &[TopRow]) -> Option<String> {
+    let source = rows
         .iter()
-        .enumerate()
-        .map(|(idx, row)| {
-            let share = share_of(row, total_cost, total_tokens, basis);
-            let mut obj = json!({
-                "rank": idx + 1,
-                "name": row.name,
-                "count": row.count,
-                "input_tokens": row.stats.input_tokens,
-                "output_tokens": row.stats.output_tokens,
-                "cache_creation": row.stats.cache_creation,
-                "cache_read": row.stats.cache_read,
-                "reasoning_tokens": row.stats.reasoning_tokens,
-                "total_tokens": row.stats.total_tokens(),
-                "share_percent": (share * 100.0).round() / 100.0,
-            });
-            if show_cost {
-                obj["cost_usd"] = if row.cost.is_nan() {
-                    serde_json::Value::Null
-                } else {
-                    json!((row.cost * 100_000.0).round() / 100_000.0)
-                };
-                if let Some(conv) = currency
-                    && !row.cost.is_nan()
-                {
-                    obj["cost_local"] = json!(conv.format(row.cost));
-                }
-                if include_estimated {
-                    obj["cost_kind"] = json!(row.cost_kind.as_str());
-                    obj["estimated_cost_usd"] = if row.estimated_cost.is_nan() {
-                        serde_json::Value::Null
-                    } else {
-                        json!((row.estimated_cost * 100_000.0).round() / 100_000.0)
-                    };
-                    if let Some(conv) = currency
-                        && !row.estimated_cost.is_nan()
-                    {
-                        obj["estimated_cost_local"] = json!(conv.format(row.estimated_cost));
-                    }
-                }
-            }
-            obj
-        })
-        .collect();
-
-    json!({
-        "dimension": match dim {
-            TopDimension::Model => "model",
-            TopDimension::Project => "project",
-        },
-        "limit": limit,
-        "displayed": limited.len(),
-        "total_rows": rows.len(),
-        "share_basis": match basis {
-            ShareBasis::Cost => "cost",
-            ShareBasis::Tokens => "tokens",
-        },
-        "entries": entries,
-    })
-    .to_string()
+        .map(|row| row.pricing_source)
+        .reduce(crate::pricing::PricingSource::combine)?;
+    match source {
+        crate::pricing::PricingSource::Live => None,
+        crate::pricing::PricingSource::Cache => {
+            Some(format!("Pricing source: cache{}.", top_cache_suffix(rows)))
+        }
+        crate::pricing::PricingSource::CacheStale => Some(format!(
+            "Pricing source: stale cache{}.",
+            top_cache_suffix(rows)
+        )),
+        crate::pricing::PricingSource::Fallback => {
+            Some("Pricing source: fallback estimates.".to_string())
+        }
+        crate::pricing::PricingSource::Mixed => {
+            Some(format!("Pricing source: mixed{}.", top_cache_suffix(rows)))
+        }
+    }
 }
 
-/// CSV output. Header columns mirror the JSON keys.
-pub(crate) fn output_top_csv(
-    rows: &[TopRow],
-    dim: TopDimension,
-    limit: usize,
-    show_cost: bool,
-    currency: Option<&CurrencyConverter>,
-) -> String {
-    let limited = take_top(rows, limit);
-    let total_cost = sum_cost(&limited);
-    let total_tokens = sum_tokens(&limited);
-    let basis = share_basis(&limited);
-
-    let mut out = String::new();
-    let dim_col = match dim {
-        TopDimension::Model => "model",
-        TopDimension::Project => "project",
+fn top_cache_suffix(rows: &[TopRow]) -> String {
+    let Some(age) = rows.iter().find_map(|row| row.pricing_cache_age_seconds) else {
+        return String::new();
     };
-    let _ = write!(
-        out,
-        "rank,{dim_col},count,input_tokens,output_tokens,cache_creation,cache_read,reasoning_tokens,total_tokens,share_percent"
-    );
-    if show_cost {
-        out.push_str(",cost_usd");
-        if currency.is_some() {
-            out.push_str(",cost_local");
-        }
-        if limited.iter().any(|row| row.estimated_cost > 0.0) {
-            out.push_str(",cost_kind,estimated_cost_usd");
-            if currency.is_some() {
-                out.push_str(",estimated_cost_local");
-            }
-        }
+    let hours = age as f64 / 3600.0;
+    match rows
+        .iter()
+        .find_map(|row| row.pricing_cache_mtime_epoch_seconds)
+    {
+        Some(mtime) => format!(" ({hours:.1}h old, mtime {mtime})"),
+        None => format!(" ({hours:.1}h old)"),
     }
-    out.push('\n');
-    let include_estimated = show_cost && limited.iter().any(|row| row.estimated_cost > 0.0);
-
-    for (idx, row) in limited.iter().enumerate() {
-        let share = share_of(row, total_cost, total_tokens, basis);
-        let _ = write!(
-            out,
-            "{},{},{},{},{},{},{},{},{},{:.2}",
-            idx + 1,
-            csv_escape(&row.name),
-            row.count,
-            row.stats.input_tokens,
-            row.stats.output_tokens,
-            row.stats.cache_creation,
-            row.stats.cache_read,
-            row.stats.reasoning_tokens,
-            row.stats.total_tokens(),
-            share,
-        );
-        if show_cost {
-            if row.cost.is_nan() {
-                out.push(',');
-                if currency.is_some() {
-                    out.push(',');
-                }
-            } else {
-                let _ = write!(out, ",{:.6}", row.cost);
-                if let Some(conv) = currency {
-                    let _ = write!(out, ",{}", csv_escape(&conv.format(row.cost)));
-                }
-            }
-            if include_estimated {
-                let _ = write!(out, ",{}", row.cost_kind.as_str());
-                if row.estimated_cost.is_nan() {
-                    out.push(',');
-                } else {
-                    let _ = write!(out, ",{:.6}", row.estimated_cost);
-                }
-                if let Some(conv) = currency {
-                    if row.estimated_cost.is_nan() {
-                        out.push(',');
-                    } else {
-                        let _ = write!(out, ",{}", csv_escape(&conv.format(row.estimated_cost)));
-                    }
-                }
-            }
-        }
-        out.push('\n');
-    }
-    out
 }
 
-fn take_top(rows: &[TopRow], limit: usize) -> Vec<TopRow> {
+pub(super) fn take_top(rows: &[TopRow], limit: usize) -> Vec<TopRow> {
     let n = limit.min(rows.len());
     rows.iter().take(n).cloned().collect()
 }
 
-fn sum_cost(rows: &[TopRow]) -> f64 {
+pub(super) fn sum_cost(rows: &[TopRow]) -> f64 {
     let mut total = 0.0;
     for row in rows {
         if row.cost.is_nan() {
@@ -535,14 +447,15 @@ fn sum_cost(rows: &[TopRow]) -> f64 {
     total
 }
 
-fn sum_tokens(rows: &[TopRow]) -> i64 {
+pub(super) fn sum_tokens(rows: &[TopRow]) -> i64 {
     rows.iter().map(|r| r.stats.total_tokens()).sum()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pricing::PricingDb;
+    use crate::output::{output_top_csv, output_top_json};
+    use crate::pricing::{PricingDb, PricingSource};
 
     fn stats_of(input: i64, output: i64, count: i64) -> Stats {
         Stats {
@@ -610,6 +523,9 @@ mod tests {
                 cost: f64::NAN,
                 estimated_cost: 0.0,
                 cost_kind: CostKind::Real,
+                pricing_source: PricingSource::Fallback,
+                pricing_cache_age_seconds: None,
+                pricing_cache_mtime_epoch_seconds: None,
             },
             TopRow {
                 name: "b".into(),
@@ -618,6 +534,9 @@ mod tests {
                 cost: f64::NAN,
                 estimated_cost: 0.0,
                 cost_kind: CostKind::Real,
+                pricing_source: PricingSource::Fallback,
+                pricing_cache_age_seconds: None,
+                pricing_cache_mtime_epoch_seconds: None,
             },
         ];
         assert_eq!(share_basis(&rows), ShareBasis::Tokens);
@@ -635,6 +554,9 @@ mod tests {
                 cost: 0.25,
                 estimated_cost: 0.0,
                 cost_kind: CostKind::Real,
+                pricing_source: PricingSource::Fallback,
+                pricing_cache_age_seconds: None,
+                pricing_cache_mtime_epoch_seconds: None,
             },
             TopRow {
                 name: "b".into(),
@@ -643,6 +565,9 @@ mod tests {
                 cost: 0.75,
                 estimated_cost: 0.0,
                 cost_kind: CostKind::Real,
+                pricing_source: PricingSource::Fallback,
+                pricing_cache_age_seconds: None,
+                pricing_cache_mtime_epoch_seconds: None,
             },
         ];
         assert_eq!(share_basis(&rows), ShareBasis::Cost);
@@ -661,6 +586,9 @@ mod tests {
                 cost: f64::NAN,
                 estimated_cost: 0.0,
                 cost_kind: CostKind::Real,
+                pricing_source: PricingSource::Fallback,
+                pricing_cache_age_seconds: None,
+                pricing_cache_mtime_epoch_seconds: None,
             },
             TopRow {
                 name: "high-cost".into(),
@@ -669,6 +597,9 @@ mod tests {
                 cost: 5.0,
                 estimated_cost: 0.0,
                 cost_kind: CostKind::Real,
+                pricing_source: PricingSource::Fallback,
+                pricing_cache_age_seconds: None,
+                pricing_cache_mtime_epoch_seconds: None,
             },
             TopRow {
                 name: "low-cost".into(),
@@ -677,6 +608,9 @@ mod tests {
                 cost: 1.0,
                 estimated_cost: 0.0,
                 cost_kind: CostKind::Real,
+                pricing_source: PricingSource::Fallback,
+                pricing_cache_age_seconds: None,
+                pricing_cache_mtime_epoch_seconds: None,
             },
         ];
         sort_rows(&mut rows);
@@ -695,6 +629,9 @@ mod tests {
                 cost: f64::NAN,
                 estimated_cost: 0.0,
                 cost_kind: CostKind::Real,
+                pricing_source: PricingSource::Fallback,
+                pricing_cache_age_seconds: None,
+                pricing_cache_mtime_epoch_seconds: None,
             })
             .collect();
         let csv = output_top_csv(&rows, TopDimension::Model, 5, false, None);
@@ -711,6 +648,9 @@ mod tests {
             cost: 1.5,
             estimated_cost: 0.0,
             cost_kind: CostKind::Real,
+            pricing_source: PricingSource::Fallback,
+            pricing_cache_age_seconds: None,
+            pricing_cache_mtime_epoch_seconds: None,
         }];
         let json = output_top_json(&rows, TopDimension::Model, 10, true, None);
         let val: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -720,6 +660,7 @@ mod tests {
         assert_eq!(val["entries"][0]["rank"], 1);
         assert_eq!(val["entries"][0]["share_percent"], 100.0);
         assert_eq!(val["entries"][0]["cost_usd"], 1.5);
+        assert_eq!(val["entries"][0]["pricing_source"], "fallback");
     }
 
     #[test]
@@ -732,6 +673,9 @@ mod tests {
                 cost: f64::NAN,
                 estimated_cost: 0.0,
                 cost_kind: CostKind::Real,
+                pricing_source: PricingSource::Fallback,
+                pricing_cache_age_seconds: None,
+                pricing_cache_mtime_epoch_seconds: None,
             },
             TopRow {
                 name: "b".into(),
@@ -740,6 +684,9 @@ mod tests {
                 cost: f64::NAN,
                 estimated_cost: 0.0,
                 cost_kind: CostKind::Real,
+                pricing_source: PricingSource::Fallback,
+                pricing_cache_age_seconds: None,
+                pricing_cache_mtime_epoch_seconds: None,
             },
         ];
         let json = output_top_json(&rows, TopDimension::Model, 10, true, None);
@@ -758,6 +705,9 @@ mod tests {
             cost: f64::NAN,
             estimated_cost: 0.0,
             cost_kind: CostKind::Real,
+            pricing_source: PricingSource::Fallback,
+            pricing_cache_age_seconds: None,
+            pricing_cache_mtime_epoch_seconds: None,
         }];
         let csv = output_top_csv(&rows, TopDimension::Project, 1, false, None);
         let lines: Vec<&str> = csv.lines().collect();
@@ -773,14 +723,17 @@ mod tests {
             cost: 1.5,
             estimated_cost: 0.0,
             cost_kind: CostKind::Real,
+            pricing_source: PricingSource::Fallback,
+            pricing_cache_age_seconds: None,
+            pricing_cache_mtime_epoch_seconds: None,
         }];
         let converter = CurrencyConverter::from_rate_for_test("CNY", 7.0, "CNY ");
 
         let csv = output_top_csv(&rows, TopDimension::Model, 1, true, Some(&converter));
 
         let lines: Vec<&str> = csv.lines().collect();
-        assert!(lines[0].ends_with(",cost_usd,cost_local"));
-        assert!(lines[1].ends_with(",1.500000,CNY 10.50"));
+        assert!(lines[0].ends_with(",cost_usd,cost_local,pricing_source"));
+        assert!(lines[1].ends_with(",1.500000,CNY 10.50,fallback"));
     }
 
     #[test]

--- a/src/output/top.rs
+++ b/src/output/top.rs
@@ -77,7 +77,7 @@ pub(crate) fn rank_by_model_with_cost_mode(
             let cost_kind = stats.cost_kind();
             let pricing_source = pricing_db
                 .pricing_source_for_model(&model)
-                .unwrap_or_else(|| pricing_db.source());
+                .unwrap_or(crate::pricing::PricingSource::Unknown);
             let (pricing_cache_age_seconds, pricing_cache_mtime_epoch_seconds) =
                 top_cache_metadata(pricing_source, pricing_db);
             TopRow {
@@ -410,6 +410,9 @@ fn top_pricing_note(rows: &[TopRow]) -> Option<String> {
         )),
         crate::pricing::PricingSource::Fallback => {
             Some("Pricing source: fallback estimates.".to_string())
+        }
+        crate::pricing::PricingSource::Unknown => {
+            Some("Pricing source: unknown unpriced models.".to_string())
         }
         crate::pricing::PricingSource::Mixed => {
             Some(format!("Pricing source: mixed{}.", top_cache_suffix(rows)))

--- a/src/output/top_structured.rs
+++ b/src/output/top_structured.rs
@@ -1,0 +1,223 @@
+use std::fmt::Write;
+
+use serde_json::json;
+
+use crate::cli::TopDimension;
+use crate::output::format::csv_escape;
+use crate::output::top::{
+    ShareBasis, TopRow, share_basis, share_of, sum_cost, sum_tokens, take_top,
+};
+use crate::pricing::{CurrencyConverter, PricingSource};
+
+/// JSON output. Always includes share, basis, and full stats so downstream
+/// tooling does not have to recompute them.
+pub(crate) fn output_top_json(
+    rows: &[TopRow],
+    dim: TopDimension,
+    limit: usize,
+    show_cost: bool,
+    currency: Option<&CurrencyConverter>,
+) -> String {
+    let limited = take_top(rows, limit);
+    let total_cost = sum_cost(&limited);
+    let total_tokens = sum_tokens(&limited);
+    let basis = share_basis(&limited);
+    let include_estimated = show_cost && limited.iter().any(|row| row.estimated_cost > 0.0);
+
+    let entries: Vec<serde_json::Value> = limited
+        .iter()
+        .enumerate()
+        .map(|(idx, row)| {
+            let share = share_of(row, total_cost, total_tokens, basis);
+            let mut obj = json!({
+                "rank": idx + 1,
+                "name": row.name,
+                "count": row.count,
+                "input_tokens": row.stats.input_tokens,
+                "output_tokens": row.stats.output_tokens,
+                "cache_creation": row.stats.cache_creation,
+                "cache_read": row.stats.cache_read,
+                "reasoning_tokens": row.stats.reasoning_tokens,
+                "total_tokens": row.stats.total_tokens(),
+                "share_percent": (share * 100.0).round() / 100.0,
+            });
+            if show_cost {
+                obj["cost_usd"] = if row.cost.is_nan() {
+                    serde_json::Value::Null
+                } else {
+                    json!((row.cost * 100_000.0).round() / 100_000.0)
+                };
+                add_pricing_source_json(&mut obj, row);
+                if let Some(conv) = currency
+                    && !row.cost.is_nan()
+                {
+                    obj["cost_local"] = json!(conv.format(row.cost));
+                }
+                if include_estimated {
+                    obj["cost_kind"] = json!(row.cost_kind.as_str());
+                    obj["estimated_cost_usd"] = if row.estimated_cost.is_nan() {
+                        serde_json::Value::Null
+                    } else {
+                        json!((row.estimated_cost * 100_000.0).round() / 100_000.0)
+                    };
+                    if let Some(conv) = currency
+                        && !row.estimated_cost.is_nan()
+                    {
+                        obj["estimated_cost_local"] = json!(conv.format(row.estimated_cost));
+                    }
+                }
+            }
+            obj
+        })
+        .collect();
+
+    json!({
+        "dimension": match dim {
+            TopDimension::Model => "model",
+            TopDimension::Project => "project",
+        },
+        "limit": limit,
+        "displayed": limited.len(),
+        "total_rows": rows.len(),
+        "share_basis": match basis {
+            ShareBasis::Cost => "cost",
+            ShareBasis::Tokens => "tokens",
+        },
+        "entries": entries,
+    })
+    .to_string()
+}
+
+/// CSV output. Header columns mirror the JSON keys.
+pub(crate) fn output_top_csv(
+    rows: &[TopRow],
+    dim: TopDimension,
+    limit: usize,
+    show_cost: bool,
+    currency: Option<&CurrencyConverter>,
+) -> String {
+    let limited = take_top(rows, limit);
+    let total_cost = sum_cost(&limited);
+    let total_tokens = sum_tokens(&limited);
+    let basis = share_basis(&limited);
+
+    let mut out = String::new();
+    let dim_col = match dim {
+        TopDimension::Model => "model",
+        TopDimension::Project => "project",
+    };
+    let _ = write!(
+        out,
+        "rank,{dim_col},count,input_tokens,output_tokens,cache_creation,cache_read,reasoning_tokens,total_tokens,share_percent"
+    );
+    if show_cost {
+        out.push_str(",cost_usd");
+        if currency.is_some() {
+            out.push_str(",cost_local");
+        }
+        if limited.iter().any(|row| row.estimated_cost > 0.0) {
+            out.push_str(",cost_kind,estimated_cost_usd");
+            if currency.is_some() {
+                out.push_str(",estimated_cost_local");
+            }
+        }
+        append_pricing_source_csv_header(&mut out, &limited);
+    }
+    out.push('\n');
+    let include_estimated = show_cost && limited.iter().any(|row| row.estimated_cost > 0.0);
+
+    for (idx, row) in limited.iter().enumerate() {
+        let share = share_of(row, total_cost, total_tokens, basis);
+        let _ = write!(
+            out,
+            "{},{},{},{},{},{},{},{},{},{:.2}",
+            idx + 1,
+            csv_escape(&row.name),
+            row.count,
+            row.stats.input_tokens,
+            row.stats.output_tokens,
+            row.stats.cache_creation,
+            row.stats.cache_read,
+            row.stats.reasoning_tokens,
+            row.stats.total_tokens(),
+            share,
+        );
+        if show_cost {
+            if row.cost.is_nan() {
+                out.push(',');
+                if currency.is_some() {
+                    out.push(',');
+                }
+            } else {
+                let _ = write!(out, ",{:.6}", row.cost);
+                if let Some(conv) = currency {
+                    let _ = write!(out, ",{}", csv_escape(&conv.format(row.cost)));
+                }
+            }
+            if include_estimated {
+                let _ = write!(out, ",{}", row.cost_kind.as_str());
+                if row.estimated_cost.is_nan() {
+                    out.push(',');
+                } else {
+                    let _ = write!(out, ",{:.6}", row.estimated_cost);
+                }
+                if let Some(conv) = currency {
+                    if row.estimated_cost.is_nan() {
+                        out.push(',');
+                    } else {
+                        let _ = write!(out, ",{}", csv_escape(&conv.format(row.estimated_cost)));
+                    }
+                }
+            }
+            append_pricing_source_csv_fields(&mut out, row, &limited);
+        }
+        out.push('\n');
+    }
+    out
+}
+
+fn add_pricing_source_json(obj: &mut serde_json::Value, row: &TopRow) {
+    obj["pricing_source"] = json!(row.pricing_source.as_str());
+    if needs_cache_fields(row) {
+        if let Some(age) = row.pricing_cache_age_seconds {
+            obj["pricing_cache_age_seconds"] = json!(age);
+        }
+        if let Some(mtime) = row.pricing_cache_mtime_epoch_seconds {
+            obj["pricing_cache_mtime_epoch_seconds"] = json!(mtime);
+        }
+    }
+}
+
+fn append_pricing_source_csv_header(out: &mut String, rows: &[TopRow]) {
+    out.push_str(",pricing_source");
+    if rows
+        .iter()
+        .any(|row| row.pricing_cache_age_seconds.is_some())
+    {
+        out.push_str(",pricing_cache_age_seconds,pricing_cache_mtime_epoch_seconds");
+    }
+}
+
+fn append_pricing_source_csv_fields(out: &mut String, row: &TopRow, rows: &[TopRow]) {
+    let _ = write!(out, ",{}", row.pricing_source.as_str());
+    if !rows
+        .iter()
+        .any(|row| row.pricing_cache_age_seconds.is_some())
+    {
+        return;
+    }
+    if needs_cache_fields(row) {
+        let age = row.pricing_cache_age_seconds.unwrap_or_default();
+        let mtime = row.pricing_cache_mtime_epoch_seconds.unwrap_or_default();
+        let _ = write!(out, ",{age},{mtime}");
+    } else {
+        out.push_str(",,");
+    }
+}
+
+fn needs_cache_fields(row: &TopRow) -> bool {
+    matches!(
+        row.pricing_source,
+        PricingSource::Cache | PricingSource::CacheStale | PricingSource::Mixed
+    ) && row.pricing_cache_age_seconds.is_some()
+}

--- a/src/pricing/cache.rs
+++ b/src/pricing/cache.rs
@@ -4,11 +4,19 @@ use std::io::{BufWriter, ErrorKind, Write};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use super::source::CacheMetadata;
+
 const APP_CACHE_DIR: &str = "ccstats";
 const PRICING_CACHE_FILE: &str = "pricing.json";
 
 pub(super) type RawPricingCache = HashMap<String, serde_json::Value>;
-type FreshRawPricingCache = (RawPricingCache, Duration);
+#[derive(Debug)]
+pub(super) struct RawPricingCacheSnapshot {
+    pub(super) data: RawPricingCache,
+    pub(super) metadata: CacheMetadata,
+}
+
+type FreshRawPricingCache = RawPricingCacheSnapshot;
 type CacheReadResult<T> = Result<Option<T>, CacheReadError>;
 
 #[derive(Debug)]
@@ -128,25 +136,50 @@ pub(super) fn get_cache_path() -> Option<PathBuf> {
     cache_paths().write_path
 }
 
+#[cfg(test)]
 pub(super) fn load_raw_cache_from_paths(paths: &[PathBuf]) -> CacheReadResult<RawPricingCache> {
+    Ok(load_raw_cache_snapshot_from_paths(paths)?.map(|snapshot| snapshot.data))
+}
+
+pub(super) fn load_raw_cache_snapshot_from_paths(
+    paths: &[PathBuf],
+) -> CacheReadResult<RawPricingCacheSnapshot> {
     for path in paths {
-        let file = match File::open(path) {
-            Ok(file) => file,
+        let meta = match fs::metadata(path) {
+            Ok(meta) => meta,
             Err(error) if error.kind() == ErrorKind::NotFound => continue,
             Err(source) => {
-                return Err(CacheReadError::Open {
+                return Err(CacheReadError::Metadata {
                     path: path.clone(),
                     source,
                 });
             }
         };
+        let modified = meta.modified().map_err(|source| CacheReadError::Modified {
+            path: path.clone(),
+            source,
+        })?;
+        let file = File::open(path).map_err(|source| CacheReadError::Open {
+            path: path.clone(),
+            source,
+        })?;
         let data = serde_json::from_reader(file).map_err(|source| CacheReadError::Malformed {
             path: path.clone(),
             source,
         })?;
-        return Ok(Some(data));
+        return Ok(Some(RawPricingCacheSnapshot {
+            data,
+            metadata: cache_metadata(modified),
+        }));
     }
     Ok(None)
+}
+
+fn cache_metadata(modified: SystemTime) -> CacheMetadata {
+    let age = SystemTime::now()
+        .duration_since(modified)
+        .unwrap_or(Duration::MAX);
+    CacheMetadata { age, modified }
 }
 
 pub(super) fn load_raw_cache_if_fresh_from_paths(
@@ -168,10 +201,8 @@ pub(super) fn load_raw_cache_if_fresh_from_paths(
             path: path.clone(),
             source,
         })?;
-        let age = SystemTime::now()
-            .duration_since(modified)
-            .unwrap_or(Duration::ZERO);
-        if age > ttl {
+        let metadata = cache_metadata(modified);
+        if metadata.age > ttl {
             return Ok(None);
         }
         let file = File::open(path).map_err(|source| CacheReadError::Open {
@@ -182,14 +213,14 @@ pub(super) fn load_raw_cache_if_fresh_from_paths(
             path: path.clone(),
             source,
         })?;
-        return Ok(Some((data, age)));
+        return Ok(Some(RawPricingCacheSnapshot { data, metadata }));
     }
     Ok(None)
 }
 
-pub(super) fn load_raw_cache() -> CacheReadResult<RawPricingCache> {
+pub(super) fn load_raw_cache_snapshot() -> CacheReadResult<RawPricingCacheSnapshot> {
     let paths = cache_paths();
-    load_raw_cache_from_paths(&paths.read_paths)
+    load_raw_cache_snapshot_from_paths(&paths.read_paths)
 }
 
 pub(super) fn load_raw_cache_if_fresh(ttl: Duration) -> CacheReadResult<FreshRawPricingCache> {
@@ -386,12 +417,12 @@ mod tests {
         let legacy_path = legacy_cache_file(home_root.path());
         save_raw_cache_to_path(&sample_raw_data("legacy-model"), &legacy_path).unwrap();
 
-        let (data, _age) =
+        let snapshot =
             load_raw_cache_if_fresh_from_paths(&paths.read_paths, Duration::from_secs(60))
                 .unwrap()
                 .unwrap();
 
-        assert!(data.contains_key("legacy-model"));
+        assert!(snapshot.data.contains_key("legacy-model"));
     }
 
     #[test]

--- a/src/pricing/cost.rs
+++ b/src/pricing/cost.rs
@@ -144,19 +144,27 @@ pub(crate) fn pricing_source_for_models(
     models: &HashMap<String, Stats>,
     pricing_db: &PricingDb,
 ) -> PricingSource {
+    pricing_source_for_models_with_cost(models, pricing_db).unwrap_or_else(|| pricing_db.source())
+}
+
+fn pricing_source_for_models_with_cost(
+    models: &HashMap<String, Stats>,
+    pricing_db: &PricingDb,
+) -> Option<PricingSource> {
     let mut source: Option<PricingSource> = None;
     for (model, stats) in models {
         if !stats.cost_tokens().has_entries() {
             continue;
         }
-        if let Some(model_source) = pricing_db.pricing_source_for_model(model) {
-            source = Some(match source {
-                Some(current) => current.combine(model_source),
-                None => model_source,
-            });
-        }
+        let model_source = pricing_db
+            .pricing_source_for_model(model)
+            .unwrap_or(PricingSource::Unknown);
+        source = Some(match source {
+            Some(current) => current.combine(model_source),
+            None => model_source,
+        });
     }
-    source.unwrap_or_else(|| pricing_db.source())
+    source
 }
 
 pub(crate) fn pricing_source_for_model_maps<'a>(
@@ -165,11 +173,12 @@ pub(crate) fn pricing_source_for_model_maps<'a>(
 ) -> PricingSource {
     let mut source: Option<PricingSource> = None;
     for map in maps {
-        let map_source = pricing_source_for_models(map, pricing_db);
-        source = Some(match source {
-            Some(current) => current.combine(map_source),
-            None => map_source,
-        });
+        if let Some(map_source) = pricing_source_for_models_with_cost(map, pricing_db) {
+            source = Some(match source {
+                Some(current) => current.combine(map_source),
+                None => map_source,
+            });
+        }
     }
     source.unwrap_or_else(|| pricing_db.source())
 }

--- a/src/pricing/cost.rs
+++ b/src/pricing/cost.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use crate::core::{CostKind, CostTokens, Stats};
 
 use super::db::PricingDb;
+use super::source::PricingSource;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CostDisplayMode {
@@ -137,6 +138,40 @@ pub(crate) fn model_cost_kind(models: &HashMap<String, Stats>) -> CostKind {
         (false, true) => CostKind::EstimatedProxy,
         _ => CostKind::Real,
     }
+}
+
+pub(crate) fn pricing_source_for_models(
+    models: &HashMap<String, Stats>,
+    pricing_db: &PricingDb,
+) -> PricingSource {
+    let mut source: Option<PricingSource> = None;
+    for (model, stats) in models {
+        if !stats.cost_tokens().has_entries() {
+            continue;
+        }
+        if let Some(model_source) = pricing_db.pricing_source_for_model(model) {
+            source = Some(match source {
+                Some(current) => current.combine(model_source),
+                None => model_source,
+            });
+        }
+    }
+    source.unwrap_or_else(|| pricing_db.source())
+}
+
+pub(crate) fn pricing_source_for_model_maps<'a>(
+    maps: impl IntoIterator<Item = &'a HashMap<String, Stats>>,
+    pricing_db: &PricingDb,
+) -> PricingSource {
+    let mut source: Option<PricingSource> = None;
+    for map in maps {
+        let map_source = pricing_source_for_models(map, pricing_db);
+        source = Some(match source {
+            Some(current) => current.combine(map_source),
+            None => map_source,
+        });
+    }
+    source.unwrap_or_else(|| pricing_db.source())
 }
 
 /// Borrowed item with precomputed total cost.

--- a/src/pricing/db.rs
+++ b/src/pricing/db.rs
@@ -299,10 +299,13 @@ impl Default for PricingDb {
 mod tests {
     use super::*;
     use crate::core::Stats;
-    use crate::pricing::{attach_costs, calculate_cost, sum_model_costs};
+    use crate::pricing::{
+        attach_costs, calculate_cost, pricing_source_for_models, sum_model_costs,
+    };
     use serde_json::json;
     use std::fs;
     use std::path::PathBuf;
+    use std::time::SystemTime;
     use tempfile::TempDir;
 
     fn sample_raw_pricing(model: &str) -> HashMap<String, serde_json::Value> {
@@ -686,6 +689,72 @@ mod tests {
         // Second call hits cache
         let p2 = db.get_pricing("sonnet-4");
         assert_eq!(p1.unwrap().input, p2.unwrap().input);
+    }
+
+    #[test]
+    fn pricing_source_tracks_live_known_model() {
+        let db = PricingDb::from_raw_data(
+            sample_raw_pricing("claude-3-5-sonnet-20241022"),
+            false,
+            PricingSource::Live,
+            None,
+        );
+
+        assert_eq!(
+            db.pricing_source_for_model("claude-3-5-sonnet-20241022"),
+            Some(PricingSource::Live)
+        );
+    }
+
+    #[test]
+    fn pricing_source_tracks_stale_cache_known_model() {
+        let metadata = CacheMetadata {
+            age: Duration::from_secs(2 * 24 * 60 * 60),
+            modified: SystemTime::now() - Duration::from_secs(2 * 24 * 60 * 60),
+        };
+        let db = PricingDb::from_raw_data(
+            sample_raw_pricing("claude-3-5-sonnet-20241022"),
+            false,
+            PricingSource::CacheStale,
+            Some(metadata),
+        );
+
+        assert_eq!(
+            db.pricing_source_for_model("claude-3-5-sonnet-20241022"),
+            Some(PricingSource::CacheStale)
+        );
+        assert!(matches!(db.cache_age_seconds(), Some(age) if age >= 24 * 60 * 60));
+    }
+
+    #[test]
+    fn pricing_source_combines_known_and_fallback_as_mixed() {
+        let db = PricingDb::from_raw_data(
+            sample_raw_pricing("claude-3-5-sonnet-20241022"),
+            false,
+            PricingSource::Cache,
+            None,
+        );
+        let models = HashMap::from([
+            (
+                "claude-3-5-sonnet-20241022".to_string(),
+                Stats {
+                    input_tokens: 100,
+                    ..Default::default()
+                },
+            ),
+            (
+                "gpt-5".to_string(),
+                Stats {
+                    input_tokens: 100,
+                    ..Default::default()
+                },
+            ),
+        ]);
+
+        assert_eq!(
+            pricing_source_for_models(&models, &db),
+            PricingSource::Mixed
+        );
     }
 
     #[test]

--- a/src/pricing/db.rs
+++ b/src/pricing/db.rs
@@ -3,15 +3,20 @@ use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 use super::cache::{
-    CacheReadError, CacheWriteError, load_raw_cache, load_raw_cache_if_fresh, save_raw_cache,
+    CacheReadError, CacheWriteError, load_raw_cache_if_fresh, load_raw_cache_snapshot,
+    save_raw_cache,
 };
 use super::provider::fetch_litellm_raw;
 use super::resolver::{fallback_pricing, parse_litellm_data, resolve_pricing_known};
+use super::source::{CacheMetadata, PricingSource};
 use super::types::ModelPricing;
 
 #[derive(Debug, Clone)]
 enum ResolvedPricing {
-    Known(ModelPricing),
+    Known {
+        pricing: ModelPricing,
+        source: PricingSource,
+    },
     Unknown,
 }
 
@@ -27,6 +32,8 @@ pub(crate) struct PricingDb {
     models: HashMap<String, ModelPricing>,
     resolved: RefCell<HashMap<String, ResolvedPricing>>,
     strict_unknown: bool,
+    source: PricingSource,
+    cache_metadata: Option<CacheMetadata>,
 }
 
 const PRICING_CACHE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
@@ -37,27 +44,57 @@ impl PricingDb {
             models: HashMap::new(),
             resolved: RefCell::new(HashMap::new()),
             strict_unknown,
+            source: PricingSource::Fallback,
+            cache_metadata: None,
         }
     }
 
-    fn from_raw_data(data: HashMap<String, serde_json::Value>, strict_unknown: bool) -> Self {
+    fn from_raw_data(
+        data: HashMap<String, serde_json::Value>,
+        strict_unknown: bool,
+        source: PricingSource,
+        cache_metadata: Option<CacheMetadata>,
+    ) -> Self {
         Self {
             models: parse_litellm_data(data),
             resolved: RefCell::new(HashMap::new()),
             strict_unknown,
+            source,
+            cache_metadata,
         }
     }
 
     fn load_from_cache(strict_unknown: bool) -> Result<Option<Self>, CacheReadError> {
-        Ok(load_raw_cache()?.map(|raw_data| Self::from_raw_data(raw_data, strict_unknown)))
+        Ok(load_raw_cache_snapshot()?.map(|snapshot| {
+            let source = if snapshot.metadata.age > PRICING_CACHE_TTL {
+                PricingSource::CacheStale
+            } else {
+                PricingSource::Cache
+            };
+            Self::from_raw_data(
+                snapshot.data,
+                strict_unknown,
+                source,
+                Some(snapshot.metadata),
+            )
+        }))
     }
 
     fn load_from_cache_if_fresh(
         ttl: Duration,
         strict_unknown: bool,
     ) -> Result<Option<(Self, Duration)>, CacheReadError> {
-        Ok(load_raw_cache_if_fresh(ttl)?
-            .map(|(raw_data, age)| (Self::from_raw_data(raw_data, strict_unknown), age)))
+        Ok(load_raw_cache_if_fresh(ttl)?.map(|snapshot| {
+            (
+                Self::from_raw_data(
+                    snapshot.data,
+                    strict_unknown,
+                    PricingSource::Cache,
+                    Some(snapshot.metadata),
+                ),
+                snapshot.metadata.age,
+            )
+        }))
     }
 
     pub(crate) fn load(offline: bool, strict_unknown: bool) -> Self {
@@ -123,7 +160,7 @@ impl PricingDb {
         if let Some(raw_data) = fetch_litellm_raw() {
             let fetch_time = start.elapsed();
             let save_result = save_raw_cache(&raw_data);
-            let db = Self::from_raw_data(raw_data, strict_unknown);
+            let db = Self::from_raw_data(raw_data, strict_unknown, PricingSource::Live, None);
             if !quiet {
                 eprintln!(
                     " {} models ({:.2}ms)",
@@ -191,23 +228,47 @@ impl PricingDb {
     }
 
     pub(super) fn get_pricing(&self, model: &str) -> Option<ModelPricing> {
+        self.resolve_pricing(model).map(|(pricing, _)| pricing)
+    }
+
+    pub(crate) fn pricing_source_for_model(&self, model: &str) -> Option<PricingSource> {
+        self.resolve_pricing(model).map(|(_, source)| source)
+    }
+
+    pub(crate) fn source(&self) -> PricingSource {
+        self.source
+    }
+
+    pub(crate) fn cache_age_seconds(&self) -> Option<u64> {
+        self.cache_metadata.map(CacheMetadata::age_seconds)
+    }
+
+    pub(crate) fn cache_modified_epoch_seconds(&self) -> Option<u64> {
+        self.cache_metadata
+            .map(CacheMetadata::modified_epoch_seconds)
+    }
+
+    fn resolve_pricing(&self, model: &str) -> Option<(ModelPricing, PricingSource)> {
         if let Some(cached) = self.resolved.borrow().get(model) {
             return match cached {
-                ResolvedPricing::Known(pricing) => Some(pricing.clone()),
+                ResolvedPricing::Known { pricing, source } => Some((pricing.clone(), *source)),
                 ResolvedPricing::Unknown => None,
             };
         }
 
-        let pricing = resolve_pricing_known(model, &self.models).or_else(|| {
-            if self.strict_unknown {
-                None
-            } else {
-                fallback_pricing(model)
-            }
-        });
+        let pricing = if let Some(pricing) = resolve_pricing_known(model, &self.models) {
+            Some((pricing, self.source))
+        } else if self.strict_unknown {
+            None
+        } else {
+            fallback_pricing(model).map(|pricing| (pricing, PricingSource::Fallback))
+        };
 
         let cached = match &pricing {
-            Some(pricing) => ResolvedPricing::Known(pricing.clone()),
+            Some((pricing, source)) => ResolvedPricing::Known {
+                pricing: pricing.clone(),
+                source: *source,
+            },
             None => ResolvedPricing::Unknown,
         };
         self.resolved.borrow_mut().insert(model.to_string(), cached);
@@ -227,6 +288,8 @@ impl Default for PricingDb {
             models: HashMap::new(),
             resolved: RefCell::new(HashMap::new()),
             strict_unknown: false,
+            source: PricingSource::Fallback,
+            cache_metadata: None,
         }
     }
 }
@@ -309,7 +372,7 @@ mod tests {
         let raw_data = sample_raw_pricing("gpt-5");
 
         let save_result = super::super::cache::save_raw_cache_to_path(&raw_data, &cache_path);
-        let db = PricingDb::from_raw_data(raw_data, false);
+        let db = PricingDb::from_raw_data(raw_data, false, PricingSource::Live, None);
 
         assert!(save_result.is_err());
         assert!(db.get_pricing("gpt-5").is_some());

--- a/src/pricing/mod.rs
+++ b/src/pricing/mod.rs
@@ -4,12 +4,15 @@ pub(crate) mod currency;
 mod db;
 mod provider;
 mod resolver;
+mod source;
 mod types;
 
 pub(crate) use cost::{
     CostDisplayMode, attach_costs, calculate_cost, calculate_display_cost,
-    calculate_estimated_proxy_cost, model_cost_kind, sum_display_model_costs,
-    sum_estimated_proxy_model_costs, sum_model_costs,
+    calculate_estimated_proxy_cost, model_cost_kind, pricing_source_for_model_maps,
+    pricing_source_for_models, sum_display_model_costs, sum_estimated_proxy_model_costs,
+    sum_model_costs,
 };
 pub(crate) use currency::CurrencyConverter;
 pub(crate) use db::PricingDb;
+pub(crate) use source::PricingSource;

--- a/src/pricing/source.rs
+++ b/src/pricing/source.rs
@@ -6,6 +6,7 @@ pub(crate) enum PricingSource {
     Cache,
     CacheStale,
     Fallback,
+    Unknown,
     Mixed,
 }
 
@@ -16,6 +17,7 @@ impl PricingSource {
             PricingSource::Cache => "cache",
             PricingSource::CacheStale => "cache_stale",
             PricingSource::Fallback => "fallback",
+            PricingSource::Unknown => "unknown",
             PricingSource::Mixed => "mixed",
         }
     }

--- a/src/pricing/source.rs
+++ b/src/pricing/source.rs
@@ -1,0 +1,49 @@
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PricingSource {
+    Live,
+    Cache,
+    CacheStale,
+    Fallback,
+    Mixed,
+}
+
+impl PricingSource {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            PricingSource::Live => "live",
+            PricingSource::Cache => "cache",
+            PricingSource::CacheStale => "cache_stale",
+            PricingSource::Fallback => "fallback",
+            PricingSource::Mixed => "mixed",
+        }
+    }
+
+    pub(crate) fn combine(self, other: Self) -> Self {
+        if self == other {
+            self
+        } else {
+            PricingSource::Mixed
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct CacheMetadata {
+    pub(super) age: Duration,
+    pub(super) modified: SystemTime,
+}
+
+impl CacheMetadata {
+    pub(crate) fn age_seconds(self) -> u64 {
+        self.age.as_secs()
+    }
+
+    pub(crate) fn modified_epoch_seconds(self) -> u64 {
+        self.modified
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO)
+            .as_secs()
+    }
+}

--- a/tests/cli_budget_currency_statusline.rs
+++ b/tests/cli_budget_currency_statusline.rs
@@ -159,6 +159,83 @@ fn strict_pricing_sets_unknown_cost_to_null() {
     let arr = json.as_array().expect("array output");
     assert_eq!(arr.len(), 1);
     assert!(arr[0]["cost"].is_null());
+    assert_eq!(arr[0]["pricing_source"].as_str(), Some("unknown"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn strict_pricing_csv_marks_unknown_source() {
+    let root = unique_temp_dir("strict-pricing-csv");
+    let codex_home = root.join("codex-home");
+    let session_file = codex_home.join("sessions").join("strict-session.jsonl");
+    write_file(
+        &session_file,
+        r#"{"timestamp":"2026-02-06T11:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":50,"cached_input_tokens":0,"output_tokens":10,"reasoning_output_tokens":0,"total_tokens":60},"last_token_usage":{"input_tokens":50,"cached_input_tokens":0,"output_tokens":10,"reasoning_output_tokens":0,"total_tokens":60},"model":"mystery-model"}}}
+"#,
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "codex",
+            "daily",
+            "--csv",
+            "-O",
+            "--strict-pricing",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("CODEX_HOME", &codex_home)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let output = String::from_utf8(stdout).expect("utf8 stdout");
+    let lines: Vec<&str> = output.lines().collect();
+    assert!(lines[0].ends_with(",cost,pricing_source"));
+    assert!(lines[1].ends_with(",N/A,unknown"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn strict_pricing_table_marks_unknown_source() {
+    let root = unique_temp_dir("strict-pricing-table");
+    let codex_home = root.join("codex-home");
+    let session_file = codex_home.join("sessions").join("strict-session.jsonl");
+    write_file(
+        &session_file,
+        r#"{"timestamp":"2026-02-06T11:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":50,"cached_input_tokens":0,"output_tokens":10,"reasoning_output_tokens":0,"total_tokens":60},"last_token_usage":{"input_tokens":50,"cached_input_tokens":0,"output_tokens":10,"reasoning_output_tokens":0,"total_tokens":60},"model":"mystery-model"}}}
+"#,
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "codex",
+            "daily",
+            "-O",
+            "--strict-pricing",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("CODEX_HOME", &codex_home)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let output = String::from_utf8(stdout).expect("utf8 stdout");
+    assert!(output.contains("N/A"), "stdout: {output}");
+    assert!(
+        output.contains("Pricing source: unknown unpriced models."),
+        "stdout: {output}"
+    );
+    assert!(!output.contains("fallback estimates"), "stdout: {output}");
 
     let _ = fs::remove_dir_all(root);
 }

--- a/tests/cli_budget_currency_statusline.rs
+++ b/tests/cli_budget_currency_statusline.rs
@@ -3,8 +3,9 @@ mod common;
 use chrono::Utc;
 use common::{run_ccstats, unique_temp_dir, write_file};
 use serde_json::Value;
-use std::fs;
+use std::fs::{self, File, FileTimes};
 use std::path::Path;
+use std::time::{Duration, SystemTime};
 
 fn write_exchange_rates_cache(home: &Path, rates: &str) {
     write_file(&home.join(".cache/ccstats/exchange_rates.json"), rates);
@@ -14,6 +15,18 @@ fn write_pricing_cache(home: &Path, xdg_cache: &Path, contents: &str) {
     write_file(&xdg_cache.join("ccstats/pricing.json"), contents);
     write_file(&home.join("Library/Caches/ccstats/pricing.json"), contents);
     write_file(&home.join(".cache/ccstats/pricing.json"), contents);
+}
+
+fn set_mtime(path: &Path, modified: SystemTime) {
+    let file = File::options().write(true).open(path).expect("open cache");
+    file.set_times(FileTimes::new().set_modified(modified))
+        .expect("set cache mtime");
+}
+
+fn set_pricing_cache_mtime(home: &Path, xdg_cache: &Path, modified: SystemTime) {
+    set_mtime(&xdg_cache.join("ccstats/pricing.json"), modified);
+    set_mtime(&home.join("Library/Caches/ccstats/pricing.json"), modified);
+    set_mtime(&home.join(".cache/ccstats/pricing.json"), modified);
 }
 
 #[test]
@@ -298,6 +311,153 @@ fn daily_outputs_fresh_cache_pricing_source() {
 }
 
 #[test]
+fn daily_json_reports_stale_cache_pricing_source() {
+    let root = unique_temp_dir("daily-stale-cache-pricing-source");
+    let xdg_cache = root.join("xdg-cache");
+    write_pricing_cache(
+        &root,
+        &xdg_cache,
+        r#"{"claude-3-5-sonnet-20241022":{"input_cost_per_token":0.000001,"output_cost_per_token":0.000002}}"#,
+    );
+    set_pricing_cache_mtime(
+        &root,
+        &xdg_cache,
+        SystemTime::now() - Duration::from_secs(2 * 24 * 60 * 60),
+    );
+    let claude_file = root.join(".claude/projects/myproject/session-a.jsonl");
+    write_file(
+        &claude_file,
+        r#"{"timestamp":"2026-02-06T12:00:00Z","message":{"id":"msg_1","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":100,"output_tokens":50}}}
+"#,
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "-j",
+            "-O",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("HOME", &root), ("XDG_CACHE_HOME", &xdg_cache)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    let row = &json.as_array().expect("array output")[0];
+    assert_eq!(row["pricing_source"].as_str(), Some("cache_stale"));
+    assert!(row["pricing_cache_age_seconds"].as_u64().unwrap() >= 24 * 60 * 60);
+    assert!(row["pricing_cache_mtime_epoch_seconds"].as_u64().is_some());
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn daily_outputs_mixed_pricing_source() {
+    let root = unique_temp_dir("daily-mixed-pricing-source");
+    let xdg_cache = root.join("xdg-cache");
+    write_pricing_cache(
+        &root,
+        &xdg_cache,
+        r#"{"claude-3-5-sonnet-20241022":{"input_cost_per_token":0.000001,"output_cost_per_token":0.000002}}"#,
+    );
+    let claude_file = root.join(".claude/projects/myproject/session-a.jsonl");
+    write_file(
+        &claude_file,
+        r#"{"timestamp":"2026-02-06T12:00:00Z","message":{"id":"msg_1","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":100,"output_tokens":50}}}
+{"timestamp":"2026-02-06T12:30:00Z","message":{"id":"msg_2","model":"gpt-5","stop_reason":"end_turn","usage":{"input_tokens":200,"output_tokens":100}}}
+"#,
+    );
+    let envs = [
+        ("HOME", root.as_path()),
+        ("XDG_CACHE_HOME", xdg_cache.as_path()),
+    ];
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "-j",
+            "-O",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &envs,
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    assert_eq!(
+        json.as_array().expect("array output")[0]["pricing_source"].as_str(),
+        Some("mixed")
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "--csv",
+            "-O",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &envs,
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let output = String::from_utf8(stdout).expect("utf8 stdout");
+    let fields: Vec<&str> = output.lines().nth(1).expect("row").split(',').collect();
+    assert_eq!(fields[8], "mixed");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn daily_table_reports_cache_pricing_source_footnote() {
+    let root = unique_temp_dir("daily-table-cache-pricing-source");
+    let xdg_cache = root.join("xdg-cache");
+    write_pricing_cache(
+        &root,
+        &xdg_cache,
+        r#"{"claude-3-5-sonnet-20241022":{"input_cost_per_token":0.000001,"output_cost_per_token":0.000002}}"#,
+    );
+    let claude_file = root.join(".claude/projects/myproject/session-a.jsonl");
+    write_file(
+        &claude_file,
+        r#"{"timestamp":"2026-02-06T12:00:00Z","message":{"id":"msg_1","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":100,"output_tokens":50}}}
+"#,
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "-O",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("HOME", &root), ("XDG_CACHE_HOME", &xdg_cache)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let output = String::from_utf8(stdout).expect("utf8 stdout");
+    assert!(output.contains("Pricing source: cache"), "stdout: {output}");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn daily_csv_fallback_source_omits_empty_cache_columns() {
     let root = unique_temp_dir("daily-fallback-pricing-source");
     let xdg_cache = root.join("xdg-cache");
@@ -367,6 +527,7 @@ fn statusline_json_uses_requested_currency() {
 
     let json: Value = serde_json::from_slice(&stdout).expect("json");
     assert_eq!(json["source"].as_str(), Some("Claude Code"));
+    assert_eq!(json["pricing_source"].as_str(), Some("fallback"));
     let cost = json["cost"].as_f64().expect("numeric cost");
     assert!((cost - 0.00735).abs() < f64::EPSILON);
 

--- a/tests/cli_budget_currency_statusline.rs
+++ b/tests/cli_budget_currency_statusline.rs
@@ -10,6 +10,12 @@ fn write_exchange_rates_cache(home: &Path, rates: &str) {
     write_file(&home.join(".cache/ccstats/exchange_rates.json"), rates);
 }
 
+fn write_pricing_cache(home: &Path, xdg_cache: &Path, contents: &str) {
+    write_file(&xdg_cache.join("ccstats/pricing.json"), contents);
+    write_file(&home.join("Library/Caches/ccstats/pricing.json"), contents);
+    write_file(&home.join(".cache/ccstats/pricing.json"), contents);
+}
+
 #[test]
 fn monthly_budget_json_includes_forecast() {
     let root = unique_temp_dir("monthly-budget-json");
@@ -211,9 +217,122 @@ fn daily_csv_uses_requested_currency() {
     let lines: Vec<&str> = output.lines().collect();
     assert_eq!(
         lines[0],
-        "date,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,total_tokens,cost"
+        "date,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,total_tokens,cost,pricing_source"
     );
-    assert!(lines[1].ends_with(",0.007350"), "row: {}", lines[1]);
+    assert!(
+        lines[1].ends_with(",0.007350,fallback"),
+        "row: {}",
+        lines[1]
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn daily_outputs_fresh_cache_pricing_source() {
+    let root = unique_temp_dir("daily-cache-pricing-source");
+    let xdg_cache = root.join("xdg-cache");
+    write_pricing_cache(
+        &root,
+        &xdg_cache,
+        r#"{"claude-3-5-sonnet-20241022":{"input_cost_per_token":0.000001,"output_cost_per_token":0.000002}}"#,
+    );
+    let claude_file = root.join(".claude/projects/myproject/session-a.jsonl");
+    write_file(
+        &claude_file,
+        r#"{"timestamp":"2026-02-06T12:00:00Z","message":{"id":"msg_1","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":100,"output_tokens":50}}}
+"#,
+    );
+
+    let envs = [
+        ("HOME", root.as_path()),
+        ("XDG_CACHE_HOME", xdg_cache.as_path()),
+    ];
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "-j",
+            "-O",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &envs,
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    let row = &json.as_array().expect("array output")[0];
+    assert_eq!(row["pricing_source"].as_str(), Some("cache"));
+    assert!(row["pricing_cache_age_seconds"].as_u64().is_some());
+    assert!(row["pricing_cache_mtime_epoch_seconds"].as_u64().is_some());
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "--csv",
+            "-O",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &envs,
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let output = String::from_utf8(stdout).expect("utf8 stdout");
+    let lines: Vec<&str> = output.lines().collect();
+    assert!(lines[0].ends_with(
+        ",cost,pricing_source,pricing_cache_age_seconds,pricing_cache_mtime_epoch_seconds"
+    ));
+    let fields: Vec<&str> = lines[1].split(',').collect();
+    assert_eq!(fields[8], "cache");
+    assert!(fields[9].parse::<u64>().is_ok());
+    assert!(fields[10].parse::<u64>().is_ok());
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn daily_csv_fallback_source_omits_empty_cache_columns() {
+    let root = unique_temp_dir("daily-fallback-pricing-source");
+    let xdg_cache = root.join("xdg-cache");
+    write_pricing_cache(
+        &root,
+        &xdg_cache,
+        r#"{"unrelated-model":{"input_cost_per_token":0.000001,"output_cost_per_token":0.000002}}"#,
+    );
+    let claude_file = root.join(".claude/projects/myproject/session-a.jsonl");
+    write_file(
+        &claude_file,
+        r#"{"timestamp":"2026-02-06T12:00:00Z","message":{"id":"msg_1","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":100,"output_tokens":50}}}
+"#,
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "--csv",
+            "-O",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("HOME", &root), ("XDG_CACHE_HOME", &xdg_cache)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let output = String::from_utf8(stdout).expect("utf8 stdout");
+    let lines: Vec<&str> = output.lines().collect();
+    assert!(lines[0].ends_with(",cost,pricing_source"));
+    assert!(lines[1].ends_with(",fallback"));
 
     let _ = fs::remove_dir_all(root);
 }

--- a/tests/cli_grok_cursor.rs
+++ b/tests/cli_grok_cursor.rs
@@ -170,7 +170,7 @@ fn source_flag_can_select_grok_without_subcommand() {
             "--until",
             "2026-02-06",
         ],
-        &[("GROK_HOME", &grok_home)],
+        &[("GROK_HOME", &grok_home), ("HOME", &root)],
     );
     assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
 
@@ -208,7 +208,7 @@ fn grok_daily_json_marks_estimated_proxy_cost() {
             "--until",
             "2026-02-06",
         ],
-        &[("GROK_HOME", &grok_home)],
+        &[("GROK_HOME", &grok_home), ("HOME", &root)],
     );
     assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
 
@@ -240,15 +240,15 @@ fn grok_daily_csv_marks_estimated_proxy_cost() {
             "--until",
             "2026-02-06",
         ],
-        &[("GROK_HOME", &grok_home)],
+        &[("GROK_HOME", &grok_home), ("HOME", &root)],
     );
     assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
 
     let output = String::from_utf8(stdout).expect("utf8 stdout");
     let lines: Vec<&str> = output.lines().collect();
-    assert!(lines[0].ends_with(",cost,cost_kind,estimated_cost"));
+    assert!(lines[0].ends_with(",cost,cost_kind,estimated_cost,pricing_source"));
     assert!(
-        lines[1].ends_with(",0.001500,estimated_proxy,0.001500"),
+        lines[1].ends_with(",0.001500,estimated_proxy,0.001500,fallback"),
         "stdout: {output}"
     );
 


### PR DESCRIPTION
## Summary
- track pricing source provenance across live, cache, stale cache, fallback, and mixed pricing paths
- add pricing_source and cache metadata fields to JSON/CSV/statusline/top/budget outputs while preserving unknown-model null/N/A behavior
- add CLI coverage for fresh-cache metadata and fallback-with-cache CSV column stability

Fixes #33

## Verification
- cargo fmt --check
- cargo check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- python3 checks/check_workflow.py --repo .
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH33
- git diff --check