### PR TITLE
feat: add endpoints subcommand (native vs proxy traffic breakdown)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -26,7 +26,7 @@ use crate::utils::{Timezone, filter_json};
 use serde_json::json;
 
 /// Print JSON output, optionally filtering through jq
-fn print_json(json: &str, jq_filter: Option<&str>) {
+pub(crate) fn print_json(json: &str, jq_filter: Option<&str>) {
     match jq_filter {
         Some(filter) => match filter_json(json, filter) {
             Ok(filtered) => print!("{filtered}"),
@@ -50,7 +50,7 @@ pub(crate) struct CommandContext<'a> {
     pub(crate) budget_as_of: chrono::NaiveDate,
 }
 
-fn print_no_data_hint(source_name: &str, category: &str) {
+pub(crate) fn print_no_data_hint(source_name: &str, category: &str) {
     println!(
         "No {source_name} {category} data found in the selected date range.\nHint: widen --since/--until, try `today`, or run `ccstats sources` to pick a different --source."
     );
@@ -632,6 +632,7 @@ pub(crate) fn handle_source_command(
             }
             return handle_blocks(source, ctx);
         }
+        SourceCommand::Endpoints => return crate::endpoints_cmd::handle_endpoints(source, ctx),
         SourceCommand::Statusline => return handle_statusline(source, ctx),
         SourceCommand::Tools => {
             if !caps.has_tool_calls {
@@ -766,6 +767,7 @@ pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandCo
         SourceCommand::Session
         | SourceCommand::Project
         | SourceCommand::Blocks
+        | SourceCommand::Endpoints
         | SourceCommand::Tools => {
             println!(
                 "`--source all` supports daily, weekly, monthly, today, statusline, and top views.\nHint: use a specific --source for {command:?}."

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -33,6 +33,8 @@ pub(crate) enum Commands {
     Project,
     /// Show usage by 5-hour billing blocks
     Blocks,
+    /// Show usage split by serving endpoint (native Anthropic vs proxy)
+    Endpoints,
     /// Output single line for statusline/tmux integration
     Statusline,
     /// Show tool usage statistics (Read, Bash, Edit, etc.)
@@ -105,6 +107,7 @@ pub(crate) enum SourceCommand {
     Session,
     Project,
     Blocks,
+    Endpoints,
     Statusline,
     Tools,
     Top { dim: TopDimension, limit: usize },
@@ -134,6 +137,7 @@ impl From<&Commands> for SourceCommand {
             Commands::Session => SourceCommand::Session,
             Commands::Project => SourceCommand::Project,
             Commands::Blocks => SourceCommand::Blocks,
+            Commands::Endpoints => SourceCommand::Endpoints,
             Commands::Statusline => SourceCommand::Statusline,
             Commands::Tools => SourceCommand::Tools,
             Commands::Top { dim, limit } => SourceCommand::Top {

--- a/src/core/aggregator.rs
+++ b/src/core/aggregator.rs
@@ -5,7 +5,9 @@
 use chrono::{DateTime, Duration, FixedOffset, TimeZone, Timelike};
 use std::collections::HashMap;
 
-use crate::core::types::{BlockStats, DayStats, ProjectStats, RawEntry, SessionStats, Stats};
+use crate::core::types::{
+    BlockStats, DayStats, Endpoint, EndpointStats, ProjectStats, RawEntry, SessionStats, Stats,
+};
 
 /// Aggregate entries by day (consumes entries to avoid cloning)
 pub(crate) fn aggregate_daily(entries: Vec<RawEntry>) -> HashMap<String, DayStats> {
@@ -18,6 +20,23 @@ pub(crate) fn aggregate_daily(entries: Vec<RawEntry>) -> HashMap<String, DayStat
     }
 
     day_stats
+}
+
+/// Aggregate entries by serving endpoint (native vs proxy vs unknown).
+/// Returns present endpoints in canonical order (native, proxy, unknown).
+pub(crate) fn aggregate_by_endpoint(entries: Vec<RawEntry>) -> Vec<EndpointStats> {
+    let mut map: HashMap<Endpoint, EndpointStats> = HashMap::new();
+    for entry in entries {
+        let stats = entry.to_stats();
+        let acc = map.entry(entry.endpoint).or_default();
+        acc.endpoint = entry.endpoint;
+        acc.stats.add(&stats);
+        acc.models.entry(entry.model).or_default().add(&stats);
+    }
+    Endpoint::ORDER
+        .iter()
+        .filter_map(|ep| map.remove(ep))
+        .collect()
 }
 
 pub(crate) fn merge_day_stats(
@@ -259,6 +278,7 @@ mod tests {
             reasoning_tokens: 0,
             stop_reason: Some("end_turn".to_string()),
             cost_kind: crate::core::CostKind::Real,
+            endpoint: Endpoint::Unknown,
         }
     }
 
@@ -486,6 +506,7 @@ mod tests {
                 reasoning_tokens: 0,
                 stop_reason: None,
                 cost_kind: crate::core::CostKind::Real,
+                endpoint: Endpoint::Unknown,
             },
             RawEntry {
                 timestamp: "2025-01-01T08:00:00Z".to_string(),
@@ -504,6 +525,7 @@ mod tests {
                 reasoning_tokens: 0,
                 stop_reason: None,
                 cost_kind: crate::core::CostKind::Real,
+                endpoint: Endpoint::Unknown,
             },
             RawEntry {
                 timestamp: "2025-01-01T20:00:00Z".to_string(),
@@ -522,6 +544,7 @@ mod tests {
                 reasoning_tokens: 0,
                 stop_reason: None,
                 cost_kind: crate::core::CostKind::Real,
+                endpoint: Endpoint::Unknown,
             },
         ];
         let result = aggregate_sessions(entries);

--- a/src/core/aggregator_endpoint_tests.rs
+++ b/src/core/aggregator_endpoint_tests.rs
@@ -1,0 +1,70 @@
+//! Unit tests for `aggregate_by_endpoint`.
+//!
+//! Kept in a separate file because `aggregator.rs` is at the module size limit.
+
+use crate::core::aggregate_by_endpoint;
+use crate::core::types::{CostKind, Endpoint, RawEntry};
+
+fn entry(model: &str, endpoint: Endpoint, input: i64) -> RawEntry {
+    RawEntry {
+        timestamp: "2025-01-01T00:00:00Z".to_string(),
+        timestamp_ms: 0,
+        date_str: "2025-01-01".to_string(),
+        message_id: None,
+        session_key: "s".to_string(),
+        session_id: "s".to_string(),
+        project_path: String::new(),
+        model: model.to_string(),
+        input_tokens: input,
+        output_tokens: 0,
+        cache_creation: 0,
+        cache_creation_1h: 0,
+        cache_read: 0,
+        reasoning_tokens: 0,
+        stop_reason: Some("end_turn".to_string()),
+        cost_kind: CostKind::Real,
+        endpoint,
+    }
+}
+
+#[test]
+fn groups_orders_and_sums_across_endpoints() {
+    // Insert out of canonical order to prove ORDER is applied, not insertion order.
+    let entries = vec![
+        entry("m", Endpoint::Proxy, 100),
+        entry("m", Endpoint::Native, 10),
+        entry("m", Endpoint::Unknown, 1),
+        entry("m", Endpoint::Native, 20),
+    ];
+
+    let result = aggregate_by_endpoint(entries);
+
+    // Canonical order: Native, Proxy, Unknown.
+    assert_eq!(
+        result.iter().map(|e| e.endpoint).collect::<Vec<_>>(),
+        vec![Endpoint::Native, Endpoint::Proxy, Endpoint::Unknown]
+    );
+
+    let native = &result[0];
+    assert_eq!(native.stats.count, 2);
+    assert_eq!(native.stats.input_tokens, 30);
+    // Per-model map accumulates within the endpoint.
+    assert_eq!(native.models.get("m").map(|s| s.input_tokens), Some(30));
+
+    assert_eq!(result[1].stats.count, 1);
+    assert_eq!(result[1].stats.input_tokens, 100);
+    assert_eq!(result[2].stats.count, 1);
+}
+
+#[test]
+fn empty_input_yields_no_endpoints() {
+    assert!(aggregate_by_endpoint(Vec::new()).is_empty());
+}
+
+#[test]
+fn omits_absent_endpoints() {
+    // Only proxy present -> result has exactly one row, not three.
+    let result = aggregate_by_endpoint(vec![entry("m", Endpoint::Proxy, 5)]);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].endpoint, Endpoint::Proxy);
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,6 +1,8 @@
 //! Core module - shared types and logic for all data sources
 
 mod aggregator;
+#[cfg(test)]
+mod aggregator_endpoint_tests;
 mod dedup;
 mod tool_aggregator;
 mod tool_types;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -7,8 +7,8 @@ mod tool_types;
 mod types;
 
 pub(crate) use aggregator::{
-    aggregate_blocks, aggregate_daily, aggregate_projects, aggregate_sessions,
-    aggregate_sessions_map, format_project_name, merge_day_stats,
+    aggregate_blocks, aggregate_by_endpoint, aggregate_daily, aggregate_projects,
+    aggregate_sessions, aggregate_sessions_map, format_project_name, merge_day_stats,
 };
 pub(crate) use dedup::{DedupAccumulator, source_wide_message_id};
 pub(crate) use tool_aggregator::aggregate_tools;
@@ -16,6 +16,6 @@ pub(crate) use tool_aggregator::aggregate_tools;
 pub(crate) use tool_types::ToolStats;
 pub(crate) use tool_types::{ToolCall, ToolCallIdentity, ToolSummary};
 pub(crate) use types::{
-    BlockStats, CostKind, CostTokens, DataQuality, DateFilter, DayStats, LoadResult, ProjectStats,
-    RawEntry, SessionStats, Stats,
+    BlockStats, CostKind, CostTokens, DataQuality, DateFilter, DayStats, Endpoint, EndpointStats,
+    LoadResult, ProjectStats, RawEntry, SessionStats, Stats,
 };

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -92,6 +92,38 @@ impl CostKind {
     }
 }
 
+/// Serving endpoint an entry was routed through.
+///
+/// Derived from the Claude Code `inference_geo` usage field (see
+/// `source/claude/parser.rs`). This field is non-standard and undocumented;
+/// the classification is empirically derived and may change across Claude Code
+/// versions or proxies. Non-Claude sources are always `Unknown`.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Endpoint {
+    /// Native Anthropic endpoint (`inference_geo == "not_available"`).
+    Native,
+    /// Third-party proxy / gateway (`inference_geo == ""`): does not report
+    /// cache creation and bills full context as raw input.
+    Proxy,
+    /// Field absent, other value, or non-Claude source.
+    #[default]
+    Unknown,
+}
+
+impl Endpoint {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Endpoint::Native => "native",
+            Endpoint::Proxy => "proxy",
+            Endpoint::Unknown => "unknown",
+        }
+    }
+
+    /// Canonical display order for tables/JSON.
+    pub(crate) const ORDER: [Endpoint; 3] = [Endpoint::Native, Endpoint::Proxy, Endpoint::Unknown];
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct CostTokens {
     pub(crate) input_tokens: i64,
@@ -183,6 +215,14 @@ pub(crate) struct BlockStats {
     pub(crate) models: HashMap<String, Stats>,
 }
 
+/// Per-endpoint (native vs proxy) statistics
+#[derive(Debug, Default, Clone)]
+pub(crate) struct EndpointStats {
+    pub(crate) endpoint: Endpoint,
+    pub(crate) stats: Stats,
+    pub(crate) models: HashMap<String, Stats>,
+}
+
 /// Raw entry parsed from source files
 /// All sources convert their native format to this unified structure
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -217,6 +257,9 @@ pub(crate) struct RawEntry {
     pub(crate) stop_reason: Option<String>,
     #[serde(default)]
     pub(crate) cost_kind: CostKind,
+    /// Serving endpoint (native vs proxy); Claude-only, else `Unknown`.
+    #[serde(default)]
+    pub(crate) endpoint: Endpoint,
 }
 
 impl RawEntry {
@@ -453,6 +496,7 @@ mod tests {
             reasoning_tokens: 10,
             stop_reason: None,
             cost_kind: CostKind::Real,
+            endpoint: Endpoint::Unknown,
         };
         let s = entry.to_stats();
         assert_eq!(s.input_tokens, 100);

--- a/src/endpoints_cmd.rs
+++ b/src/endpoints_cmd.rs
@@ -1,0 +1,51 @@
+//! Handler for the `endpoints` subcommand (native vs proxy breakdown).
+//!
+//! Lives in its own module to keep `app.rs` under the module size limit.
+
+use crate::app::{CommandContext, print_json, print_no_data_hint};
+use crate::output::{
+    EndpointTableOptions, OutputFormat, output_endpoint_json, print_endpoint_table,
+};
+use crate::source::{Source, load_endpoints};
+
+pub(crate) fn handle_endpoints(source: &dyn Source, ctx: &CommandContext<'_>) {
+    if !source.capabilities().has_endpoints {
+        println!(
+            "{} does not support endpoint breakdown.\nHint: switch with `--source claude` (or alias `--source cc`).",
+            source.display_name()
+        );
+        return;
+    }
+
+    let endpoints = load_endpoints(source, ctx.filter, ctx.timezone);
+    if endpoints.is_empty() {
+        print_no_data_hint(source.display_name(), "endpoint");
+        return;
+    }
+
+    match ctx.cli.output_format() {
+        OutputFormat::Csv => {
+            eprintln!("CSV output is not available for the endpoints view; use --json.");
+        }
+        OutputFormat::Json => {
+            let json = output_endpoint_json(
+                &endpoints,
+                ctx.pricing_db,
+                ctx.cli.show_cost(),
+                ctx.currency,
+            );
+            print_json(&json, ctx.jq_filter);
+        }
+        OutputFormat::Table => print_endpoint_table(
+            &endpoints,
+            ctx.pricing_db,
+            EndpointTableOptions {
+                use_color: ctx.cli.use_color(),
+                show_cost: ctx.cli.show_cost(),
+                source_label: source.display_name(),
+                number_format: ctx.number_format,
+                currency: ctx.currency,
+            },
+        ),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ mod cli;
 mod config;
 mod consts;
 mod core;
+mod endpoints_cmd;
 mod error;
 mod output;
 mod pricing;

--- a/src/output/endpoints.rs
+++ b/src/output/endpoints.rs
@@ -1,0 +1,256 @@
+//! Output for per-endpoint (native vs proxy) usage breakdown.
+
+use comfy_table::{Cell, Color};
+
+use crate::core::{EndpointStats, Stats};
+use crate::output::format::{
+    NumberFormat, cost_json_value, create_styled_table, format_cost, format_number, header_cell,
+    right_cell,
+};
+use crate::output::pricing_meta;
+use crate::pricing::{CurrencyConverter, PricingDb, sum_model_costs};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct EndpointTableOptions<'a> {
+    pub(crate) use_color: bool,
+    pub(crate) show_cost: bool,
+    pub(crate) source_label: &'a str,
+    pub(crate) number_format: NumberFormat,
+    pub(crate) currency: Option<&'a CurrencyConverter>,
+}
+
+/// Average input tokens per call — the key signal that distinguishes native
+/// (well-cached, small raw input) from proxy (full context billed as input).
+fn avg_input_per_call(stats: &Stats) -> i64 {
+    if stats.count <= 0 {
+        0
+    } else {
+        stats.input_tokens / stats.count
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+pub(crate) fn print_endpoint_table(
+    endpoints: &[EndpointStats],
+    pricing_db: &PricingDb,
+    options: EndpointTableOptions<'_>,
+) {
+    let use_color = options.use_color;
+    let show_cost = options.show_cost;
+    let number_format = options.number_format;
+
+    let mut table = create_styled_table();
+    let mut header = vec![
+        header_cell("Endpoint", use_color),
+        header_cell("Calls", use_color),
+        header_cell("Input", use_color),
+        header_cell("Output", use_color),
+        header_cell("Cache Create", use_color),
+        header_cell("Cache Read", use_color),
+        header_cell("Total", use_color),
+        header_cell("Avg In/Call", use_color),
+    ];
+    if show_cost {
+        header.push(header_cell("Cost", use_color));
+    }
+    table.set_header(header);
+
+    let cost_color = if use_color { Some(Color::Green) } else { None };
+    let mut total_stats = Stats::default();
+    let mut total_cost = 0.0;
+
+    for ep in endpoints {
+        let ep_cost = sum_model_costs(&ep.models, pricing_db);
+        total_cost += ep_cost;
+        total_stats.add(&ep.stats);
+
+        let mut row = vec![
+            Cell::new(ep.endpoint.as_str()),
+            right_cell(&format_number(ep.stats.count, number_format), None, false),
+            right_cell(
+                &format_number(ep.stats.input_tokens, number_format),
+                None,
+                false,
+            ),
+            right_cell(
+                &format_number(ep.stats.output_tokens, number_format),
+                None,
+                false,
+            ),
+            right_cell(
+                &format_number(ep.stats.cache_creation, number_format),
+                None,
+                false,
+            ),
+            right_cell(
+                &format_number(ep.stats.cache_read, number_format),
+                None,
+                false,
+            ),
+            right_cell(
+                &format_number(ep.stats.total_tokens(), number_format),
+                None,
+                false,
+            ),
+            right_cell(
+                &format_number(avg_input_per_call(&ep.stats), number_format),
+                None,
+                false,
+            ),
+        ];
+        if show_cost {
+            row.push(right_cell(
+                &format_cost(ep_cost, options.currency),
+                cost_color,
+                false,
+            ));
+        }
+        table.add_row(row);
+    }
+
+    // Total row
+    let mut total_row = vec![
+        Cell::new("TOTAL"),
+        right_cell(&format_number(total_stats.count, number_format), None, true),
+        right_cell(
+            &format_number(total_stats.input_tokens, number_format),
+            None,
+            true,
+        ),
+        right_cell(
+            &format_number(total_stats.output_tokens, number_format),
+            None,
+            true,
+        ),
+        right_cell(
+            &format_number(total_stats.cache_creation, number_format),
+            None,
+            true,
+        ),
+        right_cell(
+            &format_number(total_stats.cache_read, number_format),
+            None,
+            true,
+        ),
+        right_cell(
+            &format_number(total_stats.total_tokens(), number_format),
+            None,
+            true,
+        ),
+        right_cell(
+            &format_number(avg_input_per_call(&total_stats), number_format),
+            None,
+            true,
+        ),
+    ];
+    if show_cost {
+        total_row.push(right_cell(
+            &format_cost(total_cost, options.currency),
+            cost_color,
+            true,
+        ));
+    }
+    table.add_row(total_row);
+
+    println!("\n  {} Usage by Endpoint\n", options.source_label);
+    println!("{table}");
+    if show_cost
+        && let Some(note) =
+            pricing_meta::note_for_maps(endpoints.iter().map(|ep| &ep.models), pricing_db)
+    {
+        println!("\n  {note}");
+    }
+    println!(
+        "\n  proxy = third-party gateway (does not report cache creation; bills full context as input)\n"
+    );
+}
+
+pub(crate) fn output_endpoint_json(
+    endpoints: &[EndpointStats],
+    pricing_db: &PricingDb,
+    show_cost: bool,
+    currency: Option<&CurrencyConverter>,
+) -> String {
+    let output: Vec<serde_json::Value> = endpoints
+        .iter()
+        .map(|ep| {
+            let ep_cost = sum_model_costs(&ep.models, pricing_db);
+            let mut models: Vec<_> = ep.models.keys().cloned().collect();
+            models.sort();
+            let mut obj = serde_json::json!({
+                "endpoint": ep.endpoint.as_str(),
+                "calls": ep.stats.count,
+                "input_tokens": ep.stats.input_tokens,
+                "output_tokens": ep.stats.output_tokens,
+                "cache_creation_tokens": ep.stats.cache_creation,
+                "cache_read_tokens": ep.stats.cache_read,
+                "total_tokens": ep.stats.total_tokens(),
+                "avg_input_per_call": avg_input_per_call(&ep.stats),
+                "models": models,
+            });
+            if show_cost {
+                obj["cost"] = cost_json_value(ep_cost, currency);
+                pricing_meta::add_json(&mut obj, &ep.models, pricing_db);
+            }
+            obj
+        })
+        .collect();
+
+    serde_json::to_string_pretty(&output).unwrap_or_else(|e| {
+        eprintln!("Failed to serialize JSON output: {e}");
+        "[]".to_string()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::Endpoint;
+    use std::collections::HashMap;
+
+    fn make_endpoint(endpoint: Endpoint, input: i64, count: i64) -> EndpointStats {
+        EndpointStats {
+            endpoint,
+            stats: Stats {
+                input_tokens: input,
+                count,
+                ..Default::default()
+            },
+            models: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn avg_input_handles_zero_count() {
+        let stats = Stats {
+            input_tokens: 100,
+            count: 0,
+            ..Default::default()
+        };
+        assert_eq!(avg_input_per_call(&stats), 0);
+    }
+
+    #[test]
+    fn avg_input_divides_by_call_count() {
+        let stats = Stats {
+            input_tokens: 1000,
+            count: 4,
+            ..Default::default()
+        };
+        assert_eq!(avg_input_per_call(&stats), 250);
+    }
+
+    #[test]
+    fn json_contains_endpoint_and_avg_fields() {
+        let db = PricingDb::default();
+        let endpoints = vec![
+            make_endpoint(Endpoint::Native, 1000, 10),
+            make_endpoint(Endpoint::Proxy, 5000, 5),
+        ];
+        let json = output_endpoint_json(&endpoints, &db, false, None);
+        assert!(json.contains("\"endpoint\": \"native\""));
+        assert!(json.contains("\"endpoint\": \"proxy\""));
+        assert!(json.contains("\"avg_input_per_call\": 100"));
+        assert!(json.contains("\"avg_input_per_call\": 1000"));
+    }
+}

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,6 +1,7 @@
 mod blocks;
 mod budget;
 mod csv;
+mod endpoints;
 mod format;
 mod json;
 mod period;
@@ -34,6 +35,7 @@ pub(crate) use csv::{
     append_data_quality_csv_comment, output_block_csv, output_monthly_budget_csv,
     output_period_csv_with_quality, output_project_csv, output_session_csv,
 };
+pub(crate) use endpoints::{EndpointTableOptions, output_endpoint_json, print_endpoint_table};
 pub(crate) use format::NumberFormat;
 pub(crate) use json::output_period_json_with_quality;
 pub(crate) use period::Period;

--- a/src/sdk/batch.rs
+++ b/src/sdk/batch.rs
@@ -361,6 +361,7 @@ mod tests {
                     reasoning_tokens: 0,
                     stop_reason: Some("complete".to_string()),
                     cost_kind: crate::core::CostKind::Real,
+                    endpoint: crate::core::Endpoint::Unknown,
                 }],
                 errors: 0,
             }

--- a/src/source/claude/config.rs
+++ b/src/source/claude/config.rs
@@ -46,6 +46,7 @@ impl Source for ClaudeSource {
             has_cache_creation: true,
             needs_dedup: true,
             has_tool_calls: true,
+            has_endpoints: true,
         }
     }
 

--- a/src/source/claude/parser.rs
+++ b/src/source/claude/parser.rs
@@ -10,7 +10,7 @@ use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
 use crate::consts::{DATE_FORMAT, UNKNOWN};
-use crate::core::{RawEntry, source_wide_message_id};
+use crate::core::{Endpoint, RawEntry, source_wide_message_id};
 use crate::source::ParseOutput;
 use crate::utils::Timezone;
 
@@ -41,6 +41,11 @@ struct Usage {
     cache_read_input_tokens: Option<i64>,
     /// TTL breakdown of cache creation tokens (newer Claude Code versions).
     cache_creation: Option<CacheCreation>,
+    /// Non-standard, undocumented field emitted by Claude Code. Empirically it
+    /// distinguishes the native Anthropic endpoint (`"not_available"`) from
+    /// third-party proxies/gateways (`""`). Used only to classify `Endpoint`;
+    /// values may change across versions/proxies.
+    inference_geo: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]
@@ -301,6 +306,8 @@ fn parse_entry_with_debug(
     let local_dt = timezone.to_fixed_offset(utc_dt);
     let date = local_dt.date_naive();
 
+    let endpoint = classify_endpoint(usage.inference_geo.as_deref());
+
     let cache_creation = non_negative_tokens(usage.cache_creation_input_tokens);
     let cache_creation_1h = non_negative_tokens(
         usage
@@ -327,7 +334,18 @@ fn parse_entry_with_debug(
         reasoning_tokens: 0, // Claude doesn't have reasoning tokens
         stop_reason: msg.stop_reason,
         cost_kind: crate::core::CostKind::Real,
+        endpoint,
     })
+}
+
+/// Classify the serving endpoint from the non-standard `inference_geo` field.
+/// See the `Usage.inference_geo` doc comment for the caveats.
+fn classify_endpoint(inference_geo: Option<&str>) -> Endpoint {
+    match inference_geo {
+        Some("not_available") => Endpoint::Native,
+        Some("") => Endpoint::Proxy,
+        _ => Endpoint::Unknown,
+    }
 }
 
 #[cfg(test)]
@@ -427,6 +445,7 @@ mod tests {
                     cache_creation_input_tokens: None,
                     cache_read_input_tokens: None,
                     cache_creation: None,
+                    inference_geo: None,
                 }),
             }),
         }
@@ -548,6 +567,7 @@ mod tests {
                     cache_creation_input_tokens: Some(30),
                     cache_read_input_tokens: Some(20),
                     cache_creation: None,
+                    inference_geo: None,
                 }),
             }),
         };
@@ -571,6 +591,7 @@ mod tests {
                     cache_creation_input_tokens: None,
                     cache_read_input_tokens: None,
                     cache_creation: None,
+                    inference_geo: None,
                 }),
             }),
         };
@@ -598,6 +619,7 @@ mod tests {
                     cache_creation: Some(CacheCreation {
                         ephemeral_1h_input_tokens: Some(25),
                     }),
+                    inference_geo: None,
                 }),
             }),
         };
@@ -624,6 +646,7 @@ mod tests {
                     cache_creation: Some(CacheCreation {
                         ephemeral_1h_input_tokens: Some(99),
                     }),
+                    inference_geo: None,
                 }),
             }),
         };
@@ -657,6 +680,7 @@ mod tests {
                     cache_creation_input_tokens: Some(-30),
                     cache_read_input_tokens: Some(-20),
                     cache_creation: None,
+                    inference_geo: None,
                 }),
             }),
         };

--- a/src/source/claude/parser.rs
+++ b/src/source/claude/parser.rs
@@ -353,6 +353,21 @@ mod tests {
     use super::*;
 
     // ========================================================================
+    // classify_endpoint
+    // ========================================================================
+
+    #[test]
+    fn classify_endpoint_maps_inference_geo() {
+        assert_eq!(classify_endpoint(Some("not_available")), Endpoint::Native);
+        assert_eq!(classify_endpoint(Some("")), Endpoint::Proxy);
+        assert_eq!(classify_endpoint(None), Endpoint::Unknown);
+        // Any other value (e.g. a real geo or a future sentinel) is Unknown,
+        // never silently misclassified as native/proxy.
+        assert_eq!(classify_endpoint(Some("us-east")), Endpoint::Unknown);
+        assert_eq!(classify_endpoint(Some("NOT_AVAILABLE")), Endpoint::Unknown);
+    }
+
+    // ========================================================================
     // normalize_model_name
     // ========================================================================
 

--- a/src/source/codex/config.rs
+++ b/src/source/codex/config.rs
@@ -45,6 +45,7 @@ impl Source for CodexSource {
             has_cache_creation: false,
             needs_dedup: true,
             has_tool_calls: false,
+            has_endpoints: false,
         }
     }
 

--- a/src/source/codex/parser.rs
+++ b/src/source/codex/parser.rs
@@ -542,6 +542,7 @@ fn push_codex_entry(
         reasoning_tokens,
         stop_reason: Some("complete".to_string()), // Codex events are always complete
         cost_kind: crate::core::CostKind::Real,
+        endpoint: crate::core::Endpoint::Unknown,
     });
 }
 

--- a/src/source/cursor/config.rs
+++ b/src/source/cursor/config.rs
@@ -48,6 +48,7 @@ impl Source for CursorSource {
             has_cache_creation: false,
             needs_dedup: false,
             has_tool_calls: false,
+            has_endpoints: false,
         }
     }
 

--- a/src/source/cursor/parser.rs
+++ b/src/source/cursor/parser.rs
@@ -259,6 +259,7 @@ fn entry_from_bubble(
         reasoning_tokens: 0,
         stop_reason: Some("complete".to_string()),
         cost_kind: crate::core::CostKind::Real,
+        endpoint: crate::core::Endpoint::Unknown,
     })
 }
 
@@ -309,6 +310,7 @@ fn entry_from_generation(generation: &Value, path: &Path, timezone: Timezone) ->
         reasoning_tokens: 0,
         stop_reason: Some("complete".to_string()),
         cost_kind: crate::core::CostKind::Real,
+        endpoint: crate::core::Endpoint::Unknown,
     })
 }
 

--- a/src/source/grok/config.rs
+++ b/src/source/grok/config.rs
@@ -45,6 +45,7 @@ impl Source for GrokSource {
             has_cache_creation: false,
             needs_dedup: false,
             has_tool_calls: false,
+            has_endpoints: false,
         }
     }
 

--- a/src/source/grok/parser.rs
+++ b/src/source/grok/parser.rs
@@ -358,6 +358,7 @@ pub(super) fn parse_grok_signal_file_with_debug(
             reasoning_tokens: 0,
             stop_reason: Some("context_snapshot".to_string()),
             cost_kind: CostKind::EstimatedProxy,
+            endpoint: crate::core::Endpoint::Unknown,
         }],
         errors,
     }

--- a/src/source/loader.rs
+++ b/src/source/loader.rs
@@ -6,9 +6,9 @@ use std::time::Instant;
 
 use crate::consts::DATE_FORMAT;
 use crate::core::{
-    BlockStats, DateFilter, DedupAccumulator, LoadResult, ProjectStats, RawEntry, SessionStats,
-    aggregate_blocks, aggregate_daily, aggregate_projects, aggregate_sessions,
-    aggregate_sessions_map, merge_day_stats,
+    BlockStats, DateFilter, DedupAccumulator, EndpointStats, LoadResult, ProjectStats, RawEntry,
+    SessionStats, aggregate_blocks, aggregate_by_endpoint, aggregate_daily, aggregate_projects,
+    aggregate_sessions, aggregate_sessions_map, merge_day_stats,
 };
 use crate::source::Source;
 use crate::utils::Timezone;
@@ -17,14 +17,14 @@ use chrono::NaiveDate;
 use chrono::{DateTime, FixedOffset, Utc};
 
 /// Load data from a source
-struct DataLoader<'a> {
+pub(super) struct DataLoader<'a> {
     source: &'a dyn Source,
     quiet: bool,
     debug: bool,
 }
 
 impl<'a> DataLoader<'a> {
-    fn new(source: &'a dyn Source, quiet: bool, debug: bool) -> Self {
+    pub(super) fn new(source: &'a dyn Source, quiet: bool, debug: bool) -> Self {
         Self {
             source,
             quiet,
@@ -403,6 +403,23 @@ impl<'a> DataLoader<'a> {
         projects
     }
 
+    /// Load per-endpoint stats (native vs proxy). Only for sources that
+    /// populate the endpoint field (Claude); others return empty.
+    pub(super) fn load_endpoints(
+        &self,
+        filter: &DateFilter,
+        timezone: Timezone,
+    ) -> Vec<EndpointStats> {
+        if !self.source.capabilities().has_endpoints {
+            return Vec::new();
+        }
+        let (final_entries, _skipped, _) = self.load_deduped_entries_incremental(filter, timezone);
+        if final_entries.is_empty() {
+            return Vec::new();
+        }
+        aggregate_by_endpoint(final_entries)
+    }
+
     /// Load block stats (only for sources that support it)
     fn load_blocks(&self, filter: &DateFilter, timezone: Timezone) -> Vec<BlockStats> {
         if !self.source.capabilities().has_billing_blocks {
@@ -562,6 +579,7 @@ mod tests {
             reasoning_tokens: 0,
             stop_reason: Some("end_turn".to_string()),
             cost_kind: crate::core::CostKind::Real,
+            endpoint: crate::core::Endpoint::Unknown,
         }
     }
 

--- a/src/source/loader_quality_tests.rs
+++ b/src/source/loader_quality_tests.rs
@@ -60,6 +60,7 @@ fn entry(id: &str, input_tokens: i64) -> RawEntry {
         reasoning_tokens: 0,
         stop_reason: Some("end_turn".to_string()),
         cost_kind: crate::core::CostKind::Real,
+        endpoint: crate::core::Endpoint::Unknown,
     }
 }
 

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -38,6 +38,8 @@ pub(crate) struct Capabilities {
     pub(crate) needs_dedup: bool,
     /// Supports tool-call discovery and parsing
     pub(crate) has_tool_calls: bool,
+    /// Populates the serving-endpoint field (native vs proxy classification)
+    pub(crate) has_endpoints: bool,
 }
 
 /// Data source trait - implemented by each CLI tool
@@ -83,3 +85,14 @@ pub(crate) use registry::{ALL_SOURCES, all_sources, get_source, source_choices, 
 
 // Re-export loader functions
 pub(crate) use loader::{load_blocks, load_daily, load_projects, load_sessions, load_tool_calls};
+
+/// Load per-endpoint stats (native vs proxy) for a source. Claude-only; other
+/// sources return empty. Lives here (not in `loader.rs`) to keep that file
+/// under the module size limit.
+pub(crate) fn load_endpoints(
+    source: &dyn Source,
+    filter: &crate::core::DateFilter,
+    timezone: Timezone,
+) -> Vec<crate::core::EndpointStats> {
+    loader::DataLoader::new(source, false, false).load_endpoints(filter, timezone)
+}


### PR DESCRIPTION
Closes #88

## What / Why

Adds a new `endpoints` subcommand that splits Claude Code usage by serving endpoint (native Anthropic vs third-party proxy), classified from the non-standard `inference_geo` usage field (`"not_available"` → native, `""` → proxy).

Proxy-routed traffic does not report `cache_creation` and bills the full context as raw input, silently inflating cost and distorting cache metrics. On a real dataset ~21% of calls were proxy, with ~16× the average input/call of native and `cache_creation` always 0. See #88 for the full finding.

## Usage

```
ccstats endpoints --source claude          # table
ccstats endpoints --source claude --json    # scripting
```

The **Avg In/Call** column is the key signal (native ~939 vs proxy ~15,185).

## Changes

- `core`: `Endpoint` enum + `EndpointStats` + `RawEntry.endpoint`
- `aggregator`: `aggregate_by_endpoint` (weighted sum/sum)
- `claude/parser`: parse `inference_geo` + `classify_endpoint`
- `Capabilities.has_endpoints` (Claude only; other sources → `unknown`)
- new `endpoints` subcommand (table + JSON)
- handler in `endpoints_cmd.rs`, pub loader wrapper in `source/mod.rs` to keep `app.rs` / `loader.rs` under the module size limit

## Proof

- `cargo test` — all pass (494 lib + integration), incl. 3 new unit tests
- `cargo clippy --all-targets` — clean
- `cargo fmt --check` — clean
- Cross-checked tool output against an independent `jq` baseline: proxy share 20.6% (jq 21%), avg-input 16× (jq 17×), proxy `cache_creation == 0` — consistent (absolute counts differ only because the tool deduplicates streaming entries)

## Notes / Review focus

- **Stacked on #87** (base is `fix/claude-sidechain-and-1h-cache-pricing`) because it builds on that branch's `cache_creation_1h` work; merge after #87.
- `inference_geo` is **undocumented**; classification is empirical and may change across Claude Code versions/proxies (flagged in code comments). This is the main thing to sanity-check.
- CSV output is intentionally not supported for this view (use `--json`).