### PR TITLE
feat: report prompt cache hit rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ let summary = summarize_cost_with_cli_config(SummaryOptions {
 println!("today: ${:.2}", summary.cost_usd.unwrap_or(0.0));
 ```
 
-The SDK uses the same source registry, parsers, aggregation logic, pricing cache, and fallback pricing as the CLI. Use `summarize_cost_with_cli_config` when SDK output should follow the same persisted CLI defaults for timezone, offline pricing, strict pricing, and currency. Use `summarize_cost` when the caller wants fully explicit options. Returned summaries include total tokens, cache read/create tokens, reasoning tokens, per-model breakdowns, `cost_usd`, and an optional converted `cost` when `SummaryOptions::currency` is set.
+The SDK uses the same source registry, parsers, aggregation logic, pricing cache, and fallback pricing as the CLI. Use `summarize_cost_with_cli_config` when SDK output should follow the same persisted CLI defaults for timezone, offline pricing, strict pricing, and currency. Use `summarize_cost` when the caller wants fully explicit options. Returned summaries include total tokens, cache read/create tokens, cache hit rate, reasoning tokens, per-model breakdowns, `cost_usd`, and an optional converted `cost` when `SummaryOptions::currency` is set.
 
 Apps that need several windows at once can use the batch API so source logs,
 pricing, and currency are loaded once for the request:
@@ -419,6 +419,22 @@ Source root env overrides are independent of config keys:
 - `reasoning_tokens`
 - `cache_creation_tokens`
 - `cache_read_tokens`
+- `cache_hit_rate`
+
+### Cache Hit Rate
+
+Statistical table, JSON, CSV, statusline, top, session, project, and block outputs
+report prompt-cache hit rate as:
+
+```text
+cache_read / (input + cache_creation + cache_read) * 100
+```
+
+Table output uses one decimal place and a `%` suffix. JSON uses the numeric
+`cache_hit_rate` field, while CSV uses a two-decimal `cache_hit_rate` column.
+Claude and Codex expose the required cache-read metric. Cursor, Grok, and
+mixed `--source all` output report the value as unavailable (`N/A`, `null`, or
+an empty CSV field) instead of treating missing metrics as zero.
 
 ### Parsing Warnings
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -19,8 +19,8 @@ use crate::output::{
 };
 use crate::pricing::{CostDisplayMode, PricingDb};
 use crate::source::{
-    ALL_SOURCES, Capabilities, Source, all_sources, load_blocks, load_daily, load_projects,
-    load_sessions, load_tool_calls,
+    ALL_SOURCES, Capabilities, Source, all_capabilities, all_sources, load_blocks, load_daily,
+    load_projects, load_sessions, load_tool_calls,
 };
 use crate::utils::{Timezone, filter_json};
 use serde_json::json;
@@ -83,6 +83,7 @@ fn render_session(sessions: &[SessionStats], source: &dyn Source, ctx: &CommandC
                 ctx.pricing_db,
                 ctx.cli.sort_order(),
                 ctx.cli.show_cost(),
+                source.capabilities().has_cache_read,
                 ctx.currency,
             );
             print!("{csv}");
@@ -93,6 +94,7 @@ fn render_session(sessions: &[SessionStats], source: &dyn Source, ctx: &CommandC
                 ctx.pricing_db,
                 ctx.cli.sort_order(),
                 ctx.cli.show_cost(),
+                source.capabilities().has_cache_read,
                 ctx.currency,
             );
             print_json(&json, ctx.jq_filter);
@@ -105,6 +107,7 @@ fn render_session(sessions: &[SessionStats], source: &dyn Source, ctx: &CommandC
                 use_color: ctx.cli.use_color(),
                 compact: ctx.cli.compact,
                 show_cost: ctx.cli.show_cost(),
+                supports_cache_read: source.capabilities().has_cache_read,
                 number_format: ctx.number_format,
                 source_label: source.display_name(),
                 timezone: ctx.timezone,
@@ -132,6 +135,7 @@ fn render_project(projects: &[ProjectStats], source: &dyn Source, ctx: &CommandC
                 ctx.pricing_db,
                 ctx.cli.sort_order(),
                 ctx.cli.show_cost(),
+                source.capabilities().has_cache_read,
                 ctx.currency,
             );
             print!("{csv}");
@@ -142,6 +146,7 @@ fn render_project(projects: &[ProjectStats], source: &dyn Source, ctx: &CommandC
                 ctx.pricing_db,
                 ctx.cli.sort_order(),
                 ctx.cli.show_cost(),
+                source.capabilities().has_cache_read,
                 ctx.currency,
             );
             print_json(&json, ctx.jq_filter);
@@ -154,6 +159,7 @@ fn render_project(projects: &[ProjectStats], source: &dyn Source, ctx: &CommandC
                 use_color: ctx.cli.use_color(),
                 compact: ctx.cli.compact,
                 show_cost: ctx.cli.show_cost(),
+                supports_cache_read: source.capabilities().has_cache_read,
                 source_label: source.display_name(),
                 number_format: ctx.number_format,
                 currency: ctx.currency,
@@ -180,6 +186,7 @@ fn render_blocks(blocks: &[BlockStats], source: &dyn Source, ctx: &CommandContex
                 ctx.pricing_db,
                 ctx.cli.sort_order(),
                 ctx.cli.show_cost(),
+                source.capabilities().has_cache_read,
                 ctx.currency,
             );
             print!("{csv}");
@@ -190,6 +197,7 @@ fn render_blocks(blocks: &[BlockStats], source: &dyn Source, ctx: &CommandContex
                 ctx.pricing_db,
                 ctx.cli.sort_order(),
                 ctx.cli.show_cost(),
+                source.capabilities().has_cache_read,
                 ctx.currency,
             );
             print_json(&json, ctx.jq_filter);
@@ -202,6 +210,7 @@ fn render_blocks(blocks: &[BlockStats], source: &dyn Source, ctx: &CommandContex
                 use_color: ctx.cli.use_color(),
                 compact: ctx.cli.compact,
                 show_cost: ctx.cli.show_cost(),
+                supports_cache_read: source.capabilities().has_cache_read,
                 source_label: source.display_name(),
                 number_format: ctx.number_format,
                 currency: ctx.currency,
@@ -215,6 +224,7 @@ fn handle_top(
     dim: TopDimension,
     limit: usize,
     source_label: &str,
+    supports_cache_read: bool,
     ctx: &CommandContext<'_>,
     cost_mode: CostDisplayMode,
 ) {
@@ -223,24 +233,27 @@ fn handle_top(
         return;
     }
 
-    render_top(rows, dim, limit, source_label, ctx, cost_mode);
-}
-
-fn render_top(
-    rows: &[TopRow],
-    dim: TopDimension,
-    limit: usize,
-    source_label: &str,
-    ctx: &CommandContext<'_>,
-    cost_mode: CostDisplayMode,
-) {
     match ctx.cli.output_format() {
         OutputFormat::Csv => {
-            let csv = output_top_csv(rows, dim, limit, ctx.cli.show_cost(), ctx.currency);
+            let csv = output_top_csv(
+                rows,
+                dim,
+                limit,
+                ctx.cli.show_cost(),
+                supports_cache_read,
+                ctx.currency,
+            );
             print!("{csv}");
         }
         OutputFormat::Json => {
-            let json = output_top_json(rows, dim, limit, ctx.cli.show_cost(), ctx.currency);
+            let json = output_top_json(
+                rows,
+                dim,
+                limit,
+                ctx.cli.show_cost(),
+                supports_cache_read,
+                ctx.currency,
+            );
             print_json(&json, ctx.jq_filter);
         }
         OutputFormat::Table => print_top_table(
@@ -249,6 +262,7 @@ fn render_top(
                 use_color: ctx.cli.use_color(),
                 compact: ctx.cli.compact,
                 show_cost: ctx.cli.show_cost(),
+                supports_cache_read,
                 source_label,
                 number_format: ctx.number_format,
                 currency: ctx.currency,
@@ -275,6 +289,7 @@ fn handle_top_for_source(
                 dim,
                 limit,
                 source.display_name(),
+                source.capabilities().has_cache_read,
                 ctx,
                 CostDisplayMode::Total,
             );
@@ -294,6 +309,7 @@ fn handle_top_for_source(
                 dim,
                 limit,
                 source.display_name(),
+                source.capabilities().has_cache_read,
                 ctx,
                 CostDisplayMode::Total,
             );
@@ -334,7 +350,7 @@ fn render_tools(summary: &ToolSummary, ctx: &CommandContext<'_>) {
 
 fn handle_sources(ctx: &CommandContext<'_>) {
     let sources: Vec<&dyn Source> = all_sources().collect();
-    let mut all_caps = all_sources_capabilities();
+    let mut all_caps = all_capabilities();
     all_caps.has_projects = false;
     all_caps.has_billing_blocks = false;
 
@@ -454,6 +470,7 @@ fn handle_statusline(source: &dyn Source, ctx: &CommandContext<'_>) {
             source.display_name(),
             ctx.number_format,
             ctx.currency,
+            source.capabilities().has_cache_read,
             Some(result.data_quality()),
             CostDisplayMode::Total,
         );
@@ -465,11 +482,13 @@ fn handle_statusline(source: &dyn Source, ctx: &CommandContext<'_>) {
             source.display_name(),
             ctx.number_format,
             ctx.currency,
+            source.capabilities().has_cache_read,
             CostDisplayMode::Total,
         );
     }
 }
 
+#[allow(clippy::too_many_lines)]
 fn render_period_result(
     result: &LoadResult,
     period: Period,
@@ -491,6 +510,7 @@ fn render_period_result(
                         order: ctx.cli.sort_order(),
                         breakdown: ctx.cli.breakdown,
                         show_cost: ctx.cli.show_cost(),
+                        supports_cache_read: caps.has_cache_read,
                         limit: budget,
                         as_of: ctx.budget_as_of,
                         currency: ctx.currency,
@@ -507,6 +527,7 @@ fn render_period_result(
                     ctx.cli.sort_order(),
                     ctx.cli.breakdown,
                     ctx.cli.show_cost(),
+                    caps.has_cache_read,
                     ctx.currency,
                     Some(result.data_quality()),
                     cost_mode,
@@ -522,6 +543,7 @@ fn render_period_result(
                 ctx.cli.sort_order(),
                 ctx.cli.breakdown,
                 ctx.cli.show_cost(),
+                caps.has_cache_read,
                 ctx.currency,
                 Some(result.data_quality()),
                 cost_mode,
@@ -559,6 +581,7 @@ fn render_period_result(
                     number_format: ctx.number_format,
                     show_reasoning: caps.has_reasoning_tokens,
                     show_cache_creation: caps.has_cache_creation,
+                    supports_cache_read: caps.has_cache_read,
                     currency: ctx.currency,
                     cost_mode,
                 },
@@ -608,7 +631,6 @@ pub(crate) fn handle_source_command(
 ) {
     let caps = source.capabilities();
 
-    // Non-period commands: dispatch and return early
     match command {
         SourceCommand::Sources => return handle_sources(ctx),
         SourceCommand::Session => return handle_session(source, ctx),
@@ -663,34 +685,12 @@ pub(crate) fn handle_source_command(
     handle_period(source, command, &caps, ctx);
 }
 
-fn all_sources_capabilities() -> Capabilities {
-    let mut combined = Capabilities::default();
-    for source in all_sources() {
-        let caps = source.capabilities();
-        combined.has_projects |= caps.has_projects;
-        combined.has_billing_blocks |= caps.has_billing_blocks;
-        combined.has_reasoning_tokens |= caps.has_reasoning_tokens;
-        combined.has_cache_creation |= caps.has_cache_creation;
-        combined.needs_dedup |= caps.needs_dedup;
-        combined.has_tool_calls |= caps.has_tool_calls;
-    }
-    combined
-}
-
 fn load_all_daily(ctx: &CommandContext<'_>, quiet: bool) -> (LoadResult, Capabilities) {
     let start = Instant::now();
     let mut combined = LoadResult::default();
-    let mut caps = Capabilities::default();
+    let caps = all_capabilities();
 
     for source in all_sources() {
-        let source_caps = source.capabilities();
-        caps.has_projects |= source_caps.has_projects;
-        caps.has_billing_blocks |= source_caps.has_billing_blocks;
-        caps.has_reasoning_tokens |= source_caps.has_reasoning_tokens;
-        caps.has_cache_creation |= source_caps.has_cache_creation;
-        caps.needs_dedup |= source_caps.needs_dedup;
-        caps.has_tool_calls |= source_caps.has_tool_calls;
-
         let result = load_daily(source, ctx.filter, ctx.timezone, quiet, ctx.cli.debug);
         combined.skipped += result.skipped;
         combined.valid += result.valid;
@@ -707,7 +707,7 @@ pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandCo
     match command {
         SourceCommand::Sources => return handle_sources(ctx),
         SourceCommand::Statusline => {
-            let (result, _) = load_all_daily(ctx, true);
+            let (result, caps) = load_all_daily(ctx, true);
             if ctx.cli.json {
                 let json = print_statusline_json_with_quality(
                     &result.day_stats,
@@ -715,6 +715,7 @@ pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandCo
                     "All Sources",
                     ctx.number_format,
                     ctx.currency,
+                    caps.has_cache_read,
                     Some(result.data_quality()),
                     CostDisplayMode::RealOnly,
                 );
@@ -726,6 +727,7 @@ pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandCo
                     "All Sources",
                     ctx.number_format,
                     ctx.currency,
+                    caps.has_cache_read,
                     CostDisplayMode::RealOnly,
                 );
             }
@@ -748,7 +750,7 @@ pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandCo
                 );
                 return;
             }
-            let (result, _) = load_all_daily(ctx, false);
+            let (result, caps) = load_all_daily(ctx, false);
             let rows = rank_by_model_with_cost_mode(
                 &result.day_stats,
                 ctx.pricing_db,
@@ -759,6 +761,7 @@ pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandCo
                 dim,
                 limit,
                 "All Sources",
+                caps.has_cache_read,
                 ctx,
                 CostDisplayMode::RealOnly,
             );

--- a/src/app.rs
+++ b/src/app.rs
@@ -19,11 +19,10 @@ use crate::output::{
 };
 use crate::pricing::{CostDisplayMode, PricingDb};
 use crate::source::{
-    ALL_SOURCES, Capabilities, Source, all_capabilities, all_sources, load_blocks, load_daily,
-    load_projects, load_sessions, load_tool_calls,
+    Capabilities, Source, all_capabilities, all_sources, load_blocks, load_daily, load_projects,
+    load_sessions, load_tool_calls,
 };
 use crate::utils::{Timezone, filter_json};
-use serde_json::json;
 
 /// Print JSON output, optionally filtering through jq
 pub(crate) fn print_json(json: &str, jq_filter: Option<&str>) {
@@ -348,118 +347,6 @@ fn render_tools(summary: &ToolSummary, ctx: &CommandContext<'_>) {
     }
 }
 
-fn handle_sources(ctx: &CommandContext<'_>) {
-    let sources: Vec<&dyn Source> = all_sources().collect();
-    let mut all_caps = all_capabilities();
-    all_caps.has_projects = false;
-    all_caps.has_billing_blocks = false;
-
-    render_sources(&sources, &all_caps, ctx);
-}
-
-fn render_sources(sources: &[&dyn Source], all_caps: &Capabilities, ctx: &CommandContext<'_>) {
-    match ctx.cli.output_format() {
-        OutputFormat::Csv => render_sources_csv(sources, all_caps),
-        OutputFormat::Json => render_sources_json(sources, all_caps, ctx),
-        OutputFormat::Table => print_sources_table(sources, all_caps),
-    }
-}
-
-fn render_sources_csv(sources: &[&dyn Source], all_caps: &Capabilities) {
-    println!(
-        "name,display_name,aliases,has_projects,has_billing_blocks,has_reasoning_tokens,has_cache_creation,needs_dedup"
-    );
-    println!(
-        "{},All Sources,,{},{},{},{},{}",
-        ALL_SOURCES,
-        all_caps.has_projects,
-        all_caps.has_billing_blocks,
-        all_caps.has_reasoning_tokens,
-        all_caps.has_cache_creation,
-        all_caps.needs_dedup
-    );
-    for source in sources {
-        let caps = source.capabilities();
-        let aliases = source.aliases().join("|");
-        println!(
-            "{},{},{},{},{},{},{},{}",
-            source.name(),
-            source.display_name(),
-            aliases,
-            caps.has_projects,
-            caps.has_billing_blocks,
-            caps.has_reasoning_tokens,
-            caps.has_cache_creation,
-            caps.needs_dedup
-        );
-    }
-}
-
-fn render_sources_json(sources: &[&dyn Source], all_caps: &Capabilities, ctx: &CommandContext<'_>) {
-    let mut payload = vec![json!({
-        "name": ALL_SOURCES,
-        "display_name": "All Sources",
-        "aliases": [],
-        "capabilities": {
-            "has_projects": all_caps.has_projects,
-            "has_billing_blocks": all_caps.has_billing_blocks,
-            "has_reasoning_tokens": all_caps.has_reasoning_tokens,
-            "has_cache_creation": all_caps.has_cache_creation,
-            "needs_dedup": all_caps.needs_dedup
-        }
-    })];
-    payload.extend(sources.iter().map(|source| {
-        let caps = source.capabilities();
-        json!({
-            "name": source.name(),
-            "display_name": source.display_name(),
-            "aliases": source.aliases(),
-            "capabilities": {
-                "has_projects": caps.has_projects,
-                "has_billing_blocks": caps.has_billing_blocks,
-                "has_reasoning_tokens": caps.has_reasoning_tokens,
-                "has_cache_creation": caps.has_cache_creation,
-                "needs_dedup": caps.needs_dedup
-            }
-        })
-    }));
-    let json = serde_json::to_string(&payload).unwrap_or_else(|_| "[]".to_string());
-    print_json(&json, ctx.jq_filter);
-}
-
-fn print_sources_table(sources: &[&dyn Source], all_caps: &Capabilities) {
-    println!("Available sources:");
-    println!(
-        "- {} (All Sources) aliases: - | has_projects={} has_billing_blocks={} has_reasoning_tokens={} has_cache_creation={} needs_dedup={}",
-        ALL_SOURCES,
-        all_caps.has_projects,
-        all_caps.has_billing_blocks,
-        all_caps.has_reasoning_tokens,
-        all_caps.has_cache_creation,
-        all_caps.needs_dedup
-    );
-    for source in sources {
-        let caps = source.capabilities();
-        let aliases = if source.aliases().is_empty() {
-            "-".to_string()
-        } else {
-            source.aliases().join(", ")
-        };
-        println!(
-            "- {} ({}) aliases: {} | has_projects={} has_billing_blocks={} has_reasoning_tokens={} has_cache_creation={} needs_dedup={}",
-            source.name(),
-            source.display_name(),
-            aliases,
-            caps.has_projects,
-            caps.has_billing_blocks,
-            caps.has_reasoning_tokens,
-            caps.has_cache_creation,
-            caps.needs_dedup
-        );
-    }
-    println!("Hint: use `--source <name|alias>` (e.g. `--source codex` or `--source cx`).");
-}
-
 /// Statusline keeps its compact single-line semantics outside generic output dispatch.
 fn handle_statusline(source: &dyn Source, ctx: &CommandContext<'_>) {
     let result = load_daily(source, ctx.filter, ctx.timezone, true, false);
@@ -632,7 +519,7 @@ pub(crate) fn handle_source_command(
     let caps = source.capabilities();
 
     match command {
-        SourceCommand::Sources => return handle_sources(ctx),
+        SourceCommand::Sources => return crate::sources_cmd::handle_sources(ctx),
         SourceCommand::Session => return handle_session(source, ctx),
         SourceCommand::Project => {
             if !caps.has_projects {
@@ -705,7 +592,7 @@ fn load_all_daily(ctx: &CommandContext<'_>, quiet: bool) -> (LoadResult, Capabil
 /// Handle aggregate commands across every registered data source.
 pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandContext<'_>) {
     match command {
-        SourceCommand::Sources => return handle_sources(ctx),
+        SourceCommand::Sources => return crate::sources_cmd::handle_sources(ctx),
         SourceCommand::Statusline => {
             let (result, caps) = load_all_daily(ctx, true);
             if ctx.cli.json {

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -44,6 +44,27 @@ impl Stats {
             + self.cache_read
     }
 
+    /// Percentage of reported input-side tokens served from the prompt cache.
+    ///
+    /// `supports_cache_read` comes from the selected source capability. Keeping
+    /// it explicit prevents sources that do not report cache reads from being
+    /// misrepresented as a real 0% hit rate.
+    pub(crate) fn cache_hit_rate(&self, supports_cache_read: bool) -> Option<f64> {
+        if !supports_cache_read {
+            return None;
+        }
+
+        let input = i128::from(self.input_tokens.max(0));
+        let cache_creation = i128::from(self.cache_creation.max(0));
+        let cache_read = i128::from(self.cache_read.max(0));
+        let total_input = input + cache_creation + cache_read;
+        if total_input == 0 {
+            None
+        } else {
+            Some(cache_read as f64 / total_input as f64 * 100.0)
+        }
+    }
+
     pub(crate) fn cost_tokens(&self) -> CostTokens {
         CostTokens {
             input_tokens: self.input_tokens,
@@ -361,6 +382,30 @@ mod tests {
             skipped_chunks: 0,
             estimated_proxy: CostTokens::default(),
         }
+    }
+
+    #[test]
+    fn cache_hit_rate_uses_all_input_side_tokens() {
+        let stats = make_stats(100, 50, 20, 80, 10);
+        assert_eq!(stats.cache_hit_rate(true), Some(40.0));
+    }
+
+    #[test]
+    fn cache_hit_rate_is_zero_when_supported_without_hits() {
+        let stats = make_stats(100, 50, 0, 0, 0);
+        assert_eq!(stats.cache_hit_rate(true), Some(0.0));
+    }
+
+    #[test]
+    fn cache_hit_rate_is_unavailable_without_input_or_source_support() {
+        assert_eq!(Stats::default().cache_hit_rate(true), None);
+        assert_eq!(make_stats(100, 0, 0, 50, 0).cache_hit_rate(false), None);
+    }
+
+    #[test]
+    fn cache_hit_rate_clamps_negative_components() {
+        let stats = make_stats(-100, 0, -20, 80, 0);
+        assert_eq!(stats.cache_hit_rate(true), Some(100.0));
     }
 
     // --- Stats ---

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ mod output;
 mod pricing;
 mod sdk;
 mod source;
+mod sources_cmd;
 mod utils;
 
 pub use sdk::{

--- a/src/output/blocks.rs
+++ b/src/output/blocks.rs
@@ -3,8 +3,9 @@ use comfy_table::{Cell, Color};
 use crate::cli::SortOrder;
 use crate::core::{BlockStats, Stats};
 use crate::output::format::{
-    NumberFormat, cost_json_value, create_styled_table, format_compact, format_cost, format_number,
-    header_cell, right_cell, styled_cell,
+    NumberFormat, cache_hit_rate_json_value, cost_json_value, create_styled_table,
+    format_cache_hit_rate, format_compact, format_cost, format_number, header_cell, right_cell,
+    styled_cell,
 };
 use crate::output::pricing_meta;
 use crate::pricing::{
@@ -12,11 +13,13 @@ use crate::pricing::{
 };
 
 #[derive(Debug, Clone, Copy)]
+#[allow(clippy::struct_excessive_bools)]
 pub(crate) struct BlockTableOptions<'a> {
     pub(crate) order: SortOrder,
     pub(crate) use_color: bool,
     pub(crate) compact: bool,
     pub(crate) show_cost: bool,
+    pub(crate) supports_cache_read: bool,
     pub(crate) source_label: &'a str,
     pub(crate) number_format: NumberFormat,
     pub(crate) currency: Option<&'a CurrencyConverter>,
@@ -45,10 +48,9 @@ pub(crate) fn print_block_table(
     let mut table = create_styled_table();
 
     if compact {
-        let mut header = vec![
-            header_cell("Block", use_color),
-            header_cell("Total", use_color),
-        ];
+        let mut header = vec![header_cell("Block", use_color)];
+        header.push(header_cell("Cache Hit", use_color));
+        header.push(header_cell("Total", use_color));
         if show_cost {
             header.push(header_cell("Cost", use_color));
         }
@@ -60,8 +62,9 @@ pub(crate) fn print_block_table(
             header_cell("Output", use_color),
             header_cell("Cache Create", use_color),
             header_cell("Cache Read", use_color),
-            header_cell("Total", use_color),
         ];
+        header.push(header_cell("Cache Hit", use_color));
+        header.push(header_cell("Total", use_color));
         if show_cost {
             header.push(header_cell("Cost", use_color));
         }
@@ -88,14 +91,17 @@ pub(crate) fn print_block_table(
         let block_label = format!("{} - {}", block.block_start, block.block_end);
 
         if compact {
-            let mut row = vec![
-                Cell::new(&block_label),
-                right_cell(
-                    &format_compact(block.stats.total_tokens(), number_format),
-                    None,
-                    false,
-                ),
-            ];
+            let mut row = vec![Cell::new(&block_label)];
+            row.push(right_cell(
+                &format_cache_hit_rate(block.stats.cache_hit_rate(options.supports_cache_read)),
+                None,
+                false,
+            ));
+            row.push(right_cell(
+                &format_compact(block.stats.total_tokens(), number_format),
+                None,
+                false,
+            ));
             if show_cost {
                 row.push(right_cell(
                     &format_cost(block_cost, options.currency),
@@ -127,12 +133,17 @@ pub(crate) fn print_block_table(
                     None,
                     false,
                 ),
-                right_cell(
-                    &format_number(block.stats.total_tokens(), number_format),
-                    None,
-                    false,
-                ),
             ];
+            row.push(right_cell(
+                &format_cache_hit_rate(block.stats.cache_hit_rate(options.supports_cache_read)),
+                None,
+                false,
+            ));
+            row.push(right_cell(
+                &format_number(block.stats.total_tokens(), number_format),
+                None,
+                false,
+            ));
             if show_cost {
                 row.push(right_cell(
                     &format_cost(block_cost, options.currency),
@@ -149,14 +160,17 @@ pub(crate) fn print_block_table(
 
     // Add total row
     if compact {
-        let mut row = vec![
-            styled_cell("TOTAL", cyan, true),
-            right_cell(
-                &format_compact(total_stats.total_tokens(), number_format),
-                cyan,
-                true,
-            ),
-        ];
+        let mut row = vec![styled_cell("TOTAL", cyan, true)];
+        row.push(right_cell(
+            &format_cache_hit_rate(total_stats.cache_hit_rate(options.supports_cache_read)),
+            cyan,
+            true,
+        ));
+        row.push(right_cell(
+            &format_compact(total_stats.total_tokens(), number_format),
+            cyan,
+            true,
+        ));
         if show_cost {
             row.push(right_cell(
                 &format_cost(total_cost, options.currency),
@@ -188,12 +202,17 @@ pub(crate) fn print_block_table(
                 cyan,
                 true,
             ),
-            right_cell(
-                &format_number(total_stats.total_tokens(), number_format),
-                cyan,
-                true,
-            ),
         ];
+        row.push(right_cell(
+            &format_cache_hit_rate(total_stats.cache_hit_rate(options.supports_cache_read)),
+            cyan,
+            true,
+        ));
+        row.push(right_cell(
+            &format_number(total_stats.total_tokens(), number_format),
+            cyan,
+            true,
+        ));
         if show_cost {
             row.push(right_cell(
                 &format_cost(total_cost, options.currency),
@@ -229,6 +248,7 @@ pub(crate) fn output_block_json(
     pricing_db: &PricingDb,
     order: SortOrder,
     show_cost: bool,
+    supports_cache_read: bool,
     currency: Option<&CurrencyConverter>,
 ) -> String {
     let mut sorted_blocks: Vec<_> = blocks.iter().collect();
@@ -252,6 +272,9 @@ pub(crate) fn output_block_json(
                 "output_tokens": block.stats.output_tokens,
                 "cache_creation_tokens": block.stats.cache_creation,
                 "cache_read_tokens": block.stats.cache_read,
+                "cache_hit_rate": cache_hit_rate_json_value(
+                    block.stats.cache_hit_rate(supports_cache_read)
+                ),
                 "total_tokens": block.stats.total_tokens(),
                 "models": models,
             });
@@ -319,7 +342,7 @@ mod tests {
     #[test]
     fn output_block_json_empty_input() {
         let db = PricingDb::default();
-        let json_str = output_block_json(&[], &db, SortOrder::Asc, false, None);
+        let json_str = output_block_json(&[], &db, SortOrder::Asc, false, true, None);
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&json_str).unwrap();
         assert!(parsed.is_empty());
     }
@@ -333,7 +356,7 @@ mod tests {
             1000,
             500,
         )];
-        let json_str = output_block_json(&blocks, &db, SortOrder::Asc, false, None);
+        let json_str = output_block_json(&blocks, &db, SortOrder::Asc, false, true, None);
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&json_str).unwrap();
 
         assert_eq!(parsed.len(), 1);
@@ -349,7 +372,7 @@ mod tests {
     fn output_block_json_includes_cost_when_requested() {
         let db = PricingDb::default();
         let blocks = vec![make_block("2026-02-12 10:00", "2026-02-12 15:00", 100, 50)];
-        let json_str = output_block_json(&blocks, &db, SortOrder::Asc, true, None);
+        let json_str = output_block_json(&blocks, &db, SortOrder::Asc, true, true, None);
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&json_str).unwrap();
 
         assert!(parsed[0].get("cost").is_some());
@@ -363,7 +386,7 @@ mod tests {
             make_block("2026-02-12 05:00", "2026-02-12 10:00", 200, 100),
             make_block("2026-02-12 10:00", "2026-02-12 15:00", 300, 150),
         ];
-        let json_str = output_block_json(&blocks, &db, SortOrder::Asc, false, None);
+        let json_str = output_block_json(&blocks, &db, SortOrder::Asc, false, true, None);
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&json_str).unwrap();
 
         assert_eq!(parsed[0]["block_start"], "2026-02-12 05:00");
@@ -378,7 +401,7 @@ mod tests {
             make_block("2026-02-12 05:00", "2026-02-12 10:00", 100, 50),
             make_block("2026-02-12 15:00", "2026-02-12 20:00", 200, 100),
         ];
-        let json_str = output_block_json(&blocks, &db, SortOrder::Desc, false, None);
+        let json_str = output_block_json(&blocks, &db, SortOrder::Desc, false, true, None);
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&json_str).unwrap();
 
         assert_eq!(parsed[0]["block_start"], "2026-02-12 15:00");
@@ -396,11 +419,12 @@ mod tests {
             200,
             300,
         )];
-        let json_str = output_block_json(&blocks, &db, SortOrder::Asc, false, None);
+        let json_str = output_block_json(&blocks, &db, SortOrder::Asc, false, true, None);
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&json_str).unwrap();
 
         assert_eq!(parsed[0]["cache_creation_tokens"], 200);
         assert_eq!(parsed[0]["cache_read_tokens"], 300);
+        assert_eq!(parsed[0]["cache_hit_rate"], 20.0);
         assert_eq!(parsed[0]["total_tokens"], 2000); // 1000+500+200+300
     }
 
@@ -418,7 +442,7 @@ mod tests {
             stats: Stats::default(),
             models,
         }];
-        let json_str = output_block_json(&blocks, &db, SortOrder::Asc, false, None);
+        let json_str = output_block_json(&blocks, &db, SortOrder::Asc, false, true, None);
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&json_str).unwrap();
 
         let model_list: Vec<&str> = parsed[0]["models"]

--- a/src/output/budget.rs
+++ b/src/output/budget.rs
@@ -35,6 +35,7 @@ pub(crate) struct MonthlyBudgetOptions<'a> {
     pub(crate) order: SortOrder,
     pub(crate) breakdown: bool,
     pub(crate) show_cost: bool,
+    pub(crate) supports_cache_read: bool,
     pub(crate) limit: f64,
     pub(crate) as_of: NaiveDate,
     pub(crate) currency: Option<&'a CurrencyConverter>,

--- a/src/output/csv.rs
+++ b/src/output/csv.rs
@@ -5,7 +5,7 @@ use super::session::compare_session_last_timestamp;
 use crate::cli::SortOrder;
 use crate::core::{BlockStats, DataQuality, DayStats, ProjectStats, SessionStats};
 use crate::output::budget::{MonthlyBudgetOptions, MonthlyBudgetReport, monthly_budget_reports};
-use crate::output::format::{compare_cost, csv_escape};
+use crate::output::format::{cache_hit_rate_csv_value, compare_cost, csv_escape};
 use crate::output::period::{Period, aggregate_day_stats_by_period};
 use crate::output::pricing_meta;
 use crate::pricing::{
@@ -31,6 +31,7 @@ pub(crate) fn output_period_csv(
         order,
         breakdown,
         show_cost,
+        true,
         currency,
         None,
         CostDisplayMode::Total,
@@ -45,6 +46,7 @@ pub(crate) fn output_period_csv_with_quality(
     order: SortOrder,
     breakdown: bool,
     show_cost: bool,
+    supports_cache_read: bool,
     currency: Option<&CurrencyConverter>,
     data_quality: Option<DataQuality>,
     cost_mode: CostDisplayMode,
@@ -68,6 +70,7 @@ pub(crate) fn output_period_csv_with_quality(
         label,
         pricing_db,
         show_cost,
+        supports_cache_read,
         currency,
         include_cost_kind: period_csv_includes_cost_kind(&rows, breakdown, show_cost),
         pricing_source: pricing_source_for_model_maps(
@@ -90,6 +93,7 @@ struct PeriodCsvContext<'a> {
     label: &'a str,
     pricing_db: &'a PricingDb,
     show_cost: bool,
+    supports_cache_read: bool,
     currency: Option<&'a CurrencyConverter>,
     include_cost_kind: bool,
     pricing_source: crate::pricing::PricingSource,
@@ -132,7 +136,7 @@ fn write_period_csv_breakdown(
 ) {
     let _ = write!(
         out,
-        "{},model,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,total_tokens",
+        "{},model,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens",
         ctx.label
     );
     write_period_cost_header(out, ctx);
@@ -143,7 +147,7 @@ fn write_period_csv_breakdown(
         for (model, model_stats) in &models {
             let _ = write!(
                 out,
-                "{},{},{},{},{},{},{},{}",
+                "{},{},{},{},{},{},{},{},{}",
                 csv_escape(key),
                 csv_escape(model),
                 model_stats.input_tokens,
@@ -151,6 +155,7 @@ fn write_period_csv_breakdown(
                 model_stats.reasoning_tokens,
                 model_stats.cache_creation,
                 model_stats.cache_read,
+                cache_hit_rate_csv_value(model_stats.cache_hit_rate(ctx.supports_cache_read)),
                 model_stats.total_tokens(),
             );
             if ctx.show_cost {
@@ -186,7 +191,7 @@ fn write_period_csv_standard(
 ) {
     let _ = write!(
         out,
-        "{},input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,total_tokens",
+        "{},input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens",
         ctx.label
     );
     write_period_cost_header(out, ctx);
@@ -194,13 +199,14 @@ fn write_period_csv_standard(
     for &(key, stats) in rows {
         let _ = write!(
             out,
-            "{},{},{},{},{},{},{}",
+            "{},{},{},{},{},{},{},{}",
             csv_escape(key),
             stats.stats.input_tokens,
             stats.stats.output_tokens,
             stats.stats.reasoning_tokens,
             stats.stats.cache_creation,
             stats.stats.cache_read,
+            cache_hit_rate_csv_value(stats.stats.cache_hit_rate(ctx.supports_cache_read)),
             stats.stats.total_tokens(),
         );
         if ctx.show_cost {
@@ -292,6 +298,7 @@ fn budget_csv_pricing_source(
         .unwrap_or_else(|| pricing_db.source())
 }
 
+#[allow(clippy::too_many_lines)]
 pub(crate) fn output_monthly_budget_csv(
     day_stats: &HashMap<String, DayStats>,
     pricing_db: &PricingDb,
@@ -315,7 +322,7 @@ pub(crate) fn output_monthly_budget_csv(
     if options.breakdown {
         let _ = write!(
             out,
-            "month,model,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,total_tokens"
+            "month,model,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
         );
         if options.show_cost {
             let _ = write!(out, ",cost");
@@ -333,7 +340,7 @@ pub(crate) fn output_monthly_budget_csv(
             for (model, model_stats) in &models {
                 let _ = write!(
                     out,
-                    "{},{},{},{},{},{},{},{}",
+                    "{},{},{},{},{},{},{},{},{}",
                     csv_escape(&report.month),
                     csv_escape(model),
                     model_stats.input_tokens,
@@ -341,6 +348,9 @@ pub(crate) fn output_monthly_budget_csv(
                     model_stats.reasoning_tokens,
                     model_stats.cache_creation,
                     model_stats.cache_read,
+                    cache_hit_rate_csv_value(
+                        model_stats.cache_hit_rate(options.supports_cache_read)
+                    ),
                     model_stats.total_tokens(),
                 );
                 if options.show_cost {
@@ -361,7 +371,7 @@ pub(crate) fn output_monthly_budget_csv(
     } else {
         let _ = write!(
             out,
-            "month,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,total_tokens"
+            "month,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
         );
         if options.show_cost {
             let _ = write!(out, ",cost");
@@ -376,13 +386,14 @@ pub(crate) fn output_monthly_budget_csv(
             };
             let _ = write!(
                 out,
-                "{},{},{},{},{},{},{}",
+                "{},{},{},{},{},{},{},{}",
                 csv_escape(&report.month),
                 stats.stats.input_tokens,
                 stats.stats.output_tokens,
                 stats.stats.reasoning_tokens,
                 stats.stats.cache_creation,
                 stats.stats.cache_read,
+                cache_hit_rate_csv_value(stats.stats.cache_hit_rate(options.supports_cache_read)),
                 stats.stats.total_tokens(),
             );
             if options.show_cost {
@@ -408,6 +419,7 @@ pub(crate) fn output_session_csv(
     pricing_db: &PricingDb,
     order: SortOrder,
     show_cost: bool,
+    supports_cache_read: bool,
     currency: Option<&CurrencyConverter>,
 ) -> String {
     let mut sorted: Vec<_> = sessions.iter().collect();
@@ -427,7 +439,7 @@ pub(crate) fn output_session_csv(
         pricing_meta::csv_has_cache_fields(pricing_source, pricing_db);
     let _ = write!(
         out,
-        "session_id,project_path,first_timestamp,last_timestamp,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,total_tokens"
+        "session_id,project_path,first_timestamp,last_timestamp,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
     );
     if show_cost {
         let _ = write!(out, ",cost");
@@ -441,7 +453,7 @@ pub(crate) fn output_session_csv(
     for s in &sorted {
         let _ = write!(
             out,
-            "{},{},{},{},{},{},{},{},{},{}",
+            "{},{},{},{},{},{},{},{},{},{},{}",
             csv_escape(&s.session_id),
             csv_escape(&s.project_path),
             csv_escape(&s.first_timestamp),
@@ -451,6 +463,7 @@ pub(crate) fn output_session_csv(
             s.stats.reasoning_tokens,
             s.stats.cache_creation,
             s.stats.cache_read,
+            cache_hit_rate_csv_value(s.stats.cache_hit_rate(supports_cache_read)),
             s.stats.total_tokens(),
         );
         if show_cost {
@@ -482,6 +495,7 @@ pub(crate) fn output_project_csv(
     pricing_db: &PricingDb,
     order: SortOrder,
     show_cost: bool,
+    supports_cache_read: bool,
     currency: Option<&CurrencyConverter>,
 ) -> String {
     let mut sorted: Vec<_> = projects.iter().collect();
@@ -511,7 +525,7 @@ pub(crate) fn output_project_csv(
         pricing_meta::csv_has_cache_fields(pricing_source, pricing_db);
     let _ = write!(
         out,
-        "project_name,project_path,sessions,input_tokens,output_tokens,total_tokens"
+        "project_name,project_path,sessions,input_tokens,output_tokens,cache_hit_rate,total_tokens"
     );
     if show_cost {
         let _ = write!(out, ",cost");
@@ -525,12 +539,13 @@ pub(crate) fn output_project_csv(
     for p in &sorted {
         let _ = write!(
             out,
-            "{},{},{},{},{},{}",
+            "{},{},{},{},{},{},{}",
             csv_escape(&p.project_name),
             csv_escape(&p.project_path),
             p.session_count,
             p.stats.input_tokens,
             p.stats.output_tokens,
+            cache_hit_rate_csv_value(p.stats.cache_hit_rate(supports_cache_read)),
             p.stats.total_tokens(),
         );
         if show_cost {
@@ -563,6 +578,7 @@ pub(crate) fn output_block_csv(
     pricing_db: &PricingDb,
     order: SortOrder,
     show_cost: bool,
+    supports_cache_read: bool,
     currency: Option<&CurrencyConverter>,
 ) -> String {
     let mut sorted: Vec<_> = blocks.iter().collect();
@@ -582,7 +598,7 @@ pub(crate) fn output_block_csv(
         pricing_meta::csv_has_cache_fields(pricing_source, pricing_db);
     let _ = write!(
         out,
-        "block_start,block_end,input_tokens,output_tokens,cache_creation_tokens,cache_read_tokens,total_tokens"
+        "block_start,block_end,input_tokens,output_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
     );
     if show_cost {
         let _ = write!(out, ",cost");
@@ -596,13 +612,14 @@ pub(crate) fn output_block_csv(
     for b in &sorted {
         let _ = write!(
             out,
-            "{},{},{},{},{},{},{}",
+            "{},{},{},{},{},{},{},{}",
             csv_escape(&b.block_start),
             csv_escape(&b.block_end),
             b.stats.input_tokens,
             b.stats.output_tokens,
             b.stats.cache_creation,
             b.stats.cache_read,
+            cache_hit_rate_csv_value(b.stats.cache_hit_rate(supports_cache_read)),
             b.stats.total_tokens(),
         );
         if show_cost {

--- a/src/output/csv_tests.rs
+++ b/src/output/csv_tests.rs
@@ -54,7 +54,7 @@ fn period_csv_daily_no_cost() {
     let lines: Vec<&str> = csv.lines().collect();
     assert_eq!(
         lines[0],
-        "date,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,total_tokens"
+        "date,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
     );
     assert!(lines[1].starts_with("2025-01-01,1000,500,"));
     assert!(!lines[0].contains("cost"));
@@ -108,7 +108,7 @@ fn period_csv_converts_cost_when_currency_is_set() {
     let lines: Vec<&str> = csv.lines().collect();
     assert_eq!(
         lines[1],
-        "2025-01-01,1000000,500000,0,0,0,1500000,73.500000,fallback"
+        "2025-01-01,1000000,500000,0,0,0,0.00,1500000,73.500000,fallback"
     );
 }
 
@@ -152,12 +152,12 @@ fn session_csv_structure() {
     }];
 
     let db = PricingDb::default();
-    let csv = output_session_csv(&sessions, &db, SortOrder::Asc, false, None);
+    let csv = output_session_csv(&sessions, &db, SortOrder::Asc, false, true, None);
 
     let lines: Vec<&str> = csv.lines().collect();
     assert_eq!(
         lines[0],
-        "session_id,project_path,first_timestamp,last_timestamp,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,total_tokens"
+        "session_id,project_path,first_timestamp,last_timestamp,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
     );
     assert!(lines[1].starts_with("abc-123,/home/user/project,"));
 }
@@ -183,12 +183,12 @@ fn session_csv_includes_reasoning_and_cache_tokens() {
     }];
 
     let db = PricingDb::default();
-    let csv = output_session_csv(&sessions, &db, SortOrder::Asc, false, None);
+    let csv = output_session_csv(&sessions, &db, SortOrder::Asc, false, true, None);
     let lines: Vec<&str> = csv.lines().collect();
 
     assert_eq!(
         lines[1],
-        "reasoning,,2025-01-01T00:00:00Z,2025-01-01T01:00:00Z,1000,300,200,50,100,1650"
+        "reasoning,,2025-01-01T00:00:00Z,2025-01-01T01:00:00Z,1000,300,200,50,100,8.70,1650"
     );
 }
 
@@ -208,7 +208,7 @@ fn project_csv_structure() {
     }];
 
     let db = PricingDb::default();
-    let csv = output_project_csv(&projects, &db, SortOrder::Asc, true, None);
+    let csv = output_project_csv(&projects, &db, SortOrder::Asc, true, true, None);
 
     let lines: Vec<&str> = csv.lines().collect();
     assert!(lines[0].ends_with(",cost,pricing_source"));
@@ -232,12 +232,12 @@ fn block_csv_structure() {
     }];
 
     let db = PricingDb::default();
-    let csv = output_block_csv(&blocks, &db, SortOrder::Asc, false, None);
+    let csv = output_block_csv(&blocks, &db, SortOrder::Asc, false, true, None);
 
     let lines: Vec<&str> = csv.lines().collect();
     assert_eq!(
         lines[0],
-        "block_start,block_end,input_tokens,output_tokens,cache_creation_tokens,cache_read_tokens,total_tokens"
+        "block_start,block_end,input_tokens,output_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
     );
     assert_eq!(lines.len(), 2);
 }
@@ -280,7 +280,7 @@ fn breakdown_csv_header_includes_model() {
     let lines: Vec<&str> = csv.lines().collect();
     assert_eq!(
         lines[0],
-        "date,model,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,total_tokens"
+        "date,model,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
     );
 }
 
@@ -331,8 +331,8 @@ fn breakdown_csv_with_cost() {
     let lines: Vec<&str> = csv.lines().collect();
     assert!(lines[0].ends_with(",cost,pricing_source"));
     let fields: Vec<&str> = lines[1].split(',').collect();
-    assert_eq!(fields.len(), 10);
-    assert_eq!(fields[9], "fallback");
+    assert_eq!(fields.len(), 11);
+    assert_eq!(fields[10], "fallback");
 }
 
 #[test]

--- a/src/output/format.rs
+++ b/src/output/format.rs
@@ -119,6 +119,20 @@ pub(super) fn format_cost(cost: f64, currency: Option<&CurrencyConverter>) -> St
     }
 }
 
+pub(super) fn format_cache_hit_rate(rate: Option<f64>) -> String {
+    rate.map_or_else(|| "N/A".to_string(), |value| format!("{value:.1}%"))
+}
+
+pub(super) fn cache_hit_rate_json_value(rate: Option<f64>) -> serde_json::Value {
+    rate.map_or(serde_json::Value::Null, |value| {
+        serde_json::json!((value * 100.0).round() / 100.0)
+    })
+}
+
+pub(super) fn cache_hit_rate_csv_value(rate: Option<f64>) -> String {
+    rate.map_or_else(String::new, |value| format!("{value:.2}"))
+}
+
 pub(super) fn cost_json_value(
     cost: f64,
     currency: Option<&CurrencyConverter>,
@@ -206,7 +220,10 @@ pub(super) fn csv_escape(s: &str) -> String {
 #[cfg(test)]
 #[allow(clippy::float_cmp)]
 mod tests {
-    use super::{NumberFormat, compare_cost, format_compact, format_cost, format_number};
+    use super::{
+        NumberFormat, cache_hit_rate_csv_value, cache_hit_rate_json_value, compare_cost,
+        format_cache_hit_rate, format_compact, format_cost, format_number,
+    };
 
     #[test]
     fn format_number_with_commas() {
@@ -233,6 +250,19 @@ mod tests {
     fn format_cost_handles_nan() {
         assert_eq!(format_cost(f64::NAN, None), "N/A");
         assert_eq!(format_cost(1.234, None), "$1.23");
+    }
+
+    #[test]
+    fn cache_hit_rate_formats_for_table_json_and_csv() {
+        assert_eq!(format_cache_hit_rate(Some(12.345)), "12.3%");
+        assert_eq!(format_cache_hit_rate(None), "N/A");
+        assert_eq!(
+            cache_hit_rate_json_value(Some(12.345)),
+            serde_json::json!(12.35)
+        );
+        assert_eq!(cache_hit_rate_json_value(None), serde_json::Value::Null);
+        assert_eq!(cache_hit_rate_csv_value(Some(12.345)), "12.35");
+        assert_eq!(cache_hit_rate_csv_value(None), "");
     }
 
     #[test]

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::cli::SortOrder;
 use crate::core::{DataQuality, DayStats};
-use crate::output::format::cost_json_value;
+use crate::output::format::{cache_hit_rate_json_value, cost_json_value};
 use crate::output::period::{Period, aggregate_day_stats_by_period};
 use crate::output::pricing_meta;
 use crate::pricing::{
@@ -67,6 +67,9 @@ fn build_period_entry(
                 "reasoning_tokens": model_stats.reasoning_tokens,
                 "cache_creation_tokens": model_stats.cache_creation,
                 "cache_read_tokens": model_stats.cache_read,
+                "cache_hit_rate": cache_hit_rate_json_value(
+                    model_stats.cache_hit_rate(options.supports_cache_read)
+                ),
                 "total_tokens": model_stats.total_tokens(),
             });
             if options.show_cost {
@@ -98,6 +101,9 @@ fn build_period_entry(
             "reasoning_tokens": stats.stats.reasoning_tokens,
             "cache_creation_tokens": stats.stats.cache_creation,
             "cache_read_tokens": stats.stats.cache_read,
+            "cache_hit_rate": cache_hit_rate_json_value(
+                stats.stats.cache_hit_rate(options.supports_cache_read)
+            ),
             "total_tokens": stats.stats.total_tokens(),
             "breakdown": models_breakdown,
         });
@@ -130,6 +136,9 @@ fn build_period_entry(
             "reasoning_tokens": stats.stats.reasoning_tokens,
             "cache_creation_tokens": stats.stats.cache_creation,
             "cache_read_tokens": stats.stats.cache_read,
+            "cache_hit_rate": cache_hit_rate_json_value(
+                stats.stats.cache_hit_rate(options.supports_cache_read)
+            ),
             "total_tokens": stats.stats.total_tokens(),
             "models": models,
         });
@@ -150,6 +159,7 @@ struct PeriodJsonOptions<'a> {
     pricing_db: &'a PricingDb,
     breakdown: bool,
     show_cost: bool,
+    supports_cache_read: bool,
     currency: Option<&'a CurrencyConverter>,
     cost_mode: CostDisplayMode,
 }
@@ -179,6 +189,7 @@ pub(crate) fn output_period_json(
         order,
         breakdown,
         show_cost,
+        true,
         currency,
         None,
         CostDisplayMode::Total,
@@ -193,6 +204,7 @@ pub(crate) fn output_period_json_with_quality(
     order: SortOrder,
     breakdown: bool,
     show_cost: bool,
+    supports_cache_read: bool,
     currency: Option<&CurrencyConverter>,
     data_quality: Option<DataQuality>,
     cost_mode: CostDisplayMode,
@@ -211,6 +223,7 @@ pub(crate) fn output_period_json_with_quality(
         pricing_db,
         breakdown,
         show_cost,
+        supports_cache_read,
         currency,
         cost_mode,
     };

--- a/src/output/project.rs
+++ b/src/output/project.rs
@@ -3,8 +3,9 @@ use comfy_table::{Cell, Color};
 use crate::cli::SortOrder;
 use crate::core::{ProjectStats, Stats};
 use crate::output::format::{
-    NumberFormat, compare_cost, cost_json_value, create_styled_table, format_compact, format_cost,
-    format_number, header_cell, right_cell, styled_cell,
+    NumberFormat, cache_hit_rate_json_value, compare_cost, cost_json_value, create_styled_table,
+    format_cache_hit_rate, format_compact, format_cost, format_number, header_cell, right_cell,
+    styled_cell,
 };
 use crate::output::pricing_meta;
 use crate::pricing::{
@@ -12,11 +13,13 @@ use crate::pricing::{
 };
 
 #[derive(Debug, Clone, Copy)]
+#[allow(clippy::struct_excessive_bools)]
 pub(crate) struct ProjectTableOptions<'a> {
     pub(crate) order: SortOrder,
     pub(crate) use_color: bool,
     pub(crate) compact: bool,
     pub(crate) show_cost: bool,
+    pub(crate) supports_cache_read: bool,
     pub(crate) source_label: &'a str,
     pub(crate) number_format: NumberFormat,
     pub(crate) currency: Option<&'a CurrencyConverter>,
@@ -49,8 +52,9 @@ pub(crate) fn print_project_table(
         let mut header = vec![
             header_cell("Project", use_color),
             header_cell("Sessions", use_color),
-            header_cell("Total", use_color),
         ];
+        header.push(header_cell("Cache Hit", use_color));
+        header.push(header_cell("Total", use_color));
         if show_cost {
             header.push(header_cell("Cost", use_color));
         }
@@ -61,8 +65,9 @@ pub(crate) fn print_project_table(
             header_cell("Sessions", use_color),
             header_cell("Input", use_color),
             header_cell("Output", use_color),
-            header_cell("Total", use_color),
         ];
+        header.push(header_cell("Cache Hit", use_color));
+        header.push(header_cell("Total", use_color));
         if show_cost {
             header.push(header_cell("Cost", use_color));
         }
@@ -97,12 +102,17 @@ pub(crate) fn print_project_table(
                     None,
                     false,
                 ),
-                right_cell(
-                    &format_compact(project.stats.total_tokens(), number_format),
-                    None,
-                    false,
-                ),
             ];
+            row.push(right_cell(
+                &format_cache_hit_rate(project.stats.cache_hit_rate(options.supports_cache_read)),
+                None,
+                false,
+            ));
+            row.push(right_cell(
+                &format_compact(project.stats.total_tokens(), number_format),
+                None,
+                false,
+            ));
             if show_cost {
                 row.push(right_cell(
                     &format_cost(project_cost, options.currency),
@@ -129,12 +139,17 @@ pub(crate) fn print_project_table(
                     None,
                     false,
                 ),
-                right_cell(
-                    &format_number(project.stats.total_tokens(), number_format),
-                    None,
-                    false,
-                ),
             ];
+            row.push(right_cell(
+                &format_cache_hit_rate(project.stats.cache_hit_rate(options.supports_cache_read)),
+                None,
+                false,
+            ));
+            row.push(right_cell(
+                &format_number(project.stats.total_tokens(), number_format),
+                None,
+                false,
+            ));
             if show_cost {
                 row.push(right_cell(
                     &format_cost(project_cost, options.currency),
@@ -158,12 +173,17 @@ pub(crate) fn print_project_table(
                 cyan,
                 true,
             ),
-            right_cell(
-                &format_compact(total_stats.total_tokens(), number_format),
-                cyan,
-                true,
-            ),
         ];
+        row.push(right_cell(
+            &format_cache_hit_rate(total_stats.cache_hit_rate(options.supports_cache_read)),
+            cyan,
+            true,
+        ));
+        row.push(right_cell(
+            &format_compact(total_stats.total_tokens(), number_format),
+            cyan,
+            true,
+        ));
         if show_cost {
             row.push(right_cell(
                 &format_cost(total_cost, options.currency),
@@ -190,12 +210,17 @@ pub(crate) fn print_project_table(
                 cyan,
                 true,
             ),
-            right_cell(
-                &format_number(total_stats.total_tokens(), number_format),
-                cyan,
-                true,
-            ),
         ];
+        row.push(right_cell(
+            &format_cache_hit_rate(total_stats.cache_hit_rate(options.supports_cache_read)),
+            cyan,
+            true,
+        ));
+        row.push(right_cell(
+            &format_number(total_stats.total_tokens(), number_format),
+            cyan,
+            true,
+        ));
         if show_cost {
             row.push(right_cell(
                 &format_cost(total_cost, options.currency),
@@ -234,6 +259,7 @@ pub(crate) fn output_project_json(
     pricing_db: &PricingDb,
     order: SortOrder,
     show_cost: bool,
+    supports_cache_read: bool,
     currency: Option<&CurrencyConverter>,
 ) -> String {
     let mut sorted_projects = attach_costs(projects, |p| &p.models, pricing_db);
@@ -259,6 +285,9 @@ pub(crate) fn output_project_json(
                 "output_tokens": project.stats.output_tokens,
                 "cache_creation_tokens": project.stats.cache_creation,
                 "cache_read_tokens": project.stats.cache_read,
+                "cache_hit_rate": cache_hit_rate_json_value(
+                    project.stats.cache_hit_rate(supports_cache_read)
+                ),
                 "total_tokens": project.stats.total_tokens(),
                 "models": models,
             });
@@ -318,7 +347,7 @@ mod tests {
     #[test]
     fn output_project_json_empty() {
         let db = PricingDb::default();
-        let result = output_project_json(&[], &db, SortOrder::Desc, false, None);
+        let result = output_project_json(&[], &db, SortOrder::Desc, false, true, None);
         assert_eq!(result.trim(), "[]");
     }
 
@@ -326,7 +355,7 @@ mod tests {
     fn output_project_json_single_project() {
         let db = PricingDb::default();
         let projects = vec![make_project("myapp", "/path/myapp", 3, 1000, 500)];
-        let result = output_project_json(&projects, &db, SortOrder::Desc, false, None);
+        let result = output_project_json(&projects, &db, SortOrder::Desc, false, true, None);
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&result).unwrap();
         assert_eq!(parsed.len(), 1);
         assert_eq!(parsed[0]["project"], "myapp");
@@ -342,7 +371,7 @@ mod tests {
     fn output_project_json_with_cost() {
         let db = PricingDb::default();
         let projects = vec![make_project("app", "/app", 1, 100, 50)];
-        let result = output_project_json(&projects, &db, SortOrder::Desc, true, None);
+        let result = output_project_json(&projects, &db, SortOrder::Desc, true, true, None);
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&result).unwrap();
         assert!(parsed[0].get("cost").is_some());
     }
@@ -378,7 +407,7 @@ mod tests {
                 ),
             ]),
         }];
-        let result = output_project_json(&projects, &db, SortOrder::Desc, false, None);
+        let result = output_project_json(&projects, &db, SortOrder::Desc, false, true, None);
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&result).unwrap();
         let models = parsed[0]["models"].as_array().unwrap();
         assert_eq!(models[0], "claude");
@@ -393,13 +422,13 @@ mod tests {
             make_project("big", "/big", 1, 1000, 500),
         ];
         // Desc: big first (higher cost)
-        let desc = output_project_json(&projects, &db, SortOrder::Desc, false, None);
+        let desc = output_project_json(&projects, &db, SortOrder::Desc, false, true, None);
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&desc).unwrap();
         // With empty pricing DB, all costs are 0.0, so order is stable
         assert_eq!(parsed.len(), 2);
 
         // Asc: same with empty pricing
-        let asc = output_project_json(&projects, &db, SortOrder::Asc, false, None);
+        let asc = output_project_json(&projects, &db, SortOrder::Asc, false, true, None);
         let parsed_asc: Vec<serde_json::Value> = serde_json::from_str(&asc).unwrap();
         assert_eq!(parsed_asc.len(), 2);
     }

--- a/src/output/session.rs
+++ b/src/output/session.rs
@@ -6,8 +6,9 @@ use crate::cli::SortOrder;
 use crate::consts::DATE_FORMAT;
 use crate::core::{SessionStats, Stats, format_project_name};
 use crate::output::format::{
-    NumberFormat, cost_json_value, create_styled_table, format_compact, format_cost, format_number,
-    header_cell, right_cell, styled_cell,
+    NumberFormat, cache_hit_rate_json_value, cost_json_value, create_styled_table,
+    format_cache_hit_rate, format_compact, format_cost, format_number, header_cell, right_cell,
+    styled_cell,
 };
 use crate::output::pricing_meta;
 use crate::pricing::{
@@ -57,11 +58,13 @@ pub(super) fn compare_session_last_timestamp(a: &SessionStats, b: &SessionStats)
 }
 
 #[derive(Debug, Clone, Copy)]
+#[allow(clippy::struct_excessive_bools)]
 pub(crate) struct SessionTableOptions<'a> {
     pub(crate) order: SortOrder,
     pub(crate) use_color: bool,
     pub(crate) compact: bool,
     pub(crate) show_cost: bool,
+    pub(crate) supports_cache_read: bool,
     pub(crate) number_format: NumberFormat,
     pub(crate) source_label: &'a str,
     pub(crate) timezone: Timezone,
@@ -97,8 +100,9 @@ pub(crate) fn print_session_table(
             header_cell("Session", use_color),
             header_cell("Project", use_color),
             header_cell("Date", use_color),
-            header_cell("Total", use_color),
         ];
+        header.push(header_cell("Cache Hit", use_color));
+        header.push(header_cell("Total", use_color));
         if show_cost {
             header.push(header_cell("Cost", use_color));
         }
@@ -110,8 +114,9 @@ pub(crate) fn print_session_table(
             header_cell("Date", use_color),
             header_cell("Input", use_color),
             header_cell("Output", use_color),
-            header_cell("Total", use_color),
         ];
+        header.push(header_cell("Cache Hit", use_color));
+        header.push(header_cell("Total", use_color));
         if show_cost {
             header.push(header_cell("Cost", use_color));
         }
@@ -149,12 +154,17 @@ pub(crate) fn print_session_table(
                 Cell::new(&session_id),
                 Cell::new(&project),
                 Cell::new(&date),
-                right_cell(
-                    &format_compact(session.stats.total_tokens(), number_format),
-                    None,
-                    false,
-                ),
             ];
+            row.push(right_cell(
+                &format_cache_hit_rate(session.stats.cache_hit_rate(options.supports_cache_read)),
+                None,
+                false,
+            ));
+            row.push(right_cell(
+                &format_compact(session.stats.total_tokens(), number_format),
+                None,
+                false,
+            ));
             if show_cost {
                 row.push(right_cell(
                     &format_cost(session_cost.unwrap_or(0.0), options.currency),
@@ -178,12 +188,17 @@ pub(crate) fn print_session_table(
                     None,
                     false,
                 ),
-                right_cell(
-                    &format_number(session.stats.total_tokens(), number_format),
-                    None,
-                    false,
-                ),
             ];
+            row.push(right_cell(
+                &format_cache_hit_rate(session.stats.cache_hit_rate(options.supports_cache_read)),
+                None,
+                false,
+            ));
+            row.push(right_cell(
+                &format_number(session.stats.total_tokens(), number_format),
+                None,
+                false,
+            ));
             if show_cost {
                 row.push(right_cell(
                     &format_cost(session_cost.unwrap_or(0.0), options.currency),
@@ -204,12 +219,17 @@ pub(crate) fn print_session_table(
             styled_cell("TOTAL", cyan, true),
             Cell::new(""),
             Cell::new(""),
-            right_cell(
-                &format_compact(total_stats.total_tokens(), number_format),
-                cyan,
-                true,
-            ),
         ];
+        row.push(right_cell(
+            &format_cache_hit_rate(total_stats.cache_hit_rate(options.supports_cache_read)),
+            cyan,
+            true,
+        ));
+        row.push(right_cell(
+            &format_compact(total_stats.total_tokens(), number_format),
+            cyan,
+            true,
+        ));
         if show_cost {
             row.push(right_cell(
                 &format_cost(total_cost, options.currency),
@@ -233,12 +253,17 @@ pub(crate) fn print_session_table(
                 cyan,
                 true,
             ),
-            right_cell(
-                &format_number(total_stats.total_tokens(), number_format),
-                cyan,
-                true,
-            ),
         ];
+        row.push(right_cell(
+            &format_cache_hit_rate(total_stats.cache_hit_rate(options.supports_cache_read)),
+            cyan,
+            true,
+        ));
+        row.push(right_cell(
+            &format_number(total_stats.total_tokens(), number_format),
+            cyan,
+            true,
+        ));
         if show_cost {
             row.push(right_cell(
                 &format_cost(total_cost, options.currency),
@@ -276,6 +301,7 @@ pub(crate) fn output_session_json(
     pricing_db: &PricingDb,
     order: SortOrder,
     show_cost: bool,
+    supports_cache_read: bool,
     currency: Option<&CurrencyConverter>,
 ) -> String {
     let mut sorted_sessions: Vec<_> = sessions.iter().collect();
@@ -307,6 +333,9 @@ pub(crate) fn output_session_json(
                 "reasoning_tokens": session.stats.reasoning_tokens,
                 "cache_creation_tokens": session.stats.cache_creation,
                 "cache_read_tokens": session.stats.cache_read,
+                "cache_hit_rate": cache_hit_rate_json_value(
+                    session.stats.cache_hit_rate(supports_cache_read)
+                ),
                 "total_tokens": session.stats.total_tokens(),
                 "models": models,
             });
@@ -487,7 +516,7 @@ mod tests {
     #[test]
     fn output_session_json_empty() {
         let db = PricingDb::default();
-        let json_str = output_session_json(&[], &db, SortOrder::Asc, false, None);
+        let json_str = output_session_json(&[], &db, SortOrder::Asc, false, true, None);
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&json_str).unwrap();
         assert!(parsed.is_empty());
     }
@@ -496,7 +525,7 @@ mod tests {
     fn output_session_json_fields_present() {
         let db = PricingDb::default();
         let sessions = vec![make_session("sess-1", "2026-02-12T10:00:00Z", 1000, 500)];
-        let json_str = output_session_json(&sessions, &db, SortOrder::Asc, false, None);
+        let json_str = output_session_json(&sessions, &db, SortOrder::Asc, false, true, None);
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&json_str).unwrap();
 
         assert_eq!(parsed.len(), 1);
@@ -513,7 +542,7 @@ mod tests {
     fn output_session_json_includes_cost_when_requested() {
         let db = PricingDb::default();
         let sessions = vec![make_session("sess-1", "2026-02-12T10:00:00Z", 100, 50)];
-        let json_str = output_session_json(&sessions, &db, SortOrder::Asc, true, None);
+        let json_str = output_session_json(&sessions, &db, SortOrder::Asc, true, true, None);
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&json_str).unwrap();
 
         assert!(parsed[0].get("cost").is_some());
@@ -527,12 +556,12 @@ mod tests {
             make_session("early", "2026-02-12T08:00:00Z", 200, 100),
         ];
 
-        let asc = output_session_json(&sessions, &db, SortOrder::Asc, false, None);
+        let asc = output_session_json(&sessions, &db, SortOrder::Asc, false, true, None);
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&asc).unwrap();
         assert_eq!(parsed[0]["session_id"], "early");
         assert_eq!(parsed[1]["session_id"], "late");
 
-        let desc = output_session_json(&sessions, &db, SortOrder::Desc, false, None);
+        let desc = output_session_json(&sessions, &db, SortOrder::Desc, false, true, None);
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&desc).unwrap();
         assert_eq!(parsed[0]["session_id"], "late");
         assert_eq!(parsed[1]["session_id"], "early");
@@ -551,7 +580,7 @@ mod tests {
             models,
             ..Default::default()
         }];
-        let json_str = output_session_json(&sessions, &db, SortOrder::Asc, false, None);
+        let json_str = output_session_json(&sessions, &db, SortOrder::Asc, false, true, None);
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&json_str).unwrap();
 
         let model_list: Vec<&str> = parsed[0]["models"]

--- a/src/output/statusline.rs
+++ b/src/output/statusline.rs
@@ -1,7 +1,10 @@
 use std::collections::HashMap;
 
 use crate::core::{DataQuality, DayStats, Stats};
-use crate::output::format::{NumberFormat, cost_json_value, format_compact, format_cost};
+use crate::output::format::{
+    NumberFormat, cache_hit_rate_json_value, cost_json_value, format_cache_hit_rate,
+    format_compact, format_cost,
+};
 use crate::output::pricing_meta;
 use crate::pricing::{
     CostDisplayMode, CurrencyConverter, PricingDb, sum_display_model_costs,
@@ -42,6 +45,7 @@ pub(crate) fn print_statusline(
     source_label: &str,
     number_format: NumberFormat,
     currency: Option<&CurrencyConverter>,
+    supports_cache_read: bool,
     cost_mode: CostDisplayMode,
 ) {
     let t = aggregate_totals(day_stats, pricing_db, cost_mode);
@@ -60,6 +64,10 @@ pub(crate) fn print_statusline(
             format_compact(t.stats.reasoning_tokens, number_format)
         ));
     }
+    parts.push(format!(
+        "Cache Hit: {}",
+        format_cache_hit_rate(t.stats.cache_hit_rate(supports_cache_read))
+    ));
     println!("{}", parts.join(" | "));
 }
 
@@ -78,17 +86,20 @@ pub(crate) fn print_statusline_json(
         source_label,
         number_format,
         currency,
+        true,
         None,
         CostDisplayMode::Total,
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn print_statusline_json_with_quality(
     day_stats: &HashMap<String, DayStats>,
     pricing_db: &PricingDb,
     source_label: &str,
     number_format: NumberFormat,
     currency: Option<&CurrencyConverter>,
+    supports_cache_read: bool,
     data_quality: Option<DataQuality>,
     cost_mode: CostDisplayMode,
 ) -> String {
@@ -101,6 +112,9 @@ pub(crate) fn print_statusline_json_with_quality(
         "reasoning_tokens": t.stats.reasoning_tokens,
         "cache_creation_tokens": t.stats.cache_creation,
         "cache_read_tokens": t.stats.cache_read,
+        "cache_hit_rate": cache_hit_rate_json_value(
+            t.stats.cache_hit_rate(supports_cache_read)
+        ),
         "total_tokens": t.stats.total_tokens(),
         "cost": cost_json_value(t.cost, currency),
         "formatted": {
@@ -232,6 +246,7 @@ mod tests {
         assert_eq!(v["reasoning_tokens"].as_i64(), Some(100));
         assert_eq!(v["cache_creation_tokens"].as_i64(), Some(50));
         assert_eq!(v["cache_read_tokens"].as_i64(), Some(700));
+        assert_eq!(v["cache_hit_rate"].as_f64(), Some(14.74));
         assert_eq!(v["total_tokens"].as_i64(), Some(10850));
     }
 

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 use crate::cli::SortOrder;
 use crate::core::{DayStats, Stats};
 use crate::output::format::{
-    NumberFormat, create_styled_table, format_compact, format_cost, format_number, header_cell,
-    right_cell, styled_cell,
+    NumberFormat, create_styled_table, format_cache_hit_rate, format_compact, format_cost,
+    format_number, header_cell, right_cell, styled_cell,
 };
 use crate::output::period::{Period, aggregate_day_stats_by_period};
 use crate::output::pricing_meta;
@@ -24,6 +24,7 @@ pub(crate) struct TokenTableOptions<'a> {
     pub(crate) number_format: NumberFormat,
     pub(crate) show_reasoning: bool,
     pub(crate) show_cache_creation: bool,
+    pub(crate) supports_cache_read: bool,
     pub(crate) currency: Option<&'a CurrencyConverter>,
     pub(crate) cost_mode: CostDisplayMode,
 }
@@ -100,11 +101,9 @@ fn build_header(cfg: &PeriodConfig, breakdown: bool, opts: &TokenTableOptions<'_
         if cfg.show_calls {
             h.push(header_cell("Calls", c));
         }
-        h.extend([
-            header_cell("In", c),
-            header_cell("Out", c),
-            header_cell("Total", c),
-        ]);
+        h.extend([header_cell("In", c), header_cell("Out", c)]);
+        h.push(header_cell("Cache Hit", c));
+        h.push(header_cell("Total", c));
         if opts.show_cost {
             h.push(header_cell("Cost", c));
         }
@@ -122,6 +121,7 @@ fn build_header(cfg: &PeriodConfig, breakdown: bool, opts: &TokenTableOptions<'_
             h.push(header_cell("Cache Creation", c));
         }
         h.push(header_cell("Cache Read", c));
+        h.push(header_cell("Cache Hit", c));
         if opts.show_cost {
             h.push(header_cell("Cost", c));
         }
@@ -138,7 +138,9 @@ fn build_header(cfg: &PeriodConfig, breakdown: bool, opts: &TokenTableOptions<'_
         if opts.show_cache_creation {
             h.push(header_cell("Cache Creation", c));
         }
-        h.extend([header_cell("Cache Read", c), header_cell("Total", c)]);
+        h.push(header_cell("Cache Read", c));
+        h.push(header_cell("Cache Hit", c));
+        h.push(header_cell("Total", c));
         if opts.show_cost {
             h.push(header_cell("Cost", c));
         }
@@ -168,8 +170,17 @@ fn add_compact_rows(
     row.extend([
         right_cell(&format_compact(data.stats.input_tokens, nf), None, false),
         right_cell(&format_compact(data.stats.output_tokens, nf), None, false),
-        right_cell(&format_compact(data.stats.total_tokens(), nf), None, false),
     ]);
+    row.push(right_cell(
+        &format_cache_hit_rate(data.stats.cache_hit_rate(opts.supports_cache_read)),
+        None,
+        false,
+    ));
+    row.push(right_cell(
+        &format_compact(data.stats.total_tokens(), nf),
+        None,
+        false,
+    ));
     if opts.show_cost {
         row.push(right_cell(
             &format_cost(cost, opts.currency),
@@ -224,6 +235,11 @@ fn add_breakdown_rows(
         }
         row.push(right_cell(
             &format_number(stats.cache_read, nf),
+            None,
+            false,
+        ));
+        row.push(right_cell(
+            &format_cache_hit_rate(stats.cache_hit_rate(opts.supports_cache_read)),
             None,
             false,
         ));
@@ -290,6 +306,11 @@ fn add_standard_rows(
         false,
     ));
     row.push(right_cell(
+        &format_cache_hit_rate(data.stats.cache_hit_rate(opts.supports_cache_read)),
+        None,
+        false,
+    ));
+    row.push(right_cell(
         &format_number(data.stats.total_tokens(), nf),
         None,
         false,
@@ -337,8 +358,17 @@ fn add_total_row(
         row.extend([
             right_cell(&format_compact(total_stats.input_tokens, nf), cyan, true),
             right_cell(&format_compact(total_stats.output_tokens, nf), cyan, true),
-            right_cell(&format_compact(total_stats.total_tokens(), nf), cyan, true),
         ]);
+        row.push(right_cell(
+            &format_cache_hit_rate(total_stats.cache_hit_rate(opts.supports_cache_read)),
+            cyan,
+            true,
+        ));
+        row.push(right_cell(
+            &format_compact(total_stats.total_tokens(), nf),
+            cyan,
+            true,
+        ));
         if opts.show_cost {
             row.push(right_cell(
                 &format_cost(total_cost, opts.currency),
@@ -376,6 +406,11 @@ fn add_total_row(
         }
         row.push(right_cell(
             &format_number(total_stats.cache_read, nf),
+            cyan,
+            true,
+        ));
+        row.push(right_cell(
+            &format_cache_hit_rate(total_stats.cache_hit_rate(opts.supports_cache_read)),
             cyan,
             true,
         ));

--- a/src/output/table_tests.rs
+++ b/src/output/table_tests.rs
@@ -13,6 +13,7 @@ fn default_opts() -> TokenTableOptions<'static> {
         number_format: NumberFormat::default(),
         show_reasoning: false,
         show_cache_creation: false,
+        supports_cache_read: false,
         currency: None,
         cost_mode: CostDisplayMode::Total,
     }
@@ -27,7 +28,7 @@ fn header_compact_daily_with_cost() {
         ..default_opts()
     };
     let h = build_header(&cfg, false, &opts);
-    assert_eq!(h.len(), 6);
+    assert_eq!(h.len(), 7);
 }
 
 #[test]
@@ -39,7 +40,7 @@ fn header_compact_weekly_no_calls() {
         ..default_opts()
     };
     let h = build_header(&cfg, false, &opts);
-    assert_eq!(h.len(), 4);
+    assert_eq!(h.len(), 5);
 }
 
 #[test]
@@ -52,9 +53,10 @@ fn header_breakdown_daily_all_columns() {
         ..default_opts()
     };
     let h = build_header(&cfg, true, &opts);
-    assert_eq!(h.len(), 9);
+    assert_eq!(h.len(), 10);
     assert_eq!(h[6].content(), "Cache Creation");
     assert_eq!(h[7].content(), "Cache Read");
+    assert_eq!(h[8].content(), "Cache Hit");
 }
 
 #[test]
@@ -62,7 +64,7 @@ fn header_breakdown_monthly_minimal() {
     let cfg = period_config(Period::Month);
     let opts = default_opts();
     let h = build_header(&cfg, true, &opts);
-    assert_eq!(h.len(), 5);
+    assert_eq!(h.len(), 6);
 }
 
 #[test]
@@ -75,9 +77,21 @@ fn header_standard_daily_all_columns() {
         ..default_opts()
     };
     let h = build_header(&cfg, false, &opts);
-    assert_eq!(h.len(), 10);
+    assert_eq!(h.len(), 11);
     assert_eq!(h[6].content(), "Cache Creation");
     assert_eq!(h[7].content(), "Cache Read");
+    assert_eq!(h[8].content(), "Cache Hit");
+}
+
+#[test]
+fn header_includes_cache_hit_when_source_does_not_support_cache_reads() {
+    let cfg = period_config(Period::Day);
+    let opts = TokenTableOptions {
+        supports_cache_read: false,
+        ..default_opts()
+    };
+    let h = build_header(&cfg, false, &opts);
+    assert!(h.iter().any(|cell| cell.content() == "Cache Hit"));
 }
 
 #[test]
@@ -85,7 +99,7 @@ fn header_standard_weekly_minimal() {
     let cfg = period_config(Period::Week);
     let opts = default_opts();
     let h = build_header(&cfg, false, &opts);
-    assert_eq!(h.len(), 6);
+    assert_eq!(h.len(), 7);
 }
 
 #[test]

--- a/src/output/top.rs
+++ b/src/output/top.rs
@@ -12,8 +12,8 @@ use comfy_table::{Attribute, Cell, CellAlignment, Color};
 use crate::cli::TopDimension;
 use crate::core::{CostKind, DayStats, ProjectStats, Stats};
 use crate::output::format::{
-    NumberFormat, create_styled_table, format_compact, format_cost, format_number, header_cell,
-    right_cell, styled_cell,
+    NumberFormat, create_styled_table, format_cache_hit_rate, format_compact, format_cost,
+    format_number, header_cell, right_cell, styled_cell,
 };
 use crate::pricing::{
     CostDisplayMode, CurrencyConverter, PricingDb, calculate_display_cost, model_cost_kind,
@@ -35,10 +35,12 @@ pub(crate) struct TopRow {
 }
 
 #[derive(Debug, Clone, Copy)]
+#[allow(clippy::struct_excessive_bools)]
 pub(crate) struct TopTableOptions<'a> {
     pub(crate) use_color: bool,
     pub(crate) compact: bool,
     pub(crate) show_cost: bool,
+    pub(crate) supports_cache_read: bool,
     pub(crate) source_label: &'a str,
     pub(crate) number_format: NumberFormat,
     pub(crate) currency: Option<&'a CurrencyConverter>,
@@ -251,6 +253,7 @@ pub(crate) fn print_top_table(rows: &[TopRow], options: TopTableOptions<'_>) {
         header.push(header_cell("Input", options.use_color));
         header.push(header_cell("Output", options.use_color));
     }
+    header.push(header_cell("Cache Hit", options.use_color));
     header.push(header_cell("Total", options.use_color));
     header.push(header_cell("Share", options.use_color));
     if options.show_cost {
@@ -282,6 +285,11 @@ pub(crate) fn print_top_table(rows: &[TopRow], options: TopTableOptions<'_>) {
             ));
         }
         cells.push(right_cell(
+            &format_cache_hit_rate(row.stats.cache_hit_rate(options.supports_cache_read)),
+            None,
+            false,
+        ));
+        cells.push(right_cell(
             &format_compact(row.stats.total_tokens(), options.number_format),
             None,
             false,
@@ -303,6 +311,10 @@ pub(crate) fn print_top_table(rows: &[TopRow], options: TopTableOptions<'_>) {
     let displayed_total_count: i64 = limited.iter().map(|r| r.count).sum();
     let displayed_total_input: i64 = limited.iter().map(|r| r.stats.input_tokens).sum();
     let displayed_total_output: i64 = limited.iter().map(|r| r.stats.output_tokens).sum();
+    let mut displayed_stats = Stats::default();
+    for row in &limited {
+        displayed_stats.add(&row.stats);
+    }
     let mut total_row = vec![
         styled_cell("", bold_cyan, true),
         styled_cell("TOTAL", bold_cyan, true),
@@ -324,6 +336,11 @@ pub(crate) fn print_top_table(rows: &[TopRow], options: TopTableOptions<'_>) {
             true,
         ));
     }
+    total_row.push(right_cell(
+        &format_cache_hit_rate(displayed_stats.cache_hit_rate(options.supports_cache_read)),
+        bold_cyan,
+        true,
+    ));
     total_row.push(right_cell(
         &format_compact(displayed_total_tokens, options.number_format),
         bold_cyan,
@@ -638,7 +655,7 @@ mod tests {
                 pricing_cache_mtime_epoch_seconds: None,
             })
             .collect();
-        let csv = output_top_csv(&rows, TopDimension::Model, 5, false, None);
+        let csv = output_top_csv(&rows, TopDimension::Model, 5, false, true, None);
         let lines: Vec<&str> = csv.lines().collect();
         assert_eq!(lines.len(), 6); // header + 5 rows
     }
@@ -656,7 +673,7 @@ mod tests {
             pricing_cache_age_seconds: None,
             pricing_cache_mtime_epoch_seconds: None,
         }];
-        let json = output_top_json(&rows, TopDimension::Model, 10, true, None);
+        let json = output_top_json(&rows, TopDimension::Model, 10, true, true, None);
         let val: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(val["dimension"], "model");
         assert_eq!(val["share_basis"], "cost");
@@ -693,7 +710,7 @@ mod tests {
                 pricing_cache_mtime_epoch_seconds: None,
             },
         ];
-        let json = output_top_json(&rows, TopDimension::Model, 10, true, None);
+        let json = output_top_json(&rows, TopDimension::Model, 10, true, true, None);
         let val: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(val["share_basis"], "tokens");
         // cost_usd should be JSON null for NaN
@@ -713,7 +730,7 @@ mod tests {
             pricing_cache_age_seconds: None,
             pricing_cache_mtime_epoch_seconds: None,
         }];
-        let csv = output_top_csv(&rows, TopDimension::Project, 1, false, None);
+        let csv = output_top_csv(&rows, TopDimension::Project, 1, false, true, None);
         let lines: Vec<&str> = csv.lines().collect();
         assert!(lines[1].contains("\"weird,name\""), "csv: {}", lines[1]);
     }
@@ -733,7 +750,7 @@ mod tests {
         }];
         let converter = CurrencyConverter::from_rate_for_test("CNY", 7.0, "CNY ");
 
-        let csv = output_top_csv(&rows, TopDimension::Model, 1, true, Some(&converter));
+        let csv = output_top_csv(&rows, TopDimension::Model, 1, true, true, Some(&converter));
 
         let lines: Vec<&str> = csv.lines().collect();
         assert!(lines[0].ends_with(",cost_usd,cost_local,pricing_source"));
@@ -742,7 +759,7 @@ mod tests {
 
     #[test]
     fn empty_rows_produce_header_only_csv() {
-        let csv = output_top_csv(&[], TopDimension::Model, 10, false, None);
+        let csv = output_top_csv(&[], TopDimension::Model, 10, false, true, None);
         assert_eq!(csv.lines().count(), 1);
     }
 }

--- a/src/output/top_structured.rs
+++ b/src/output/top_structured.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 use serde_json::json;
 
 use crate::cli::TopDimension;
-use crate::output::format::csv_escape;
+use crate::output::format::{cache_hit_rate_csv_value, cache_hit_rate_json_value, csv_escape};
 use crate::output::top::{
     ShareBasis, TopRow, share_basis, share_of, sum_cost, sum_tokens, take_top,
 };
@@ -16,6 +16,7 @@ pub(crate) fn output_top_json(
     dim: TopDimension,
     limit: usize,
     show_cost: bool,
+    supports_cache_read: bool,
     currency: Option<&CurrencyConverter>,
 ) -> String {
     let limited = take_top(rows, limit);
@@ -37,6 +38,9 @@ pub(crate) fn output_top_json(
                 "output_tokens": row.stats.output_tokens,
                 "cache_creation": row.stats.cache_creation,
                 "cache_read": row.stats.cache_read,
+                "cache_hit_rate": cache_hit_rate_json_value(
+                    row.stats.cache_hit_rate(supports_cache_read)
+                ),
                 "reasoning_tokens": row.stats.reasoning_tokens,
                 "total_tokens": row.stats.total_tokens(),
                 "share_percent": (share * 100.0).round() / 100.0,
@@ -94,6 +98,7 @@ pub(crate) fn output_top_csv(
     dim: TopDimension,
     limit: usize,
     show_cost: bool,
+    supports_cache_read: bool,
     currency: Option<&CurrencyConverter>,
 ) -> String {
     let limited = take_top(rows, limit);
@@ -108,7 +113,7 @@ pub(crate) fn output_top_csv(
     };
     let _ = write!(
         out,
-        "rank,{dim_col},count,input_tokens,output_tokens,cache_creation,cache_read,reasoning_tokens,total_tokens,share_percent"
+        "rank,{dim_col},count,input_tokens,output_tokens,cache_creation,cache_read,cache_hit_rate,reasoning_tokens,total_tokens,share_percent"
     );
     if show_cost {
         out.push_str(",cost_usd");
@@ -130,7 +135,7 @@ pub(crate) fn output_top_csv(
         let share = share_of(row, total_cost, total_tokens, basis);
         let _ = write!(
             out,
-            "{},{},{},{},{},{},{},{},{},{:.2}",
+            "{},{},{},{},{},{},{},{},{},{},{:.2}",
             idx + 1,
             csv_escape(&row.name),
             row.count,
@@ -138,6 +143,7 @@ pub(crate) fn output_top_csv(
             row.stats.output_tokens,
             row.stats.cache_creation,
             row.stats.cache_read,
+            cache_hit_rate_csv_value(row.stats.cache_hit_rate(supports_cache_read)),
             row.stats.reasoning_tokens,
             row.stats.total_tokens(),
             share,

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -176,6 +176,8 @@ pub struct TokenBreakdown {
     /// Reported prompt-cache hit rate as a percentage from 0 to 100.
     /// `None` means the source does not expose trustworthy cache-read data or
     /// the summary has no input-side tokens.
+    // Default keeps summaries serialized before this field existed loadable.
+    #[serde(default)]
     pub cache_hit_rate: Option<f64>,
     pub total_tokens: i64,
 }
@@ -525,6 +527,22 @@ mod tests {
                 .resolve(NaiveDate::from_ymd_opt(2026, 5, 9).unwrap())
                 .is_err()
         );
+    }
+
+    #[test]
+    fn token_breakdown_deserializes_legacy_json_without_cache_hit_rate() {
+        let legacy = r#"{
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "reasoning_tokens": 0,
+            "cache_creation_tokens": 3,
+            "cache_read_tokens": 2,
+            "total_tokens": 20
+        }"#;
+        let tokens: TokenBreakdown =
+            serde_json::from_str(legacy).expect("legacy breakdown without cache_hit_rate");
+        assert_eq!(tokens.cache_hit_rate, None);
+        assert_eq!(tokens.total_tokens, 20);
     }
 
     #[test]

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -166,13 +166,17 @@ impl Default for SummaryOptions {
 }
 
 /// Token totals for a summary or model row.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct TokenBreakdown {
     pub input_tokens: i64,
     pub output_tokens: i64,
     pub reasoning_tokens: i64,
     pub cache_creation_tokens: i64,
     pub cache_read_tokens: i64,
+    /// Reported prompt-cache hit rate as a percentage from 0 to 100.
+    /// `None` means the source does not expose trustworthy cache-read data or
+    /// the summary has no input-side tokens.
+    pub cache_hit_rate: Option<f64>,
     pub total_tokens: i64,
 }
 
@@ -300,13 +304,14 @@ fn apply_cli_config(mut options: SummaryOptions, config: &Config) -> SummaryOpti
 }
 
 impl TokenBreakdown {
-    fn from_stats(stats: &Stats) -> Self {
+    fn from_stats(stats: &Stats, supports_cache_read: bool) -> Self {
         Self {
             input_tokens: stats.input_tokens,
             output_tokens: stats.output_tokens,
             reasoning_tokens: stats.reasoning_tokens,
             cache_creation_tokens: stats.cache_creation,
             cache_read_tokens: stats.cache_read,
+            cache_hit_rate: stats.cache_hit_rate(supports_cache_read),
             total_tokens: stats.total_tokens(),
         }
     }
@@ -328,6 +333,7 @@ pub(in crate::sdk) fn build_cost_summary(
     let cost_usd = finite_cost(sum_model_costs(&models, pricing_db));
     let estimated_cost_usd =
         finite_positive_cost(sum_estimated_proxy_model_costs(&models, pricing_db));
+    let supports_cache_read = source.capabilities().has_cache_read;
 
     CostSummary {
         source: usage_source,
@@ -342,8 +348,8 @@ pub(in crate::sdk) fn build_cost_summary(
         estimated_cost: convert_cost(estimated_cost_usd, currency),
         estimated_cost_usd,
         cost_kind: model_cost_kind(&models).as_str().to_string(),
-        tokens: TokenBreakdown::from_stats(&stats),
-        models: summarize_models(&models, pricing_db, currency),
+        tokens: TokenBreakdown::from_stats(&stats, supports_cache_read),
+        models: summarize_models(&models, pricing_db, currency, supports_cache_read),
         valid_entries: result.valid,
         skipped_entries: result.skipped,
         parse_error_entries: result.parse_errors,
@@ -402,6 +408,7 @@ fn summarize_models(
     models: &HashMap<String, Stats>,
     pricing_db: &PricingDb,
     currency: Option<&CurrencyConverter>,
+    supports_cache_read: bool,
 ) -> Vec<ModelCostSummary> {
     let mut rows: Vec<_> = models
         .iter()
@@ -416,7 +423,7 @@ fn summarize_models(
                 estimated_cost: convert_cost(estimated_cost_usd, currency),
                 estimated_cost_usd,
                 cost_kind: stats.cost_kind().as_str().to_string(),
-                tokens: TokenBreakdown::from_stats(stats),
+                tokens: TokenBreakdown::from_stats(stats, supports_cache_read),
             }
         })
         .collect();
@@ -539,7 +546,7 @@ mod tests {
             },
         );
 
-        let rows = summarize_models(&models, &pricing_db, None);
+        let rows = summarize_models(&models, &pricing_db, None, true);
 
         assert_eq!(rows[0].model, "gpt-5-alpha");
         assert_eq!(rows[1].model, "gpt-5-zeta");

--- a/src/source/claude/config.rs
+++ b/src/source/claude/config.rs
@@ -44,6 +44,7 @@ impl Source for ClaudeSource {
             has_billing_blocks: true,
             has_reasoning_tokens: false,
             has_cache_creation: true,
+            has_cache_read: true,
             needs_dedup: true,
             has_tool_calls: true,
             has_endpoints: true,

--- a/src/source/codex/config.rs
+++ b/src/source/codex/config.rs
@@ -43,6 +43,7 @@ impl Source for CodexSource {
             has_billing_blocks: false, // Different billing model
             has_reasoning_tokens: true,
             has_cache_creation: false,
+            has_cache_read: true,
             needs_dedup: true,
             has_tool_calls: false,
             has_endpoints: false,

--- a/src/source/cursor/config.rs
+++ b/src/source/cursor/config.rs
@@ -46,6 +46,7 @@ impl Source for CursorSource {
             has_billing_blocks: false,
             has_reasoning_tokens: false,
             has_cache_creation: false,
+            has_cache_read: false,
             needs_dedup: false,
             has_tool_calls: false,
             has_endpoints: false,

--- a/src/source/grok/config.rs
+++ b/src/source/grok/config.rs
@@ -43,6 +43,7 @@ impl Source for GrokSource {
             has_billing_blocks: false,
             has_reasoning_tokens: false,
             has_cache_creation: false,
+            has_cache_read: false,
             needs_dedup: false,
             has_tool_calls: false,
             has_endpoints: false,

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -34,12 +34,38 @@ pub(crate) struct Capabilities {
     pub(crate) has_reasoning_tokens: bool,
     /// Has cache creation tokens
     pub(crate) has_cache_creation: bool,
+    /// Has trustworthy prompt-cache read tokens
+    pub(crate) has_cache_read: bool,
     /// Requires deduplication (streaming creates duplicate entries)
     pub(crate) needs_dedup: bool,
     /// Supports tool-call discovery and parsing
     pub(crate) has_tool_calls: bool,
     /// Populates the serving-endpoint field (native vs proxy classification)
     pub(crate) has_endpoints: bool,
+}
+
+impl Capabilities {
+    pub(crate) fn combine<'a>(sources: impl IntoIterator<Item = &'a dyn Source>) -> Self {
+        let mut combined = Self {
+            has_cache_read: true,
+            ..Self::default()
+        };
+        let mut has_sources = false;
+        for source in sources {
+            has_sources = true;
+            let caps = source.capabilities();
+            combined.has_projects |= caps.has_projects;
+            combined.has_billing_blocks |= caps.has_billing_blocks;
+            combined.has_reasoning_tokens |= caps.has_reasoning_tokens;
+            combined.has_cache_creation |= caps.has_cache_creation;
+            combined.has_cache_read &= caps.has_cache_read;
+            combined.needs_dedup |= caps.needs_dedup;
+            combined.has_tool_calls |= caps.has_tool_calls;
+            combined.has_endpoints |= caps.has_endpoints;
+        }
+        combined.has_cache_read &= has_sources;
+        combined
+    }
 }
 
 /// Data source trait - implemented by each CLI tool
@@ -82,6 +108,10 @@ pub(crate) type BoxedSource = Box<dyn Source>;
 
 // Re-export registry functions
 pub(crate) use registry::{ALL_SOURCES, all_sources, get_source, source_choices, suggest_source};
+
+pub(crate) fn all_capabilities() -> Capabilities {
+    Capabilities::combine(all_sources())
+}
 
 // Re-export loader functions
 pub(crate) use loader::{load_blocks, load_daily, load_projects, load_sessions, load_tool_calls};

--- a/src/source/registry.rs
+++ b/src/source/registry.rs
@@ -188,6 +188,7 @@ mod tests {
         assert!(caps.has_projects);
         assert!(caps.has_billing_blocks);
         assert!(caps.has_cache_creation);
+        assert!(caps.has_cache_read);
         assert!(caps.needs_dedup);
         assert!(caps.has_tool_calls);
         assert!(!caps.has_reasoning_tokens);
@@ -200,6 +201,7 @@ mod tests {
         assert!(!caps.has_projects);
         assert!(!caps.has_billing_blocks);
         assert!(!caps.has_cache_creation);
+        assert!(caps.has_cache_read);
         assert!(caps.needs_dedup);
         assert!(caps.has_reasoning_tokens);
         assert!(!caps.has_tool_calls);
@@ -212,6 +214,7 @@ mod tests {
         assert!(!caps.has_projects);
         assert!(!caps.has_billing_blocks);
         assert!(!caps.has_cache_creation);
+        assert!(!caps.has_cache_read);
         assert!(!caps.needs_dedup);
         assert!(!caps.has_reasoning_tokens);
         assert!(!caps.has_tool_calls);
@@ -224,6 +227,7 @@ mod tests {
         assert!(caps.has_projects);
         assert!(!caps.has_billing_blocks);
         assert!(!caps.has_cache_creation);
+        assert!(!caps.has_cache_read);
         assert!(!caps.needs_dedup);
         assert!(!caps.has_reasoning_tokens);
         assert!(!caps.has_tool_calls);

--- a/src/sources_cmd.rs
+++ b/src/sources_cmd.rs
@@ -1,0 +1,126 @@
+//! Handler and renderers for the `sources` subcommand (capability listing).
+//!
+//! Lives in its own module to keep `app.rs` under the module size limit.
+
+use crate::app::{CommandContext, print_json};
+use crate::output::OutputFormat;
+use crate::source::{ALL_SOURCES, Capabilities, Source, all_capabilities, all_sources};
+use serde_json::json;
+
+pub(crate) fn handle_sources(ctx: &CommandContext<'_>) {
+    let sources: Vec<&dyn Source> = all_sources().collect();
+    let mut all_caps = all_capabilities();
+    all_caps.has_projects = false;
+    all_caps.has_billing_blocks = false;
+
+    render_sources(&sources, &all_caps, ctx);
+}
+
+fn render_sources(sources: &[&dyn Source], all_caps: &Capabilities, ctx: &CommandContext<'_>) {
+    match ctx.cli.output_format() {
+        OutputFormat::Csv => render_sources_csv(sources, all_caps),
+        OutputFormat::Json => render_sources_json(sources, all_caps, ctx),
+        OutputFormat::Table => print_sources_table(sources, all_caps),
+    }
+}
+
+fn render_sources_csv(sources: &[&dyn Source], all_caps: &Capabilities) {
+    println!(
+        "name,display_name,aliases,has_projects,has_billing_blocks,has_reasoning_tokens,has_cache_creation,has_cache_read,needs_dedup"
+    );
+    println!(
+        "{},All Sources,,{},{},{},{},{},{}",
+        ALL_SOURCES,
+        all_caps.has_projects,
+        all_caps.has_billing_blocks,
+        all_caps.has_reasoning_tokens,
+        all_caps.has_cache_creation,
+        all_caps.has_cache_read,
+        all_caps.needs_dedup
+    );
+    for source in sources {
+        let caps = source.capabilities();
+        let aliases = source.aliases().join("|");
+        println!(
+            "{},{},{},{},{},{},{},{},{}",
+            source.name(),
+            source.display_name(),
+            aliases,
+            caps.has_projects,
+            caps.has_billing_blocks,
+            caps.has_reasoning_tokens,
+            caps.has_cache_creation,
+            caps.has_cache_read,
+            caps.needs_dedup
+        );
+    }
+}
+
+fn render_sources_json(sources: &[&dyn Source], all_caps: &Capabilities, ctx: &CommandContext<'_>) {
+    let mut payload = vec![json!({
+        "name": ALL_SOURCES,
+        "display_name": "All Sources",
+        "aliases": [],
+        "capabilities": {
+            "has_projects": all_caps.has_projects,
+            "has_billing_blocks": all_caps.has_billing_blocks,
+            "has_reasoning_tokens": all_caps.has_reasoning_tokens,
+            "has_cache_creation": all_caps.has_cache_creation,
+            "has_cache_read": all_caps.has_cache_read,
+            "needs_dedup": all_caps.needs_dedup
+        }
+    })];
+    payload.extend(sources.iter().map(|source| {
+        let caps = source.capabilities();
+        json!({
+            "name": source.name(),
+            "display_name": source.display_name(),
+            "aliases": source.aliases(),
+            "capabilities": {
+                "has_projects": caps.has_projects,
+                "has_billing_blocks": caps.has_billing_blocks,
+                "has_reasoning_tokens": caps.has_reasoning_tokens,
+                "has_cache_creation": caps.has_cache_creation,
+                "has_cache_read": caps.has_cache_read,
+                "needs_dedup": caps.needs_dedup
+            }
+        })
+    }));
+    let json = serde_json::to_string(&payload).unwrap_or_else(|_| "[]".to_string());
+    print_json(&json, ctx.jq_filter);
+}
+
+fn print_sources_table(sources: &[&dyn Source], all_caps: &Capabilities) {
+    println!("Available sources:");
+    println!(
+        "- {} (All Sources) aliases: - | has_projects={} has_billing_blocks={} has_reasoning_tokens={} has_cache_creation={} has_cache_read={} needs_dedup={}",
+        ALL_SOURCES,
+        all_caps.has_projects,
+        all_caps.has_billing_blocks,
+        all_caps.has_reasoning_tokens,
+        all_caps.has_cache_creation,
+        all_caps.has_cache_read,
+        all_caps.needs_dedup
+    );
+    for source in sources {
+        let caps = source.capabilities();
+        let aliases = if source.aliases().is_empty() {
+            "-".to_string()
+        } else {
+            source.aliases().join(", ")
+        };
+        println!(
+            "- {} ({}) aliases: {} | has_projects={} has_billing_blocks={} has_reasoning_tokens={} has_cache_creation={} has_cache_read={} needs_dedup={}",
+            source.name(),
+            source.display_name(),
+            aliases,
+            caps.has_projects,
+            caps.has_billing_blocks,
+            caps.has_reasoning_tokens,
+            caps.has_cache_creation,
+            caps.has_cache_read,
+            caps.needs_dedup
+        );
+    }
+    println!("Hint: use `--source <name|alias>` (e.g. `--source codex` or `--source cx`).");
+}

--- a/tests/cli_budget_currency_statusline.rs
+++ b/tests/cli_budget_currency_statusline.rs
@@ -105,6 +105,7 @@ fn monthly_budget_csv_includes_budget_columns() {
     let mut lines = output.lines();
     let header = lines.next().expect("header");
     let row = lines.next().expect("row");
+    assert!(header.contains("cache_hit_rate"));
     assert!(header.contains("budget_projected"));
     assert!(header.contains("budget_status"));
     assert!(row.contains("over_budget"));
@@ -307,7 +308,7 @@ fn daily_csv_uses_requested_currency() {
     let lines: Vec<&str> = output.lines().collect();
     assert_eq!(
         lines[0],
-        "date,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,total_tokens,cost,pricing_source"
+        "date,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens,cost,pricing_source"
     );
     assert!(
         lines[1].ends_with(",0.007350,fallback"),
@@ -380,9 +381,9 @@ fn daily_outputs_fresh_cache_pricing_source() {
         ",cost,pricing_source,pricing_cache_age_seconds,pricing_cache_mtime_epoch_seconds"
     ));
     let fields: Vec<&str> = lines[1].split(',').collect();
-    assert_eq!(fields[8], "cache");
-    assert!(fields[9].parse::<u64>().is_ok());
+    assert_eq!(fields[9], "cache");
     assert!(fields[10].parse::<u64>().is_ok());
+    assert!(fields[11].parse::<u64>().is_ok());
 
     let _ = fs::remove_dir_all(root);
 }
@@ -492,7 +493,7 @@ fn daily_outputs_mixed_pricing_source() {
     assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
     let output = String::from_utf8(stdout).expect("utf8 stdout");
     let fields: Vec<&str> = output.lines().nth(1).expect("row").split(',').collect();
-    assert_eq!(fields[8], "mixed");
+    assert_eq!(fields[9], "mixed");
 
     let _ = fs::remove_dir_all(root);
 }

--- a/tests/cli_claude.rs
+++ b/tests/cli_claude.rs
@@ -64,6 +64,7 @@ fn claude_project_json_aggregates_sessions() {
 
     assert_eq!(myapp["session_count"].as_i64(), Some(2));
     assert_eq!(myapp["total_tokens"].as_i64(), Some(460));
+    assert_eq!(myapp["cache_hit_rate"].as_f64(), Some(6.06));
     // Models should be sorted alphabetically
     let models: Vec<&str> = myapp["models"]
         .as_array()
@@ -521,10 +522,29 @@ fn claude_daily_csv_outputs_correct_format() {
     assert_eq!(lines.len(), 2, "header + 1 data row");
     assert_eq!(
         lines[0],
-        "date,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,total_tokens"
+        "date,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
     );
     // input=100, output=50, reasoning=0, cache_creation=10, cache_read=20, total=180
-    assert_eq!(lines[1], "2026-02-06,100,50,0,10,20,180");
+    assert_eq!(lines[1], "2026-02-06,100,50,0,10,20,15.38,180");
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "-O",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("HOME", &root)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let table = String::from_utf8(stdout).expect("utf8 table");
+    assert!(table.contains("Cache Hit"), "table: {table}");
+    assert!(table.contains("15.4%"), "table: {table}");
 
     let _ = fs::remove_dir_all(root);
 }
@@ -568,13 +588,13 @@ fn claude_session_csv_outputs_correct_format() {
     assert_eq!(lines.len(), 3, "header + 2 sessions");
     assert_eq!(
         lines[0],
-        "session_id,project_path,first_timestamp,last_timestamp,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,total_tokens"
+        "session_id,project_path,first_timestamp,last_timestamp,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
     );
     // Sessions sorted by last_timestamp asc: session-a (10:00) then session-b (11:00)
     assert!(lines[1].starts_with("session-a,"));
-    assert!(lines[1].ends_with(",100,50,0,0,0,150"));
+    assert!(lines[1].ends_with(",100,50,0,0,0,0.00,150"));
     assert!(lines[2].starts_with("session-b,"));
-    assert!(lines[2].ends_with(",200,80,0,0,0,280"));
+    assert!(lines[2].ends_with(",200,80,0,0,0,0.00,280"));
 
     let _ = fs::remove_dir_all(root);
 }
@@ -618,19 +638,19 @@ fn claude_project_csv_outputs_correct_format() {
     assert_eq!(lines.len(), 3, "header + 2 projects");
     assert_eq!(
         lines[0],
-        "project_name,project_path,sessions,input_tokens,output_tokens,total_tokens"
+        "project_name,project_path,sessions,input_tokens,output_tokens,cache_hit_rate,total_tokens"
     );
     // With --no-cost, all costs are 0.0 so order is undefined — find by name
     let myapp_line = lines
         .iter()
         .find(|l| l.starts_with("myapp,"))
         .expect("myapp row");
-    assert!(myapp_line.ends_with(",1,100,50,150"));
+    assert!(myapp_line.ends_with(",1,100,50,0.00,150"));
     let other_line = lines
         .iter()
         .find(|l| l.starts_with("other-project,"))
         .expect("other-project row");
-    assert!(other_line.ends_with(",1,200,80,280"));
+    assert!(other_line.ends_with(",1,200,80,0.00,280"));
 
     let _ = fs::remove_dir_all(root);
 }
@@ -671,14 +691,14 @@ fn claude_blocks_csv_outputs_correct_format() {
     assert_eq!(lines.len(), 3, "header + 2 blocks");
     assert_eq!(
         lines[0],
-        "block_start,block_end,input_tokens,output_tokens,cache_creation_tokens,cache_read_tokens,total_tokens"
+        "block_start,block_end,input_tokens,output_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
     );
     // Block 1: 10:00-15:00, input=100, output=50, cache_creation=10, cache_read=20, total=180
     assert!(lines[1].contains("10:00"));
-    assert!(lines[1].ends_with(",100,50,10,20,180"));
+    assert!(lines[1].ends_with(",100,50,10,20,15.38,180"));
     // Block 2: 15:00-20:00, input=300, output=150, cache_creation=0, cache_read=0, total=450
     assert!(lines[2].contains("15:00"));
-    assert!(lines[2].ends_with(",300,150,0,0,450"));
+    assert!(lines[2].ends_with(",300,150,0,0,0.00,450"));
 
     let _ = fs::remove_dir_all(root);
 }

--- a/tests/cli_codex_source_routing.rs
+++ b/tests/cli_codex_source_routing.rs
@@ -41,6 +41,7 @@ fn codex_daily_json_reads_session_data() {
     // OpenAI output_tokens(30) includes reasoning_output_tokens(10).
     // After separating: non_cached_input=80, output=20, reasoning=10, cache_read=20 → total=130
     assert_eq!(arr[0]["total_tokens"].as_i64(), Some(130));
+    assert_eq!(arr[0]["cache_hit_rate"].as_f64(), Some(20.0));
 
     let _ = fs::remove_dir_all(root);
 }
@@ -260,6 +261,7 @@ fn source_all_daily_json_merges_registered_sources() {
     assert_eq!(arr[0]["input_tokens"].as_i64(), Some(110));
     assert_eq!(arr[0]["output_tokens"].as_i64(), Some(55));
     assert_eq!(arr[0]["total_tokens"].as_i64(), Some(165));
+    assert!(arr[0]["cache_hit_rate"].is_null());
 
     let models = arr[0]["models"].as_array().expect("models");
     assert_eq!(models.len(), 2);
@@ -677,11 +679,11 @@ fn codex_session_csv_includes_reasoning_and_cache_tokens() {
     let row = lines.next().expect("row");
     assert_eq!(
         header,
-        "session_id,project_path,first_timestamp,last_timestamp,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,total_tokens"
+        "session_id,project_path,first_timestamp,last_timestamp,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
     );
     assert_eq!(
         row,
-        "reasoning-session,,2026-02-06T10:00:00Z,2026-02-06T10:00:00Z,900,300,200,0,100,1500"
+        "reasoning-session,,2026-02-06T10:00:00Z,2026-02-06T10:00:00Z,900,300,200,0,100,10.00,1500"
     );
 
     let _ = fs::remove_dir_all(root);

--- a/tests/cli_codex_source_routing.rs
+++ b/tests/cli_codex_source_routing.rs
@@ -282,6 +282,7 @@ fn sources_outputs_expose_same_capability_columns() {
         "has_billing_blocks",
         "has_reasoning_tokens",
         "has_cache_creation",
+        "has_cache_read",
         "needs_dedup",
     ];
 

--- a/tests/cli_grok_cursor.rs
+++ b/tests/cli_grok_cursor.rs
@@ -141,10 +141,32 @@ fn source_flag_can_select_cursor_without_subcommand() {
     assert_eq!(arr[0]["input_tokens"].as_i64(), Some(100));
     assert_eq!(arr[0]["output_tokens"].as_i64(), Some(40));
     assert_eq!(arr[0]["total_tokens"].as_i64(), Some(140));
+    assert!(arr[0]["cache_hit_rate"].is_null());
     assert_eq!(
         arr[0]["models"].as_array().unwrap()[0].as_str(),
         Some("claude-4-sonnet")
     );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "--source",
+            "cursor",
+            "-O",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("CURSOR_HOME", &cursor_home)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let table = String::from_utf8(stdout).expect("utf8 table");
+    assert!(table.contains("Cache Hit"), "table: {table}");
+    assert!(table.contains("N/A"), "table: {table}");
 
     let _ = fs::remove_dir_all(root);
 }
@@ -181,6 +203,7 @@ fn source_flag_can_select_grok_without_subcommand() {
     assert_eq!(arr[0]["input_tokens"].as_i64(), Some(1500));
     assert_eq!(arr[0]["output_tokens"].as_i64(), Some(0));
     assert_eq!(arr[0]["total_tokens"].as_i64(), Some(1500));
+    assert!(arr[0]["cache_hit_rate"].is_null());
     assert_eq!(
         arr[0]["models"].as_array().unwrap()[0].as_str(),
         Some("grok-build")

--- a/tests/negative_token_integration.rs
+++ b/tests/negative_token_integration.rs
@@ -156,6 +156,7 @@ fn all_sources_daily_json_clamps_negative_claude_and_cursor_tokens() {
     assert_eq!(row["output_tokens"].as_i64(), Some(90));
     assert_eq!(row["cache_creation_tokens"].as_i64(), Some(0));
     assert_eq!(row["cache_read_tokens"].as_i64(), Some(20));
+    assert!(row["cache_hit_rate"].is_null());
     assert_eq!(row["total_tokens"].as_i64(), Some(135));
 
     for key in [

--- a/tests/sdk_integration.rs
+++ b/tests/sdk_integration.rs
@@ -143,6 +143,7 @@ fn sdk_summarizes_codex_cost_without_running_cli() {
     assert_eq!(summary.currency, "USD");
     assert_eq!(summary.tokens.input_tokens, 80);
     assert_eq!(summary.tokens.cache_read_tokens, 20);
+    assert_eq!(summary.tokens.cache_hit_rate, Some(20.0));
     assert_eq!(summary.tokens.output_tokens, 20);
     assert_eq!(summary.tokens.reasoning_tokens, 10);
     assert_eq!(summary.tokens.total_tokens, 130);
@@ -399,6 +400,7 @@ fn sdk_summarizes_grok_context_tokens_without_running_cli() {
     assert_eq!(summary.tokens.input_tokens, 1500);
     assert_eq!(summary.tokens.output_tokens, 0);
     assert_eq!(summary.tokens.total_tokens, 1500);
+    assert_eq!(summary.tokens.cache_hit_rate, None);
     assert_eq!(summary.models.len(), 1);
     assert_eq!(summary.models[0].model, "grok-build");
     assert!(summary.cost_usd.is_some_and(|cost| cost > 0.0));


### PR DESCRIPTION
## What

Add prompt-cache hit rate reporting across ccstats usage summaries.

- Calculate `cache_read / (input + cache_creation + cache_read) * 100`.
- Add `Cache Hit` to table output and `cache_hit_rate` to JSON/CSV output.
- Cover daily, weekly, monthly, session, project, blocks, top, statusline, monthly-budget CSV, and the Rust SDK.
- Report unavailable values as `N/A`, `null`, or an empty CSV field for Cursor, Grok, and mixed `--source all` data.
- Leave the `endpoints` command unchanged.

## Why

ccstats already reports cache creation and cache-read token counts, but it does not expose the percentage of input-side tokens served from cache. Users currently have to calculate that metric manually, and sources without trustworthy cache-read data must not be misrepresented as a real 0% hit rate.

## Test Plan

- [x] `cargo check --locked` passes
- [x] `cargo test --locked` passes (583 tests)
- [x] `cargo clippy --all-targets --all-features --locked -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `python3 checks/check_workflow.py --repo .` passes
- [x] Tested the installed binary locally with Claude/Codex numeric output and Cursor unavailable output


## Linked Work

- Issue: Closes #93
