### PR TITLE
fix: add Codex session origin scope

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -19,8 +19,8 @@ use crate::output::{
 };
 use crate::pricing::{CostDisplayMode, PricingDb};
 use crate::source::{
-    Capabilities, Source, all_capabilities, all_sources, load_blocks, load_daily, load_projects,
-    load_sessions, load_tool_calls,
+    Capabilities, CodexScope, Source, all_capabilities, all_sources, load_blocks, load_daily,
+    load_projects, load_sessions, load_tool_calls,
 };
 use crate::utils::{Timezone, filter_json};
 
@@ -55,6 +55,62 @@ pub(crate) fn print_no_data_hint(source_name: &str, category: &str) {
     );
 }
 
+fn codex_scope_for_source(source: &dyn Source, ctx: &CommandContext<'_>) -> Option<CodexScope> {
+    (source.name() == "codex" && ctx.cli.codex_scope != CodexScope::All)
+        .then_some(ctx.cli.codex_scope)
+}
+
+fn source_label(source: &dyn Source, ctx: &CommandContext<'_>) -> String {
+    match codex_scope_for_source(source, ctx) {
+        Some(scope) => format!("{} ({})", source.display_name(), scope.label()),
+        None => source.display_name().to_string(),
+    }
+}
+
+fn annotate_json_codex_scope(json: &str, scope: Option<CodexScope>) -> String {
+    let Some(scope) = scope else {
+        return json.to_string();
+    };
+    let Ok(mut value) = serde_json::from_str::<serde_json::Value>(json) else {
+        return json.to_string();
+    };
+
+    match &mut value {
+        serde_json::Value::Array(rows) => {
+            for row in rows {
+                if let serde_json::Value::Object(object) = row {
+                    object.insert(
+                        "codex_scope".to_string(),
+                        serde_json::Value::String(scope.as_str().to_string()),
+                    );
+                }
+            }
+        }
+        serde_json::Value::Object(object) => {
+            object.insert(
+                "codex_scope".to_string(),
+                serde_json::Value::String(scope.as_str().to_string()),
+            );
+        }
+        _ => {}
+    }
+
+    serde_json::to_string(&value).unwrap_or_else(|_| json.to_string())
+}
+
+fn annotate_csv_codex_scope(csv: String, scope: Option<CodexScope>) -> String {
+    match scope {
+        Some(scope) => format!("# codex_scope,{}\n{csv}", scope.as_str()),
+        None => csv,
+    }
+}
+
+fn print_codex_scope_note(scope: Option<CodexScope>) {
+    if let Some(scope) = scope {
+        println!("\n  Codex scope: {}", scope.as_str());
+    }
+}
+
 fn should_render_empty_structured_result(result: &LoadResult, ctx: &CommandContext<'_>) -> bool {
     result.day_stats.is_empty()
         && result.data_quality().has_warnings()
@@ -67,7 +123,7 @@ fn should_render_empty_structured_result(result: &LoadResult, ctx: &CommandConte
 fn handle_session(source: &dyn Source, ctx: &CommandContext<'_>) {
     let sessions = load_sessions(source, ctx.filter, ctx.timezone, false);
     if sessions.is_empty() {
-        print_no_data_hint(source.display_name(), "session");
+        print_no_data_hint(&source_label(source, ctx), "session");
         return;
     }
 
@@ -75,6 +131,7 @@ fn handle_session(source: &dyn Source, ctx: &CommandContext<'_>) {
 }
 
 fn render_session(sessions: &[SessionStats], source: &dyn Source, ctx: &CommandContext<'_>) {
+    let scope = codex_scope_for_source(source, ctx);
     match ctx.cli.output_format() {
         OutputFormat::Csv => {
             let csv = output_session_csv(
@@ -85,7 +142,7 @@ fn render_session(sessions: &[SessionStats], source: &dyn Source, ctx: &CommandC
                 source.capabilities().has_cache_read,
                 ctx.currency,
             );
-            print!("{csv}");
+            print!("{}", annotate_csv_codex_scope(csv, scope));
         }
         OutputFormat::Json => {
             let json = output_session_json(
@@ -96,23 +153,27 @@ fn render_session(sessions: &[SessionStats], source: &dyn Source, ctx: &CommandC
                 source.capabilities().has_cache_read,
                 ctx.currency,
             );
+            let json = annotate_json_codex_scope(&json, scope);
             print_json(&json, ctx.jq_filter);
         }
-        OutputFormat::Table => print_session_table(
-            sessions,
-            ctx.pricing_db,
-            SessionTableOptions {
-                order: ctx.cli.sort_order(),
-                use_color: ctx.cli.use_color(),
-                compact: ctx.cli.compact,
-                show_cost: ctx.cli.show_cost(),
-                supports_cache_read: source.capabilities().has_cache_read,
-                number_format: ctx.number_format,
-                source_label: source.display_name(),
-                timezone: ctx.timezone,
-                currency: ctx.currency,
-            },
-        ),
+        OutputFormat::Table => {
+            let label = source_label(source, ctx);
+            print_session_table(
+                sessions,
+                ctx.pricing_db,
+                SessionTableOptions {
+                    order: ctx.cli.sort_order(),
+                    use_color: ctx.cli.use_color(),
+                    compact: ctx.cli.compact,
+                    show_cost: ctx.cli.show_cost(),
+                    supports_cache_read: source.capabilities().has_cache_read,
+                    number_format: ctx.number_format,
+                    source_label: &label,
+                    timezone: ctx.timezone,
+                    currency: ctx.currency,
+                },
+            );
+        }
     }
 }
 
@@ -218,17 +279,23 @@ fn render_blocks(blocks: &[BlockStats], source: &dyn Source, ctx: &CommandContex
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+struct TopRenderOptions<'a> {
+    source_label: &'a str,
+    supports_cache_read: bool,
+    codex_scope: Option<CodexScope>,
+    cost_mode: CostDisplayMode,
+}
+
 fn handle_top(
     rows: &[TopRow],
     dim: TopDimension,
     limit: usize,
-    source_label: &str,
-    supports_cache_read: bool,
+    options: TopRenderOptions<'_>,
     ctx: &CommandContext<'_>,
-    cost_mode: CostDisplayMode,
 ) {
     if rows.is_empty() {
-        print_no_data_hint(source_label, "usage");
+        print_no_data_hint(options.source_label, "usage");
         return;
     }
 
@@ -239,10 +306,10 @@ fn handle_top(
                 dim,
                 limit,
                 ctx.cli.show_cost(),
-                supports_cache_read,
+                options.supports_cache_read,
                 ctx.currency,
             );
-            print!("{csv}");
+            print!("{}", annotate_csv_codex_scope(csv, options.codex_scope));
         }
         OutputFormat::Json => {
             let json = output_top_json(
@@ -250,9 +317,10 @@ fn handle_top(
                 dim,
                 limit,
                 ctx.cli.show_cost(),
-                supports_cache_read,
+                options.supports_cache_read,
                 ctx.currency,
             );
+            let json = annotate_json_codex_scope(&json, options.codex_scope);
             print_json(&json, ctx.jq_filter);
         }
         OutputFormat::Table => print_top_table(
@@ -261,13 +329,13 @@ fn handle_top(
                 use_color: ctx.cli.use_color(),
                 compact: ctx.cli.compact,
                 show_cost: ctx.cli.show_cost(),
-                supports_cache_read,
-                source_label,
+                supports_cache_read: options.supports_cache_read,
+                source_label: options.source_label,
                 number_format: ctx.number_format,
                 currency: ctx.currency,
                 dim,
                 limit,
-                cost_mode,
+                cost_mode: options.cost_mode,
             },
         ),
     }
@@ -279,6 +347,8 @@ fn handle_top_for_source(
     limit: usize,
     ctx: &CommandContext<'_>,
 ) {
+    let scope = codex_scope_for_source(source, ctx);
+    let label = source_label(source, ctx);
     match dim {
         TopDimension::Model => {
             let result = load_daily(source, ctx.filter, ctx.timezone, false, ctx.cli.debug);
@@ -287,10 +357,13 @@ fn handle_top_for_source(
                 &rows,
                 dim,
                 limit,
-                source.display_name(),
-                source.capabilities().has_cache_read,
+                TopRenderOptions {
+                    source_label: &label,
+                    supports_cache_read: source.capabilities().has_cache_read,
+                    codex_scope: scope,
+                    cost_mode: CostDisplayMode::Total,
+                },
                 ctx,
-                CostDisplayMode::Total,
             );
         }
         TopDimension::Project => {
@@ -307,10 +380,13 @@ fn handle_top_for_source(
                 &rows,
                 dim,
                 limit,
-                source.display_name(),
-                source.capabilities().has_cache_read,
+                TopRenderOptions {
+                    source_label: &label,
+                    supports_cache_read: source.capabilities().has_cache_read,
+                    codex_scope: scope,
+                    cost_mode: CostDisplayMode::Total,
+                },
                 ctx,
-                CostDisplayMode::Total,
             );
         }
     }
@@ -349,24 +425,27 @@ fn render_tools(summary: &ToolSummary, ctx: &CommandContext<'_>) {
 
 /// Statusline keeps its compact single-line semantics outside generic output dispatch.
 fn handle_statusline(source: &dyn Source, ctx: &CommandContext<'_>) {
+    let scope = codex_scope_for_source(source, ctx);
+    let label = source_label(source, ctx);
     let result = load_daily(source, ctx.filter, ctx.timezone, true, false);
     if ctx.cli.json {
         let json = print_statusline_json_with_quality(
             &result.day_stats,
             ctx.pricing_db,
-            source.display_name(),
+            &label,
             ctx.number_format,
             ctx.currency,
             source.capabilities().has_cache_read,
             Some(result.data_quality()),
             CostDisplayMode::Total,
         );
+        let json = annotate_json_codex_scope(&json, scope);
         print_json(&json, ctx.jq_filter);
     } else {
         print_statusline(
             &result.day_stats,
             ctx.pricing_db,
-            source.display_name(),
+            &label,
             ctx.number_format,
             ctx.currency,
             source.capabilities().has_cache_read,
@@ -380,6 +459,7 @@ fn render_period_result(
     result: &LoadResult,
     period: Period,
     caps: &Capabilities,
+    codex_scope: Option<CodexScope>,
     ctx: &CommandContext<'_>,
     cost_mode: CostDisplayMode,
 ) {
@@ -420,7 +500,7 @@ fn render_period_result(
                     cost_mode,
                 )
             };
-            print!("{csv}");
+            print!("{}", annotate_csv_codex_scope(csv, codex_scope));
         }
         OutputFormat::Json => {
             let mut json = output_period_json_with_quality(
@@ -447,9 +527,11 @@ fn render_period_result(
                 );
                 json = add_monthly_budget_to_json(&json, &reports);
             }
+            json = annotate_json_codex_scope(&json, codex_scope);
             print_json(&json, ctx.jq_filter);
         }
         OutputFormat::Table => {
+            print_codex_scope_note(codex_scope);
             print_period_table(
                 &result.day_stats,
                 period,
@@ -504,10 +586,17 @@ fn handle_period(
 
     let result = load_daily(source, ctx.filter, ctx.timezone, false, ctx.cli.debug);
     if result.day_stats.is_empty() && !should_render_empty_structured_result(&result, ctx) {
-        print_no_data_hint(source.display_name(), "usage");
+        print_no_data_hint(&source_label(source, ctx), "usage");
         return;
     }
-    render_period_result(&result, period, caps, ctx, CostDisplayMode::Total);
+    render_period_result(
+        &result,
+        period,
+        caps,
+        codex_scope_for_source(source, ctx),
+        ctx,
+        CostDisplayMode::Total,
+    );
 }
 
 /// Handle commands for a specific data source
@@ -647,10 +736,13 @@ pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandCo
                 &rows,
                 dim,
                 limit,
-                "All Sources",
-                caps.has_cache_read,
+                TopRenderOptions {
+                    source_label: "All Sources",
+                    supports_cache_read: caps.has_cache_read,
+                    codex_scope: None,
+                    cost_mode: CostDisplayMode::RealOnly,
+                },
                 ctx,
-                CostDisplayMode::RealOnly,
             );
             return;
         }
@@ -682,5 +774,5 @@ pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandCo
         print_no_data_hint("All Sources", "usage");
         return;
     }
-    render_period_result(&result, period, &caps, ctx, CostDisplayMode::RealOnly);
+    render_period_result(&result, period, &caps, None, ctx, CostDisplayMode::RealOnly);
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write as _;
 use std::time::Instant;
 
 use crate::cli::{Cli, SourceCommand, TopDimension};
@@ -98,11 +99,14 @@ fn annotate_json_codex_scope(json: &str, scope: Option<CodexScope>) -> String {
     serde_json::to_string(&value).unwrap_or_else(|_| json.to_string())
 }
 
-fn annotate_csv_codex_scope(csv: String, scope: Option<CodexScope>) -> String {
-    match scope {
-        Some(scope) => format!("# codex_scope,{}\n{csv}", scope.as_str()),
-        None => csv,
+fn annotate_csv_codex_scope(mut csv: String, scope: Option<CodexScope>) -> String {
+    if let Some(scope) = scope {
+        if !csv.ends_with('\n') {
+            csv.push('\n');
+        }
+        let _ = writeln!(csv, "# codex_scope,{}", scope.as_str());
     }
+    csv
 }
 
 fn print_codex_scope_note(scope: Option<CodexScope>) {

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -8,6 +8,7 @@ use clap::{Parser, ValueEnum};
 
 use crate::config::{Config, ConfigColorMode, ConfigCostMode, ConfigSortOrder};
 use crate::output::OutputFormat;
+use crate::source::CodexScope;
 
 use super::commands::Commands;
 
@@ -130,6 +131,10 @@ pub(crate) struct Cli {
     /// Data source name or alias (e.g., "claude", "codex", "cursor", "grok", "kimi", "all", "cc", "cx", "cur", "gx", "km")
     #[arg(long, global = true, value_name = "SOURCE")]
     pub(crate) source: Option<String>,
+
+    /// Filter Codex sessions by origin
+    #[arg(long, global = true, value_enum, default_value_t = CodexScope::All)]
+    pub(crate) codex_scope: CodexScope,
 }
 
 impl Cli {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ use config::Config;
 use core::DateFilter;
 use output::NumberFormat;
 use pricing::{CurrencyConverter, PricingDb};
-use source::{ALL_SOURCES, get_source, source_choices, suggest_source};
+use source::{ALL_SOURCES, CodexScope, CodexSource, get_source, source_choices, suggest_source};
 use utils::{Timezone, parse_date};
 
 enum TimezoneSource {
@@ -236,6 +236,25 @@ fn load_currency_converter(
     })
 }
 
+fn validate_codex_scope(scope: CodexScope, source_name: &str) {
+    if scope == CodexScope::All {
+        return;
+    }
+
+    if source_name.eq_ignore_ascii_case(ALL_SOURCES) {
+        eprintln!("Error: --codex-scope only supports the Codex source");
+        std::process::exit(1);
+    }
+
+    let Some(source) = get_source(source_name) else {
+        return;
+    };
+    if source.name() != "codex" {
+        eprintln!("Error: --codex-scope only supports the Codex source");
+        std::process::exit(1);
+    }
+}
+
 fn dispatch_command(source_name: &str, source_cmd: SourceCommand, context: &CommandContext<'_>) {
     if source_name.eq_ignore_ascii_case(ALL_SOURCES) {
         return handle_all_sources_command(source_cmd, context);
@@ -245,6 +264,11 @@ fn dispatch_command(source_name: &str, source_cmd: SourceCommand, context: &Comm
         eprintln!("{}", unknown_source_message(source_name));
         std::process::exit(1);
     };
+
+    if source.name() == "codex" {
+        let scoped_source = CodexSource::with_scope(context.cli.codex_scope);
+        return handle_source_command(&scoped_source, source_cmd, context);
+    }
 
     handle_source_command(source, source_cmd, context);
 }
@@ -283,6 +307,7 @@ pub fn run_cli() {
         cli.source.as_deref(),
         source_cmd,
     );
+    validate_codex_scope(cli.codex_scope, source_name);
     let currency_converter = load_currency_converter(&cli, needs_pricing, is_statusline);
 
     dispatch_command(

--- a/src/source/codex/config.rs
+++ b/src/source/codex/config.rs
@@ -4,17 +4,58 @@
 
 use std::path::{Path, PathBuf};
 
+use clap::ValueEnum;
+
 use crate::source::{Capabilities, ParseOutput, Source};
 use crate::utils::Timezone;
 
-use super::parser::{find_codex_files, parse_codex_file_with_debug};
+use super::parser::{find_codex_files, parse_codex_file_with_scope};
+
+#[derive(Debug, Clone, Copy, Default, ValueEnum, PartialEq, Eq)]
+pub(crate) enum CodexScope {
+    /// Include every Codex session origin.
+    #[default]
+    All,
+    /// Include interactive Codex CLI sessions only.
+    Interactive,
+    /// Include `codex exec` sessions only.
+    Exec,
+    /// Include spawned subagent sessions only.
+    Subagent,
+}
+
+impl CodexScope {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            CodexScope::All => "all",
+            CodexScope::Interactive => "interactive",
+            CodexScope::Exec => "exec",
+            CodexScope::Subagent => "subagent",
+        }
+    }
+
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            CodexScope::All => "all sessions",
+            CodexScope::Interactive => "interactive CLI sessions",
+            CodexScope::Exec => "exec sessions",
+            CodexScope::Subagent => "subagent sessions",
+        }
+    }
+}
 
 /// Codex data source
-pub(crate) struct CodexSource;
+pub(crate) struct CodexSource {
+    scope: CodexScope,
+}
 
 impl CodexSource {
     pub(crate) fn new() -> Self {
-        Self
+        Self::with_scope(CodexScope::All)
+    }
+
+    pub(crate) fn with_scope(scope: CodexScope) -> Self {
+        Self { scope }
     }
 }
 
@@ -55,6 +96,6 @@ impl Source for CodexSource {
     }
 
     fn parse_file(&self, path: &Path, timezone: Timezone, debug: bool) -> ParseOutput {
-        parse_codex_file_with_debug(path, timezone, debug)
+        parse_codex_file_with_scope(path, timezone, debug, self.scope)
     }
 }

--- a/src/source/codex/mod.rs
+++ b/src/source/codex/mod.rs
@@ -6,4 +6,4 @@
 mod config;
 mod parser;
 
-pub(crate) use config::CodexSource;
+pub(crate) use config::{CodexScope, CodexSource};

--- a/src/source/codex/parser.rs
+++ b/src/source/codex/parser.rs
@@ -15,6 +15,8 @@ use crate::core::RawEntry;
 use crate::source::ParseOutput;
 use crate::utils::Timezone;
 
+use super::config::CodexScope;
+
 const DEFAULT_CODEX_DIR: &str = ".codex";
 const CODEX_HOME_ENV: &str = "CODEX_HOME";
 const SESSION_SUBDIR: &str = "sessions";
@@ -41,6 +43,8 @@ struct Payload<'a> {
     id: Option<&'a str>,
     info: Option<TokenInfo<'a>>,
     model: Option<&'a str>,
+    source: Option<serde_json::Value>,
+    thread_source: Option<&'a str>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -268,6 +272,7 @@ struct CodexParseContext<'a> {
     timezone: Timezone,
     debug: bool,
     identity: CodexFileIdentity,
+    scope: CodexScope,
 }
 
 struct CodexParseState {
@@ -276,6 +281,7 @@ struct CodexParseState {
     previous_totals: Option<UsageTotals>,
     current_model: Option<String>,
     logical_session_key: String,
+    session_origin: CodexSessionOrigin,
 }
 
 impl CodexParseState {
@@ -286,6 +292,7 @@ impl CodexParseState {
             previous_totals: None,
             current_model: None,
             logical_session_key: session_key,
+            session_origin: CodexSessionOrigin::Unknown,
         }
     }
 
@@ -297,10 +304,11 @@ impl CodexParseState {
     }
 }
 
-pub(super) fn parse_codex_file_with_debug(
+pub(super) fn parse_codex_file_with_scope(
     path: &Path,
     timezone: Timezone,
     debug: bool,
+    scope: CodexScope,
 ) -> ParseOutput {
     let identity = CodexFileIdentity::from_path(path);
     let context = CodexParseContext {
@@ -308,6 +316,7 @@ pub(super) fn parse_codex_file_with_debug(
         timezone,
         debug,
         identity,
+        scope,
     };
     let file = match open_codex_file(&context) {
         Ok(file) => file,
@@ -394,19 +403,20 @@ fn process_codex_line(
     };
 
     match raw_entry.entry_type {
-        Some("session_meta") => update_logical_session_key(raw_entry.payload.as_ref(), state),
+        Some("session_meta") => update_session_metadata(raw_entry.payload.as_ref(), state),
         Some("turn_context") => update_current_model(raw_entry.payload.as_ref(), state),
         Some("event_msg") => process_event_message(&raw_entry, line_no, context, state),
         _ => {}
     }
 }
 
-fn update_logical_session_key(payload: Option<&Payload<'_>>, state: &mut CodexParseState) {
+fn update_session_metadata(payload: Option<&Payload<'_>>, state: &mut CodexParseState) {
     if let Some(payload) = payload
         && let Some(id) = non_empty_model(payload.id)
     {
         state.logical_session_key = format!("codex-session:{id}");
     }
+    state.session_origin = session_origin_from_payload(payload);
 }
 
 fn update_current_model(payload: Option<&Payload<'_>>, state: &mut CodexParseState) {
@@ -429,6 +439,9 @@ fn process_event_message(
     let Some("token_count") = payload.payload_type else {
         return;
     };
+    if !scope_includes_origin(context.scope, state.session_origin) {
+        return;
+    }
     let Some(timestamp) = raw_entry.timestamp else {
         return;
     };
@@ -442,6 +455,62 @@ fn process_event_message(
 
     let model = resolve_entry_model(payload, state);
     push_codex_entry(timestamp, utc_dt, total, delta, model, context, state);
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum CodexSessionOrigin {
+    Interactive,
+    Exec,
+    Subagent,
+    #[default]
+    Unknown,
+}
+
+fn scope_includes_origin(scope: CodexScope, origin: CodexSessionOrigin) -> bool {
+    match scope {
+        CodexScope::All => true,
+        CodexScope::Interactive => origin == CodexSessionOrigin::Interactive,
+        CodexScope::Exec => origin == CodexSessionOrigin::Exec,
+        CodexScope::Subagent => origin == CodexSessionOrigin::Subagent,
+    }
+}
+
+fn session_origin_from_payload(payload: Option<&Payload<'_>>) -> CodexSessionOrigin {
+    let Some(payload) = payload else {
+        return CodexSessionOrigin::Unknown;
+    };
+
+    if payload
+        .thread_source
+        .is_some_and(|source| source.eq_ignore_ascii_case("subagent"))
+    {
+        return CodexSessionOrigin::Subagent;
+    }
+
+    session_origin_from_source(payload.source.as_ref())
+}
+
+fn session_origin_from_source(source: Option<&serde_json::Value>) -> CodexSessionOrigin {
+    match source {
+        Some(serde_json::Value::String(source)) => {
+            match source.trim().to_ascii_lowercase().as_str() {
+                "cli" | "interactive" => CodexSessionOrigin::Interactive,
+                "exec" => CodexSessionOrigin::Exec,
+                "subagent" => CodexSessionOrigin::Subagent,
+                _ => CodexSessionOrigin::Unknown,
+            }
+        }
+        Some(serde_json::Value::Object(source)) if source.contains_key("subagent") => {
+            CodexSessionOrigin::Subagent
+        }
+        Some(serde_json::Value::Object(source)) if source.contains_key("exec") => {
+            CodexSessionOrigin::Exec
+        }
+        Some(serde_json::Value::Object(source)) if source.contains_key("cli") => {
+            CodexSessionOrigin::Interactive
+        }
+        _ => CodexSessionOrigin::Unknown,
+    }
 }
 
 fn next_usage_delta(

--- a/src/source/codex/parser_tests.rs
+++ b/src/source/codex/parser_tests.rs
@@ -170,6 +170,8 @@ fn test_extract_model_from_info_model() {
         payload_type: None,
         id: None,
         model: Some("fallback-model"),
+        source: None,
+        thread_source: None,
         info: Some(TokenInfo {
             total_token_usage: None,
             last_token_usage: None,
@@ -189,6 +191,8 @@ fn test_extract_model_falls_back_to_model_name() {
         payload_type: None,
         id: None,
         model: Some("fallback"),
+        source: None,
+        thread_source: None,
         info: Some(TokenInfo {
             total_token_usage: None,
             last_token_usage: None,
@@ -206,6 +210,8 @@ fn test_extract_model_falls_back_to_metadata() {
         payload_type: None,
         id: None,
         model: Some("fallback"),
+        source: None,
+        thread_source: None,
         info: Some(TokenInfo {
             total_token_usage: None,
             last_token_usage: None,
@@ -225,6 +231,8 @@ fn test_extract_model_falls_back_to_payload_model() {
         payload_type: None,
         id: None,
         model: Some("payload-model"),
+        source: None,
+        thread_source: None,
         info: Some(TokenInfo {
             total_token_usage: None,
             last_token_usage: None,
@@ -242,6 +250,8 @@ fn test_extract_model_no_info_uses_payload() {
         payload_type: None,
         id: None,
         model: Some("payload-only"),
+        source: None,
+        thread_source: None,
         info: None,
     };
     assert_eq!(extract_model(&payload), Some("payload-only".to_string()));
@@ -253,6 +263,8 @@ fn test_extract_model_all_none_returns_none() {
         payload_type: None,
         id: None,
         model: None,
+        source: None,
+        thread_source: None,
         info: None,
     };
     assert_eq!(extract_model(&payload), None);
@@ -264,6 +276,8 @@ fn test_extract_model_empty_strings_skipped() {
         payload_type: None,
         id: None,
         model: Some("real-model"),
+        source: None,
+        thread_source: None,
         info: Some(TokenInfo {
             total_token_usage: None,
             last_token_usage: None,
@@ -273,4 +287,60 @@ fn test_extract_model_empty_strings_skipped() {
         }),
     };
     assert_eq!(extract_model(&payload), Some("real-model".to_string()));
+}
+
+#[test]
+fn codex_origin_parses_source_strings() {
+    let cli: Payload<'_> =
+        serde_json::from_str(r#"{"source":"cli","thread_source":"user"}"#).unwrap();
+    let exec: Payload<'_> =
+        serde_json::from_str(r#"{"source":"exec","thread_source":"user"}"#).unwrap();
+
+    assert_eq!(
+        session_origin_from_payload(Some(&cli)),
+        CodexSessionOrigin::Interactive
+    );
+    assert_eq!(
+        session_origin_from_payload(Some(&exec)),
+        CodexSessionOrigin::Exec
+    );
+}
+
+#[test]
+fn codex_origin_parses_tagged_subagent_source_shapes() {
+    let review: Payload<'_> =
+        serde_json::from_str(r#"{"source":{"subagent":"review"},"thread_source":"user"}"#).unwrap();
+    let spawned: Payload<'_> = serde_json::from_str(
+        r#"{"source":{"subagent":{"thread_spawn":{"id":"child"}}},"thread_source":"user"}"#,
+    )
+    .unwrap();
+    let thread_source: Payload<'_> =
+        serde_json::from_str(r#"{"source":{"future":"shape"},"thread_source":"subagent"}"#)
+            .unwrap();
+
+    assert_eq!(
+        session_origin_from_payload(Some(&review)),
+        CodexSessionOrigin::Subagent
+    );
+    assert_eq!(
+        session_origin_from_payload(Some(&spawned)),
+        CodexSessionOrigin::Subagent
+    );
+    assert_eq!(
+        session_origin_from_payload(Some(&thread_source)),
+        CodexSessionOrigin::Subagent
+    );
+}
+
+#[test]
+fn codex_origin_keeps_unknown_shapes_out_of_named_scopes() {
+    let unknown: Payload<'_> =
+        serde_json::from_str(r#"{"source":{"future":"shape"},"thread_source":"user"}"#).unwrap();
+    let origin = session_origin_from_payload(Some(&unknown));
+
+    assert_eq!(origin, CodexSessionOrigin::Unknown);
+    assert!(scope_includes_origin(CodexScope::All, origin));
+    assert!(!scope_includes_origin(CodexScope::Interactive, origin));
+    assert!(!scope_includes_origin(CodexScope::Exec, origin));
+    assert!(!scope_includes_origin(CodexScope::Subagent, origin));
 }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -107,6 +107,8 @@ pub(crate) trait Source: Send + Sync {
 /// Box type for dynamic dispatch
 pub(crate) type BoxedSource = Box<dyn Source>;
 
+pub(crate) use codex::{CodexScope, CodexSource};
+
 // Re-export registry functions
 pub(crate) use registry::{ALL_SOURCES, all_sources, get_source, source_choices, suggest_source};
 

--- a/tests/cli_codex_source_routing.rs
+++ b/tests/cli_codex_source_routing.rs
@@ -133,6 +133,46 @@ fn codex_scope_filters_daily_json_by_session_origin() {
 }
 
 #[test]
+fn codex_scope_csv_keeps_the_header_first_and_appends_scope_metadata() {
+    let root = unique_temp_dir("codex-scope-csv");
+    let codex_home = root.join("codex-home");
+    write_codex_token_session(
+        &codex_home,
+        "exec.jsonl",
+        r#"{"id":"exec","source":"exec","thread_source":"user"}"#,
+        20,
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "codex",
+            "daily",
+            "--csv",
+            "-O",
+            "--no-cost",
+            "--codex-scope",
+            "exec",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("CODEX_HOME", &codex_home)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let csv = String::from_utf8(stdout).expect("utf8 csv");
+    let lines: Vec<_> = csv.lines().collect();
+    assert!(lines[0].starts_with("date,"), "header: {}", lines[0]);
+    assert!(lines[1].ends_with(",20"), "data row: {}", lines[1]);
+    assert_eq!(lines.last(), Some(&"# codex_scope,exec"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn codex_scope_is_rejected_for_non_codex_sources() {
     let root = unique_temp_dir("codex-scope-reject");
 

--- a/tests/cli_codex_source_routing.rs
+++ b/tests/cli_codex_source_routing.rs
@@ -2,7 +2,19 @@ mod common;
 
 use common::{run_ccstats, unique_temp_dir, write_file};
 use serde_json::Value;
-use std::fs;
+use std::{fs, path::Path};
+
+fn write_codex_token_session(codex_home: &Path, file_name: &str, meta_payload: &str, input: i64) {
+    let session_file = codex_home.join("sessions").join(file_name);
+    write_file(
+        &session_file,
+        &format!(
+            r#"{{"timestamp":"2026-02-06T10:00:00Z","type":"session_meta","payload":{meta_payload}}}
+{{"timestamp":"2026-02-06T10:00:00Z","type":"event_msg","payload":{{"type":"token_count","info":{{"total_token_usage":{{"input_tokens":{input},"cached_input_tokens":0,"output_tokens":0,"reasoning_output_tokens":0,"total_tokens":{input}}},"last_token_usage":{{"input_tokens":{input},"cached_input_tokens":0,"output_tokens":0,"reasoning_output_tokens":0,"total_tokens":{input}}},"model":"gpt-5"}}}}}}
+"#
+        ),
+    );
+}
 
 #[test]
 fn codex_daily_json_reads_session_data() {
@@ -42,6 +54,119 @@ fn codex_daily_json_reads_session_data() {
     // After separating: non_cached_input=80, output=20, reasoning=10, cache_read=20 → total=130
     assert_eq!(arr[0]["total_tokens"].as_i64(), Some(130));
     assert_eq!(arr[0]["cache_hit_rate"].as_f64(), Some(20.0));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn codex_scope_filters_daily_json_by_session_origin() {
+    let root = unique_temp_dir("codex-scope-filter");
+    let codex_home = root.join("codex-home");
+    write_codex_token_session(
+        &codex_home,
+        "interactive.jsonl",
+        r#"{"id":"interactive","source":"cli","thread_source":"user"}"#,
+        10,
+    );
+    write_codex_token_session(
+        &codex_home,
+        "exec.jsonl",
+        r#"{"id":"exec","source":"exec","thread_source":"user"}"#,
+        20,
+    );
+    write_codex_token_session(
+        &codex_home,
+        "review-subagent.jsonl",
+        r#"{"id":"review-subagent","source":{"subagent":"review"},"thread_source":"user"}"#,
+        30,
+    );
+    write_codex_token_session(
+        &codex_home,
+        "spawned-subagent.jsonl",
+        r#"{"id":"spawned-subagent","source":{"future":"shape"},"thread_source":"subagent"}"#,
+        40,
+    );
+    write_codex_token_session(
+        &codex_home,
+        "unknown.jsonl",
+        r#"{"id":"unknown","source":{"future":"shape"},"thread_source":"user"}"#,
+        50,
+    );
+
+    let cases = [
+        (None, None, 150),
+        (Some("interactive"), Some("interactive"), 10),
+        (Some("exec"), Some("exec"), 20),
+        (Some("subagent"), Some("subagent"), 70),
+    ];
+
+    for (scope_arg, expected_scope, expected_total) in cases {
+        let mut args = vec![
+            "codex",
+            "daily",
+            "-j",
+            "-O",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ];
+        if let Some(scope) = scope_arg {
+            args.push("--codex-scope");
+            args.push(scope);
+        }
+
+        let (ok, stdout, stderr) = run_ccstats(&args, &[("CODEX_HOME", &codex_home)]);
+        assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+        let json: Value = serde_json::from_slice(&stdout).expect("json");
+        let arr = json.as_array().expect("array output");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["codex_scope"].as_str(), expected_scope);
+        assert_eq!(arr[0]["total_tokens"].as_i64(), Some(expected_total));
+    }
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn codex_scope_is_rejected_for_non_codex_sources() {
+    let root = unique_temp_dir("codex-scope-reject");
+
+    let (ok, _stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "--source",
+            "claude",
+            "--codex-scope",
+            "exec",
+            "-O",
+            "--no-cost",
+        ],
+        &[("HOME", &root)],
+    );
+    assert!(!ok, "expected non-Codex scope failure");
+    let stderr = String::from_utf8_lossy(&stderr);
+    assert!(stderr.contains("--codex-scope only supports the Codex source"));
+
+    let (ok, _stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "--source",
+            "all",
+            "--codex-scope",
+            "exec",
+            "-O",
+            "--no-cost",
+        ],
+        &[("HOME", &root)],
+    );
+    assert!(!ok, "expected all-source scope failure");
+    let stderr = String::from_utf8_lossy(&stderr);
+    assert!(stderr.contains("--codex-scope only supports the Codex source"));
 
     let _ = fs::remove_dir_all(root);
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -3,6 +3,14 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+const SOURCE_ENV_VARS: &[&str] = &[
+    "CLAUDE_CONFIG_DIR",
+    "CODEX_HOME",
+    "CURSOR_HOME",
+    "GROK_HOME",
+    "KIMI_CODE_HOME",
+];
+
 pub(crate) fn unique_temp_dir(prefix: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -63,6 +71,9 @@ fn resolve_ccstats_binary() -> PathBuf {
 pub(crate) fn run_ccstats(args: &[&str], envs: &[(&str, &Path)]) -> (bool, Vec<u8>, Vec<u8>) {
     let mut cmd = Command::new(resolve_ccstats_binary());
     cmd.args(args);
+    for key in SOURCE_ENV_VARS {
+        cmd.env_remove(key);
+    }
     for (k, v) in envs {
         cmd.env(k, v);
     }


### PR DESCRIPTION
## What

Adds a Codex session-origin scope filter for `all`, `interactive`, `exec`, and `subagent` sessions while preserving the default all-session total. Filtered Codex JSON/CSV/table/statusline output now carries the selected scope so scoped totals are not mistaken for overall usage.

Fixes #96

## Why

Codex JSONL logs already record `session_meta.payload.source` and `thread_source`, but ccstats previously aggregated every Codex session together with no way to separate interactive, exec, and spawned-agent usage.

## Test Plan

- [x] `cargo fmt --check` passes
- [x] `cargo check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes
- [x] `cargo deny check` passes
- [x] Tested manually via regression coverage for string and tagged-object Codex origin metadata
