### PR TITLE
fix: count Grok turn usage instead of context snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-08-20
+
 ### Added
 - Report each resolved model's pricing lookup key and source in `--debug` output without changing structured stdout.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Report each resolved model's pricing lookup key and source in `--debug` output without changing structured stdout.
 
+### Changed
+- Read Grok `turn_completed.usage` from `updates.jsonl` as real per-turn token, call, and server-cost statistics. Context-token snapshots remain only as `estimated_proxy` fallback.
+
+### Fixed
+- Stop treating Grok `contextTokensUsed` session snapshots as cumulative input tokens, model calls, or billed cost.
+
 ## [0.4.0] - 2026-07-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "ccstats"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccstats"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Fast token and cost usage statistics CLI for Claude Code, OpenAI Codex, Cursor, Grok, and Kimi Code"

--- a/README.md
+++ b/README.md
@@ -87,16 +87,16 @@ ccstats daily --source cur
 
 ## Quick Start (Grok)
 
-Grok support reads local session `summary.json`, `signals.json`, and fallback `updates.jsonl` metadata under `~/.grok/sessions/`. These files expose local context-token snapshots, not precise provider input/output billable usage or Grok account quota usage, so ccstats reports Grok context tokens as input tokens.
+Grok support reads `turn_completed.usage` records from `~/.grok/sessions/**/updates.jsonl`. Those events are per-turn model request totals, including cache, output, reasoning, model-call counts, and server `costUsdTicks`. Sessions without `turn_completed.usage` still fall back to local context-token snapshots and keep that cost marked `estimated_proxy`.
 
 ```bash
 # Install
 brew install majiayu000/tap/ccstats
 
-# Today's local context-token trend
+# Today's Grok usage
 ccstats grok today
 
-# Daily local context-token trend
+# Daily Grok usage
 ccstats grok
 
 # Same source via alias
@@ -296,13 +296,13 @@ Current limitations:
 ### Grok
 
 ```bash
-# Today's Grok local context-token trend
+# Today's Grok usage
 ccstats grok today
 
-# Daily Grok local context-token breakdown
+# Daily Grok usage
 ccstats grok
 
-# Weekly Grok local context-token summary
+# Weekly Grok usage
 ccstats grok weekly
 
 # By session
@@ -317,9 +317,9 @@ ccstats daily --source gx
 
 By default, ccstats checks Grok session files under:
 
-- `~/.grok/sessions/**/summary.json`
-- `~/.grok/sessions/**/signals.json`
-- `~/.grok/sessions/**/updates.jsonl` when `signals.json` is missing
+- `~/.grok/sessions/**/updates.jsonl` for `turn_completed.usage`
+- `~/.grok/sessions/**/summary.json` for project path and snapshot fallback
+- `~/.grok/sessions/**/signals.json` only when a session has no `turn_completed.usage`
 
 You can override the Grok home directory with `GROK_HOME`:
 
@@ -329,9 +329,9 @@ GROK_HOME="/path/to/.grok" ccstats grok
 
 Current limitations:
 
-- Grok local session files expose context token usage, not exact provider input/output usage.
-- These local context-token totals may not match Grok account, quota, or 5-hour usage UI totals when those views use server-side accounting.
-- ccstats reports Grok context tokens as input tokens and leaves output, cache creation, cache read, and reasoning token fields at zero.
+- Account quota and weekly-allowance UI totals can still differ from local logs.
+- Sessions without `turn_completed.usage` keep the older context-token snapshot and mark that cost `estimated_proxy`.
+- Dates come from each `turn_completed` event. Snapshot fallback still uses the session `updated_at`.
 - Grok 5-hour billing blocks are not supported.
 
 ### Kimi Code
@@ -500,9 +500,9 @@ cache_read / (input + cache_creation + cache_read) * 100
 
 Table output uses one decimal place and a `%` suffix. JSON uses the numeric
 `cache_hit_rate` field, while CSV uses a two-decimal `cache_hit_rate` column.
-Claude and Codex expose the required cache-read metric. Cursor, Grok, and
-mixed `--source all` output report the value as unavailable (`N/A`, `null`, or
-an empty CSV field) instead of treating missing metrics as zero.
+Claude, Codex, Grok, and Kimi Code expose the required cache-read metric. Cursor
+and mixed `--source all` output report the value as unavailable (`N/A`, `null`,
+or an empty CSV field) instead of treating missing metrics as zero.
 
 ### Parsing Warnings
 
@@ -520,7 +520,7 @@ Warning: ignored <N> malformed records
 | OpenAI Codex | `~/.codex/sessions/` | `CODEX_HOME` | Reasoning Tokens |
 | All Sources | Multiple | Source-specific env vars | Combined daily/weekly/monthly/today/statusline summaries |
 | Cursor (experimental) | Cursor `User/globalStorage/state.vscdb` | `CURSOR_HOME` | Local SQLite `tokenCount` fields only |
-| Grok | `~/.grok/sessions/` | `GROK_HOME` | Context-token session summaries, Projects |
+| Grok | `~/.grok/sessions/` | `GROK_HOME` | Per-turn usage records, Projects, Cache / reasoning tokens, Server cost ticks |
 | Kimi Code | `~/.kimi-code/sessions/` | `KIMI_CODE_HOME` | Per-turn usage records, Projects, Cache tokens |
 
 ## Architecture

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -196,7 +196,7 @@ Source 根目录仍由环境变量覆盖：
 | Claude Code | `CLAUDE_CONFIG_DIR` | Claude config root containing `projects/` | `~/.claude` |
 | OpenAI Codex | `CODEX_HOME` | Codex root containing `sessions/` | `~/.codex` |
 | Cursor | `CURSOR_HOME` | Cursor `User` directory | Platform Cursor `User` directory |
-| Grok | `GROK_HOME` | Grok root containing `sessions/` | `~/.grok` |
+| Grok | `GROK_HOME` | Grok root containing `sessions/` (`updates.jsonl` turn usage) | `~/.grok` |
 | Kimi Code | `KIMI_CODE_HOME` | Kimi Code root containing `sessions/` | `~/.kimi-code` |
 
 ## 添加新数据源

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -53,7 +53,7 @@ pub(crate) enum Commands {
         #[command(subcommand)]
         command: Option<CodexCommands>,
     },
-    /// Grok CLI local context-token statistics
+    /// Grok CLI usage statistics
     Grok {
         #[command(subcommand)]
         command: Option<GrokCommands>,
@@ -85,17 +85,17 @@ pub(crate) enum CodexCommands {
 /// Grok-specific subcommands
 #[derive(Subcommand)]
 pub(crate) enum GrokCommands {
-    /// Show daily Grok local context-token stats (default)
+    /// Show daily Grok usage (default)
     Daily,
-    /// Show weekly Grok local context-token stats
+    /// Show weekly Grok usage
     Weekly,
-    /// Show monthly Grok local context-token stats
+    /// Show monthly Grok usage
     Monthly,
-    /// Show today's Grok local context-token stats
+    /// Show today's Grok usage
     Today,
-    /// Show Grok local context-token stats by session
+    /// Show Grok usage by session
     Session,
-    /// Show Grok local context-token stats by project
+    /// Show Grok usage by project
     Project,
     /// Output single line for statusline/tmux integration
     Statusline,

--- a/src/core/aggregator.rs
+++ b/src/core/aggregator.rs
@@ -279,6 +279,8 @@ mod tests {
             stop_reason: Some("end_turn".to_string()),
             cost_kind: crate::core::CostKind::Real,
             endpoint: Endpoint::Unknown,
+            call_count: 1,
+            recorded_cost_usd: None,
         }
     }
 
@@ -507,6 +509,8 @@ mod tests {
                 stop_reason: None,
                 cost_kind: crate::core::CostKind::Real,
                 endpoint: Endpoint::Unknown,
+                call_count: 1,
+                recorded_cost_usd: None,
             },
             RawEntry {
                 timestamp: "2025-01-01T08:00:00Z".to_string(),
@@ -526,6 +530,8 @@ mod tests {
                 stop_reason: None,
                 cost_kind: crate::core::CostKind::Real,
                 endpoint: Endpoint::Unknown,
+                call_count: 1,
+                recorded_cost_usd: None,
             },
             RawEntry {
                 timestamp: "2025-01-01T20:00:00Z".to_string(),
@@ -545,6 +551,8 @@ mod tests {
                 stop_reason: None,
                 cost_kind: crate::core::CostKind::Real,
                 endpoint: Endpoint::Unknown,
+                call_count: 1,
+                recorded_cost_usd: None,
             },
         ];
         let result = aggregate_sessions(entries);

--- a/src/core/aggregator_endpoint_tests.rs
+++ b/src/core/aggregator_endpoint_tests.rs
@@ -24,6 +24,8 @@ fn entry(model: &str, endpoint: Endpoint, input: i64) -> RawEntry {
         stop_reason: Some("end_turn".to_string()),
         cost_kind: CostKind::Real,
         endpoint,
+        call_count: 1,
+        recorded_cost_usd: None,
     }
 }
 

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -20,6 +20,15 @@ pub(crate) struct Stats {
     pub(crate) count: i64,
     pub(crate) skipped_chunks: i64,
     pub(crate) estimated_proxy: CostTokens,
+    /// Provider-reported USD cost that bypasses the local price list.
+    #[serde(default)]
+    pub(crate) recorded_cost_usd: f64,
+    /// Number of source records that contributed `recorded_cost_usd`.
+    #[serde(default)]
+    pub(crate) recorded_cost_entries: i64,
+    /// Tokens that still need local pricing (records without a provider cost).
+    #[serde(default)]
+    pub(crate) priced_tokens: CostTokens,
 }
 
 impl Stats {
@@ -33,6 +42,9 @@ impl Stats {
         self.count += other.count;
         self.skipped_chunks += other.skipped_chunks;
         self.estimated_proxy.add(&other.estimated_proxy);
+        self.recorded_cost_usd += other.recorded_cost_usd;
+        self.recorded_cost_entries += other.recorded_cost_entries;
+        self.priced_tokens.add(&other.priced_tokens);
     }
 
     /// Total tokens for display purposes
@@ -169,7 +181,7 @@ impl CostTokens {
         self.count += other.count;
     }
 
-    fn saturating_sub(self, other: &Self) -> Self {
+    pub(crate) fn saturating_sub(self, other: &Self) -> Self {
         Self {
             input_tokens: (self.input_tokens - other.input_tokens).max(0),
             output_tokens: (self.output_tokens - other.output_tokens).max(0),
@@ -281,10 +293,21 @@ pub(crate) struct RawEntry {
     /// Serving endpoint (native vs proxy); Claude-only, else `Unknown`.
     #[serde(default)]
     pub(crate) endpoint: Endpoint,
+    /// Number of model calls represented by this record. Defaults to 1.
+    #[serde(default = "default_call_count")]
+    pub(crate) call_count: i64,
+    /// Provider-reported USD cost for this record, when the source logs one.
+    #[serde(default)]
+    pub(crate) recorded_cost_usd: Option<f64>,
+}
+
+fn default_call_count() -> i64 {
+    1
 }
 
 impl RawEntry {
     pub(crate) fn to_stats(&self) -> Stats {
+        let call_count = self.call_count.max(1);
         let mut stats = Stats {
             input_tokens: self.input_tokens,
             output_tokens: self.output_tokens,
@@ -292,12 +315,21 @@ impl RawEntry {
             cache_creation_1h: self.cache_creation_1h,
             cache_read: self.cache_read,
             reasoning_tokens: self.reasoning_tokens,
-            count: 1,
+            count: call_count,
             skipped_chunks: 0,
             estimated_proxy: CostTokens::default(),
+            recorded_cost_usd: 0.0,
+            recorded_cost_entries: 0,
+            priced_tokens: CostTokens::default(),
         };
         if self.cost_kind == CostKind::EstimatedProxy {
             stats.estimated_proxy = stats.cost_tokens();
+            stats.priced_tokens = stats.cost_tokens();
+        } else if let Some(recorded) = self.recorded_cost_usd {
+            stats.recorded_cost_usd = recorded.max(0.0);
+            stats.recorded_cost_entries = 1;
+        } else {
+            stats.priced_tokens = stats.cost_tokens();
         }
         stats
     }
@@ -381,6 +413,7 @@ mod tests {
             count: 1,
             skipped_chunks: 0,
             estimated_proxy: CostTokens::default(),
+            ..Default::default()
         }
     }
 
@@ -440,6 +473,7 @@ mod tests {
             count: 999,
             skipped_chunks: 42,
             estimated_proxy: CostTokens::default(),
+            ..Default::default()
         };
         assert_eq!(s.total_tokens(), 15);
     }
@@ -463,6 +497,7 @@ mod tests {
             count: 3,
             skipped_chunks: 5,
             estimated_proxy: CostTokens::default(),
+            ..Default::default()
         };
         a.add(&b);
         assert_eq!(a.input_tokens, 110);
@@ -542,6 +577,8 @@ mod tests {
             stop_reason: None,
             cost_kind: CostKind::Real,
             endpoint: Endpoint::Unknown,
+            call_count: 1,
+            recorded_cost_usd: None,
         };
         let s = entry.to_stats();
         assert_eq!(s.input_tokens, 100);
@@ -551,6 +588,38 @@ mod tests {
         assert_eq!(s.reasoning_tokens, 10);
         assert_eq!(s.count, 1);
         assert_eq!(s.skipped_chunks, 0);
+        assert_eq!(s.recorded_cost_entries, 0);
+        assert_eq!(s.priced_tokens.input_tokens, 100);
+    }
+
+    #[test]
+    fn raw_entry_to_stats_uses_call_count_and_recorded_cost() {
+        let entry = RawEntry {
+            timestamp: String::new(),
+            timestamp_ms: 0,
+            date_str: String::new(),
+            message_id: None,
+            session_key: String::new(),
+            session_id: String::new(),
+            project_path: String::new(),
+            model: String::new(),
+            input_tokens: 10,
+            output_tokens: 2,
+            cache_creation: 0,
+            cache_creation_1h: 0,
+            cache_read: 0,
+            reasoning_tokens: 0,
+            stop_reason: None,
+            cost_kind: CostKind::Real,
+            endpoint: Endpoint::Unknown,
+            call_count: 5,
+            recorded_cost_usd: Some(1.25),
+        };
+        let stats = entry.to_stats();
+        assert_eq!(stats.count, 5);
+        assert!((stats.recorded_cost_usd - 1.25).abs() < 1e-12);
+        assert_eq!(stats.recorded_cost_entries, 1);
+        assert!(!stats.priced_tokens.has_entries());
     }
 
     // --- DateFilter ---

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -18,6 +18,9 @@ pub(crate) struct Stats {
     /// Reasoning tokens (e.g., Codex o1 models)
     pub(crate) reasoning_tokens: i64,
     pub(crate) count: i64,
+    /// Number of parsed source records represented by this aggregation.
+    #[serde(default)]
+    pub(crate) records: i64,
     pub(crate) skipped_chunks: i64,
     pub(crate) estimated_proxy: CostTokens,
     /// Provider-reported USD cost that bypasses the local price list.
@@ -33,27 +36,32 @@ pub(crate) struct Stats {
 
 impl Stats {
     pub(crate) fn add(&mut self, other: &Stats) {
-        self.input_tokens += other.input_tokens;
-        self.output_tokens += other.output_tokens;
-        self.cache_creation += other.cache_creation;
-        self.cache_creation_1h += other.cache_creation_1h;
-        self.cache_read += other.cache_read;
-        self.reasoning_tokens += other.reasoning_tokens;
-        self.count += other.count;
-        self.skipped_chunks += other.skipped_chunks;
+        self.input_tokens = self.input_tokens.saturating_add(other.input_tokens);
+        self.output_tokens = self.output_tokens.saturating_add(other.output_tokens);
+        self.cache_creation = self.cache_creation.saturating_add(other.cache_creation);
+        self.cache_creation_1h = self
+            .cache_creation_1h
+            .saturating_add(other.cache_creation_1h);
+        self.cache_read = self.cache_read.saturating_add(other.cache_read);
+        self.reasoning_tokens = self.reasoning_tokens.saturating_add(other.reasoning_tokens);
+        self.count = self.count.saturating_add(other.count);
+        self.records = self.records.saturating_add(other.records);
+        self.skipped_chunks = self.skipped_chunks.saturating_add(other.skipped_chunks);
         self.estimated_proxy.add(&other.estimated_proxy);
         self.recorded_cost_usd += other.recorded_cost_usd;
-        self.recorded_cost_entries += other.recorded_cost_entries;
+        self.recorded_cost_entries = self
+            .recorded_cost_entries
+            .saturating_add(other.recorded_cost_entries);
         self.priced_tokens.add(&other.priced_tokens);
     }
 
     /// Total tokens for display purposes
     pub(crate) fn total_tokens(&self) -> i64 {
         self.input_tokens
-            + self.output_tokens
-            + self.reasoning_tokens
-            + self.cache_creation
-            + self.cache_read
+            .saturating_add(self.output_tokens)
+            .saturating_add(self.reasoning_tokens)
+            .saturating_add(self.cache_creation)
+            .saturating_add(self.cache_read)
     }
 
     /// Percentage of reported input-side tokens served from the prompt cache.
@@ -172,24 +180,38 @@ pub(crate) struct CostTokens {
 
 impl CostTokens {
     pub(crate) fn add(&mut self, other: &Self) {
-        self.input_tokens += other.input_tokens;
-        self.output_tokens += other.output_tokens;
-        self.cache_creation += other.cache_creation;
-        self.cache_creation_1h += other.cache_creation_1h;
-        self.cache_read += other.cache_read;
-        self.reasoning_tokens += other.reasoning_tokens;
-        self.count += other.count;
+        self.input_tokens = self.input_tokens.saturating_add(other.input_tokens);
+        self.output_tokens = self.output_tokens.saturating_add(other.output_tokens);
+        self.cache_creation = self.cache_creation.saturating_add(other.cache_creation);
+        self.cache_creation_1h = self
+            .cache_creation_1h
+            .saturating_add(other.cache_creation_1h);
+        self.cache_read = self.cache_read.saturating_add(other.cache_read);
+        self.reasoning_tokens = self.reasoning_tokens.saturating_add(other.reasoning_tokens);
+        self.count = self.count.saturating_add(other.count);
     }
 
     pub(crate) fn saturating_sub(self, other: &Self) -> Self {
         Self {
-            input_tokens: (self.input_tokens - other.input_tokens).max(0),
-            output_tokens: (self.output_tokens - other.output_tokens).max(0),
-            cache_creation: (self.cache_creation - other.cache_creation).max(0),
-            cache_creation_1h: (self.cache_creation_1h - other.cache_creation_1h).max(0),
-            cache_read: (self.cache_read - other.cache_read).max(0),
-            reasoning_tokens: (self.reasoning_tokens - other.reasoning_tokens).max(0),
-            count: (self.count - other.count).max(0),
+            input_tokens: self.input_tokens.saturating_sub(other.input_tokens).max(0),
+            output_tokens: self
+                .output_tokens
+                .saturating_sub(other.output_tokens)
+                .max(0),
+            cache_creation: self
+                .cache_creation
+                .saturating_sub(other.cache_creation)
+                .max(0),
+            cache_creation_1h: self
+                .cache_creation_1h
+                .saturating_sub(other.cache_creation_1h)
+                .max(0),
+            cache_read: self.cache_read.saturating_sub(other.cache_read).max(0),
+            reasoning_tokens: self
+                .reasoning_tokens
+                .saturating_sub(other.reasoning_tokens)
+                .max(0),
+            count: self.count.saturating_sub(other.count).max(0),
         }
     }
 
@@ -307,7 +329,9 @@ fn default_call_count() -> i64 {
 
 impl RawEntry {
     pub(crate) fn to_stats(&self) -> Stats {
-        let call_count = self.call_count.max(1);
+        // Parsers default real records to one call; a synthetic residual may
+        // legitimately carry tokens or cost without representing another call.
+        let call_count = self.call_count.max(0);
         let mut stats = Stats {
             input_tokens: self.input_tokens,
             output_tokens: self.output_tokens,
@@ -316,6 +340,7 @@ impl RawEntry {
             cache_read: self.cache_read,
             reasoning_tokens: self.reasoning_tokens,
             count: call_count,
+            records: 1,
             skipped_chunks: 0,
             estimated_proxy: CostTokens::default(),
             recorded_cost_usd: 0.0,
@@ -484,6 +509,27 @@ mod tests {
     }
 
     #[test]
+    fn stats_aggregation_saturates_at_i64_max() {
+        let mut total = Stats {
+            input_tokens: i64::MAX,
+            count: i64::MAX,
+            records: i64::MAX,
+            ..Default::default()
+        };
+        total.add(&Stats {
+            input_tokens: 1,
+            count: 1,
+            records: 1,
+            ..Default::default()
+        });
+
+        assert_eq!(total.input_tokens, i64::MAX);
+        assert_eq!(total.count, i64::MAX);
+        assert_eq!(total.records, i64::MAX);
+        assert_eq!(total.total_tokens(), i64::MAX);
+    }
+
+    #[test]
     fn stats_add_accumulates_all_fields() {
         let mut a = make_stats(10, 20, 5, 3, 1);
         a.skipped_chunks = 2;
@@ -587,6 +633,7 @@ mod tests {
         assert_eq!(s.cache_read, 30);
         assert_eq!(s.reasoning_tokens, 10);
         assert_eq!(s.count, 1);
+        assert_eq!(s.records, 1);
         assert_eq!(s.skipped_chunks, 0);
         assert_eq!(s.recorded_cost_entries, 0);
         assert_eq!(s.priced_tokens.input_tokens, 100);
@@ -617,6 +664,7 @@ mod tests {
         };
         let stats = entry.to_stats();
         assert_eq!(stats.count, 5);
+        assert_eq!(stats.records, 1);
         assert!((stats.recorded_cost_usd - 1.25).abs() < 1e-12);
         assert_eq!(stats.recorded_cost_entries, 1);
         assert!(!stats.priced_tokens.has_entries());

--- a/src/output/budget.rs
+++ b/src/output/budget.rs
@@ -337,6 +337,7 @@ fn budget_pricing_note(reports: &[MonthlyBudgetReport]) -> Option<String> {
             report_cache_suffix(reports)
         )),
         PricingSource::Fallback => Some("Pricing source: fallback estimates.".to_string()),
+        PricingSource::Recorded => Some("Pricing source: recorded provider cost.".to_string()),
         PricingSource::Unknown => Some("Pricing source: unknown unpriced models.".to_string()),
         PricingSource::Mixed => Some(format!(
             "Pricing source: mixed{}.",

--- a/src/output/csv.rs
+++ b/src/output/csv.rs
@@ -175,6 +175,7 @@ fn write_period_csv_breakdown(
                 pricing_meta::append_model_csv_fields(
                     out,
                     model,
+                    model_stats,
                     ctx.pricing_db,
                     pricing_meta::csv_has_cache_fields(ctx.pricing_source, ctx.pricing_db),
                 );
@@ -360,6 +361,7 @@ pub(crate) fn output_monthly_budget_csv(
                     pricing_meta::append_model_csv_fields(
                         &mut out,
                         model,
+                        model_stats,
                         pricing_db,
                         include_pricing_cache_fields,
                     );

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -81,7 +81,12 @@ fn build_period_entry(
                 );
                 period_cost += cost;
                 model_obj["cost"] = cost_json_value(cost, options.currency);
-                pricing_meta::add_model_json(&mut model_obj, model, options.pricing_db);
+                pricing_meta::add_model_json(
+                    &mut model_obj,
+                    model,
+                    model_stats,
+                    options.pricing_db,
+                );
                 let estimated_cost =
                     calculate_estimated_proxy_cost(model_stats, model, options.pricing_db);
                 if estimated_cost > 0.0 {

--- a/src/output/period.rs
+++ b/src/output/period.rs
@@ -261,6 +261,7 @@ mod tests {
             count: 1,
             skipped_chunks: 0,
             estimated_proxy: crate::core::CostTokens::default(),
+            ..Default::default()
         };
         ds.add_stats("model-a".to_string(), &stats);
         day_stats.insert("2025-03-01".to_string(), ds);
@@ -276,6 +277,7 @@ mod tests {
             count: 2,
             skipped_chunks: 1,
             estimated_proxy: crate::core::CostTokens::default(),
+            ..Default::default()
         };
         ds2.add_stats("model-a".to_string(), &stats2);
         day_stats.insert("2025-03-10".to_string(), ds2);

--- a/src/output/pricing_meta.rs
+++ b/src/output/pricing_meta.rs
@@ -2,7 +2,8 @@ use std::{collections::HashMap, fmt::Write};
 
 use crate::core::Stats;
 use crate::pricing::{
-    PricingDb, PricingSource, pricing_source_for_model_maps, pricing_source_for_models,
+    PricingDb, PricingSource, pricing_source_for_model_maps, pricing_source_for_model_stats,
+    pricing_source_for_models,
 };
 
 fn needs_cache_fields(source: PricingSource, pricing_db: &PricingDb) -> bool {
@@ -24,10 +25,13 @@ pub(super) fn add_json(
     );
 }
 
-pub(super) fn add_model_json(obj: &mut serde_json::Value, model: &str, pricing_db: &PricingDb) {
-    let source = pricing_db
-        .pricing_source_for_model(model)
-        .unwrap_or(PricingSource::Unknown);
+pub(super) fn add_model_json(
+    obj: &mut serde_json::Value,
+    model: &str,
+    stats: &Stats,
+    pricing_db: &PricingDb,
+) {
+    let source = pricing_source_for_model_stats(model, stats, pricing_db);
     add_source_json(obj, source, pricing_db);
 }
 
@@ -91,12 +95,11 @@ pub(super) fn append_csv_fields(
 pub(super) fn append_model_csv_fields(
     out: &mut String,
     model: &str,
+    stats: &Stats,
     pricing_db: &PricingDb,
     include_cache_fields: bool,
 ) {
-    let source = pricing_db
-        .pricing_source_for_model(model)
-        .unwrap_or(PricingSource::Unknown);
+    let source = pricing_source_for_model_stats(model, stats, pricing_db);
     append_source_csv_fields(out, source, pricing_db, include_cache_fields);
 }
 

--- a/src/output/pricing_meta.rs
+++ b/src/output/pricing_meta.rs
@@ -134,6 +134,7 @@ pub(super) fn note(source: PricingSource, pricing_db: &PricingDb) -> Option<Stri
             cache_age_suffix(pricing_db)
         )),
         PricingSource::Fallback => Some("Pricing source: fallback estimates.".to_string()),
+        PricingSource::Recorded => Some("Pricing source: recorded provider cost.".to_string()),
         PricingSource::Unknown => Some("Pricing source: unknown unpriced models.".to_string()),
         PricingSource::Mixed => Some(format!(
             "Pricing source: mixed{}.",

--- a/src/output/statusline.rs
+++ b/src/output/statusline.rs
@@ -162,6 +162,7 @@ mod tests {
             count: 1,
             skipped_chunks: 0,
             estimated_proxy: crate::core::CostTokens::default(),
+            ..Default::default()
         };
         let mut day = DayStats {
             stats: stats.clone(),
@@ -188,6 +189,7 @@ mod tests {
                 count: 1,
                 skipped_chunks: 0,
                 estimated_proxy: crate::core::CostTokens::default(),
+                ..Default::default()
             },
             ..Default::default()
         };

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -45,7 +45,7 @@ pub(crate) fn print_summary_line(
     use_color: bool,
 ) {
     let stats_text = format!(
-        "{} unique API calls ({} streaming entries deduplicated)",
+        "{} usage records ({} streaming records deduplicated)",
         format_number(valid, number_format),
         format_number(skipped, number_format)
     );

--- a/src/output/table_tests.rs
+++ b/src/output/table_tests.rs
@@ -155,6 +155,7 @@ fn make_day_stats() -> DayStats {
         count: 3,
         skipped_chunks: 0,
         estimated_proxy: crate::core::CostTokens::default(),
+        ..Default::default()
     };
     day.stats = stats.clone();
     day.models.insert("claude-sonnet".to_string(), stats);

--- a/src/output/top.rs
+++ b/src/output/top.rs
@@ -428,6 +428,9 @@ fn top_pricing_note(rows: &[TopRow]) -> Option<String> {
         crate::pricing::PricingSource::Fallback => {
             Some("Pricing source: fallback estimates.".to_string())
         }
+        crate::pricing::PricingSource::Recorded => {
+            Some("Pricing source: recorded provider cost.".to_string())
+        }
         crate::pricing::PricingSource::Unknown => {
             Some("Pricing source: unknown unpriced models.".to_string())
         }
@@ -488,6 +491,7 @@ mod tests {
             count,
             skipped_chunks: 0,
             estimated_proxy: crate::core::CostTokens::default(),
+            ..Default::default()
         }
     }
 

--- a/src/output/top.rs
+++ b/src/output/top.rs
@@ -17,7 +17,8 @@ use crate::output::format::{
 };
 use crate::pricing::{
     CostDisplayMode, CurrencyConverter, PricingDb, calculate_display_cost, model_cost_kind,
-    pricing_source_for_models, sum_display_model_costs, sum_estimated_proxy_model_costs,
+    pricing_source_for_model_stats, pricing_source_for_models, sum_display_model_costs,
+    sum_estimated_proxy_model_costs,
 };
 
 /// One row in the leaderboard.
@@ -77,9 +78,7 @@ pub(crate) fn rank_by_model_with_cost_mode(
                 calculate_display_cost(&stats, &model, pricing_db, CostDisplayMode::Total)
                     - calculate_display_cost(&stats, &model, pricing_db, CostDisplayMode::RealOnly);
             let cost_kind = stats.cost_kind();
-            let pricing_source = pricing_db
-                .pricing_source_for_model(&model)
-                .unwrap_or(crate::pricing::PricingSource::Unknown);
+            let pricing_source = pricing_source_for_model_stats(&model, &stats, pricing_db);
             let (pricing_cache_age_seconds, pricing_cache_mtime_epoch_seconds) =
                 top_cache_metadata(pricing_source, pricing_db);
             TopRow {
@@ -307,10 +306,18 @@ pub(crate) fn print_top_table(rows: &[TopRow], options: TopTableOptions<'_>) {
 
     // TOTAL row reflects the displayed slice, not the full dataset, so the
     // share column always sums to 100% within the leaderboard.
-    let displayed_total_tokens: i64 = limited.iter().map(|r| r.stats.total_tokens()).sum();
-    let displayed_total_count: i64 = limited.iter().map(|r| r.count).sum();
-    let displayed_total_input: i64 = limited.iter().map(|r| r.stats.input_tokens).sum();
-    let displayed_total_output: i64 = limited.iter().map(|r| r.stats.output_tokens).sum();
+    let displayed_total_tokens = limited.iter().fold(0_i64, |total, row| {
+        total.saturating_add(row.stats.total_tokens())
+    });
+    let displayed_total_count = limited
+        .iter()
+        .fold(0_i64, |total, row| total.saturating_add(row.count));
+    let displayed_total_input = limited.iter().fold(0_i64, |total, row| {
+        total.saturating_add(row.stats.input_tokens)
+    });
+    let displayed_total_output = limited.iter().fold(0_i64, |total, row| {
+        total.saturating_add(row.stats.output_tokens)
+    });
     let mut displayed_stats = Stats::default();
     for row in &limited {
         displayed_stats.add(&row.stats);
@@ -471,7 +478,9 @@ pub(super) fn sum_cost(rows: &[TopRow]) -> f64 {
 }
 
 pub(super) fn sum_tokens(rows: &[TopRow]) -> i64 {
-    rows.iter().map(|r| r.stats.total_tokens()).sum()
+    rows.iter().fold(0_i64, |total, row| {
+        total.saturating_add(row.stats.total_tokens())
+    })
 }
 
 #[cfg(test)]

--- a/src/pricing/cost.rs
+++ b/src/pricing/cost.rs
@@ -30,12 +30,41 @@ fn calculate_token_cost(tokens: CostTokens, model: &str, pricing_db: &PricingDb)
     }
 }
 
+fn combine_recorded_and_priced(recorded_usd: f64, priced: f64, priced_tokens: CostTokens) -> f64 {
+    if priced.is_nan() {
+        if priced_tokens.has_entries() && recorded_usd == 0.0 {
+            f64::NAN
+        } else {
+            recorded_usd
+        }
+    } else {
+        recorded_usd + priced
+    }
+}
+
 pub(crate) fn calculate_cost(stats: &Stats, model: &str, pricing_db: &PricingDb) -> f64 {
-    calculate_token_cost(stats.cost_tokens(), model, pricing_db)
+    if stats.recorded_cost_entries > 0 {
+        combine_recorded_and_priced(
+            stats.recorded_cost_usd,
+            calculate_token_cost(stats.priced_tokens, model, pricing_db),
+            stats.priced_tokens,
+        )
+    } else {
+        calculate_token_cost(stats.cost_tokens(), model, pricing_db)
+    }
 }
 
 pub(crate) fn calculate_real_cost(stats: &Stats, model: &str, pricing_db: &PricingDb) -> f64 {
-    calculate_token_cost(stats.real_cost_tokens(), model, pricing_db)
+    if stats.recorded_cost_entries > 0 {
+        let priced_real = stats.priced_tokens.saturating_sub(&stats.estimated_proxy);
+        combine_recorded_and_priced(
+            stats.recorded_cost_usd,
+            calculate_token_cost(priced_real, model, pricing_db),
+            priced_real,
+        )
+    } else {
+        calculate_token_cost(stats.real_cost_tokens(), model, pricing_db)
+    }
 }
 
 pub(crate) fn calculate_estimated_proxy_cost(
@@ -65,18 +94,18 @@ pub(crate) fn calculate_display_cost(
 /// where every selected cost bucket is unknown returns NaN so callers surface
 /// N/A instead of a misleading $0.00.
 pub(crate) fn sum_model_costs(models: &HashMap<String, Stats>, pricing_db: &PricingDb) -> f64 {
-    sum_model_costs_by(models, pricing_db, Stats::cost_tokens)
+    sum_model_costs_by(models, pricing_db, calculate_cost)
 }
 
 pub(crate) fn sum_real_model_costs(models: &HashMap<String, Stats>, pricing_db: &PricingDb) -> f64 {
-    sum_model_costs_by(models, pricing_db, Stats::real_cost_tokens)
+    sum_model_costs_by(models, pricing_db, calculate_real_cost)
 }
 
 pub(crate) fn sum_estimated_proxy_model_costs(
     models: &HashMap<String, Stats>,
     pricing_db: &PricingDb,
 ) -> f64 {
-    sum_model_costs_by(models, pricing_db, |stats| stats.estimated_proxy)
+    sum_token_costs_by(models, pricing_db, |stats| stats.estimated_proxy)
 }
 
 pub(crate) fn sum_display_model_costs(
@@ -90,7 +119,45 @@ pub(crate) fn sum_display_model_costs(
     }
 }
 
+fn stats_has_cost_input(stats: &Stats) -> bool {
+    stats.cost_tokens().has_entries()
+        || stats.recorded_cost_entries > 0
+        || stats.recorded_cost_usd > 0.0
+}
+
 fn sum_model_costs_by(
+    models: &HashMap<String, Stats>,
+    pricing_db: &PricingDb,
+    cost_of: impl Fn(&Stats, &str, &PricingDb) -> f64,
+) -> f64 {
+    if models.is_empty() {
+        return 0.0;
+    }
+    let mut total = 0.0;
+    let mut any_entries = false;
+    let mut any_known = false;
+    for (model, stats) in models {
+        if !stats_has_cost_input(stats) {
+            continue;
+        }
+        any_entries = true;
+        let cost = cost_of(stats, model, pricing_db);
+        if cost.is_nan() {
+            continue;
+        }
+        total += cost;
+        any_known = true;
+    }
+    if !any_entries {
+        0.0
+    } else if any_known {
+        total
+    } else {
+        f64::NAN
+    }
+}
+
+fn sum_token_costs_by(
     models: &HashMap<String, Stats>,
     pricing_db: &PricingDb,
     tokens_of: impl Fn(&Stats) -> CostTokens,
@@ -156,6 +223,13 @@ fn pricing_source_for_models_with_cost(
 ) -> Option<PricingSource> {
     let mut source: Option<PricingSource> = None;
     for (model, stats) in models {
+        if stats.recorded_cost_entries > 0 && !stats.priced_tokens.has_entries() {
+            source = Some(match source {
+                Some(current) => current.combine(PricingSource::Recorded),
+                None => PricingSource::Recorded,
+            });
+            continue;
+        }
         if !stats.cost_tokens().has_entries() {
             continue;
         }
@@ -274,5 +348,35 @@ mod tests {
         // 200K * $20/M = $4 — all cache creation billed at the 1h rate
         let cost = calculate_real_cost(&stats, "fable-5", &db);
         assert!((cost - 4.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn recorded_cost_bypasses_local_price_list() {
+        let db = pricing_db_with("fable-5", fable_pricing());
+        let stats = Stats {
+            input_tokens: 1_000_000,
+            count: 5,
+            recorded_cost_usd: 5.134_352_2,
+            recorded_cost_entries: 1,
+            ..Default::default()
+        };
+
+        assert!((calculate_cost(&stats, "fable-5", &db) - 5.134_352_2).abs() < 1e-9);
+        assert!((calculate_real_cost(&stats, "fable-5", &db) - 5.134_352_2).abs() < 1e-9);
+        assert!((calculate_estimated_proxy_cost(&stats, "fable-5", &db) - 0.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn recorded_zero_cost_is_not_replaced_by_priced_tokens() {
+        let db = pricing_db_with("fable-5", fable_pricing());
+        let stats = Stats {
+            input_tokens: 1_000_000,
+            count: 1,
+            recorded_cost_usd: 0.0,
+            recorded_cost_entries: 1,
+            ..Default::default()
+        };
+
+        assert!((calculate_cost(&stats, "fable-5", &db) - 0.0).abs() < 1e-12);
     }
 }

--- a/src/pricing/cost.rs
+++ b/src/pricing/cost.rs
@@ -223,14 +223,15 @@ fn pricing_source_for_models_with_cost(
 ) -> Option<PricingSource> {
     let mut source: Option<PricingSource> = None;
     for (model, stats) in models {
-        if stats.recorded_cost_entries > 0 && !stats.priced_tokens.has_entries() {
+        if stats.recorded_cost_entries > 0 {
             source = Some(match source {
                 Some(current) => current.combine(PricingSource::Recorded),
                 None => PricingSource::Recorded,
             });
-            continue;
         }
-        if !stats.cost_tokens().has_entries() {
+        let has_locally_priced_tokens = stats.priced_tokens.has_entries()
+            || (stats.recorded_cost_entries == 0 && stats.cost_tokens().has_entries());
+        if !has_locally_priced_tokens {
             continue;
         }
         let model_source = pricing_db
@@ -242,6 +243,16 @@ fn pricing_source_for_models_with_cost(
         });
     }
     source
+}
+
+pub(crate) fn pricing_source_for_model_stats(
+    model: &str,
+    stats: &Stats,
+    pricing_db: &PricingDb,
+) -> PricingSource {
+    let mut models = HashMap::with_capacity(1);
+    models.insert(model.to_string(), stats.clone());
+    pricing_source_for_models(&models, pricing_db)
 }
 
 pub(crate) fn pricing_source_for_model_maps<'a>(
@@ -378,5 +389,24 @@ mod tests {
         };
 
         assert!((calculate_cost(&stats, "fable-5", &db) - 0.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn recorded_and_locally_priced_entries_report_mixed_provenance() {
+        let db = pricing_db_with("fable-5", fable_pricing());
+        let stats = Stats {
+            recorded_cost_entries: 1,
+            recorded_cost_usd: 1.0,
+            priced_tokens: CostTokens {
+                input_tokens: 10,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        assert_eq!(
+            pricing_source_for_model_stats("fable-5", &stats, &db),
+            PricingSource::Mixed
+        );
     }
 }

--- a/src/pricing/db.rs
+++ b/src/pricing/db.rs
@@ -411,6 +411,7 @@ mod tests {
             count: 1,
             skipped_chunks: 0,
             estimated_proxy: crate::core::CostTokens::default(),
+            ..Default::default()
         };
 
         let cost = calculate_cost(&stats, "sonnet-4", &db);
@@ -443,6 +444,7 @@ mod tests {
             count: 1,
             skipped_chunks: 0,
             estimated_proxy: crate::core::CostTokens::default(),
+            ..Default::default()
         };
 
         let cost = calculate_cost(&stats, "sonnet-4", &db);

--- a/src/pricing/mod.rs
+++ b/src/pricing/mod.rs
@@ -11,8 +11,8 @@ mod types;
 pub(crate) use cost::{
     CostDisplayMode, attach_costs, calculate_cost, calculate_display_cost,
     calculate_estimated_proxy_cost, model_cost_kind, pricing_source_for_model_maps,
-    pricing_source_for_models, sum_display_model_costs, sum_estimated_proxy_model_costs,
-    sum_model_costs,
+    pricing_source_for_model_stats, pricing_source_for_models, sum_display_model_costs,
+    sum_estimated_proxy_model_costs, sum_model_costs,
 };
 pub(crate) use currency::CurrencyConverter;
 pub(crate) use db::PricingDb;

--- a/src/pricing/source.rs
+++ b/src/pricing/source.rs
@@ -6,6 +6,7 @@ pub(crate) enum PricingSource {
     Cache,
     CacheStale,
     Fallback,
+    Recorded,
     Unknown,
     Mixed,
 }
@@ -17,6 +18,7 @@ impl PricingSource {
             PricingSource::Cache => "cache",
             PricingSource::CacheStale => "cache_stale",
             PricingSource::Fallback => "fallback",
+            PricingSource::Recorded => "recorded",
             PricingSource::Unknown => "unknown",
             PricingSource::Mixed => "mixed",
         }

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -35,7 +35,7 @@ pub enum UsageSource {
     Codex,
     /// Cursor composer usage data.
     Cursor,
-    /// Grok session signal summaries under `~/.grok/sessions`, or `GROK_HOME`.
+    /// Grok session usage under `~/.grok/sessions`, or `GROK_HOME`.
     Grok,
     /// Kimi Code wire logs under `~/.kimi-code/sessions`, or `KIMI_CODE_HOME`.
     Kimi,

--- a/src/sdk/batch.rs
+++ b/src/sdk/batch.rs
@@ -362,6 +362,8 @@ mod tests {
                     stop_reason: Some("complete".to_string()),
                     cost_kind: crate::core::CostKind::Real,
                     endpoint: crate::core::Endpoint::Unknown,
+                    call_count: 1,
+                    recorded_cost_usd: None,
                 }],
                 errors: 0,
             }

--- a/src/source/claude/parser.rs
+++ b/src/source/claude/parser.rs
@@ -335,6 +335,8 @@ fn parse_entry_with_debug(
         stop_reason: msg.stop_reason,
         cost_kind: crate::core::CostKind::Real,
         endpoint,
+        call_count: 1,
+        recorded_cost_usd: None,
     })
 }
 

--- a/src/source/codex/parser.rs
+++ b/src/source/codex/parser.rs
@@ -612,6 +612,8 @@ fn push_codex_entry(
         stop_reason: Some("complete".to_string()), // Codex events are always complete
         cost_kind: crate::core::CostKind::Real,
         endpoint: crate::core::Endpoint::Unknown,
+        call_count: 1,
+        recorded_cost_usd: None,
     });
 }
 

--- a/src/source/cursor/parser.rs
+++ b/src/source/cursor/parser.rs
@@ -260,6 +260,8 @@ fn entry_from_bubble(
         stop_reason: Some("complete".to_string()),
         cost_kind: crate::core::CostKind::Real,
         endpoint: crate::core::Endpoint::Unknown,
+        call_count: 1,
+        recorded_cost_usd: None,
     })
 }
 
@@ -311,6 +313,8 @@ fn entry_from_generation(generation: &Value, path: &Path, timezone: Timezone) ->
         stop_reason: Some("complete".to_string()),
         cost_kind: crate::core::CostKind::Real,
         endpoint: crate::core::Endpoint::Unknown,
+        call_count: 1,
+        recorded_cost_usd: None,
     })
 }
 

--- a/src/source/grok/config.rs
+++ b/src/source/grok/config.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use crate::source::{Capabilities, ParseOutput, Source};
 use crate::utils::Timezone;
 
-use super::parser::{find_grok_files, parse_grok_signal_file_with_debug};
+use super::parser::{find_grok_files, parse_grok_session_file_with_debug};
 
 /// Grok data source.
 pub(crate) struct GrokSource;
@@ -41,9 +41,9 @@ impl Source for GrokSource {
         Capabilities {
             has_projects: true,
             has_billing_blocks: false,
-            has_reasoning_tokens: false,
-            has_cache_creation: false,
-            has_cache_read: false,
+            has_reasoning_tokens: true,
+            has_cache_creation: true,
+            has_cache_read: true,
             needs_dedup: false,
             has_tool_calls: false,
             has_endpoints: false,
@@ -55,6 +55,6 @@ impl Source for GrokSource {
     }
 
     fn parse_file(&self, path: &Path, timezone: Timezone, debug: bool) -> ParseOutput {
-        parse_grok_signal_file_with_debug(path, timezone, debug)
+        parse_grok_session_file_with_debug(path, timezone, debug)
     }
 }

--- a/src/source/grok/config.rs
+++ b/src/source/grok/config.rs
@@ -44,7 +44,7 @@ impl Source for GrokSource {
             has_reasoning_tokens: true,
             has_cache_creation: true,
             has_cache_read: true,
-            needs_dedup: false,
+            needs_dedup: true,
             has_tool_calls: false,
             has_endpoints: false,
         }

--- a/src/source/grok/mod.rs
+++ b/src/source/grok/mod.rs
@@ -1,8 +1,10 @@
 //! Grok CLI data source
 //!
-//! Parses session signal summaries from ~/.grok/sessions/.
+//! Prefers `updates.jsonl` `turn_completed.usage` records. Sessions without
+//! those events still fall back to local context-token snapshots.
 
 mod config;
 mod parser;
+mod usage;
 
 pub(crate) use config::GrokSource;

--- a/src/source/grok/parser.rs
+++ b/src/source/grok/parser.rs
@@ -1,9 +1,9 @@
-//! Grok session signal parser
+//! Grok session parser
 //!
 //! Grok persists session metadata under `~/.grok/sessions/<cwd>/<session>/`.
-//! Local files currently expose context-token snapshots rather than precise
-//! provider input/output billing or remote account quota usage, so this parser
-//! reports those context tokens as input tokens.
+//! `updates.jsonl` `turn_completed.usage` is the billable request log. When a
+//! session has no such events, this parser falls back to `signals.json`
+//! context-token snapshots and labels them `estimated_proxy`.
 
 use std::collections::HashMap;
 use std::env;
@@ -25,6 +25,13 @@ const SIGNALS_FILE: &str = "signals.json";
 const SUMMARY_FILE: &str = "summary.json";
 const UPDATES_FILE: &str = "updates.jsonl";
 const GROK_MODEL: &str = "grok";
+
+pub(super) struct GrokSessionContext {
+    pub(super) session_id: String,
+    pub(super) session_key: String,
+    pub(super) project_path: String,
+    pub(super) fallback_model: String,
+}
 
 #[derive(Debug, Deserialize, Default)]
 #[serde(default, rename_all = "camelCase")]
@@ -83,29 +90,54 @@ pub(super) fn find_grok_files() -> Vec<PathBuf> {
         return Vec::new();
     };
 
-    let mut files = Vec::new();
-    if let Ok(entries) = glob::glob(&format!("{}/**/{SUMMARY_FILE}", sessions_dir.display())) {
-        files.extend(entries.flatten().filter(|path| path.is_file()));
-    }
+    let mut by_session: HashMap<PathBuf, PathBuf> = HashMap::new();
+    collect_session_files(
+        &sessions_dir,
+        UPDATES_FILE,
+        &mut by_session,
+        FilePreference::Preferred,
+    );
+    collect_session_files(
+        &sessions_dir,
+        SUMMARY_FILE,
+        &mut by_session,
+        FilePreference::Fallback,
+    );
+
+    let mut files: Vec<PathBuf> = by_session.into_values().collect();
     files.sort();
-    files.dedup();
     files
 }
 
-fn read_json<T>(path: &Path, debug: bool) -> Result<T, ()>
-where
-    T: for<'de> Deserialize<'de>,
-{
-    let content = fs::read_to_string(path).map_err(|err| {
-        if debug {
-            eprintln!("Failed to read {}: {}", path.display(), err);
+#[derive(Clone, Copy)]
+enum FilePreference {
+    Preferred,
+    Fallback,
+}
+
+fn collect_session_files(
+    sessions_dir: &Path,
+    file_name: &str,
+    by_session: &mut HashMap<PathBuf, PathBuf>,
+    preference: FilePreference,
+) {
+    let pattern = format!("{}/**/{file_name}", sessions_dir.display());
+    let Ok(entries) = glob::glob(&pattern) else {
+        return;
+    };
+    for path in entries.flatten().filter(|path| path.is_file()) {
+        let Some(parent) = path.parent() else {
+            continue;
+        };
+        match preference {
+            FilePreference::Preferred => {
+                by_session.insert(parent.to_path_buf(), path);
+            }
+            FilePreference::Fallback => {
+                by_session.entry(parent.to_path_buf()).or_insert(path);
+            }
         }
-    })?;
-    serde_json::from_str(&content).map_err(|err| {
-        if debug {
-            eprintln!("Invalid JSON in {}: {}", path.display(), err);
-        }
-    })
+    }
 }
 
 fn read_optional_json<T>(path: &Path, debug: bool) -> Result<Option<T>, ()>
@@ -128,7 +160,7 @@ where
     }
 }
 
-fn first_non_empty(values: &[Option<&str>]) -> Option<String> {
+pub(super) fn first_non_empty(values: &[Option<&str>]) -> Option<String> {
     values
         .iter()
         .flatten()
@@ -270,44 +302,58 @@ fn hex_value(byte: u8) -> Option<u8> {
     }
 }
 
-pub(super) fn parse_grok_signal_file_with_debug(
+pub(super) fn parse_grok_session_file_with_debug(
     path: &Path,
     timezone: Timezone,
     debug: bool,
 ) -> ParseOutput {
-    let summary_path = if path.file_name().and_then(|name| name.to_str()) == Some(SUMMARY_FILE) {
-        path.to_path_buf()
-    } else {
-        let Some(session_dir) = path.parent() else {
-            return ParseOutput {
-                entries: Vec::new(),
-                errors: 1,
-            };
-        };
-        session_dir.join(SUMMARY_FILE)
-    };
-
-    let Some(session_dir) = summary_path.parent() else {
+    let Some(session_dir) = path.parent() else {
         return ParseOutput {
             entries: Vec::new(),
             errors: 1,
         };
     };
-    let summary: Summary = match read_json(&summary_path, debug) {
-        Ok(summary) => summary,
-        Err(()) => {
-            return ParseOutput {
-                entries: Vec::new(),
-                errors: 1,
-            };
-        }
+
+    let summary_path = session_dir.join(SUMMARY_FILE);
+    let (summary, mut errors) = match read_optional_json::<Summary>(&summary_path, debug) {
+        Ok(summary) => (summary.unwrap_or_default(), 0),
+        Err(()) => (Summary::default(), 1),
     };
 
     let signals_path = session_dir.join(SIGNALS_FILE);
-    let (signals, mut errors) = match read_optional_json::<Signals>(&signals_path, debug) {
-        Ok(signals) => (signals, 0),
-        Err(()) => (None, 1),
+    let signals = if let Ok(signals) = read_optional_json::<Signals>(&signals_path, debug) {
+        signals
+    } else {
+        errors += 1;
+        None
     };
+
+    let session_id = session_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(UNKNOWN)
+        .to_string();
+    let ctx = GrokSessionContext {
+        session_key: session_dir.display().to_string(),
+        project_path: project_path(path, &summary),
+        fallback_model: model_name(signals.as_ref(), &summary),
+        session_id: session_id.clone(),
+    };
+
+    let usage = super::usage::parse_turn_completed_usage(
+        &session_dir.join(UPDATES_FILE),
+        timezone,
+        debug,
+        &ctx,
+    );
+    errors += usage.errors;
+    if !usage.entries.is_empty() {
+        return ParseOutput {
+            entries: usage.entries,
+            errors,
+        };
+    }
+
     let signal_tokens = signals.as_ref().map_or(0, total_context_tokens);
     let total_tokens = if signal_tokens > 0 {
         signal_tokens
@@ -330,15 +376,10 @@ pub(super) fn parse_grok_signal_file_with_debug(
         }
         return ParseOutput {
             entries: Vec::new(),
-            errors: 1,
+            errors: errors + 1,
         };
     };
     let local_dt = timezone.to_fixed_offset(utc_dt);
-    let session_id = session_dir
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or(UNKNOWN)
-        .to_string();
 
     ParseOutput {
         entries: vec![RawEntry {
@@ -346,10 +387,10 @@ pub(super) fn parse_grok_signal_file_with_debug(
             timestamp_ms: utc_dt.timestamp_millis(),
             date_str: local_dt.date_naive().format(DATE_FORMAT).to_string(),
             message_id: Some(session_id.clone()),
-            session_key: session_dir.display().to_string(),
+            session_key: ctx.session_key,
             session_id,
-            project_path: project_path(path, &summary),
-            model: model_name(signals.as_ref(), &summary),
+            project_path: ctx.project_path,
+            model: ctx.fallback_model,
             input_tokens: total_tokens,
             output_tokens: 0,
             cache_creation: 0,
@@ -359,6 +400,8 @@ pub(super) fn parse_grok_signal_file_with_debug(
             stop_reason: Some("context_snapshot".to_string()),
             cost_kind: CostKind::EstimatedProxy,
             endpoint: crate::core::Endpoint::Unknown,
+            call_count: 1,
+            recorded_cost_usd: None,
         }],
         errors,
     }
@@ -409,7 +452,8 @@ mod tests {
         )
         .expect("write summary");
 
-        let parsed = parse_grok_signal_file_with_debug(&session_dir.join(SIGNALS_FILE), tz(), true);
+        let parsed =
+            parse_grok_session_file_with_debug(&session_dir.join(SIGNALS_FILE), tz(), true);
         assert_eq!(parsed.errors, 0);
         assert_eq!(parsed.entries.len(), 1);
         let entry = &parsed.entries[0];
@@ -440,7 +484,8 @@ mod tests {
         )
         .expect("write summary");
 
-        let parsed = parse_grok_signal_file_with_debug(&session_dir.join(SIGNALS_FILE), tz(), true);
+        let parsed =
+            parse_grok_session_file_with_debug(&session_dir.join(SIGNALS_FILE), tz(), true);
         assert_eq!(parsed.entries[0].project_path, "/repo/from-summary/");
         assert_eq!(parsed.entries[0].model, "grok-4.3");
     }
@@ -464,11 +509,75 @@ mod tests {
 "#,
         )?;
 
-        let parsed = parse_grok_signal_file_with_debug(&session_dir.join(SUMMARY_FILE), tz(), true);
+        let parsed =
+            parse_grok_session_file_with_debug(&session_dir.join(SUMMARY_FILE), tz(), true);
         assert_eq!(parsed.errors, 0);
         assert_eq!(parsed.entries.len(), 1);
         assert_eq!(parsed.entries[0].input_tokens, 250);
         assert_eq!(parsed.entries[0].model, "grok-build");
         Ok(())
+    }
+
+    #[test]
+    fn parse_grok_session_prefers_turn_completed_over_context_snapshot() {
+        let root = tempdir().expect("temp dir");
+        let session_dir = root.path().join("%2Ftmp%2Fgrok-project").join("session-1");
+        fs::create_dir_all(&session_dir).expect("create session dir");
+        fs::write(
+            session_dir.join(SIGNALS_FILE),
+            r#"{"contextTokensUsed": 1200, "totalTokensBeforeCompaction": 300, "primaryModelId": "grok-build"}"#,
+        )
+        .expect("write signals");
+        fs::write(
+            session_dir.join(SUMMARY_FILE),
+            r#"{"updated_at": "2026-08-17T01:00:00Z", "git_root_dir": "/tmp/grok-project/"}"#,
+        )
+        .expect("write summary");
+        fs::write(
+            session_dir.join(UPDATES_FILE),
+            r#"{"timestamp":1786838400,"params":{"update":{"sessionUpdate":"turn_completed","usage":{"inputTokens":100,"outputTokens":20,"cachedReadTokens":40,"reasoningTokens":5,"modelCalls":3,"costUsdTicks":20000000000,"modelUsage":{"grok-4.5-build":{"inputTokens":100,"outputTokens":20,"cachedReadTokens":40,"reasoningTokens":5,"modelCalls":3,"costUsdTicks":20000000000}}}}}}
+"#,
+        )
+        .expect("write updates");
+
+        let parsed =
+            parse_grok_session_file_with_debug(&session_dir.join(SUMMARY_FILE), tz(), true);
+        assert_eq!(parsed.errors, 0);
+        assert_eq!(parsed.entries.len(), 1);
+        let entry = &parsed.entries[0];
+        assert_eq!(entry.input_tokens, 60);
+        assert_eq!(entry.output_tokens, 15);
+        assert_eq!(entry.cache_read, 40);
+        assert_eq!(entry.reasoning_tokens, 5);
+        assert_eq!(entry.call_count, 3);
+        assert_eq!(entry.date_str, "2026-08-16");
+        assert_eq!(entry.model, "grok-4.5-build");
+        assert_eq!(entry.cost_kind, CostKind::Real);
+        assert_eq!(entry.recorded_cost_usd, Some(2.0));
+    }
+
+    #[test]
+    fn parse_grok_session_reads_updates_without_summary() {
+        let root = tempdir().expect("temp dir");
+        let session_dir = root
+            .path()
+            .join("%2Ftmp%2Fgrok-project")
+            .join("live-session");
+        fs::create_dir_all(&session_dir).expect("create session dir");
+        fs::write(
+            session_dir.join(UPDATES_FILE),
+            r#"{"timestamp":1786838400,"params":{"sessionId":"live-session","update":{"sessionUpdate":"turn_completed","usage":{"inputTokens":8,"outputTokens":2,"modelCalls":1,"costUsdTicks":1000000000}}}}
+"#,
+        )
+        .expect("write updates");
+
+        let parsed =
+            parse_grok_session_file_with_debug(&session_dir.join(UPDATES_FILE), tz(), true);
+        assert_eq!(parsed.errors, 0);
+        assert_eq!(parsed.entries.len(), 1);
+        assert_eq!(parsed.entries[0].input_tokens, 8);
+        assert_eq!(parsed.entries[0].output_tokens, 2);
+        assert_eq!(parsed.entries[0].session_id, "live-session");
+        assert_eq!(parsed.entries[0].project_path, "/tmp/grok-project");
     }
 }

--- a/src/source/grok/parser.rs
+++ b/src/source/grok/parser.rs
@@ -242,7 +242,9 @@ fn total_update_tokens(path: &Path, debug: bool) -> (i64, usize) {
     let total = if keyed_maxes.is_empty() {
         session_max
     } else {
-        keyed_maxes.values().sum()
+        keyed_maxes
+            .values()
+            .fold(0_i64, |total, value| total.saturating_add(*value))
     };
     (total, errors)
 }
@@ -347,7 +349,7 @@ pub(super) fn parse_grok_session_file_with_debug(
         &ctx,
     );
     errors += usage.errors;
-    if !usage.entries.is_empty() {
+    if usage.saw_usage_record {
         return ParseOutput {
             entries: usage.entries,
             errors,
@@ -579,5 +581,62 @@ mod tests {
         assert_eq!(parsed.entries[0].output_tokens, 2);
         assert_eq!(parsed.entries[0].session_id, "live-session");
         assert_eq!(parsed.entries[0].project_path, "/tmp/grok-project");
+    }
+
+    #[test]
+    fn unusable_turn_usage_does_not_fall_back_to_context_snapshot() {
+        let root = tempdir().expect("temp dir");
+        let session_dir = root.path().join("project").join("session-1");
+        fs::create_dir_all(&session_dir).expect("create session dir");
+        fs::write(
+            session_dir.join(SIGNALS_FILE),
+            r#"{"contextTokensUsed": 1200, "primaryModelId": "grok-build"}"#,
+        )
+        .expect("write signals");
+        fs::write(
+            session_dir.join(SUMMARY_FILE),
+            r#"{"updated_at": "2026-08-17T01:00:00Z"}"#,
+        )
+        .expect("write summary");
+        fs::write(
+            session_dir.join(UPDATES_FILE),
+            r#"{"params":{"update":{"sessionUpdate":"turn_completed""#,
+        )
+        .expect("write updates");
+
+        let parsed =
+            parse_grok_session_file_with_debug(&session_dir.join(SUMMARY_FILE), tz(), true);
+        assert!(parsed.entries.is_empty());
+        assert_eq!(parsed.errors, 1);
+    }
+
+    #[test]
+    fn unrelated_turn_completed_text_keeps_context_snapshot_fallback() {
+        let root = tempdir().expect("temp dir");
+        let session_dir = root.path().join("project").join("session-1");
+        fs::create_dir_all(&session_dir).expect("create session dir");
+        fs::write(
+            session_dir.join(SIGNALS_FILE),
+            r#"{"contextTokensUsed": 1200, "primaryModelId": "grok-build"}"#,
+        )
+        .expect("write signals");
+        fs::write(
+            session_dir.join(SUMMARY_FILE),
+            r#"{"updated_at": "2026-08-17T01:00:00Z"}"#,
+        )
+        .expect("write summary");
+        fs::write(
+            session_dir.join(UPDATES_FILE),
+            r#"{"timestamp":1786924800,"params":{"update":{"sessionUpdate":"tool_result","content":"turn_completed"}}}
+"#,
+        )
+        .expect("write updates");
+
+        let parsed =
+            parse_grok_session_file_with_debug(&session_dir.join(SUMMARY_FILE), tz(), true);
+        assert_eq!(parsed.errors, 0);
+        assert_eq!(parsed.entries.len(), 1);
+        assert_eq!(parsed.entries[0].input_tokens, 1200);
+        assert_eq!(parsed.entries[0].cost_kind, CostKind::EstimatedProxy);
     }
 }

--- a/src/source/grok/usage.rs
+++ b/src/source/grok/usage.rs
@@ -5,8 +5,9 @@
 //! reads and `outputTokens` includes reasoning, so those nested counts are
 //! subtracted before they are stored on `RawEntry`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, hash_map::DefaultHasher};
 use std::fs::File;
+use std::hash::{Hash, Hasher};
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 
@@ -15,7 +16,6 @@ use serde::Deserialize;
 
 use crate::consts::DATE_FORMAT;
 use crate::core::{CostKind, RawEntry};
-use crate::source::ParseOutput;
 use crate::utils::Timezone;
 
 use super::parser::{GrokSessionContext, first_non_empty};
@@ -78,6 +78,7 @@ struct UpdateEnvelope {
     params: Option<UpdateParams>,
 }
 
+#[derive(Clone, Default)]
 struct NormalizedUsage {
     input_tokens: i64,
     output_tokens: i64,
@@ -88,30 +89,42 @@ struct NormalizedUsage {
     recorded_cost_usd: Option<f64>,
 }
 
+pub(super) struct TurnUsageParseOutput {
+    pub(super) entries: Vec<RawEntry>,
+    pub(super) errors: usize,
+    pub(super) saw_usage_record: bool,
+}
+
 pub(super) fn parse_turn_completed_usage(
     path: &Path,
     timezone: Timezone,
     debug: bool,
     ctx: &GrokSessionContext,
-) -> ParseOutput {
+) -> TurnUsageParseOutput {
     let file = match File::open(path) {
         Ok(file) => file,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-            return ParseOutput::default();
+            return TurnUsageParseOutput {
+                entries: Vec::new(),
+                errors: 0,
+                saw_usage_record: false,
+            };
         }
         Err(err) => {
             if debug {
                 eprintln!("Failed to read {}: {}", path.display(), err);
             }
-            return ParseOutput {
+            return TurnUsageParseOutput {
                 entries: Vec::new(),
                 errors: 1,
+                saw_usage_record: false,
             };
         }
     };
 
     let mut entries = Vec::new();
     let mut errors = 0;
+    let mut saw_usage_record = false;
     for (line_index, line) in BufReader::new(file).lines().enumerate() {
         let line = match line {
             Ok(line) => line,
@@ -128,12 +141,20 @@ pub(super) fn parse_turn_completed_usage(
                 continue;
             }
         };
-        if !line.contains(TURN_COMPLETED) {
+        if !looks_like_turn_completed_record(&line) {
             continue;
         }
+        // A turn-completed record is authoritative even when it is truncated
+        // before the usage object. Never replace it with a cumulative snapshot.
+        saw_usage_record = true;
         match parse_turn_line(&line, timezone, ctx) {
-            Ok(Some(turn_entries)) => entries.extend(turn_entries),
-            Ok(None) => {}
+            Ok(Some(turn_entries)) => {
+                saw_usage_record = true;
+                entries.extend(turn_entries);
+            }
+            Ok(None) => {
+                errors += 1;
+            }
             Err(err) => {
                 errors += 1;
                 if debug {
@@ -147,7 +168,23 @@ pub(super) fn parse_turn_completed_usage(
         }
     }
 
-    ParseOutput { entries, errors }
+    TurnUsageParseOutput {
+        entries,
+        errors,
+        saw_usage_record,
+    }
+}
+
+fn looks_like_turn_completed_record(line: &str) -> bool {
+    ["\"sessionUpdate\"", "\"session_update\""]
+        .into_iter()
+        .filter_map(|key| line.split_once(key).map(|(_, value)| value))
+        .any(|value| {
+            value
+                .trim_start()
+                .strip_prefix(':')
+                .is_some_and(|value| value.trim_start().starts_with("\"turn_completed\""))
+        })
 }
 
 fn parse_turn_line(
@@ -176,31 +213,57 @@ fn parse_turn_line(
     let event_id = params
         .and_then(|params| params.meta.as_ref())
         .and_then(|meta| meta.event_id.as_deref());
-    let message_id = first_non_empty(&[prompt_id, event_id]);
+    let base_message_id = first_non_empty(&[event_id, prompt_id]).unwrap_or_else(|| {
+        let mut hasher = DefaultHasher::new();
+        line.hash(&mut hasher);
+        format!("turn:{:016x}", hasher.finish())
+    });
     let stop_reason = update.and_then(|update| update.stop_reason.clone());
 
-    let mut model_usages: Vec<(String, &UsageTokens)> = usage
+    let total_usage = normalize_usage(&usage.tokens);
+    let has_authoritative_total_cost = total_usage.recorded_cost_usd.is_some();
+    let mut model_usages: Vec<(String, NormalizedUsage)> = usage
         .model_usage
         .iter()
         .filter(|(model, _)| !model.trim().is_empty())
-        .map(|(model, tokens)| (model.clone(), tokens))
+        .map(|(model, tokens)| {
+            let mut normalized = normalize_usage(tokens);
+            if has_authoritative_total_cost && normalized.recorded_cost_usd.is_none() {
+                normalized.recorded_cost_usd = Some(0.0);
+            }
+            (model.clone(), normalized)
+        })
         .collect();
     model_usages.sort_by(|left, right| left.0.cmp(&right.0));
     if model_usages.is_empty() {
-        model_usages.push((ctx.fallback_model.clone(), &usage.tokens));
+        model_usages.push((ctx.fallback_model.clone(), total_usage));
+    } else {
+        let attributed =
+            model_usages
+                .iter()
+                .fold(NormalizedUsage::default(), |mut sum, (_, current)| {
+                    sum.add(current);
+                    sum
+                });
+        let residual = total_usage.residual_after(&attributed);
+        if has_usage(&residual) {
+            if let Some((_, fallback)) = model_usages
+                .iter_mut()
+                .find(|(model, _)| model == &ctx.fallback_model)
+            {
+                fallback.add(&residual);
+            } else {
+                model_usages.push((ctx.fallback_model.clone(), residual));
+            }
+        }
     }
 
     let mut entries = Vec::new();
-    for (model, tokens) in model_usages {
-        let normalized = normalize_usage(tokens);
+    for (model, normalized) in model_usages {
         if !has_usage(&normalized) {
             continue;
         }
-        let message_id = match (message_id.as_deref(), model_usages_need_suffix(&entries)) {
-            (Some(id), true) => Some(format!("{id}:{model}")),
-            (Some(id), false) => Some(id.to_string()),
-            (None, _) => None,
-        };
+        let message_id = Some(format!("{base_message_id}:{model}"));
         entries.push(RawEntry {
             timestamp: utc_dt.to_rfc3339(),
             timestamp_ms: utc_dt.timestamp_millis(),
@@ -226,10 +289,6 @@ fn parse_turn_line(
     Ok(Some(entries).filter(|entries| !entries.is_empty()))
 }
 
-fn model_usages_need_suffix(entries: &[RawEntry]) -> bool {
-    !entries.is_empty()
-}
-
 fn event_time(envelope: &UpdateEnvelope) -> Option<DateTime<Utc>> {
     let meta_ms = envelope
         .params
@@ -237,8 +296,8 @@ fn event_time(envelope: &UpdateEnvelope) -> Option<DateTime<Utc>> {
         .and_then(|params| params.meta.as_ref())
         .and_then(|meta| meta.agent_timestamp_ms)
         .filter(|ms| *ms > 0);
-    if let Some(ms) = meta_ms {
-        return DateTime::<Utc>::from_timestamp_millis(ms);
+    if let Some(timestamp) = meta_ms.and_then(DateTime::<Utc>::from_timestamp_millis) {
+        return Some(timestamp);
     }
 
     let timestamp = envelope.timestamp.filter(|timestamp| *timestamp > 0)?;
@@ -265,7 +324,50 @@ fn normalize_usage(tokens: &UsageTokens) -> NormalizedUsage {
         call_count: if model_calls > 0 { model_calls } else { 1 },
         recorded_cost_usd: tokens
             .cost_usd_ticks
-            .map(|ticks| ticks.max(0) as f64 / USD_TICKS_PER_DOLLAR),
+            .filter(|ticks| *ticks >= 0)
+            .map(|ticks| ticks as f64 / USD_TICKS_PER_DOLLAR),
+    }
+}
+
+impl NormalizedUsage {
+    fn add(&mut self, other: &Self) {
+        self.input_tokens = self.input_tokens.saturating_add(other.input_tokens);
+        self.output_tokens = self.output_tokens.saturating_add(other.output_tokens);
+        self.cache_creation = self.cache_creation.saturating_add(other.cache_creation);
+        self.cache_read = self.cache_read.saturating_add(other.cache_read);
+        self.reasoning_tokens = self.reasoning_tokens.saturating_add(other.reasoning_tokens);
+        self.call_count = self.call_count.saturating_add(other.call_count);
+        self.recorded_cost_usd = match (self.recorded_cost_usd, other.recorded_cost_usd) {
+            (Some(left), Some(right)) => Some(left + right),
+            (Some(value), None) | (None, Some(value)) => Some(value),
+            (None, None) => None,
+        };
+    }
+
+    fn residual_after(&self, attributed: &Self) -> Self {
+        Self {
+            input_tokens: self
+                .input_tokens
+                .saturating_sub(attributed.input_tokens)
+                .max(0),
+            output_tokens: self
+                .output_tokens
+                .saturating_sub(attributed.output_tokens)
+                .max(0),
+            cache_creation: self
+                .cache_creation
+                .saturating_sub(attributed.cache_creation)
+                .max(0),
+            cache_read: self.cache_read.saturating_sub(attributed.cache_read).max(0),
+            reasoning_tokens: self
+                .reasoning_tokens
+                .saturating_sub(attributed.reasoning_tokens)
+                .max(0),
+            call_count: self.call_count.saturating_sub(attributed.call_count).max(0),
+            recorded_cost_usd: self
+                .recorded_cost_usd
+                .map(|total| (total - attributed.recorded_cost_usd.unwrap_or_default()).max(0.0)),
+        }
     }
 }
 
@@ -282,6 +384,7 @@ fn has_usage(usage: &NormalizedUsage) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::DedupAccumulator;
     use crate::source::grok::parser::GrokSessionContext;
     use crate::utils::Timezone;
     use std::fs;
@@ -323,7 +426,7 @@ mod tests {
         assert_eq!(entry.reasoning_tokens, 1145);
         assert_eq!(entry.call_count, 5);
         assert_eq!(entry.date_str, "2026-04-16");
-        assert_eq!(entry.message_id.as_deref(), Some("p1"));
+        assert_eq!(entry.message_id.as_deref(), Some("e1:grok-4.5-build"));
         assert_eq!(entry.stop_reason.as_deref(), Some("end_turn"));
         assert_eq!(entry.cost_kind, CostKind::Real);
         assert_eq!(entry.recorded_cost_usd, Some(0.13816));
@@ -364,7 +467,7 @@ mod tests {
         assert_eq!(parsed.entries[0].model, "grok-a");
         assert_eq!(parsed.entries[0].input_tokens, 10);
         assert_eq!(parsed.entries[0].call_count, 1);
-        assert_eq!(parsed.entries[0].message_id.as_deref(), Some("p2"));
+        assert_eq!(parsed.entries[0].message_id.as_deref(), Some("p2:grok-a"));
         assert_eq!(parsed.entries[1].model, "grok-b");
         assert_eq!(parsed.entries[1].call_count, 2);
         assert_eq!(parsed.entries[1].message_id.as_deref(), Some("p2:grok-b"));
@@ -387,6 +490,107 @@ mod tests {
         assert_eq!(usage.cache_creation, 0);
         assert_eq!(usage.reasoning_tokens, 0);
         assert_eq!(usage.call_count, 1);
-        assert_eq!(usage.recorded_cost_usd, Some(0.0));
+        assert_eq!(usage.recorded_cost_usd, None);
+    }
+
+    #[test]
+    fn preserves_top_level_residual_when_model_breakdown_is_partial() {
+        let root = tempdir().expect("temp dir");
+        let path = root.path().join("updates.jsonl");
+        fs::write(
+            &path,
+            r#"{"timestamp":1786896000,"params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"p3","usage":{"inputTokens":40,"outputTokens":8,"modelCalls":4,"costUsdTicks":400,"modelUsage":{"grok-a":{"inputTokens":10,"outputTokens":2,"modelCalls":1},"grok-build":{"inputTokens":10,"outputTokens":2,"modelCalls":1,"costUsdTicks":100}}}}}}
+"#,
+        )
+        .expect("write updates");
+
+        let parsed = parse_turn_completed_usage(&path, tz(), true, &ctx());
+        assert_eq!(parsed.entries.len(), 2);
+        let fallback = parsed
+            .entries
+            .iter()
+            .find(|entry| entry.model == "grok-build")
+            .expect("fallback model");
+        assert_eq!(fallback.input_tokens, 30);
+        assert_eq!(fallback.output_tokens, 6);
+        assert_eq!(fallback.call_count, 3);
+        let stats: Vec<_> = parsed.entries.iter().map(RawEntry::to_stats).collect();
+        assert!(stats.iter().all(|stats| !stats.priced_tokens.has_entries()));
+        assert!(
+            (stats
+                .iter()
+                .map(|stats| stats.recorded_cost_usd)
+                .sum::<f64>()
+                - 0.000_000_04)
+                .abs()
+                < 1e-18
+        );
+    }
+
+    #[test]
+    fn invalid_agent_timestamp_falls_back_to_envelope_timestamp() {
+        let root = tempdir().expect("temp dir");
+        let path = root.path().join("updates.jsonl");
+        fs::write(
+            &path,
+            r#"{"timestamp":1786896000,"params":{"update":{"sessionUpdate":"turn_completed","usage":{"inputTokens":10}},"_meta":{"agentTimestampMs":9223372036854775807}}}
+"#,
+        )
+        .expect("write updates");
+
+        let parsed = parse_turn_completed_usage(&path, tz(), true, &ctx());
+        assert_eq!(parsed.entries[0].date_str, "2026-08-16");
+    }
+
+    #[test]
+    fn duplicate_turns_deduplicate_shared_models_without_dropping_new_models() {
+        let root = tempdir().expect("temp dir");
+        let path = root.path().join("updates.jsonl");
+        fs::write(
+            &path,
+            r#"{"timestamp":1786896000,"params":{"_meta":{"eventId":"same"},"update":{"sessionUpdate":"turn_completed","usage":{"inputTokens":10,"modelUsage":{"z-grok":{"inputTokens":10}}}}}}
+{"timestamp":1786896001,"params":{"_meta":{"eventId":"same"},"update":{"sessionUpdate":"turn_completed","usage":{"inputTokens":20,"modelUsage":{"a-grok":{"inputTokens":10},"z-grok":{"inputTokens":10}}}}}}
+"#,
+        )
+        .expect("write updates");
+
+        let parsed = parse_turn_completed_usage(&path, tz(), true, &ctx());
+        let mut dedup = DedupAccumulator::new();
+        dedup.extend(parsed.entries);
+        let (entries, skipped) = dedup.finalize();
+        assert_eq!(skipped, 1);
+        assert_eq!(entries.len(), 2);
+        assert!(entries.iter().any(|entry| entry.model == "a-grok"));
+        assert!(entries.iter().any(|entry| entry.model == "z-grok"));
+    }
+
+    #[test]
+    fn residual_tokens_do_not_invent_a_model_call() {
+        let line = r#"{"timestamp":1786896000,"params":{"update":{"sessionUpdate":"turn_completed","usage":{"inputTokens":30,"modelCalls":2,"modelUsage":{"grok-a":{"inputTokens":10,"modelCalls":1},"grok-b":{"inputTokens":10,"modelCalls":1}}}}}}"#;
+        let entries = parse_turn_line(line, tz(), &ctx())
+            .expect("valid turn")
+            .expect("usage entries");
+
+        assert_eq!(
+            entries
+                .iter()
+                .map(|entry| entry.to_stats().count)
+                .sum::<i64>(),
+            2
+        );
+        assert_eq!(
+            entries.iter().map(|entry| entry.input_tokens).sum::<i64>(),
+            30
+        );
+    }
+
+    #[test]
+    fn accepts_snake_case_turn_discriminator() {
+        let line = r#"{"timestamp":1786896000,"params":{"update":{"session_update":"turn_completed","usage":{"inputTokens":10}}}}"#;
+        let entries = parse_turn_line(line, tz(), &ctx())
+            .expect("valid turn")
+            .expect("usage entries");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].input_tokens, 10);
     }
 }

--- a/src/source/grok/usage.rs
+++ b/src/source/grok/usage.rs
@@ -1,0 +1,392 @@
+//! Per-turn Grok usage from `updates.jsonl`.
+//!
+//! `turn_completed.usage` is the provider-reported request total for that turn
+//! (including every model call in the tool loop). `inputTokens` includes cache
+//! reads and `outputTokens` includes reasoning, so those nested counts are
+//! subtracted before they are stored on `RawEntry`.
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+use crate::consts::DATE_FORMAT;
+use crate::core::{CostKind, RawEntry};
+use crate::source::ParseOutput;
+use crate::utils::Timezone;
+
+use super::parser::{GrokSessionContext, first_non_empty};
+
+const TURN_COMPLETED: &str = "turn_completed";
+const USD_TICKS_PER_DOLLAR: f64 = 10_000_000_000.0;
+
+#[derive(Debug, Deserialize, Default, Clone)]
+#[serde(default, rename_all = "camelCase")]
+struct UsageTokens {
+    input_tokens: Option<i64>,
+    output_tokens: Option<i64>,
+    cached_read_tokens: Option<i64>,
+    cache_creation_tokens: Option<i64>,
+    reasoning_tokens: Option<i64>,
+    model_calls: Option<i64>,
+    cost_usd_ticks: Option<i64>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(default, rename_all = "camelCase")]
+struct TurnUsage {
+    #[serde(flatten)]
+    tokens: UsageTokens,
+    model_usage: HashMap<String, UsageTokens>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(default)]
+struct SessionUpdate {
+    #[serde(rename = "sessionUpdate", alias = "session_update")]
+    kind: Option<String>,
+    #[serde(alias = "promptId")]
+    prompt_id: Option<String>,
+    #[serde(alias = "stopReason")]
+    stop_reason: Option<String>,
+    usage: Option<TurnUsage>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(default, rename_all = "camelCase")]
+struct UpdateMeta {
+    event_id: Option<String>,
+    agent_timestamp_ms: Option<i64>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(default, rename_all = "camelCase")]
+struct UpdateParams {
+    session_id: Option<String>,
+    update: Option<SessionUpdate>,
+    #[serde(rename = "_meta")]
+    meta: Option<UpdateMeta>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(default)]
+struct UpdateEnvelope {
+    timestamp: Option<i64>,
+    params: Option<UpdateParams>,
+}
+
+struct NormalizedUsage {
+    input_tokens: i64,
+    output_tokens: i64,
+    cache_creation: i64,
+    cache_read: i64,
+    reasoning_tokens: i64,
+    call_count: i64,
+    recorded_cost_usd: Option<f64>,
+}
+
+pub(super) fn parse_turn_completed_usage(
+    path: &Path,
+    timezone: Timezone,
+    debug: bool,
+    ctx: &GrokSessionContext,
+) -> ParseOutput {
+    let file = match File::open(path) {
+        Ok(file) => file,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return ParseOutput::default();
+        }
+        Err(err) => {
+            if debug {
+                eprintln!("Failed to read {}: {}", path.display(), err);
+            }
+            return ParseOutput {
+                entries: Vec::new(),
+                errors: 1,
+            };
+        }
+    };
+
+    let mut entries = Vec::new();
+    let mut errors = 0;
+    for (line_index, line) in BufReader::new(file).lines().enumerate() {
+        let line = match line {
+            Ok(line) => line,
+            Err(err) => {
+                errors += 1;
+                if debug {
+                    eprintln!(
+                        "Failed to read {} line {}: {}",
+                        path.display(),
+                        line_index + 1,
+                        err
+                    );
+                }
+                continue;
+            }
+        };
+        if !line.contains(TURN_COMPLETED) {
+            continue;
+        }
+        match parse_turn_line(&line, timezone, ctx) {
+            Ok(Some(turn_entries)) => entries.extend(turn_entries),
+            Ok(None) => {}
+            Err(err) => {
+                errors += 1;
+                if debug {
+                    eprintln!(
+                        "Invalid JSON in {} line {}: {err}",
+                        path.display(),
+                        line_index + 1
+                    );
+                }
+            }
+        }
+    }
+
+    ParseOutput { entries, errors }
+}
+
+fn parse_turn_line(
+    line: &str,
+    timezone: Timezone,
+    ctx: &GrokSessionContext,
+) -> Result<Option<Vec<RawEntry>>, serde_json::Error> {
+    let envelope: UpdateEnvelope = serde_json::from_str(line)?;
+    let params = envelope.params.as_ref();
+    let update = params.and_then(|params| params.update.as_ref());
+    if update.and_then(|update| update.kind.as_deref()) != Some(TURN_COMPLETED) {
+        return Ok(None);
+    }
+    let Some(usage) = update.and_then(|update| update.usage.as_ref()) else {
+        return Ok(None);
+    };
+
+    let Some(utc_dt) = event_time(&envelope) else {
+        return Ok(None);
+    };
+    let local_dt = timezone.to_fixed_offset(utc_dt);
+    let date_str = local_dt.date_naive().format(DATE_FORMAT).to_string();
+    let session_id = first_non_empty(&[params.and_then(|params| params.session_id.as_deref())])
+        .unwrap_or_else(|| ctx.session_id.clone());
+    let prompt_id = update.and_then(|update| update.prompt_id.as_deref());
+    let event_id = params
+        .and_then(|params| params.meta.as_ref())
+        .and_then(|meta| meta.event_id.as_deref());
+    let message_id = first_non_empty(&[prompt_id, event_id]);
+    let stop_reason = update.and_then(|update| update.stop_reason.clone());
+
+    let mut model_usages: Vec<(String, &UsageTokens)> = usage
+        .model_usage
+        .iter()
+        .filter(|(model, _)| !model.trim().is_empty())
+        .map(|(model, tokens)| (model.clone(), tokens))
+        .collect();
+    model_usages.sort_by(|left, right| left.0.cmp(&right.0));
+    if model_usages.is_empty() {
+        model_usages.push((ctx.fallback_model.clone(), &usage.tokens));
+    }
+
+    let mut entries = Vec::new();
+    for (model, tokens) in model_usages {
+        let normalized = normalize_usage(tokens);
+        if !has_usage(&normalized) {
+            continue;
+        }
+        let message_id = match (message_id.as_deref(), model_usages_need_suffix(&entries)) {
+            (Some(id), true) => Some(format!("{id}:{model}")),
+            (Some(id), false) => Some(id.to_string()),
+            (None, _) => None,
+        };
+        entries.push(RawEntry {
+            timestamp: utc_dt.to_rfc3339(),
+            timestamp_ms: utc_dt.timestamp_millis(),
+            date_str: date_str.clone(),
+            message_id,
+            session_key: ctx.session_key.clone(),
+            session_id: session_id.clone(),
+            project_path: ctx.project_path.clone(),
+            model,
+            input_tokens: normalized.input_tokens,
+            output_tokens: normalized.output_tokens,
+            cache_creation: normalized.cache_creation,
+            cache_creation_1h: 0,
+            cache_read: normalized.cache_read,
+            reasoning_tokens: normalized.reasoning_tokens,
+            stop_reason: stop_reason.clone(),
+            cost_kind: CostKind::Real,
+            endpoint: crate::core::Endpoint::Unknown,
+            call_count: normalized.call_count,
+            recorded_cost_usd: normalized.recorded_cost_usd,
+        });
+    }
+    Ok(Some(entries).filter(|entries| !entries.is_empty()))
+}
+
+fn model_usages_need_suffix(entries: &[RawEntry]) -> bool {
+    !entries.is_empty()
+}
+
+fn event_time(envelope: &UpdateEnvelope) -> Option<DateTime<Utc>> {
+    let meta_ms = envelope
+        .params
+        .as_ref()
+        .and_then(|params| params.meta.as_ref())
+        .and_then(|meta| meta.agent_timestamp_ms)
+        .filter(|ms| *ms > 0);
+    if let Some(ms) = meta_ms {
+        return DateTime::<Utc>::from_timestamp_millis(ms);
+    }
+
+    let timestamp = envelope.timestamp.filter(|timestamp| *timestamp > 0)?;
+    if timestamp > 1_000_000_000_000 {
+        DateTime::<Utc>::from_timestamp_millis(timestamp)
+    } else {
+        DateTime::<Utc>::from_timestamp(timestamp, 0)
+    }
+}
+
+fn normalize_usage(tokens: &UsageTokens) -> NormalizedUsage {
+    let cache_read = tokens.cached_read_tokens.unwrap_or(0).max(0);
+    let cache_creation = tokens.cache_creation_tokens.unwrap_or(0).max(0);
+    let reasoning_tokens = tokens.reasoning_tokens.unwrap_or(0).max(0);
+    let raw_input = tokens.input_tokens.unwrap_or(0).max(0);
+    let raw_output = tokens.output_tokens.unwrap_or(0).max(0);
+    let model_calls = tokens.model_calls.unwrap_or(0).max(0);
+    NormalizedUsage {
+        input_tokens: (raw_input - cache_read).max(0),
+        output_tokens: (raw_output - reasoning_tokens).max(0),
+        cache_creation,
+        cache_read,
+        reasoning_tokens,
+        call_count: if model_calls > 0 { model_calls } else { 1 },
+        recorded_cost_usd: tokens
+            .cost_usd_ticks
+            .map(|ticks| ticks.max(0) as f64 / USD_TICKS_PER_DOLLAR),
+    }
+}
+
+fn has_usage(usage: &NormalizedUsage) -> bool {
+    usage.input_tokens > 0
+        || usage.output_tokens > 0
+        || usage.cache_creation > 0
+        || usage.cache_read > 0
+        || usage.reasoning_tokens > 0
+        || usage.recorded_cost_usd.is_some_and(|cost| cost > 0.0)
+        || usage.call_count > 1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::source::grok::parser::GrokSessionContext;
+    use crate::utils::Timezone;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn tz() -> Timezone {
+        Timezone::parse(Some("UTC")).unwrap()
+    }
+
+    fn ctx() -> GrokSessionContext {
+        GrokSessionContext {
+            session_id: "session-1".to_string(),
+            session_key: "/tmp/session-1".to_string(),
+            project_path: "/tmp/grok-project/".to_string(),
+            fallback_model: "grok-build".to_string(),
+        }
+    }
+
+    #[test]
+    fn parses_turn_completed_usage_and_server_cost() {
+        let root = tempdir().expect("temp dir");
+        let path = root.path().join("updates.jsonl");
+        fs::write(
+            &path,
+            r#"{"timestamp":1776374400,"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"tool_call"},"_meta":{}}}
+{"timestamp":1776374400,"method":"_x.ai/session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"turn_completed","prompt_id":"p1","stop_reason":"end_turn","usage":{"inputTokens":165026,"outputTokens":3270,"cachedReadTokens":127360,"cacheCreationTokens":0,"reasoningTokens":1145,"modelCalls":5,"costUsdTicks":1381600000,"modelUsage":{"grok-4.5-build":{"inputTokens":165026,"outputTokens":3270,"cachedReadTokens":127360,"cacheCreationTokens":0,"reasoningTokens":1145,"modelCalls":5,"costUsdTicks":1381600000}}}},"_meta":{"eventId":"e1","agentTimestampMs":1776374400123}}}
+"#,
+        )
+        .expect("write updates");
+
+        let parsed = parse_turn_completed_usage(&path, tz(), true, &ctx());
+        assert_eq!(parsed.errors, 0);
+        assert_eq!(parsed.entries.len(), 1);
+        let entry = &parsed.entries[0];
+        assert_eq!(entry.model, "grok-4.5-build");
+        assert_eq!(entry.input_tokens, 37666);
+        assert_eq!(entry.cache_read, 127_360);
+        assert_eq!(entry.output_tokens, 2125);
+        assert_eq!(entry.reasoning_tokens, 1145);
+        assert_eq!(entry.call_count, 5);
+        assert_eq!(entry.date_str, "2026-04-16");
+        assert_eq!(entry.message_id.as_deref(), Some("p1"));
+        assert_eq!(entry.stop_reason.as_deref(), Some("end_turn"));
+        assert_eq!(entry.cost_kind, CostKind::Real);
+        assert_eq!(entry.recorded_cost_usd, Some(0.13816));
+        let stats = entry.to_stats();
+        assert_eq!(stats.count, 5);
+        assert_eq!(stats.recorded_cost_entries, 1);
+        assert!((stats.recorded_cost_usd - 0.13816).abs() < 1e-12);
+    }
+
+    #[test]
+    fn dates_from_event_time_not_session_updated_at() {
+        let root = tempdir().expect("temp dir");
+        let path = root.path().join("updates.jsonl");
+        fs::write(
+            &path,
+            r#"{"timestamp":1786896000,"params":{"update":{"sessionUpdate":"turn_completed","usage":{"inputTokens":10,"outputTokens":2,"modelCalls":1,"costUsdTicks":100000000}}}}
+"#,
+        )
+        .expect("write updates");
+
+        let parsed = parse_turn_completed_usage(&path, tz(), true, &ctx());
+        assert_eq!(parsed.entries[0].date_str, "2026-08-16");
+    }
+
+    #[test]
+    fn splits_model_usage_and_keeps_per_model_cost() {
+        let root = tempdir().expect("temp dir");
+        let path = root.path().join("updates.jsonl");
+        fs::write(
+            &path,
+            r#"{"timestamp":1786896000,"params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"p2","usage":{"inputTokens":30,"outputTokens":6,"cachedReadTokens":0,"reasoningTokens":0,"modelCalls":3,"costUsdTicks":300,"modelUsage":{"grok-a":{"inputTokens":10,"outputTokens":2,"modelCalls":1,"costUsdTicks":100},"grok-b":{"inputTokens":20,"outputTokens":4,"modelCalls":2,"costUsdTicks":200}}}}}}
+"#,
+        )
+        .expect("write updates");
+
+        let parsed = parse_turn_completed_usage(&path, tz(), true, &ctx());
+        assert_eq!(parsed.entries.len(), 2);
+        assert_eq!(parsed.entries[0].model, "grok-a");
+        assert_eq!(parsed.entries[0].input_tokens, 10);
+        assert_eq!(parsed.entries[0].call_count, 1);
+        assert_eq!(parsed.entries[0].message_id.as_deref(), Some("p2"));
+        assert_eq!(parsed.entries[1].model, "grok-b");
+        assert_eq!(parsed.entries[1].call_count, 2);
+        assert_eq!(parsed.entries[1].message_id.as_deref(), Some("p2:grok-b"));
+    }
+
+    #[test]
+    fn clamps_negative_token_fields() {
+        let usage = normalize_usage(&UsageTokens {
+            input_tokens: Some(-8),
+            output_tokens: Some(-3),
+            cached_read_tokens: Some(-1),
+            cache_creation_tokens: Some(-2),
+            reasoning_tokens: Some(-4),
+            model_calls: Some(-5),
+            cost_usd_ticks: Some(-9),
+        });
+        assert_eq!(usage.input_tokens, 0);
+        assert_eq!(usage.output_tokens, 0);
+        assert_eq!(usage.cache_read, 0);
+        assert_eq!(usage.cache_creation, 0);
+        assert_eq!(usage.reasoning_tokens, 0);
+        assert_eq!(usage.call_count, 1);
+        assert_eq!(usage.recorded_cost_usd, Some(0.0));
+    }
+}

--- a/src/source/kimi/parser.rs
+++ b/src/source/kimi/parser.rs
@@ -283,6 +283,8 @@ fn parse_usage_line(
         stop_reason: None,
         cost_kind: CostKind::Real,
         endpoint: crate::core::Endpoint::Unknown,
+        call_count: 1,
+        recorded_cost_usd: None,
     })
 }
 

--- a/src/source/loader.rs
+++ b/src/source/loader.rs
@@ -239,7 +239,7 @@ impl<'a> DataLoader<'a> {
             return LoadResult::default();
         };
 
-        let valid: i64 = day_stats.values().map(|day| day.stats.count).sum();
+        let valid: i64 = day_stats.values().map(|day| day.stats.records).sum();
         if self.debug && !self.quiet {
             eprintln!("[DEBUG] Processed {} entries, {} skipped", valid, 0);
             eprintln!("[DEBUG] Days with data: {}", day_stats.len());
@@ -329,12 +329,10 @@ impl<'a> DataLoader<'a> {
                 ..LoadResult::default()
             };
         }
-
         let agg_start = Instant::now();
         let valid = final_entries.len() as i64;
         let day_stats = aggregate_daily(final_entries);
         let agg_ms = agg_start.elapsed().as_secs_f64() * 1000.0;
-
         if !self.quiet {
             if skipped > 0 {
                 eprintln!("Deduplicated {skipped} entries, aggregated ({agg_ms:.2}ms)");
@@ -342,7 +340,6 @@ impl<'a> DataLoader<'a> {
                 eprintln!("Aggregated ({agg_ms:.2}ms)");
             }
         }
-
         if self.debug && !self.quiet {
             eprintln!("[DEBUG] Processed {valid} entries, {skipped} skipped");
             eprintln!("[DEBUG] Days with data: {}", day_stats.len());

--- a/src/source/loader.rs
+++ b/src/source/loader.rs
@@ -580,6 +580,8 @@ mod tests {
             stop_reason: Some("end_turn".to_string()),
             cost_kind: crate::core::CostKind::Real,
             endpoint: crate::core::Endpoint::Unknown,
+            call_count: 1,
+            recorded_cost_usd: None,
         }
     }
 

--- a/src/source/loader_quality_tests.rs
+++ b/src/source/loader_quality_tests.rs
@@ -61,6 +61,8 @@ fn entry(id: &str, input_tokens: i64) -> RawEntry {
         stop_reason: Some("end_turn".to_string()),
         cost_kind: crate::core::CostKind::Real,
         endpoint: crate::core::Endpoint::Unknown,
+        call_count: 1,
+        recorded_cost_usd: None,
     }
 }
 

--- a/src/source/registry.rs
+++ b/src/source/registry.rs
@@ -238,10 +238,10 @@ mod tests {
         let caps = source.capabilities();
         assert!(caps.has_projects);
         assert!(!caps.has_billing_blocks);
-        assert!(!caps.has_cache_creation);
-        assert!(!caps.has_cache_read);
+        assert!(caps.has_cache_creation);
+        assert!(caps.has_cache_read);
         assert!(!caps.needs_dedup);
-        assert!(!caps.has_reasoning_tokens);
+        assert!(caps.has_reasoning_tokens);
         assert!(!caps.has_tool_calls);
     }
 

--- a/src/source/registry.rs
+++ b/src/source/registry.rs
@@ -240,7 +240,7 @@ mod tests {
         assert!(!caps.has_billing_blocks);
         assert!(caps.has_cache_creation);
         assert!(caps.has_cache_read);
-        assert!(!caps.needs_dedup);
+        assert!(caps.needs_dedup);
         assert!(caps.has_reasoning_tokens);
         assert!(!caps.has_tool_calls);
     }

--- a/tests/cli_grok_cursor.rs
+++ b/tests/cli_grok_cursor.rs
@@ -66,6 +66,35 @@ fn write_grok_session_at(grok_home: &Path, created_at: &str, updated_at: &str) {
     );
 }
 
+fn write_grok_turn_session(grok_home: &Path) {
+    let session_dir = grok_home
+        .join("sessions")
+        .join("%2Ftmp%2Fgrok-project")
+        .join("grok-turn-session");
+    write_file(
+        &session_dir.join("signals.json"),
+        r#"{
+  "contextTokensUsed": 999999,
+  "primaryModelId": "grok-build"
+}"#,
+    );
+    write_file(
+        &session_dir.join("summary.json"),
+        r#"{
+  "created_at": "2026-08-15T09:00:00Z",
+  "updated_at": "2026-08-17T10:00:00Z",
+  "current_model_id": "grok-build",
+  "git_root_dir": "/tmp/grok-project/"
+}"#,
+    );
+    write_file(
+        &session_dir.join("updates.jsonl"),
+        r#"{"timestamp":1786838400,"method":"_x.ai/session/update","params":{"sessionId":"grok-turn-session","update":{"sessionUpdate":"turn_completed","prompt_id":"p1","stop_reason":"end_turn","usage":{"inputTokens":100,"outputTokens":20,"cachedReadTokens":40,"reasoningTokens":5,"modelCalls":3,"costUsdTicks":20000000000,"modelUsage":{"grok-4.5-build":{"inputTokens":100,"outputTokens":20,"cachedReadTokens":40,"reasoningTokens":5,"modelCalls":3,"costUsdTicks":20000000000}}}},"_meta":{"eventId":"e1","agentTimestampMs":1786838400000}}}
+{"timestamp":1786924800,"method":"_x.ai/session/update","params":{"sessionId":"grok-turn-session","update":{"sessionUpdate":"turn_completed","prompt_id":"p2","usage":{"inputTokens":50,"outputTokens":10,"cachedReadTokens":10,"reasoningTokens":2,"modelCalls":2,"costUsdTicks":5000000000,"modelUsage":{"grok-4.5-build":{"inputTokens":50,"outputTokens":10,"cachedReadTokens":10,"reasoningTokens":2,"modelCalls":2,"costUsdTicks":5000000000}}}},"_meta":{"agentTimestampMs":1786924800000}}}
+"#,
+    );
+}
+
 fn write_grok_update_only_session(grok_home: &Path) {
     let session_dir = grok_home
         .join("sessions")
@@ -203,7 +232,7 @@ fn source_flag_can_select_grok_without_subcommand() {
     assert_eq!(arr[0]["input_tokens"].as_i64(), Some(1500));
     assert_eq!(arr[0]["output_tokens"].as_i64(), Some(0));
     assert_eq!(arr[0]["total_tokens"].as_i64(), Some(1500));
-    assert!(arr[0]["cache_hit_rate"].is_null());
+    assert_eq!(arr[0]["cache_hit_rate"].as_f64(), Some(0.0));
     assert_eq!(
         arr[0]["models"].as_array().unwrap()[0].as_str(),
         Some("grok-build")
@@ -515,6 +544,115 @@ fn grok_source_falls_back_to_updates_when_signals_missing() {
         arr[0]["models"].as_array().unwrap()[0].as_str(),
         Some("grok-build")
     );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn grok_daily_json_reads_turn_completed_usage_by_event_date() {
+    let root = unique_temp_dir("grok-turn-usage");
+    let grok_home = root.join("grok-home");
+    write_grok_turn_session(&grok_home);
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "grok",
+            "daily",
+            "-j",
+            "-O",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-08-16",
+            "--until",
+            "2026-08-16",
+        ],
+        &[("GROK_HOME", &grok_home), ("HOME", &root)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    let arr = json.as_array().expect("array output");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["date"].as_str(), Some("2026-08-16"));
+    assert_eq!(arr[0]["input_tokens"].as_i64(), Some(60));
+    assert_eq!(arr[0]["output_tokens"].as_i64(), Some(15));
+    assert_eq!(arr[0]["reasoning_tokens"].as_i64(), Some(5));
+    assert_eq!(arr[0]["cache_read_tokens"].as_i64(), Some(40));
+    assert_eq!(arr[0]["total_tokens"].as_i64(), Some(120));
+    assert_close(arr[0]["cache_hit_rate"].as_f64().unwrap(), 40.0);
+    assert_close(arr[0]["cost"].as_f64().unwrap(), 2.0);
+    assert_eq!(arr[0]["pricing_source"].as_str(), Some("recorded"));
+    assert!(arr[0].get("cost_kind").is_none() || arr[0]["cost_kind"].is_null());
+    assert_eq!(
+        arr[0]["models"].as_array().unwrap()[0].as_str(),
+        Some("grok-4.5-build")
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn grok_daily_table_counts_model_calls_not_sessions() {
+    let root = unique_temp_dir("grok-turn-calls");
+    let grok_home = root.join("grok-home");
+    write_grok_turn_session(&grok_home);
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "grok",
+            "daily",
+            "-O",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-08-16",
+            "--until",
+            "2026-08-17",
+        ],
+        &[("GROK_HOME", &grok_home), ("HOME", &root)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let table = String::from_utf8(stdout).expect("utf8 table");
+    assert!(
+        table.contains("5") && table.contains("Calls"),
+        "table should count 5 model calls: {table}"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn all_sources_includes_grok_server_cost_in_real_total() {
+    let root = unique_temp_dir("all-sources-grok-real");
+    let grok_home = root.join("grok-home");
+    write_claude_session(&root);
+    write_grok_turn_session(&grok_home);
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "--source",
+            "all",
+            "-j",
+            "-O",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-08-16",
+            "--until",
+            "2026-08-16",
+        ],
+        &[("HOME", &root), ("GROK_HOME", &grok_home)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    let arr = json.as_array().expect("array output");
+    assert_eq!(arr.len(), 1);
+    assert_close(arr[0]["cost"].as_f64().unwrap(), 2.0);
+    assert!(arr[0].get("estimated_cost").is_none() || arr[0]["estimated_cost"].is_null());
 
     let _ = fs::remove_dir_all(root);
 }

--- a/tests/sdk_integration.rs
+++ b/tests/sdk_integration.rs
@@ -400,7 +400,7 @@ fn sdk_summarizes_grok_context_tokens_without_running_cli() {
     assert_eq!(summary.tokens.input_tokens, 1500);
     assert_eq!(summary.tokens.output_tokens, 0);
     assert_eq!(summary.tokens.total_tokens, 1500);
-    assert_eq!(summary.tokens.cache_hit_rate, None);
+    assert_eq!(summary.tokens.cache_hit_rate, Some(0.0));
     assert_eq!(summary.models.len(), 1);
     assert_eq!(summary.models[0].model, "grok-build");
     assert!(summary.cost_usd.is_some_and(|cost| cost > 0.0));


### PR DESCRIPTION
# Summary

`ccstats grok` 现在读取 `updates.jsonl` 里的 `turn_completed.usage`，按事件时间统计真实模型调用、cache/output/reasoning，以及服务端 `costUsdTicks`。没有这些事件的旧会话仍走上下文快照，并保持 `estimated_proxy`。

本地 2026-08-16 日志验证：Calls 286，Total 36,529,018，Cost $5.1343522。

Closes #100

## Linked Work

- Issue: https://github.com/majiayu000/ccstats/issues/100
- 相关：#16 / #18 / #35

## Verification

- `cargo test --offline`
- `cargo clippy --offline --all-targets -- -D warnings`
- 本机 `~/.grok/sessions` 2026-08-16 与 `turn_completed.usage` 汇总一致