### PR TITLE
fix: align Grok weekly cost with inference usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Calculate Grok 4.5 and 4.6 USD cost from per-inference `unified.jsonl` token records, including prompt-cache rates and the 200k-token whole-request pricing tier, instead of using `turn_completed.costUsdTicks` as the Grok Build weekly-allowance value.
+
+### Fixed
+- Preserve Grok inference records in an atomic ccstats ledger so upstream head trimming does not remove usage that ccstats has already observed.
+
 ## [0.5.0] - 2026-08-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ ccstats daily --source cur
 
 ## Quick Start (Grok)
 
-Grok support reads `turn_completed.usage` records from `~/.grok/sessions/**/updates.jsonl`. Those events are per-turn model request totals, including cache, output, reasoning, model-call counts, and server `costUsdTicks`. Sessions without `turn_completed.usage` still fall back to local context-token snapshots and keep that cost marked `estimated_proxy`.
+Grok support reads each `shell.turn.inference_done` record from `~/.grok/logs/unified.jsonl`. It reports uncached input, cached prompt, completion, and reasoning tokens, then calculates Grok 4.5/4.6 USD cost per inference using xAI's short- or long-context price for the whole request. Observed records are kept in an atomic ccstats ledger because Grok trims the live log in place.
 
 ```bash
 # Install
@@ -316,11 +316,15 @@ ccstats grok project
 ccstats daily --source gx
 ```
 
-By default, ccstats checks Grok session files under:
+By default, ccstats uses:
 
-- `~/.grok/sessions/**/updates.jsonl` for `turn_completed.usage`
-- `~/.grok/sessions/**/summary.json` for project path and snapshot fallback
-- `~/.grok/sessions/**/signals.json` only when a session has no `turn_completed.usage`
+- `~/.grok/logs/unified.jsonl` for per-inference token records
+- `~/.grok/sessions/**/summary.json` for model, project, and session metadata
+- the platform cache directory under `ccstats/grok/<source-root>/inference-v1.jsonl` for the durable, deduplicated ledger
+
+For Grok 4.5 and 4.6, requests below 200k prompt tokens use the short-context rates. Requests at or above 200k use the long-context input, cached-input, and output rates for the entire inference. `completion_tokens` already includes reasoning, so ccstats separates the displayed fields without charging reasoning twice. Rates follow the [xAI pricing reference](https://docs.x.ai/developers/pricing).
+
+If `unified.jsonl` is unavailable, ccstats retains the older session `turn_completed.usage` and context-snapshot fallback for installations that do not emit inference telemetry.
 
 You can override the Grok home directory with `GROK_HOME`:
 
@@ -330,9 +334,9 @@ GROK_HOME="/path/to/.grok" ccstats grok
 
 Current limitations:
 
-- Account quota and weekly-allowance UI totals can still differ from local logs.
-- Sessions without `turn_completed.usage` keep the older context-token snapshot and mark that cost `estimated_proxy`.
-- Dates come from each `turn_completed` event. Snapshot fallback still uses the session `updated_at`.
+- The durable ledger starts when ccstats first observes an inference. It cannot recover records Grok trimmed before the first run.
+- Session fallback totals use the fields available in those files and can differ from the Grok Build weekly allowance.
+- Grok models without a published ccstats per-inference tier fall back to the normal pricing resolver.
 - Grok 5-hour billing blocks are not supported.
 
 ### Kimi Code
@@ -520,7 +524,7 @@ Warning: ignored <N> malformed records
 | OpenAI Codex | `~/.codex/sessions/` | `CODEX_HOME` | Reasoning Tokens |
 | All Sources | Multiple | Source-specific env vars | Combined daily/weekly/monthly/today/statusline summaries |
 | Cursor | Cursor usage API | `CURSOR_API_KEY` / `CURSOR_SESSION_TOKEN` | Per-event tokens, cache tokens, recorded `chargedCents` |
-| Grok | `~/.grok/sessions/` | `GROK_HOME` | Per-turn usage records, Projects, Cache / reasoning tokens, Server cost ticks |
+| Grok | `~/.grok/logs/unified.jsonl` | `GROK_HOME` | Per-inference usage, Projects, Cache / reasoning tokens, 200k pricing tier, durable ledger |
 | Kimi Code | `~/.kimi-code/sessions/` | `KIMI_CODE_HOME` | Per-turn usage records, Projects, Cache tokens |
 
 ## Architecture

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,6 +32,11 @@ src/
 │   │   ├── client.rs      # Usage API 客户端
 │   │   ├── parser.rs      # Usage event 解析逻辑
 │   │   └── mod.rs
+│   ├── grok/              # Grok 数据源
+│   │   ├── config.rs      # Source trait 实现
+│   │   ├── unified.rs     # inference 解析、分档计价和原子持久化
+│   │   ├── parser.rs      # 旧版 session fallback
+│   │   └── mod.rs
 │   ├── loader.rs          # 统一数据加载器
 │   ├── registry.rs        # 数据源注册表
 │   └── mod.rs             # Source trait 定义
@@ -197,7 +202,7 @@ Source 根目录仍由环境变量覆盖：
 | Claude Code | `CLAUDE_CONFIG_DIR` | Claude config root containing `projects/` | `~/.claude` |
 | OpenAI Codex | `CODEX_HOME` | Codex root containing `sessions/` | `~/.codex` |
 | Cursor | `CURSOR_API_KEY` / `CURSOR_SESSION_TOKEN` | Admin API key or dashboard session cookie | Optional `CURSOR_USAGE_FILE` replay |
-| Grok | `GROK_HOME` | Grok root containing `sessions/` (`updates.jsonl` turn usage) | `~/.grok` |
+| Grok | `GROK_HOME` | Grok root containing `logs/unified.jsonl` and `sessions/` metadata | `~/.grok` |
 | Kimi Code | `KIMI_CODE_HOME` | Kimi Code root containing `sessions/` | `~/.kimi-code` |
 
 ## 添加新数据源

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -35,7 +35,7 @@ pub enum UsageSource {
     Codex,
     /// Cursor composer usage data.
     Cursor,
-    /// Grok session usage under `~/.grok/sessions`, or `GROK_HOME`.
+    /// Grok inference usage under `~/.grok/logs/unified.jsonl`, or `GROK_HOME`.
     Grok,
     /// Kimi Code wire logs under `~/.kimi-code/sessions`, or `KIMI_CODE_HOME`.
     Kimi,

--- a/src/source/grok/config.rs
+++ b/src/source/grok/config.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use crate::source::{Capabilities, ParseOutput, Source};
 use crate::utils::Timezone;
 
-use super::parser::{find_grok_files, parse_grok_session_file_with_debug};
+use super::unified::{find_grok_files, parse_grok_file_with_debug};
 
 /// Grok data source.
 pub(crate) struct GrokSource;
@@ -55,6 +55,6 @@ impl Source for GrokSource {
     }
 
     fn parse_file(&self, path: &Path, timezone: Timezone, debug: bool) -> ParseOutput {
-        parse_grok_session_file_with_debug(path, timezone, debug)
+        parse_grok_file_with_debug(path, timezone, debug)
     }
 }

--- a/src/source/grok/mod.rs
+++ b/src/source/grok/mod.rs
@@ -1,10 +1,11 @@
 //! Grok CLI data source
 //!
-//! Prefers `updates.jsonl` `turn_completed.usage` records. Sessions without
-//! those events still fall back to local context-token snapshots.
+//! Prefers durable `logs/unified.jsonl` inference records. Installations
+//! without unified inference telemetry still use session usage records.
 
 mod config;
 mod parser;
+mod unified;
 mod usage;
 
 pub(crate) use config::GrokSource;

--- a/src/source/grok/unified.rs
+++ b/src/source/grok/unified.rs
@@ -1,0 +1,645 @@
+//! Durable Grok inference usage from `logs/unified.jsonl`.
+//!
+//! Grok trims the head of its unified log in place. Before ccstats parses the
+//! file, it merges every inference record into an atomic, source-root-scoped
+//! ledger under the platform cache directory.
+
+use std::collections::{BTreeMap, HashMap, hash_map::DefaultHasher};
+use std::env;
+use std::fs::{self, File, OpenOptions};
+use std::hash::{Hash, Hasher};
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::consts::{DATE_FORMAT, UNKNOWN};
+use crate::core::{CostKind, RawEntry};
+use crate::source::ParseOutput;
+use crate::utils::Timezone;
+
+const APP_CACHE_DIR: &str = "ccstats";
+const GROK_CACHE_DIR: &str = "grok";
+const GROK_HOME_ENV: &str = "GROK_HOME";
+const DEFAULT_GROK_DIR: &str = ".grok";
+const UNIFIED_LOG: &str = "unified.jsonl";
+const LEDGER_FILE: &str = "inference-v1.jsonl";
+const INFERENCE_DONE: &str = "shell.turn.inference_done";
+const LONG_CONTEXT_THRESHOLD: i64 = 200_000;
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(default)]
+struct UnifiedEnvelope {
+    ts: Option<String>,
+    sid: Option<String>,
+    msg: Option<String>,
+    ctx: Option<InferenceContext>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(default)]
+struct InferenceContext {
+    loop_index: Option<i64>,
+    prompt_tokens: Option<i64>,
+    cached_prompt_tokens: Option<i64>,
+    completion_tokens: Option<i64>,
+    reasoning_tokens: Option<i64>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(default)]
+struct SessionSummary {
+    current_model_id: Option<String>,
+    git_root_dir: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct SessionMetadata {
+    session_key: String,
+    project_path: String,
+    model: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct InferenceRecord {
+    event_key: String,
+    timestamp: String,
+    session_id: String,
+    session_key: String,
+    project_path: String,
+    model: String,
+    prompt_tokens: i64,
+    cached_prompt_tokens: i64,
+    completion_tokens: i64,
+    reasoning_tokens: i64,
+}
+
+#[derive(Clone, Copy)]
+struct TokenRates {
+    input: f64,
+    cache_read: f64,
+    output: f64,
+}
+
+fn api_cost_usd(
+    model: &str,
+    prompt_tokens: i64,
+    cached_prompt_tokens: i64,
+    completion_tokens: i64,
+) -> Option<f64> {
+    let model = model.to_ascii_lowercase();
+    let is_long = prompt_tokens.max(0) >= LONG_CONTEXT_THRESHOLD;
+    let rates = if model.contains("grok-4.6") {
+        if is_long {
+            TokenRates {
+                input: 4e-6,
+                cache_read: 1e-6,
+                output: 12e-6,
+            }
+        } else {
+            TokenRates {
+                input: 2e-6,
+                cache_read: 0.5e-6,
+                output: 6e-6,
+            }
+        }
+    } else if model.contains("grok-4.5") {
+        if is_long {
+            TokenRates {
+                input: 4e-6,
+                cache_read: 0.6e-6,
+                output: 12e-6,
+            }
+        } else {
+            TokenRates {
+                input: 2e-6,
+                cache_read: 0.3e-6,
+                output: 6e-6,
+            }
+        }
+    } else {
+        return None;
+    };
+
+    let prompt_tokens = prompt_tokens.max(0);
+    let cached_prompt_tokens = cached_prompt_tokens.clamp(0, prompt_tokens);
+    let uncached_prompt_tokens = prompt_tokens.saturating_sub(cached_prompt_tokens);
+    let completion_tokens = completion_tokens.max(0);
+    Some(
+        uncached_prompt_tokens as f64 * rates.input
+            + cached_prompt_tokens as f64 * rates.cache_read
+            + completion_tokens as f64 * rates.output,
+    )
+}
+
+fn grok_home() -> Option<PathBuf> {
+    env::var_os(GROK_HOME_ENV)
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|home| home.join(DEFAULT_GROK_DIR)))
+}
+
+fn source_root_hash(path: &Path) -> String {
+    let mut hasher = DefaultHasher::new();
+    path.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+fn ledger_path(grok_home: &Path) -> Option<PathBuf> {
+    dirs::cache_dir().map(|cache_dir| {
+        cache_dir
+            .join(APP_CACHE_DIR)
+            .join(GROK_CACHE_DIR)
+            .join(source_root_hash(grok_home))
+            .join(LEDGER_FILE)
+    })
+}
+
+pub(super) fn find_grok_files() -> Vec<PathBuf> {
+    let Some(grok_home) = grok_home() else {
+        return Vec::new();
+    };
+    let source_path = grok_home.join("logs").join(UNIFIED_LOG);
+    let sessions_dir = grok_home.join("sessions");
+    let ledger_path = ledger_path(&grok_home);
+
+    if source_path.is_file() {
+        if let Some(path) = ledger_path.as_deref() {
+            match sync_ledger_at(&source_path, path, &sessions_dir) {
+                Ok(records) if records > 0 => return vec![path.to_path_buf()],
+                Ok(_) => {}
+                Err(error) => {
+                    eprintln!(
+                        "Warning: failed to persist Grok inference log; reading the live log only: {error}"
+                    );
+                }
+            }
+        }
+        return vec![source_path];
+    }
+
+    if let Some(path) = ledger_path
+        && path.is_file()
+    {
+        return vec![path];
+    }
+
+    super::parser::find_grok_files()
+}
+
+pub(super) fn parse_grok_file_with_debug(
+    path: &Path,
+    timezone: Timezone,
+    debug: bool,
+) -> ParseOutput {
+    match path.file_name().and_then(|name| name.to_str()) {
+        Some(LEDGER_FILE) => parse_ledger_file(path, timezone, debug),
+        Some(UNIFIED_LOG) => parse_live_unified_file(path, timezone, debug),
+        _ => super::parser::parse_grok_session_file_with_debug(path, timezone, debug),
+    }
+}
+
+fn sync_ledger_at(
+    source_path: &Path,
+    ledger_path: &Path,
+    sessions_dir: &Path,
+) -> Result<usize, String> {
+    let mut records = load_ledger(ledger_path)?;
+    for record in read_inference_records(source_path, sessions_dir)? {
+        records.insert(record.event_key.clone(), record);
+    }
+    write_ledger_atomic(ledger_path, &records)?;
+    Ok(records.len())
+}
+
+fn load_ledger(path: &Path) -> Result<BTreeMap<String, InferenceRecord>, String> {
+    let file = match File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(BTreeMap::new()),
+        Err(error) => return Err(format!("failed to open {}: {error}", path.display())),
+    };
+    let mut records = BTreeMap::new();
+    for (line_index, line) in BufReader::new(file).lines().enumerate() {
+        let line = line.map_err(|error| {
+            format!(
+                "failed to read {} line {}: {error}",
+                path.display(),
+                line_index + 1
+            )
+        })?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let record: InferenceRecord = serde_json::from_str(&line).map_err(|error| {
+            format!(
+                "malformed ledger {} line {}: {error}",
+                path.display(),
+                line_index + 1
+            )
+        })?;
+        records.insert(record.event_key.clone(), record);
+    }
+    Ok(records)
+}
+
+fn read_inference_records(
+    path: &Path,
+    sessions_dir: &Path,
+) -> Result<Vec<InferenceRecord>, String> {
+    let file =
+        File::open(path).map_err(|error| format!("failed to open {}: {error}", path.display()))?;
+    let session_metadata = load_session_metadata(sessions_dir);
+    let mut records = Vec::new();
+
+    for (line_index, line) in BufReader::new(file).lines().enumerate() {
+        let line = line.map_err(|error| {
+            format!(
+                "failed to read {} line {}: {error}",
+                path.display(),
+                line_index + 1
+            )
+        })?;
+        if !line.contains(INFERENCE_DONE) {
+            continue;
+        }
+        let envelope: UnifiedEnvelope = serde_json::from_str(&line).map_err(|error| {
+            format!(
+                "malformed inference record {} line {}: {error}",
+                path.display(),
+                line_index + 1
+            )
+        })?;
+        if envelope.msg.as_deref() != Some(INFERENCE_DONE) {
+            continue;
+        }
+        let Some(record) = normalize_inference(envelope, &session_metadata) else {
+            continue;
+        };
+        records.push(record);
+    }
+    Ok(records)
+}
+
+fn load_session_metadata(sessions_root: &Path) -> HashMap<String, SessionMetadata> {
+    let pattern = format!("{}/**/summary.json", sessions_root.display());
+    let Ok(paths) = glob::glob(&pattern) else {
+        return HashMap::new();
+    };
+    paths
+        .flatten()
+        .filter_map(|path| {
+            let summary: SessionSummary = serde_json::from_reader(File::open(&path).ok()?).ok()?;
+            let session_path = path.parent()?;
+            let session_id = session_path.file_name()?.to_str()?.to_string();
+            let project_path = summary.git_root_dir.unwrap_or_else(|| {
+                session_path
+                    .parent()
+                    .and_then(Path::file_name)
+                    .and_then(|name| name.to_str())
+                    .unwrap_or_default()
+                    .to_string()
+            });
+            let model = summary
+                .current_model_id
+                .filter(|model| !model.trim().is_empty())
+                .unwrap_or_else(|| "grok".to_string());
+            Some((
+                session_id,
+                SessionMetadata {
+                    session_key: session_path.display().to_string(),
+                    project_path,
+                    model,
+                },
+            ))
+        })
+        .collect()
+}
+
+fn normalize_inference(
+    envelope: UnifiedEnvelope,
+    session_metadata: &HashMap<String, SessionMetadata>,
+) -> Option<InferenceRecord> {
+    let timestamp = envelope.ts?.trim().to_string();
+    DateTime::parse_from_rfc3339(&timestamp).ok()?;
+    let session_id = envelope.sid?.trim().to_string();
+    if session_id.is_empty() {
+        return None;
+    }
+    let ctx = envelope.ctx?;
+    let prompt_tokens = ctx.prompt_tokens?.max(0);
+    let cached_prompt_tokens = ctx
+        .cached_prompt_tokens
+        .unwrap_or(0)
+        .clamp(0, prompt_tokens);
+    let completion_tokens = ctx.completion_tokens.unwrap_or(0).max(0);
+    let reasoning_tokens = ctx
+        .reasoning_tokens
+        .unwrap_or(0)
+        .clamp(0, completion_tokens);
+    let loop_index = ctx.loop_index.unwrap_or(0).max(0);
+    let metadata = session_metadata
+        .get(&session_id)
+        .cloned()
+        .unwrap_or_else(|| SessionMetadata {
+            session_key: session_id.clone(),
+            project_path: String::new(),
+            model: "grok".to_string(),
+        });
+    let event_key = format!("{session_id}:{timestamp}:{loop_index}");
+
+    Some(InferenceRecord {
+        event_key,
+        timestamp,
+        session_id,
+        session_key: metadata.session_key,
+        project_path: metadata.project_path,
+        model: metadata.model,
+        prompt_tokens,
+        cached_prompt_tokens,
+        completion_tokens,
+        reasoning_tokens,
+    })
+}
+
+fn write_ledger_atomic(
+    path: &Path,
+    records: &BTreeMap<String, InferenceRecord>,
+) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)
+        .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+    let (temp_path, file) = create_temp_file(parent)?;
+    let write_result = (|| {
+        let mut writer = BufWriter::new(file);
+        for record in records.values() {
+            serde_json::to_writer(&mut writer, record)
+                .map_err(|error| format!("failed to serialize {}: {error}", path.display()))?;
+            writer
+                .write_all(b"\n")
+                .map_err(|error| format!("failed to write {}: {error}", temp_path.display()))?;
+        }
+        writer
+            .flush()
+            .map_err(|error| format!("failed to flush {}: {error}", temp_path.display()))?;
+        writer
+            .get_ref()
+            .sync_all()
+            .map_err(|error| format!("failed to sync {}: {error}", temp_path.display()))
+    })();
+    if let Err(error) = write_result {
+        let _ = fs::remove_file(&temp_path);
+        return Err(error);
+    }
+    fs::rename(&temp_path, path).map_err(|error| {
+        let _ = fs::remove_file(&temp_path);
+        format!(
+            "failed to replace {} with {}: {error}",
+            path.display(),
+            temp_path.display()
+        )
+    })
+}
+
+fn create_temp_file(parent: &Path) -> Result<(PathBuf, File), String> {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_nanos();
+    let process_id = std::process::id();
+    for attempt in 0..32 {
+        let path = parent.join(format!(".{LEDGER_FILE}.{process_id}.{nanos}.{attempt}.tmp"));
+        match OpenOptions::new().write(true).create_new(true).open(&path) {
+            Ok(file) => return Ok((path, file)),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(error) => return Err(format!("failed to create {}: {error}", path.display())),
+        }
+    }
+    Err(format!(
+        "failed to create a unique temporary ledger in {}",
+        parent.display()
+    ))
+}
+
+fn parse_live_unified_file(path: &Path, timezone: Timezone, debug: bool) -> ParseOutput {
+    let sessions_dir = grok_home()
+        .map(|home| home.join("sessions"))
+        .unwrap_or_default();
+    match read_inference_records(path, &sessions_dir) {
+        Ok(records) => records_to_parse_output(records, timezone),
+        Err(error) => {
+            if debug {
+                eprintln!("{error}");
+            }
+            ParseOutput {
+                entries: Vec::new(),
+                errors: 1,
+            }
+        }
+    }
+}
+
+fn parse_ledger_file(path: &Path, timezone: Timezone, debug: bool) -> ParseOutput {
+    match load_ledger(path) {
+        Ok(records) => records_to_parse_output(records.into_values(), timezone),
+        Err(error) => {
+            if debug {
+                eprintln!("{error}");
+            }
+            ParseOutput {
+                entries: Vec::new(),
+                errors: 1,
+            }
+        }
+    }
+}
+
+fn records_to_parse_output(
+    records: impl IntoIterator<Item = InferenceRecord>,
+    timezone: Timezone,
+) -> ParseOutput {
+    let mut errors = 0;
+    let entries = records
+        .into_iter()
+        .filter_map(|record| {
+            let Ok(utc_dt) = record.timestamp.parse::<DateTime<Utc>>() else {
+                errors += 1;
+                return None;
+            };
+            let prompt_tokens = record.prompt_tokens.max(0);
+            let cache_read = record.cached_prompt_tokens.clamp(0, prompt_tokens);
+            let input_tokens = prompt_tokens.saturating_sub(cache_read);
+            let completion_tokens = record.completion_tokens.max(0);
+            let reasoning_tokens = record.reasoning_tokens.clamp(0, completion_tokens);
+            let output_tokens = completion_tokens.saturating_sub(reasoning_tokens);
+            let recorded_cost_usd =
+                api_cost_usd(&record.model, prompt_tokens, cache_read, completion_tokens);
+            let date_str = timezone
+                .to_fixed_offset(utc_dt)
+                .date_naive()
+                .format(DATE_FORMAT)
+                .to_string();
+            Some(RawEntry {
+                timestamp: utc_dt.to_rfc3339(),
+                timestamp_ms: utc_dt.timestamp_millis(),
+                date_str,
+                message_id: Some(record.event_key),
+                session_key: record.session_key,
+                session_id: if record.session_id.is_empty() {
+                    UNKNOWN.to_string()
+                } else {
+                    record.session_id
+                },
+                project_path: record.project_path,
+                model: record.model,
+                input_tokens,
+                output_tokens,
+                cache_creation: 0,
+                cache_creation_1h: 0,
+                cache_read,
+                reasoning_tokens,
+                stop_reason: Some("inference_done".to_string()),
+                cost_kind: CostKind::Real,
+                endpoint: crate::core::Endpoint::Unknown,
+                call_count: 1,
+                recorded_cost_usd,
+            })
+        })
+        .collect();
+    ParseOutput { entries, errors }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn tz() -> Timezone {
+        Timezone::parse(Some("UTC")).expect("UTC timezone")
+    }
+
+    fn write_session_summary(sessions_root: &Path, session_id: &str, model: &str) {
+        let session_path = sessions_root.join("%2Ftmp%2Fgrok-project").join(session_id);
+        fs::create_dir_all(&session_path).expect("create session dir");
+        fs::write(
+            session_path.join("summary.json"),
+            format!(r#"{{"current_model_id":"{model}","git_root_dir":"/tmp/grok-project"}}"#),
+        )
+        .expect("write summary");
+    }
+
+    fn inference_line(
+        timestamp: &str,
+        session_id: &str,
+        loop_index: i64,
+        prompt: i64,
+        cached: i64,
+        completion: i64,
+        reasoning: i64,
+    ) -> String {
+        format!(
+            r#"{{"ts":"{timestamp}","sid":"{session_id}","msg":"shell.turn.inference_done","ctx":{{"loop_index":{loop_index},"prompt_tokens":{prompt},"cached_prompt_tokens":{cached},"completion_tokens":{completion},"reasoning_tokens":{reasoning}}}}}"#
+        )
+    }
+
+    #[test]
+    fn prices_grok_46_short_and_long_context_requests() {
+        let short = api_cost_usd("grok-4.6", 150_000, 140_000, 1_000).expect("known model");
+        let long =
+            api_cost_usd("grok-4.6-build", 250_000, 240_000, 1_000).expect("known model alias");
+
+        assert!((short - 0.096).abs() < 1e-12);
+        assert!((long - 0.292).abs() < 1e-12);
+    }
+
+    #[test]
+    fn prices_grok_45_with_its_cache_rates() {
+        let short = api_cost_usd("grok-4.5", 150_000, 140_000, 1_000).expect("known model");
+        let long =
+            api_cost_usd("grok-4.5-build", 250_000, 240_000, 1_000).expect("known model alias");
+
+        assert!((short - 0.068).abs() < 1e-12);
+        assert!((long - 0.196).abs() < 1e-12);
+    }
+
+    #[test]
+    fn parses_completion_without_double_counting_reasoning() {
+        let root = tempdir().expect("temp dir");
+        let sessions_dir = root.path().join("sessions");
+        let source_path = root.path().join("unified.jsonl");
+        let ledger_path = root.path().join("grok-inference.jsonl");
+        write_session_summary(&sessions_dir, "session-1", "grok-4.6");
+        fs::write(
+            &source_path,
+            inference_line(
+                "2026-08-21T05:42:57.046Z",
+                "session-1",
+                1,
+                148_540,
+                148_224,
+                1_356,
+                949,
+            ),
+        )
+        .expect("write source");
+
+        assert_eq!(
+            sync_ledger_at(&source_path, &ledger_path, &sessions_dir).expect("sync ledger"),
+            1
+        );
+        let parsed = parse_ledger_file(&ledger_path, tz(), true);
+        assert_eq!(parsed.errors, 0);
+        assert_eq!(parsed.entries.len(), 1);
+        let entry = &parsed.entries[0];
+        assert_eq!(entry.input_tokens, 316);
+        assert_eq!(entry.cache_read, 148_224);
+        assert_eq!(entry.output_tokens, 407);
+        assert_eq!(entry.reasoning_tokens, 949);
+        assert_eq!(entry.to_stats().total_tokens(), 149_896);
+        assert!((entry.recorded_cost_usd.expect("calculated cost") - 0.082_88).abs() < 1e-12);
+    }
+
+    #[test]
+    fn ledger_deduplicates_and_survives_source_trimming() {
+        let root = tempdir().expect("temp dir");
+        let sessions_dir = root.path().join("sessions");
+        let source_path = root.path().join("unified.jsonl");
+        let ledger_path = root.path().join("grok-inference.jsonl");
+        write_session_summary(&sessions_dir, "session-1", "grok-4.6");
+        let first = inference_line("2026-08-21T05:42:57.046Z", "session-1", 1, 100, 50, 10, 4);
+        let second = inference_line("2026-08-21T05:43:11.682Z", "session-1", 2, 200, 150, 20, 8);
+        fs::write(&source_path, format!("{first}\n{second}\n")).expect("write source");
+
+        assert_eq!(
+            sync_ledger_at(&source_path, &ledger_path, &sessions_dir).expect("first sync"),
+            2
+        );
+        assert_eq!(
+            sync_ledger_at(&source_path, &ledger_path, &sessions_dir).expect("repeat sync"),
+            2
+        );
+
+        fs::write(&source_path, format!("{second}\n")).expect("trim source head");
+        assert_eq!(
+            sync_ledger_at(&source_path, &ledger_path, &sessions_dir).expect("trimmed sync"),
+            2
+        );
+        let parsed = parse_ledger_file(&ledger_path, tz(), true);
+        assert_eq!(parsed.errors, 0);
+        assert_eq!(parsed.entries.len(), 2);
+        assert_eq!(
+            parsed
+                .entries
+                .iter()
+                .map(|entry| entry.input_tokens + entry.cache_read)
+                .sum::<i64>(),
+            300
+        );
+    }
+}

--- a/src/source/grok/unified.rs
+++ b/src/source/grok/unified.rs
@@ -166,15 +166,7 @@ pub(super) fn find_grok_files() -> Vec<PathBuf> {
 
     if source_path.is_file() {
         if let Some(path) = ledger_path.as_deref() {
-            match sync_ledger_at(&source_path, path, &sessions_dir) {
-                Ok(records) if records > 0 => return vec![path.to_path_buf()],
-                Ok(_) => {}
-                Err(error) => {
-                    eprintln!(
-                        "Warning: failed to persist Grok inference log; reading the live log only: {error}"
-                    );
-                }
-            }
+            return vec![sync_or_select_grok_file(&source_path, path, &sessions_dir)];
         }
         return vec![source_path];
     }
@@ -186,6 +178,29 @@ pub(super) fn find_grok_files() -> Vec<PathBuf> {
     }
 
     super::parser::find_grok_files()
+}
+
+fn sync_or_select_grok_file(
+    source_path: &Path,
+    ledger_path: &Path,
+    sessions_dir: &Path,
+) -> PathBuf {
+    match sync_ledger_at(source_path, ledger_path, sessions_dir) {
+        Ok(records) if records > 0 => ledger_path.to_path_buf(),
+        Ok(_) => source_path.to_path_buf(),
+        Err(error) if ledger_path.is_file() => {
+            eprintln!(
+                "Warning: failed to ingest the latest Grok inference log; using the last persisted ledger: {error}"
+            );
+            ledger_path.to_path_buf()
+        }
+        Err(error) => {
+            eprintln!(
+                "Warning: failed to persist Grok inference log; reading the live log only: {error}"
+            );
+            source_path.to_path_buf()
+        }
+    }
 }
 
 pub(super) fn parse_grok_file_with_debug(
@@ -640,6 +655,40 @@ mod tests {
                 .map(|entry| entry.input_tokens + entry.cache_read)
                 .sum::<i64>(),
             300
+        );
+    }
+
+    #[test]
+    fn malformed_live_tail_keeps_last_persisted_ledger_visible() {
+        let root = tempdir().expect("temp dir");
+        let sessions_dir = root.path().join("sessions");
+        let source_path = root.path().join("unified.jsonl");
+        let ledger_path = root.path().join("grok-inference.jsonl");
+        write_session_summary(&sessions_dir, "session-1", "grok-4.6");
+        fs::write(
+            &source_path,
+            inference_line("2026-08-21T05:42:57.046Z", "session-1", 1, 100, 50, 10, 4),
+        )
+        .expect("write initial source");
+        assert_eq!(
+            sync_ledger_at(&source_path, &ledger_path, &sessions_dir).expect("initial sync"),
+            1
+        );
+
+        fs::write(
+            &source_path,
+            r#"{"msg":"shell.turn.inference_done","ctx":{"prompt_tokens":200"#,
+        )
+        .expect("write partial live record");
+
+        let selected = sync_or_select_grok_file(&source_path, &ledger_path, &sessions_dir);
+        assert_eq!(selected, ledger_path);
+        let parsed = parse_ledger_file(&selected, tz(), true);
+        assert_eq!(parsed.errors, 0);
+        assert_eq!(parsed.entries.len(), 1);
+        assert_eq!(
+            parsed.entries[0].input_tokens + parsed.entries[0].cache_read,
+            100
         );
     }
 }


### PR DESCRIPTION
## Summary

- read Grok `shell.turn.inference_done` token records instead of treating `costUsdTicks` as the Grok Build weekly dollar allowance
- calculate Grok 4.5/4.6 cost per inference with cache pricing and the 200k whole-request tier
- persist observed inference records in an atomic, deduplicated ledger so Grok head trimming does not erase already ingested history
- keep the existing `ccstats grok` command and Cost output

Fixes #105

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --offline --all-targets -- -D warnings`
- `cargo test --offline` (555 unit tests plus all integration tests)
- local fixture/live-log check: Mac `$242.474616`, remote snapshot `$247.482614`, combined `$489.957230`

## Boundary

The durable ledger cannot recover inference records Grok trimmed before ccstats first observed them.