### PR TITLE
Expose Codex weekly quota through the Rust SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Expose provider-authoritative Codex weekly quota reports through the Rust SDK with typed data and errors.
+
 ### Changed
 - Calculate Grok 4.5 and 4.6 USD cost from per-inference `unified.jsonl` token records, including prompt-cache rates and the 200k-token whole-request pricing tier, instead of using `turn_completed.costUsdTicks` as the Grok Build weekly-allowance value.
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,22 @@ println!("today: ${:.2}", summary.cost_usd.unwrap_or(0.0));
 
 The SDK uses the same source registry, parsers, aggregation logic, pricing cache, and fallback pricing as the CLI. Use `summarize_cost_with_cli_config` when SDK output should follow the same persisted CLI defaults for timezone, offline pricing, strict pricing, and currency. Use `summarize_cost` when the caller wants fully explicit options. Returned summaries include total tokens, cache read/create tokens, cache hit rate, reasoning tokens, per-model breakdowns, `cost_usd`, and an optional converted `cost` when `SummaryOptions::currency` is set.
 
+Codex weekly quota pace is also available as structured SDK data without
+spawning the CLI:
+
+```rust
+use ccstats::load_codex_weekly_quota;
+
+let quota = load_codex_weekly_quota(None)?;
+println!("weekly used: {:.1}%", quota.used_pct);
+println!("projected at reset: {:.1}%", quota.projected_pct_at_reset);
+```
+
+Pass `Some(codex_home)` to read an explicit Codex home without modifying
+process environment variables. The explicit path is authoritative and never
+falls back to `CODEX_HOME` or `~/.codex`. Missing, stale, malformed, and
+unreadable snapshots return typed `CodexQuotaError` values.
+
 Apps that need several windows at once can use the batch API so source logs,
 pricing, and currency are loaded once for the request:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,8 @@
 //! Claude Code, `OpenAI` Codex, Cursor, Grok, and Kimi Code session logs.
 //!
 //! The public SDK entry points are [`summarize_cost`] and
-//! [`summarize_cost_ranges`] for explicit options, plus
+//! [`summarize_cost_ranges`] for cost analytics, [`load_codex_weekly_quota`]
+//! for provider-authoritative Codex quota pace, plus
 //! [`summarize_cost_with_cli_config`] and
 //! [`summarize_cost_ranges_with_cli_config`] for CLI-aligned config defaults.
 //! The binary target calls [`run_cli`] to preserve the existing command-line
@@ -32,8 +33,9 @@ mod sources_cmd;
 mod utils;
 
 pub use sdk::{
-    CostSummary, ModelCostSummary, MultiCostSummary, MultiSummaryOptions, SdkError, SummaryOptions,
-    TokenBreakdown, UsageRange, UsageSource, summarize_cost, summarize_cost_ranges,
+    CodexQuotaError, CodexQuotaStatus, CodexWeeklyQuota, CostSummary, ModelCostSummary,
+    MultiCostSummary, MultiSummaryOptions, SdkError, SummaryOptions, TokenBreakdown, UsageRange,
+    UsageSource, load_codex_weekly_quota, summarize_cost, summarize_cost_ranges,
     summarize_cost_ranges_with_cli_config, summarize_cost_with_cli_config,
 };
 

--- a/src/output/quota.rs
+++ b/src/output/quota.rs
@@ -1,7 +1,7 @@
 use comfy_table::{Cell, Color};
 use serde_json::json;
 
-use crate::source::{CodexQuotaReport, QuotaStatus};
+use crate::source::{CodexQuotaStatus, CodexWeeklyQuota};
 use crate::utils::Timezone;
 
 use super::format::{create_styled_table, header_cell, right_cell, styled_cell};
@@ -14,14 +14,14 @@ fn timestamp(value: chrono::DateTime<chrono::Utc>) -> String {
     value.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
 }
 
-pub(crate) fn output_quota_json(report: &CodexQuotaReport) -> String {
+pub(crate) fn output_quota_json(report: &CodexWeeklyQuota) -> String {
     json!({
         "source": "codex",
         "window": "weekly",
         "window_minutes": report.window_minutes,
         "used_pct": rounded_pct(report.used_pct),
         "remaining_pct": rounded_pct(report.remaining_pct),
-        "projected_pct_at_reset": rounded_pct(report.projected_pct),
+        "projected_pct_at_reset": rounded_pct(report.projected_pct_at_reset),
         "status": report.status.as_str(),
         "observed_at": timestamp(report.observed_at),
         "resets_at": timestamp(report.resets_at),
@@ -30,7 +30,7 @@ pub(crate) fn output_quota_json(report: &CodexQuotaReport) -> String {
     .to_string()
 }
 
-pub(crate) fn output_quota_csv(report: &CodexQuotaReport) -> String {
+pub(crate) fn output_quota_csv(report: &CodexWeeklyQuota) -> String {
     let depletion = report
         .estimated_depletion_at
         .map(timestamp)
@@ -41,7 +41,7 @@ codex,weekly,{},{:.2},{:.2},{:.2},{},{},{},{}\n",
         report.window_minutes,
         report.used_pct,
         report.remaining_pct,
-        report.projected_pct,
+        report.projected_pct_at_reset,
         report.status.as_str(),
         timestamp(report.observed_at),
         timestamp(report.resets_at),
@@ -49,7 +49,7 @@ codex,weekly,{},{:.2},{:.2},{:.2},{},{},{},{}\n",
     )
 }
 
-pub(crate) fn print_quota_table(report: &CodexQuotaReport, timezone: Timezone, use_color: bool) {
+pub(crate) fn print_quota_table(report: &CodexWeeklyQuota, timezone: Timezone, use_color: bool) {
     let mut table = create_styled_table();
     table.set_header(vec![
         header_cell("Window", use_color),
@@ -63,9 +63,9 @@ pub(crate) fn print_quota_table(report: &CodexQuotaReport, timezone: Timezone, u
 
     let status_color = if use_color {
         match report.status {
-            QuotaStatus::OnTrack => Some(Color::Green),
-            QuotaStatus::Watch => Some(Color::Yellow),
-            QuotaStatus::LikelyExhausted | QuotaStatus::Exhausted => Some(Color::Red),
+            CodexQuotaStatus::OnTrack => Some(Color::Green),
+            CodexQuotaStatus::Watch => Some(Color::Yellow),
+            CodexQuotaStatus::LikelyExhausted | CodexQuotaStatus::Exhausted => Some(Color::Red),
         }
     } else {
         None
@@ -85,7 +85,7 @@ pub(crate) fn print_quota_table(report: &CodexQuotaReport, timezone: Timezone, u
         right_cell(&format!("{:.1}%", report.used_pct), status_color, false),
         right_cell(&format!("{:.1}%", report.remaining_pct), None, false),
         right_cell(
-            &format!("{:.1}%", report.projected_pct),
+            &format!("{:.1}%", report.projected_pct_at_reset),
             status_color,
             false,
         ),
@@ -113,16 +113,16 @@ mod tests {
     use chrono::DateTime;
 
     use super::*;
-    fn report() -> CodexQuotaReport {
-        CodexQuotaReport {
+    fn report() -> CodexWeeklyQuota {
+        CodexWeeklyQuota {
             observed_at: "2026-08-22T00:00:00Z".parse::<DateTime<_>>().unwrap(),
             resets_at: "2026-08-28T00:00:00Z".parse::<DateTime<_>>().unwrap(),
             estimated_depletion_at: Some("2026-08-25T00:00:00Z".parse::<DateTime<_>>().unwrap()),
             window_minutes: 10_080,
             used_pct: 25.0,
             remaining_pct: 75.0,
-            projected_pct: 175.0,
-            status: QuotaStatus::LikelyExhausted,
+            projected_pct_at_reset: 175.0,
+            status: CodexQuotaStatus::LikelyExhausted,
         }
     }
 

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -4,6 +4,7 @@ mod batch;
 
 use std::cmp::Ordering;
 use std::collections::HashMap;
+use std::path::Path;
 use std::str::FromStr;
 
 use chrono::{Datelike, Days, NaiveDate, Utc};
@@ -16,8 +17,10 @@ use crate::pricing::{
     CurrencyConverter, PricingDb, calculate_cost, calculate_estimated_proxy_cost, model_cost_kind,
     sum_estimated_proxy_model_costs, sum_model_costs,
 };
-use crate::source::{Source, get_source, load_daily};
+use crate::source::{Source, get_source, load_daily, load_weekly_quota_from_home};
 use crate::utils::Timezone;
+
+pub use crate::source::{CodexQuotaError, CodexQuotaStatus, CodexWeeklyQuota};
 
 pub use batch::{
     MultiCostSummary, MultiSummaryOptions, summarize_cost_ranges,
@@ -233,6 +236,23 @@ pub enum SdkError {
 
     #[error("{0}")]
     Configuration(String),
+}
+
+/// Load the newest provider-authoritative Codex weekly quota snapshot.
+///
+/// Pass an explicit Codex home to avoid process-global environment discovery.
+/// The home must contain a `sessions` directory and is never replaced by a
+/// fallback path. Passing `None` honors `CODEX_HOME` before `~/.codex`.
+///
+/// # Errors
+///
+/// Returns an error when the sessions directory or a usable weekly snapshot
+/// cannot be found, a session file cannot be inspected or read, or the newest
+/// snapshot is stale or malformed.
+pub fn load_codex_weekly_quota(
+    codex_home: Option<&Path>,
+) -> Result<CodexWeeklyQuota, CodexQuotaError> {
+    load_weekly_quota_from_home(codex_home)
 }
 
 /// Summarize local token usage and estimated cost.

--- a/src/source/codex/mod.rs
+++ b/src/source/codex/mod.rs
@@ -8,4 +8,5 @@ mod parser;
 mod quota;
 
 pub(crate) use config::{CodexScope, CodexSource};
-pub(crate) use quota::{CodexQuotaReport, QuotaStatus, load_weekly_quota};
+pub use quota::{CodexQuotaError, CodexQuotaStatus, CodexWeeklyQuota};
+pub(crate) use quota::{load_weekly_quota, load_weekly_quota_from_home};

--- a/src/source/codex/parser.rs
+++ b/src/source/codex/parser.rs
@@ -159,24 +159,25 @@ impl UsageTotals {
 // File discovery
 // ============================================================================
 
-fn get_codex_sessions_dir() -> Option<PathBuf> {
+pub(super) fn codex_sessions_dir_candidate() -> Option<PathBuf> {
     // An explicit CODEX_HOME is authoritative, even when it is invalid.
     if let Some(codex_home) = env::var_os(CODEX_HOME_ENV) {
-        let path = PathBuf::from(codex_home).join(SESSION_SUBDIR);
-        return path.is_dir().then_some(path);
+        return Some(PathBuf::from(codex_home).join(SESSION_SUBDIR));
     }
 
     // Fall back to ~/.codex/sessions
     let home = dirs::home_dir()?;
-    let path = home.join(DEFAULT_CODEX_DIR).join(SESSION_SUBDIR);
-    if path.is_dir() { Some(path) } else { None }
+    Some(home.join(DEFAULT_CODEX_DIR).join(SESSION_SUBDIR))
+}
+
+fn get_codex_sessions_dir() -> Option<PathBuf> {
+    codex_sessions_dir_candidate().filter(|path| path.is_dir())
 }
 
 pub(super) fn find_codex_files() -> Vec<PathBuf> {
     let Some(sessions_dir) = get_codex_sessions_dir() else {
         return Vec::new();
     };
-
     let mut files = Vec::new();
     if let Ok(entries) = glob::glob(&format!("{}/**/*.jsonl", sessions_dir.display())) {
         for entry in entries.flatten() {

--- a/src/source/codex/quota.rs
+++ b/src/source/codex/quota.rs
@@ -4,30 +4,37 @@
 //! module reads the newest 10,080-minute window and projects its current pace;
 //! token totals are deliberately not used as a quota proxy.
 
-use std::fs::File;
+use std::ffi::OsStr;
+use std::fs::{self, File};
 use std::io::{self, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Duration, NaiveDate, Utc};
-use serde::Deserialize;
+use serde::de::Error as _;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
-use super::parser::find_codex_files;
+use super::parser::codex_sessions_dir_candidate;
 
 const WEEKLY_WINDOW_MINUTES: i64 = 7 * 24 * 60;
 const DISCOVERY_MARGIN_MINUTES: i64 = 24 * 60;
 const MAX_CLOCK_SKEW_SECONDS: i64 = 5 * 60;
 const REVERSE_READ_CHUNK_SIZE: usize = 64 * 1024;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum QuotaStatus {
+/// Projected risk for the current Codex weekly quota window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(rename_all = "snake_case")]
+pub enum CodexQuotaStatus {
     OnTrack,
     Watch,
     LikelyExhausted,
     Exhausted,
 }
 
-impl QuotaStatus {
-    pub(crate) fn as_str(self) -> &'static str {
+impl CodexQuotaStatus {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
         match self {
             Self::OnTrack => "on_track",
             Self::Watch => "watch",
@@ -37,16 +44,58 @@ impl QuotaStatus {
     }
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct CodexQuotaReport {
-    pub(crate) observed_at: DateTime<Utc>,
-    pub(crate) resets_at: DateTime<Utc>,
-    pub(crate) estimated_depletion_at: Option<DateTime<Utc>>,
-    pub(crate) window_minutes: i64,
-    pub(crate) used_pct: f64,
-    pub(crate) remaining_pct: f64,
-    pub(crate) projected_pct: f64,
-    pub(crate) status: QuotaStatus,
+/// Provider-authoritative Codex weekly quota usage with a pace projection.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct CodexWeeklyQuota {
+    pub observed_at: DateTime<Utc>,
+    pub resets_at: DateTime<Utc>,
+    pub estimated_depletion_at: Option<DateTime<Utc>>,
+    pub window_minutes: i64,
+    pub used_pct: f64,
+    pub remaining_pct: f64,
+    pub projected_pct_at_reset: f64,
+    pub status: CodexQuotaStatus,
+}
+
+/// Errors returned while discovering or reading a Codex weekly quota snapshot.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum CodexQuotaError {
+    #[error("Codex sessions directory was not found at {}", path.display())]
+    SessionsDirectoryNotFound { path: PathBuf },
+
+    #[error(
+        "no Codex weekly quota snapshot was found. Start a Codex CLI session to refresh rate-limit data."
+    )]
+    SnapshotNotFound,
+
+    #[error("failed to {action} Codex session {}: {source}", path.display())]
+    SessionFile {
+        action: &'static str,
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+
+    #[error("the newest Codex weekly quota snapshot is dated in the future")]
+    SnapshotInFuture,
+
+    #[error(
+        "the newest Codex weekly quota snapshot expired at {reset}. Start a Codex CLI session to refresh it.",
+        reset = resets_at.to_rfc3339()
+    )]
+    SnapshotExpired { resets_at: DateTime<Utc> },
+
+    #[error("the newest Codex weekly quota snapshot has invalid {reason}")]
+    InvalidSnapshotTiming { reason: &'static str },
+
+    #[error("failed to discover Codex sessions under {}: {source}", path.display())]
+    SessionDiscovery {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -55,6 +104,24 @@ struct QuotaSnapshot {
     resets_at: DateTime<Utc>,
     window_minutes: i64,
     used_pct: f64,
+}
+
+#[derive(Debug)]
+enum SnapshotLineError {
+    Incomplete,
+    Invalid(io::Error),
+}
+
+impl SnapshotLineError {
+    fn into_io_error(self) -> io::Error {
+        match self {
+            Self::Incomplete => io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "incomplete trailing Codex session record",
+            ),
+            Self::Invalid(error) => error,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -85,21 +152,103 @@ struct RateLimitWindow {
     resets_at: i64,
 }
 
-pub(crate) fn load_weekly_quota() -> Result<CodexQuotaReport, String> {
-    load_weekly_quota_at(Utc::now())
+pub(crate) fn load_weekly_quota() -> Result<CodexWeeklyQuota, CodexQuotaError> {
+    load_weekly_quota_from_home(None)
 }
 
-fn load_weekly_quota_at(now: DateTime<Utc>) -> Result<CodexQuotaReport, String> {
-    let files = recent_codex_files(find_codex_files(), now)?;
-    let latest = latest_snapshot_in_files(files)?.ok_or_else(|| {
-            "no Codex weekly quota snapshot was found. Start a Codex CLI session to refresh rate-limit data."
-                .to_string()
-        })?;
+pub(crate) fn load_weekly_quota_from_home(
+    codex_home: Option<&Path>,
+) -> Result<CodexWeeklyQuota, CodexQuotaError> {
+    let explicit_home = codex_home.is_some();
+    let sessions_dir = if let Some(codex_home) = codex_home {
+        codex_home.join("sessions")
+    } else {
+        codex_sessions_dir_candidate().ok_or(CodexQuotaError::SnapshotNotFound)?
+    };
+    if let Err(error) = validate_sessions_dir(&sessions_dir) {
+        return match (explicit_home, error) {
+            (false, CodexQuotaError::SessionsDirectoryNotFound { .. }) => {
+                Err(CodexQuotaError::SnapshotNotFound)
+            }
+            (_, error) => Err(error),
+        };
+    }
+    let files = discover_quota_files(&sessions_dir)?;
+    load_weekly_quota_from_files_at(files, Utc::now())
+}
 
+fn validate_sessions_dir(sessions_dir: &Path) -> Result<(), CodexQuotaError> {
+    match fs::symlink_metadata(sessions_dir) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            Err(CodexQuotaError::SessionDiscovery {
+                path: sessions_dir.to_path_buf(),
+                source: io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "Codex sessions directory must not be a symbolic link",
+                ),
+            })
+        }
+        Ok(metadata) if metadata.is_dir() => Ok(()),
+        Ok(_) => Err(CodexQuotaError::SessionsDirectoryNotFound {
+            path: sessions_dir.to_path_buf(),
+        }),
+        Err(source) if source.kind() == io::ErrorKind::NotFound => {
+            Err(CodexQuotaError::SessionsDirectoryNotFound {
+                path: sessions_dir.to_path_buf(),
+            })
+        }
+        Err(source) => Err(CodexQuotaError::SessionDiscovery {
+            path: sessions_dir.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+fn discover_quota_files(sessions_dir: &Path) -> Result<Vec<PathBuf>, CodexQuotaError> {
+    let mut pending = vec![sessions_dir.to_path_buf()];
+    let mut files = Vec::new();
+    while let Some(directory) = pending.pop() {
+        let entries =
+            fs::read_dir(&directory).map_err(|source| CodexQuotaError::SessionDiscovery {
+                path: directory.clone(),
+                source,
+            })?;
+        for entry in entries {
+            let entry = entry.map_err(|source| CodexQuotaError::SessionDiscovery {
+                path: directory.clone(),
+                source,
+            })?;
+            let path = entry.path();
+            let file_type =
+                entry
+                    .file_type()
+                    .map_err(|source| CodexQuotaError::SessionDiscovery {
+                        path: path.clone(),
+                        source,
+                    })?;
+            if file_type.is_dir() {
+                pending.push(path);
+            } else if file_type.is_file() && path.extension() == Some(OsStr::new("jsonl")) {
+                files.push(path);
+            }
+        }
+    }
+    Ok(files)
+}
+
+fn load_weekly_quota_from_files_at(
+    files: Vec<PathBuf>,
+    now: DateTime<Utc>,
+) -> Result<CodexWeeklyQuota, CodexQuotaError> {
+    let files = recent_codex_files(files, now)?;
+    let latest = latest_snapshot_in_files(files)?.ok_or(CodexQuotaError::SnapshotNotFound)?;
     build_report(&latest, now)
 }
 
-fn recent_codex_files(files: Vec<PathBuf>, now: DateTime<Utc>) -> Result<Vec<PathBuf>, String> {
+fn recent_codex_files(
+    files: Vec<PathBuf>,
+    now: DateTime<Utc>,
+) -> Result<Vec<PathBuf>, CodexQuotaError> {
     let cutoff = now - Duration::minutes(WEEKLY_WINDOW_MINUTES + DISCOVERY_MARGIN_MINUTES);
     files
         .into_iter()
@@ -109,10 +258,11 @@ fn recent_codex_files(files: Vec<PathBuf>, now: DateTime<Utc>) -> Result<Vec<Pat
             let modified = match path.metadata().and_then(|metadata| metadata.modified()) {
                 Ok(modified) => DateTime::<Utc>::from(modified),
                 Err(error) => {
-                    return Some(Err(format!(
-                        "failed to inspect Codex session {}: {error}",
-                        path.display()
-                    )));
+                    return Some(Err(CodexQuotaError::SessionFile {
+                        action: "inspect",
+                        path,
+                        source: error,
+                    }));
                 }
             };
             (path_is_recent || modified >= cutoff).then_some(Ok(path))
@@ -140,7 +290,7 @@ fn session_path_date(path: &Path) -> Option<NaiveDate> {
     NaiveDate::from_ymd_opt(year, month, day)
 }
 
-fn latest_snapshot_in_files(files: Vec<PathBuf>) -> Result<Option<QuotaSnapshot>, String> {
+fn latest_snapshot_in_files(files: Vec<PathBuf>) -> Result<Option<QuotaSnapshot>, CodexQuotaError> {
     let mut latest: Option<QuotaSnapshot> = None;
     for path in files {
         if let Some(snapshot) = latest_snapshot_in_file(&path)?
@@ -154,11 +304,17 @@ fn latest_snapshot_in_files(files: Vec<PathBuf>) -> Result<Option<QuotaSnapshot>
     Ok(latest)
 }
 
-fn latest_snapshot_in_file(path: &Path) -> Result<Option<QuotaSnapshot>, String> {
-    let mut file = File::open(path)
-        .map_err(|error| format!("failed to open Codex session {}: {error}", path.display()))?;
-    latest_snapshot_from_seekable(&mut file)
-        .map_err(|error| format!("failed to read Codex session {}: {error}", path.display()))
+fn latest_snapshot_in_file(path: &Path) -> Result<Option<QuotaSnapshot>, CodexQuotaError> {
+    let mut file = File::open(path).map_err(|source| CodexQuotaError::SessionFile {
+        action: "open",
+        path: path.to_path_buf(),
+        source,
+    })?;
+    latest_snapshot_from_seekable(&mut file).map_err(|source| CodexQuotaError::SessionFile {
+        action: "read",
+        path: path.to_path_buf(),
+        source,
+    })
 }
 
 fn latest_snapshot_from_seekable<R: Read + Seek>(
@@ -194,8 +350,9 @@ fn latest_snapshot_from_seekable<R: Read + Seek>(
                 match snapshot_from_bytes(line) {
                     Ok(Some(snapshot)) => return Ok(Some(snapshot)),
                     Ok(None) => {}
-                    Err(_) if trailing_segment && !ends_with_newline => {}
-                    Err(error) => return Err(error),
+                    Err(SnapshotLineError::Incomplete)
+                        if trailing_segment && !ends_with_newline => {}
+                    Err(error) => return Err(error.into_io_error()),
                 }
             }
             trailing_segment = false;
@@ -209,15 +366,26 @@ fn latest_snapshot_from_seekable<R: Read + Seek>(
     }
     match snapshot_from_bytes(&suffix) {
         Ok(snapshot) => Ok(snapshot),
-        Err(_) if trailing_segment && !ends_with_newline => Ok(None),
-        Err(error) => Err(error),
+        Err(SnapshotLineError::Incomplete) if trailing_segment && !ends_with_newline => Ok(None),
+        Err(error) => Err(error.into_io_error()),
     }
 }
 
-fn snapshot_from_bytes(line: &[u8]) -> io::Result<Option<QuotaSnapshot>> {
-    let line = std::str::from_utf8(line)
-        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
-    snapshot_from_line(line).map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+fn snapshot_from_bytes(line: &[u8]) -> Result<Option<QuotaSnapshot>, SnapshotLineError> {
+    let line = std::str::from_utf8(line).map_err(|error| {
+        if error.error_len().is_none() {
+            SnapshotLineError::Incomplete
+        } else {
+            SnapshotLineError::Invalid(io::Error::new(io::ErrorKind::InvalidData, error))
+        }
+    })?;
+    snapshot_from_line(line).map_err(|error| {
+        if error.is_eof() {
+            SnapshotLineError::Incomplete
+        } else {
+            SnapshotLineError::Invalid(io::Error::new(io::ErrorKind::InvalidData, error))
+        }
+    })
 }
 
 fn snapshot_from_line(line: &str) -> serde_json::Result<Option<QuotaSnapshot>> {
@@ -228,12 +396,6 @@ fn snapshot_from_line(line: &str) -> serde_json::Result<Option<QuotaSnapshot>> {
     if entry.entry_type != Some("event_msg") {
         return Ok(None);
     }
-    let Some(observed_at) = entry
-        .timestamp
-        .and_then(|timestamp| timestamp.parse::<DateTime<Utc>>().ok())
-    else {
-        return Ok(None);
-    };
     let Some(payload) = entry.payload else {
         return Ok(None);
     };
@@ -243,25 +405,38 @@ fn snapshot_from_line(line: &str) -> serde_json::Result<Option<QuotaSnapshot>> {
     let Some(limits) = payload.rate_limits else {
         return Ok(None);
     };
-
-    Ok([limits.primary, limits.secondary]
+    let Some(window) = [limits.primary, limits.secondary]
         .into_iter()
         .flatten()
-        .find_map(|window| snapshot_from_window(observed_at, &window)))
+        .find(|window| window.window_minutes == WEEKLY_WINDOW_MINUTES)
+    else {
+        return Ok(None);
+    };
+    let timestamp = entry
+        .timestamp
+        .ok_or_else(|| serde_json::Error::custom("weekly quota snapshot has no timestamp"))?;
+    let observed_at = timestamp.parse::<DateTime<Utc>>().map_err(|error| {
+        serde_json::Error::custom(format!(
+            "weekly quota snapshot has invalid timestamp: {error}"
+        ))
+    })?;
+
+    snapshot_from_window(observed_at, &window).map(Some)
 }
 
 fn snapshot_from_window(
     observed_at: DateTime<Utc>,
     window: &RateLimitWindow,
-) -> Option<QuotaSnapshot> {
-    if window.window_minutes != WEEKLY_WINDOW_MINUTES
-        || !window.used_percent.is_finite()
-        || !(0.0..=100.0).contains(&window.used_percent)
-    {
-        return None;
+) -> serde_json::Result<QuotaSnapshot> {
+    if !window.used_percent.is_finite() || !(0.0..=100.0).contains(&window.used_percent) {
+        return Err(serde_json::Error::custom(
+            "weekly quota snapshot has invalid used percentage",
+        ));
     }
-    let resets_at = DateTime::from_timestamp(window.resets_at, 0)?;
-    Some(QuotaSnapshot {
+    let resets_at = DateTime::from_timestamp(window.resets_at, 0).ok_or_else(|| {
+        serde_json::Error::custom("weekly quota snapshot has invalid reset timestamp")
+    })?;
+    Ok(QuotaSnapshot {
         observed_at,
         resets_at,
         window_minutes: window.window_minutes,
@@ -269,25 +444,29 @@ fn snapshot_from_window(
     })
 }
 
-fn build_report(snapshot: &QuotaSnapshot, now: DateTime<Utc>) -> Result<CodexQuotaReport, String> {
+fn build_report(
+    snapshot: &QuotaSnapshot,
+    now: DateTime<Utc>,
+) -> Result<CodexWeeklyQuota, CodexQuotaError> {
     if snapshot.observed_at > now + Duration::seconds(MAX_CLOCK_SKEW_SECONDS) {
-        return Err("the newest Codex weekly quota snapshot is dated in the future".to_string());
+        return Err(CodexQuotaError::SnapshotInFuture);
     }
     if now >= snapshot.resets_at {
-        return Err(format!(
-            "the newest Codex weekly quota snapshot expired at {}. Start a Codex CLI session to refresh it.",
-            snapshot.resets_at.to_rfc3339()
-        ));
+        return Err(CodexQuotaError::SnapshotExpired {
+            resets_at: snapshot.resets_at,
+        });
     }
 
     let window_start = snapshot.resets_at - Duration::minutes(snapshot.window_minutes);
     let elapsed = snapshot.observed_at - window_start;
     if elapsed <= Duration::zero() || snapshot.observed_at >= snapshot.resets_at {
-        return Err("the newest Codex weekly quota snapshot has invalid window timing".to_string());
+        return Err(CodexQuotaError::InvalidSnapshotTiming {
+            reason: "window timing",
+        });
     }
     let elapsed_seconds = elapsed
         .num_nanoseconds()
-        .ok_or_else(|| "the newest Codex weekly quota snapshot has invalid timing".to_string())?
+        .ok_or(CodexQuotaError::InvalidSnapshotTiming { reason: "timing" })?
         as f64
         / 1_000_000_000.0;
 
@@ -302,23 +481,23 @@ fn build_report(snapshot: &QuotaSnapshot, now: DateTime<Utc>) -> Result<CodexQuo
         window_start + Duration::seconds(seconds_to_limit.round() as i64)
     });
     let status = if snapshot.used_pct >= 100.0 {
-        QuotaStatus::Exhausted
+        CodexQuotaStatus::Exhausted
     } else if projected_pct > 100.0 {
-        QuotaStatus::LikelyExhausted
+        CodexQuotaStatus::LikelyExhausted
     } else if projected_pct >= 90.0 {
-        QuotaStatus::Watch
+        CodexQuotaStatus::Watch
     } else {
-        QuotaStatus::OnTrack
+        CodexQuotaStatus::OnTrack
     };
 
-    Ok(CodexQuotaReport {
+    Ok(CodexWeeklyQuota {
         observed_at: snapshot.observed_at,
         resets_at: snapshot.resets_at,
         estimated_depletion_at,
         window_minutes: snapshot.window_minutes,
         used_pct: snapshot.used_pct,
         remaining_pct: (100.0 - snapshot.used_pct).max(0.0),
-        projected_pct,
+        projected_pct_at_reset: projected_pct,
         status,
     })
 }
@@ -360,16 +539,13 @@ mod tests {
     }
 
     #[test]
-    fn newest_valid_snapshot_wins_and_invalid_windows_are_ignored() {
+    fn malformed_newest_weekly_snapshot_fails_closed() {
         let input = r#"{"timestamp":"2026-08-21T08:00:00Z","type":"event_msg","payload":{"type":"token_count","rate_limits":{"primary":{"used_percent":20.0,"window_minutes":10080,"resets_at":1787801336}}}}
 {"timestamp":"2026-08-21T09:00:00Z","type":"event_msg","payload":{"type":"token_count","rate_limits":{"primary":{"used_percent":30.0,"window_minutes":10080,"resets_at":1787801336}}}}
 {"timestamp":"2026-08-21T10:00:00Z","type":"event_msg","payload":{"type":"token_count","rate_limits":{"primary":{"used_percent":999.0,"window_minutes":10080,"resets_at":1787801336}}}}"#;
-        let snapshot = latest_snapshot_from_seekable(&mut Cursor::new(input))
-            .unwrap()
-            .unwrap();
+        let error = latest_snapshot_from_seekable(&mut Cursor::new(input)).unwrap_err();
 
-        assert_eq!(snapshot.observed_at, utc("2026-08-21T09:00:00Z"));
-        assert_close(snapshot.used_pct, 30.0);
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
     }
 
     #[test]
@@ -446,6 +622,20 @@ mod tests {
     }
 
     #[test]
+    fn incomplete_trailing_utf8_does_not_hide_latest_complete_snapshot() {
+        let mut input = br#"{"timestamp":"2026-08-21T09:00:00Z","type":"event_msg","payload":{"type":"token_count","rate_limits":{"primary":{"used_percent":30.0,"window_minutes":10080,"resets_at":1787801336}}}}
+"#
+        .to_vec();
+        input.extend_from_slice(&[0xe2, 0x82]);
+
+        let snapshot = latest_snapshot_from_seekable(&mut Cursor::new(input))
+            .unwrap()
+            .unwrap();
+
+        assert_close(snapshot.used_pct, 30.0);
+    }
+
+    #[test]
     fn projection_uses_provider_window_boundaries() {
         let snapshot = QuotaSnapshot {
             observed_at: utc("2026-08-22T00:00:00Z"),
@@ -457,8 +647,8 @@ mod tests {
         let report = build_report(&snapshot, utc("2026-08-22T01:00:00Z")).unwrap();
 
         assert_close(report.remaining_pct, 75.0);
-        assert_close(report.projected_pct, 175.0);
-        assert_eq!(report.status, QuotaStatus::LikelyExhausted);
+        assert_close(report.projected_pct_at_reset, 175.0);
+        assert_eq!(report.status, CodexQuotaStatus::LikelyExhausted);
         assert_eq!(
             report.estimated_depletion_at,
             Some(utc("2026-08-25T00:00:00Z"))
@@ -476,7 +666,11 @@ mod tests {
 
         let error = build_report(&snapshot, utc("2026-08-22T00:00:00Z")).unwrap_err();
 
-        assert!(error.contains("expired"));
+        assert!(matches!(
+            error,
+            CodexQuotaError::SnapshotExpired { resets_at }
+                if resets_at == utc("2026-08-22T00:00:00Z")
+        ));
     }
 
     #[test]
@@ -490,7 +684,7 @@ mod tests {
 
         let error = build_report(&snapshot, utc("2026-08-22T00:00:00Z")).unwrap_err();
 
-        assert!(error.contains("future"));
+        assert!(matches!(error, CodexQuotaError::SnapshotInFuture));
     }
 
     #[test]
@@ -518,7 +712,7 @@ mod tests {
 
         let report = build_report(&snapshot, utc("2026-08-21T00:00:01Z")).unwrap();
 
-        assert_close(report.projected_pct, 0.0);
+        assert_close(report.projected_pct_at_reset, 0.0);
     }
 
     #[test]
@@ -532,8 +726,8 @@ mod tests {
 
         let report = build_report(&snapshot, utc("2026-08-22T01:00:00Z")).unwrap();
 
-        assert_close(report.projected_pct, 0.0);
-        assert_eq!(report.status, QuotaStatus::OnTrack);
+        assert_close(report.projected_pct_at_reset, 0.0);
+        assert_eq!(report.status, CodexQuotaStatus::OnTrack);
         assert_eq!(report.estimated_depletion_at, None);
     }
 }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -113,7 +113,8 @@ pub(crate) trait Source: Send + Sync {
 /// Box type for dynamic dispatch
 pub(crate) type BoxedSource = Box<dyn Source>;
 
-pub(crate) use codex::{CodexQuotaReport, CodexScope, CodexSource, QuotaStatus, load_weekly_quota};
+pub use codex::{CodexQuotaError, CodexQuotaStatus, CodexWeeklyQuota};
+pub(crate) use codex::{CodexScope, CodexSource, load_weekly_quota, load_weekly_quota_from_home};
 
 // Re-export registry functions
 pub(crate) use registry::{ALL_SOURCES, all_sources, get_source, source_choices, suggest_source};

--- a/tests/sdk_integration.rs
+++ b/tests/sdk_integration.rs
@@ -3,12 +3,112 @@ use std::path::Path;
 use std::sync::Mutex;
 
 use ccstats::{
-    CostSummary, MultiSummaryOptions, SummaryOptions, UsageRange, UsageSource, summarize_cost,
-    summarize_cost_ranges,
+    CodexQuotaError, CodexQuotaStatus, CostSummary, MultiSummaryOptions, SummaryOptions,
+    UsageRange, UsageSource, load_codex_weekly_quota, summarize_cost, summarize_cost_ranges,
 };
-use chrono::{Datelike, Days, NaiveDate, Utc};
+use chrono::{Datelike, Days, Duration, NaiveDate, Utc};
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+#[test]
+fn sdk_loads_codex_weekly_quota_from_explicit_home() {
+    let root = tempfile::tempdir().expect("temp dir");
+    let codex_home = root.path().join("isolated-[quota]*-home");
+    let session_file = codex_home.join("sessions").join("quota.jsonl");
+    let now = Utc::now();
+    let observed_at = now - Duration::hours(1);
+    let resets_at = now + Duration::days(6);
+    let event = serde_json::json!({
+        "timestamp": observed_at.to_rfc3339(),
+        "type": "event_msg",
+        "payload": {
+            "type": "token_count",
+            "rate_limits": {
+                "secondary": {
+                    "used_percent": 25.0,
+                    "window_minutes": 10_080,
+                    "resets_at": resets_at.timestamp(),
+                }
+            }
+        }
+    });
+    write_file(&session_file, &format!("{event}\n"));
+
+    let report = load_codex_weekly_quota(Some(&codex_home)).expect("load quota report");
+
+    assert_eq!(report.observed_at, observed_at);
+    assert_eq!(report.resets_at.timestamp(), resets_at.timestamp());
+    assert_eq!(report.window_minutes, 10_080);
+    assert_eq!(report.used_pct, 25.0);
+    assert_eq!(report.remaining_pct, 75.0);
+    assert!(report.projected_pct_at_reset > 100.0);
+    assert_eq!(report.status, CodexQuotaStatus::LikelyExhausted);
+
+    let serialized = serde_json::to_value(&report).expect("serialize quota report");
+    assert_eq!(serialized["status"], "likely_exhausted");
+    assert_eq!(
+        serialized["projected_pct_at_reset"],
+        report.projected_pct_at_reset
+    );
+}
+
+#[test]
+fn sdk_explicit_codex_home_never_falls_back() {
+    let root = tempfile::tempdir().expect("temp dir");
+    let codex_home = root.path().join("missing-codex-home");
+
+    let error = load_codex_weekly_quota(Some(&codex_home)).expect_err("missing sessions dir");
+
+    assert!(matches!(
+        error,
+        CodexQuotaError::SessionsDirectoryNotFound { path }
+            if path == codex_home.join("sessions")
+    ));
+}
+
+#[test]
+fn sdk_codex_weekly_quota_errors_are_typed() {
+    let root = tempfile::tempdir().expect("temp dir");
+    let codex_home = root.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    fs::create_dir_all(&sessions_dir).expect("create sessions dir");
+
+    let missing = load_codex_weekly_quota(Some(&codex_home)).expect_err("missing snapshot");
+    assert!(matches!(missing, CodexQuotaError::SnapshotNotFound));
+
+    let malformed_file = sessions_dir.join("malformed.jsonl");
+    write_file(&malformed_file, "{not json}\n");
+    let malformed = load_codex_weekly_quota(Some(&codex_home)).expect_err("malformed snapshot");
+    assert!(matches!(
+        malformed,
+        CodexQuotaError::SessionFile {
+            action: "read",
+            path,
+            source,
+        } if path == malformed_file && source.kind() == std::io::ErrorKind::InvalidData
+    ));
+}
+
+#[cfg(unix)]
+#[test]
+fn sdk_rejects_symlinked_codex_sessions_root() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempfile::tempdir().expect("temp dir");
+    let codex_home = root.path().join("codex-home");
+    let real_sessions = root.path().join("real-sessions");
+    fs::create_dir_all(&codex_home).expect("create Codex home");
+    fs::create_dir_all(&real_sessions).expect("create real sessions");
+    symlink(&real_sessions, codex_home.join("sessions")).expect("link sessions root");
+
+    let error = load_codex_weekly_quota(Some(&codex_home)).expect_err("reject sessions symlink");
+    assert!(matches!(
+        error,
+        CodexQuotaError::SessionDiscovery { path, source }
+            if path == codex_home.join("sessions")
+                && source.kind() == std::io::ErrorKind::InvalidInput
+    ));
+}
 
 fn write_file(path: &Path, content: &str) {
     if let Some(parent) = path.parent() {


### PR DESCRIPTION
## Summary

- expose `load_codex_weekly_quota` with an optional authoritative Codex home
- add serializable, non-exhaustive `CodexWeeklyQuota` and `CodexQuotaStatus` types
- return structured `CodexQuotaError` variants for discovery, file, stale, and malformed data failures
- keep CLI JSON/CSV/table output on the same shared implementation
- replace quota discovery globbing with fallible path-native traversal that does not follow directory symlinks
- fail closed on complete malformed weekly candidates while tolerating genuinely incomplete JSON/UTF-8 tail writes
- document the SDK entry point and add external integration coverage

Closes #107.

## Validation

- `cargo fmt --check`
- `cargo check --all-targets`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`

## Review

- independent Codex-native API review: no findings after fixes
- Codex CLI review findings fixed: typed fail-closed candidates, path-native fallible discovery, root symlink rejection, partial UTF-8 tail handling, RFC3339 error preservation

## Residual risk

The existing reverse reader can copy very large single-line records quadratically. That behavior already exists on `main` and is unchanged by this SDK exposure.