### PR TITLE
feat: estimate Codex weekly API-equivalent value

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,9 @@ CODEX_HOME="/path/to/.codex" ccstats codex daily
 `ccstats quota` reads the newest server-provided 10,080-minute rate-limit
 snapshot from local Codex session logs. It reports the used and remaining
 percentages, reset time, projected percentage at reset, and an estimated
-depletion time when the current pace would exceed 100%.
+depletion time when the current pace would exceed 100%. It also prices local
+usage from the exact active quota window and divides it by the reported used
+fraction to estimate the full week's API-equivalent USD value and token count.
 
 ```bash
 # Human-readable table
@@ -296,9 +298,10 @@ ccstats quota --json
 ccstats quota --csv
 ```
 
-The projection is a linear pace estimate, not an exact token allowance. Codex
-usage depends on model choice, context, reasoning, tools, retrieval, and cache
-behavior. If no current weekly snapshot exists, the command exits with an error
+The dollar and token figures are approximations, not official provider
+allowances. They vary with the current model and cache mix; token totals are
+only comparable while that mix stays similar. Use `--no-cost` to omit the value
+estimate. If no current weekly snapshot exists, the command exits with an error
 instead of estimating quota from token totals.
 
 ### Cursor

--- a/README.md
+++ b/README.md
@@ -300,9 +300,12 @@ ccstats quota --csv
 
 The dollar and token figures are approximations, not official provider
 allowances. They vary with the current model and cache mix; token totals are
-only comparable while that mix stays similar. Use `--no-cost` to omit the value
-estimate. If no current weekly snapshot exists, the command exits with an error
-instead of estimating quota from token totals.
+only comparable while that mix stays similar. Dollar values use ccstats' current
+model price resolution; request-level pricing tiers may not be represented. Use
+`--no-cost` to omit the value estimate. Quota estimates are reported in USD, so
+an explicit non-USD `--currency` is rejected. If no current weekly snapshot
+exists, the command exits with an error instead of estimating quota from token
+totals.
 
 ### Cursor
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,6 +260,22 @@ fn validate_codex_scope(scope: CodexScope, source_name: &str) {
     }
 }
 
+fn validate_quota_currency(cli: &Cli, source_cmd: SourceCommand, currency_was_set: bool) {
+    if source_cmd == SourceCommand::Quota
+        && cli.show_cost()
+        && currency_was_set
+        && cli
+            .currency
+            .as_deref()
+            .is_some_and(|currency| !currency.eq_ignore_ascii_case("USD"))
+    {
+        eprintln!(
+            "Error: --currency is not supported for quota estimates; API-equivalent value is reported in USD"
+        );
+        std::process::exit(1);
+    }
+}
+
 fn dispatch_command(source_name: &str, source_cmd: SourceCommand, context: &CommandContext<'_>) {
     if source_name.eq_ignore_ascii_case(ALL_SOURCES) {
         return handle_all_sources_command(source_cmd, context);
@@ -286,12 +302,14 @@ fn dispatch_command(source_name: &str, source_cmd: SourceCommand, context: &Comm
 pub fn run_cli() {
     let raw_cli = Cli::parse();
     let cli_timezone_was_set = raw_cli.timezone.is_some();
+    let cli_currency_was_set = raw_cli.currency.is_some();
     let parsed_command = parse_command(raw_cli.command.as_ref());
     let source_cmd = parsed_command.command;
     let is_statusline = source_cmd.is_statusline();
 
     let config = load_config(is_statusline);
     let cli = raw_cli.with_config(&config);
+    validate_quota_currency(&cli, source_cmd, cli_currency_was_set);
     let timezone = resolve_timezone(cli.timezone.as_deref(), cli_timezone_was_set);
     let number_format = resolve_number_format(cli.locale.as_deref());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,8 @@
 //!
 //! The public SDK entry points are [`summarize_cost`] and
 //! [`summarize_cost_ranges`] for cost analytics, [`load_codex_weekly_quota`]
-//! for provider-authoritative Codex quota pace, plus
+//! for provider-authoritative Codex quota pace,
+//! [`estimate_codex_weekly_value`] for an API-equivalent weekly estimate, plus
 //! [`summarize_cost_with_cli_config`] and
 //! [`summarize_cost_ranges_with_cli_config`] for CLI-aligned config defaults.
 //! The binary target calls [`run_cli`] to preserve the existing command-line
@@ -33,9 +34,10 @@ mod sources_cmd;
 mod utils;
 
 pub use sdk::{
-    CodexQuotaError, CodexQuotaStatus, CodexWeeklyQuota, CostSummary, ModelCostSummary,
-    MultiCostSummary, MultiSummaryOptions, SdkError, SummaryOptions, TokenBreakdown, UsageRange,
-    UsageSource, load_codex_weekly_quota, summarize_cost, summarize_cost_ranges,
+    CodexQuotaError, CodexQuotaStatus, CodexWeeklyQuota, CodexWeeklyValueError,
+    CodexWeeklyValueEstimate, CostSummary, ModelCostSummary, MultiCostSummary, MultiSummaryOptions,
+    SdkError, SummaryOptions, TokenBreakdown, UsageRange, UsageSource, estimate_codex_weekly_value,
+    load_codex_weekly_quota, summarize_cost, summarize_cost_ranges,
     summarize_cost_ranges_with_cli_config, summarize_cost_with_cli_config,
 };
 
@@ -303,7 +305,7 @@ pub fn run_cli() {
     let budget_as_of = until.map_or(today, |end| end.min(today));
     let filter = build_date_filter(source_cmd, today, since, until);
     let show_cost = cli.show_cost();
-    let needs_pricing = source_cmd != SourceCommand::Quota && (is_statusline || show_cost);
+    let needs_pricing = is_statusline || show_cost;
     let pricing_db = load_pricing_db(&cli, needs_pricing, is_statusline);
     let source_name = resolve_source_name(
         parsed_command.source_hint,
@@ -311,7 +313,8 @@ pub fn run_cli() {
         source_cmd,
     );
     validate_codex_scope(cli.codex_scope, source_name);
-    let currency_converter = load_currency_converter(&cli, needs_pricing, is_statusline);
+    let needs_currency = source_cmd != SourceCommand::Quota && needs_pricing;
+    let currency_converter = load_currency_converter(&cli, needs_currency, is_statusline);
 
     dispatch_command(
         source_name,

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -41,7 +41,9 @@ pub(crate) use format::NumberFormat;
 pub(crate) use json::output_period_json_with_quality;
 pub(crate) use period::Period;
 pub(crate) use project::{ProjectTableOptions, output_project_json, print_project_table};
-pub(crate) use quota::{output_quota_csv, output_quota_json, print_quota_table};
+pub(crate) use quota::{
+    QuotaValueEstimate, output_quota_csv, output_quota_json, print_quota_table,
+};
 pub(crate) use session::{SessionTableOptions, output_session_json, print_session_table};
 pub(crate) use statusline::{print_statusline, print_statusline_json_with_quality};
 pub(crate) use table::{PeriodSummaryFooter, TokenTableOptions, print_period_table};

--- a/src/output/quota.rs
+++ b/src/output/quota.rs
@@ -81,9 +81,23 @@ pub(crate) fn output_quota_csv(
         .estimated_depletion_at
         .map(timestamp)
         .unwrap_or_default();
+    let Some(value_estimate) = value_estimate else {
+        return format!(
+            "source,window,window_minutes,used_pct,remaining_pct,projected_pct_at_reset,status,observed_at,resets_at,estimated_depletion_at\n\
+codex,weekly,{},{:.2},{:.2},{:.2},{},{},{},{}\n",
+            report.window_minutes,
+            report.used_pct,
+            report.remaining_pct,
+            report.projected_pct_at_reset,
+            report.status.as_str(),
+            timestamp(report.observed_at),
+            timestamp(report.resets_at),
+            depletion,
+        );
+    };
     let (observed_cost, weekly_value, observed_tokens, weekly_tokens, window_start, error) =
         match value_estimate {
-            Some(Ok(estimate)) => (
+            Ok(estimate) => (
                 format!("{:.6}", estimate.observed_cost_usd),
                 format!("{:.6}", estimate.estimated_weekly_value_usd),
                 estimate.observed_tokens.to_string(),
@@ -91,21 +105,13 @@ pub(crate) fn output_quota_csv(
                 timestamp(estimate.window_started_at),
                 String::new(),
             ),
-            Some(Err(error)) => (
+            Err(error) => (
                 String::new(),
                 String::new(),
                 String::new(),
                 String::new(),
                 String::new(),
                 csv_field(&error.to_string()),
-            ),
-            None => (
-                String::new(),
-                String::new(),
-                String::new(),
-                String::new(),
-                String::new(),
-                String::new(),
             ),
         };
     format!(

--- a/src/output/quota.rs
+++ b/src/output/quota.rs
@@ -1,21 +1,34 @@
 use comfy_table::{Cell, Color};
 use serde_json::json;
 
+use crate::sdk::{CodexWeeklyValueError, CodexWeeklyValueEstimate};
 use crate::source::{CodexQuotaStatus, CodexWeeklyQuota};
 use crate::utils::Timezone;
 
-use super::format::{create_styled_table, header_cell, right_cell, styled_cell};
+use super::format::{
+    NumberFormat, create_styled_table, format_compact, header_cell, right_cell, styled_cell,
+};
 
 fn rounded_pct(value: f64) -> f64 {
     (value * 100.0).round() / 100.0
+}
+
+fn rounded_cost(value: f64) -> f64 {
+    (value * 1_000_000.0).round() / 1_000_000.0
 }
 
 fn timestamp(value: chrono::DateTime<chrono::Utc>) -> String {
     value.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
 }
 
-pub(crate) fn output_quota_json(report: &CodexWeeklyQuota) -> String {
-    json!({
+pub(crate) type QuotaValueEstimate<'a> =
+    Option<Result<&'a CodexWeeklyValueEstimate, &'a CodexWeeklyValueError>>;
+
+pub(crate) fn output_quota_json(
+    report: &CodexWeeklyQuota,
+    value_estimate: QuotaValueEstimate<'_>,
+) -> String {
+    let mut output = json!({
         "source": "codex",
         "window": "weekly",
         "window_minutes": report.window_minutes,
@@ -26,18 +39,78 @@ pub(crate) fn output_quota_json(report: &CodexWeeklyQuota) -> String {
         "observed_at": timestamp(report.observed_at),
         "resets_at": timestamp(report.resets_at),
         "estimated_depletion_at": report.estimated_depletion_at.map(timestamp),
-    })
-    .to_string()
+    });
+
+    match value_estimate {
+        Some(Ok(estimate)) => {
+            output["value_estimate"] = json!({
+                "kind": "api_equivalent",
+                "observed_cost_usd": rounded_cost(estimate.observed_cost_usd),
+                "estimated_weekly_value_usd": rounded_cost(estimate.estimated_weekly_value_usd),
+                "observed_tokens": estimate.observed_tokens,
+                "estimated_weekly_tokens": estimate.estimated_weekly_tokens.round(),
+                "window_started_at": timestamp(estimate.window_started_at),
+                "valid_entries": estimate.valid_entries,
+                "dedup_skipped_entries": estimate.dedup_skipped_entries,
+            });
+            output["value_estimate_error"] = serde_json::Value::Null;
+        }
+        Some(Err(error)) => {
+            output["value_estimate"] = serde_json::Value::Null;
+            output["value_estimate_error"] = json!(error.to_string());
+        }
+        None => {}
+    }
+
+    output.to_string()
 }
 
-pub(crate) fn output_quota_csv(report: &CodexWeeklyQuota) -> String {
+fn csv_field(value: &str) -> String {
+    if value.contains([',', '"', '\n', '\r']) {
+        format!("\"{}\"", value.replace('"', "\"\""))
+    } else {
+        value.to_string()
+    }
+}
+
+pub(crate) fn output_quota_csv(
+    report: &CodexWeeklyQuota,
+    value_estimate: QuotaValueEstimate<'_>,
+) -> String {
     let depletion = report
         .estimated_depletion_at
         .map(timestamp)
         .unwrap_or_default();
+    let (observed_cost, weekly_value, observed_tokens, weekly_tokens, window_start, error) =
+        match value_estimate {
+            Some(Ok(estimate)) => (
+                format!("{:.6}", estimate.observed_cost_usd),
+                format!("{:.6}", estimate.estimated_weekly_value_usd),
+                estimate.observed_tokens.to_string(),
+                format!("{:.0}", estimate.estimated_weekly_tokens),
+                timestamp(estimate.window_started_at),
+                String::new(),
+            ),
+            Some(Err(error)) => (
+                String::new(),
+                String::new(),
+                String::new(),
+                String::new(),
+                String::new(),
+                csv_field(&error.to_string()),
+            ),
+            None => (
+                String::new(),
+                String::new(),
+                String::new(),
+                String::new(),
+                String::new(),
+                String::new(),
+            ),
+        };
     format!(
-        "source,window,window_minutes,used_pct,remaining_pct,projected_pct_at_reset,status,observed_at,resets_at,estimated_depletion_at\n\
-codex,weekly,{},{:.2},{:.2},{:.2},{},{},{},{}\n",
+        "source,window,window_minutes,used_pct,remaining_pct,projected_pct_at_reset,status,observed_at,resets_at,estimated_depletion_at,observed_cost_usd,estimated_weekly_value_usd,observed_tokens,estimated_weekly_tokens,value_window_started_at,value_estimate_error\n\
+codex,weekly,{},{:.2},{:.2},{:.2},{},{},{},{},{},{},{},{},{},{}\n",
         report.window_minutes,
         report.used_pct,
         report.remaining_pct,
@@ -46,10 +119,22 @@ codex,weekly,{},{:.2},{:.2},{:.2},{},{},{},{}\n",
         timestamp(report.observed_at),
         timestamp(report.resets_at),
         depletion,
+        observed_cost,
+        weekly_value,
+        observed_tokens,
+        weekly_tokens,
+        window_start,
+        error,
     )
 }
 
-pub(crate) fn print_quota_table(report: &CodexWeeklyQuota, timezone: Timezone, use_color: bool) {
+pub(crate) fn print_quota_table(
+    report: &CodexWeeklyQuota,
+    value_estimate: QuotaValueEstimate<'_>,
+    timezone: Timezone,
+    number_format: NumberFormat,
+    use_color: bool,
+) {
     let mut table = create_styled_table();
     table.set_header(vec![
         header_cell("Window", use_color),
@@ -106,6 +191,33 @@ pub(crate) fn print_quota_table(report: &CodexWeeklyQuota, timezone: Timezone, u
             .to_fixed_offset(report.observed_at)
             .format("%Y-%m-%d %H:%M:%S %:z")
     );
+    match value_estimate {
+        Some(Ok(estimate)) => {
+            println!(
+                "API-equivalent weekly value: ≈${:.2} (observed ${:.2} at {:.1}% used)",
+                estimate.estimated_weekly_value_usd, estimate.observed_cost_usd, estimate.used_pct,
+            );
+            println!(
+                "Estimated weekly tokens at the current model/cache mix: ≈{} (observed {})",
+                format_compact(
+                    estimate.estimated_weekly_tokens.round() as i64,
+                    number_format
+                ),
+                format_compact(estimate.observed_tokens, number_format),
+            );
+            println!(
+                "Value window: {} to the quota observation above.",
+                timezone
+                    .to_fixed_offset(estimate.window_started_at)
+                    .format("%Y-%m-%d %H:%M:%S %:z")
+            );
+            println!(
+                "Dollar and token values are local API-pricing estimates, not official provider allowances."
+            );
+        }
+        Some(Err(error)) => println!("API-equivalent weekly value unavailable: {error}"),
+        None => {}
+    }
 }
 
 #[cfg(test)]
@@ -126,33 +238,72 @@ mod tests {
         }
     }
 
+    fn value_estimate() -> CodexWeeklyValueEstimate {
+        CodexWeeklyValueEstimate {
+            observed_at: "2026-08-22T00:00:00Z".parse::<DateTime<_>>().unwrap(),
+            window_started_at: "2026-08-21T00:00:00Z".parse::<DateTime<_>>().unwrap(),
+            resets_at: "2026-08-28T00:00:00Z".parse::<DateTime<_>>().unwrap(),
+            used_pct: 25.0,
+            observed_cost_usd: 50.0,
+            estimated_weekly_value_usd: 200.0,
+            observed_tokens: 1_000_000,
+            estimated_weekly_tokens: 4_000_000.0,
+            valid_entries: 12,
+            dedup_skipped_entries: 2,
+        }
+    }
+
     #[test]
     fn json_contains_machine_readable_quota_fields() {
-        let value: serde_json::Value = serde_json::from_str(&output_quota_json(&report())).unwrap();
+        let estimate = value_estimate();
+        let value: serde_json::Value =
+            serde_json::from_str(&output_quota_json(&report(), Some(Ok(&estimate)))).unwrap();
 
         assert_eq!(value["window"], "weekly");
         assert_eq!(value["used_pct"], 25.0);
         assert_eq!(value["projected_pct_at_reset"], 175.0);
         assert_eq!(value["status"], "likely_exhausted");
         assert_eq!(value["resets_at"], "2026-08-28T00:00:00Z");
+        assert_eq!(value["value_estimate"]["kind"], "api_equivalent");
+        assert_eq!(value["value_estimate"]["observed_cost_usd"], 50.0);
+        assert_eq!(value["value_estimate"]["estimated_weekly_value_usd"], 200.0);
+        assert_eq!(
+            value["value_estimate"]["estimated_weekly_tokens"],
+            4_000_000.0
+        );
+        assert!(value["value_estimate_error"].is_null());
     }
 
     #[test]
     fn csv_has_stable_header_and_values() {
-        let csv = output_quota_csv(&report());
+        let estimate = value_estimate();
+        let csv = output_quota_csv(&report(), Some(Ok(&estimate)));
         let mut lines = csv.lines();
 
         assert_eq!(
             lines.next(),
             Some(
-                "source,window,window_minutes,used_pct,remaining_pct,projected_pct_at_reset,status,observed_at,resets_at,estimated_depletion_at"
+                "source,window,window_minutes,used_pct,remaining_pct,projected_pct_at_reset,status,observed_at,resets_at,estimated_depletion_at,observed_cost_usd,estimated_weekly_value_usd,observed_tokens,estimated_weekly_tokens,value_window_started_at,value_estimate_error"
             )
         );
+        let values = lines.next().unwrap();
+        assert!(values.starts_with("codex,weekly,10080,25.00,75.00,175.00,likely_exhausted"));
+        assert!(values.contains(",50.000000,200.000000,1000000,4000000,"));
+    }
+
+    #[test]
+    fn json_exposes_value_estimate_error_without_hiding_quota() {
+        let error = CodexWeeklyValueError::ZeroUsagePercentage;
+        let value: serde_json::Value =
+            serde_json::from_str(&output_quota_json(&report(), Some(Err(&error)))).unwrap();
+
+        assert_eq!(value["used_pct"], 25.0);
+        assert!(value["value_estimate"].is_null());
         assert!(
-            lines
-                .next()
+            value["value_estimate_error"]
+                .as_str()
                 .unwrap()
-                .starts_with("codex,weekly,10080,25.00,75.00,175.00,likely_exhausted")
+                .contains("used percentage is zero")
         );
     }
 }

--- a/src/quota_cmd.rs
+++ b/src/quota_cmd.rs
@@ -1,5 +1,8 @@
 use crate::app::{CommandContext, print_json};
-use crate::output::{OutputFormat, output_quota_csv, output_quota_json, print_quota_table};
+use crate::output::{
+    OutputFormat, QuotaValueEstimate, output_quota_csv, output_quota_json, print_quota_table,
+};
+use crate::sdk::estimate_codex_weekly_value_with_pricing;
 use crate::source::load_weekly_quota;
 
 pub(crate) fn handle_quota(ctx: &CommandContext<'_>) {
@@ -10,10 +13,24 @@ pub(crate) fn handle_quota(ctx: &CommandContext<'_>) {
             std::process::exit(1);
         }
     };
+    let value_estimate = ctx
+        .cli
+        .show_cost()
+        .then(|| estimate_codex_weekly_value_with_pricing(&report, None, ctx.pricing_db));
+    let rendered_estimate: QuotaValueEstimate<'_> = value_estimate.as_ref().map(Result::as_ref);
 
     match ctx.cli.output_format() {
-        OutputFormat::Json => print_json(&output_quota_json(&report), ctx.jq_filter),
-        OutputFormat::Csv => print!("{}", output_quota_csv(&report)),
-        OutputFormat::Table => print_quota_table(&report, ctx.timezone, ctx.cli.use_color()),
+        OutputFormat::Json => print_json(
+            &output_quota_json(&report, rendered_estimate),
+            ctx.jq_filter,
+        ),
+        OutputFormat::Csv => print!("{}", output_quota_csv(&report, rendered_estimate)),
+        OutputFormat::Table => print_quota_table(
+            &report,
+            rendered_estimate,
+            ctx.timezone,
+            ctx.number_format,
+            ctx.cli.use_color(),
+        ),
     }
 }

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::str::FromStr;
 
-use chrono::{Datelike, Days, NaiveDate, Utc};
+use chrono::{Datelike, Days, Duration, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -17,7 +17,9 @@ use crate::pricing::{
     CurrencyConverter, PricingDb, calculate_cost, calculate_estimated_proxy_cost, model_cost_kind,
     sum_estimated_proxy_model_costs, sum_model_costs,
 };
-use crate::source::{Source, get_source, load_daily, load_weekly_quota_from_home};
+use crate::source::{
+    Source, get_source, load_daily, load_weekly_quota_from_home, load_weekly_window_usage_from_home,
+};
 use crate::utils::Timezone;
 
 pub use crate::source::{CodexQuotaError, CodexQuotaStatus, CodexWeeklyQuota};
@@ -225,6 +227,49 @@ pub struct CostSummary {
     pub elapsed_ms: f64,
 }
 
+/// API-equivalent value inferred for the active Codex weekly quota window.
+///
+/// This is an approximation based on local token pricing and the current
+/// model/cache mix. It is not an official dollar allowance from the provider.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CodexWeeklyValueEstimate {
+    pub observed_at: chrono::DateTime<Utc>,
+    pub window_started_at: chrono::DateTime<Utc>,
+    pub resets_at: chrono::DateTime<Utc>,
+    pub used_pct: f64,
+    pub observed_cost_usd: f64,
+    pub estimated_weekly_value_usd: f64,
+    pub observed_tokens: i64,
+    pub estimated_weekly_tokens: f64,
+    pub valid_entries: i64,
+    pub dedup_skipped_entries: i64,
+}
+
+/// Errors returned while estimating Codex weekly API-equivalent value.
+#[derive(Debug, Error)]
+pub enum CodexWeeklyValueError {
+    #[error(transparent)]
+    Quota(#[from] CodexQuotaError),
+
+    #[error("cannot estimate weekly value while the provider-reported used percentage is zero")]
+    ZeroUsagePercentage,
+
+    #[error("no Codex token usage matched the active weekly quota window")]
+    NoUsageInWindow,
+
+    #[error("cannot price Codex models in the active weekly window: {models}")]
+    UnpricedModels { models: String },
+
+    #[error("no positive API-equivalent cost was available for the active weekly window")]
+    NoPricedUsageInWindow,
+
+    #[error("failed to load pricing data for the weekly value estimate: {message}")]
+    Pricing { message: String },
+
+    #[error("the weekly value calculation produced a non-finite result")]
+    NonFiniteEstimate,
+}
+
 /// Errors returned by the public SDK API.
 #[derive(Debug, Error)]
 pub enum SdkError {
@@ -253,6 +298,87 @@ pub fn load_codex_weekly_quota(
     codex_home: Option<&Path>,
 ) -> Result<CodexWeeklyQuota, CodexQuotaError> {
     load_weekly_quota_from_home(codex_home)
+}
+
+/// Estimate the API-equivalent dollar value represented by the active Codex
+/// weekly quota.
+///
+/// Local token usage is aligned to the exact provider window, from
+/// `resets_at - window_minutes` through the quota snapshot's `observed_at`.
+/// The estimate divides that observed cost and token count by the
+/// provider-reported used fraction.
+///
+/// # Errors
+///
+/// Returns an error when the quota snapshot or matching usage cannot be read,
+/// the used percentage is zero, any matched model cannot be priced, or pricing
+/// data is unavailable.
+pub fn estimate_codex_weekly_value(
+    codex_home: Option<&Path>,
+    offline: bool,
+    strict_pricing: bool,
+) -> Result<CodexWeeklyValueEstimate, CodexWeeklyValueError> {
+    let quota = load_weekly_quota_from_home(codex_home)?;
+    let pricing_db = PricingDb::try_load_quiet(offline, strict_pricing).map_err(|error| {
+        CodexWeeklyValueError::Pricing {
+            message: error.to_string(),
+        }
+    })?;
+    estimate_codex_weekly_value_with_pricing(&quota, codex_home, &pricing_db)
+}
+
+pub(crate) fn estimate_codex_weekly_value_with_pricing(
+    quota: &CodexWeeklyQuota,
+    codex_home: Option<&Path>,
+    pricing_db: &PricingDb,
+) -> Result<CodexWeeklyValueEstimate, CodexWeeklyValueError> {
+    if quota.used_pct <= 0.0 {
+        return Err(CodexWeeklyValueError::ZeroUsagePercentage);
+    }
+
+    let usage = load_weekly_window_usage_from_home(quota, codex_home)?;
+    let observed_tokens = usage.stats.total_tokens();
+    if usage.valid_entries == 0 || observed_tokens <= 0 {
+        return Err(CodexWeeklyValueError::NoUsageInWindow);
+    }
+
+    let mut unpriced_models: Vec<_> = usage
+        .models
+        .iter()
+        .filter(|(model, stats)| !calculate_cost(stats, model, pricing_db).is_finite())
+        .map(|(model, _)| model.clone())
+        .collect();
+    unpriced_models.sort();
+    if !unpriced_models.is_empty() {
+        return Err(CodexWeeklyValueError::UnpricedModels {
+            models: unpriced_models.join(", "),
+        });
+    }
+
+    let observed_cost_usd = sum_model_costs(&usage.models, pricing_db);
+    if !observed_cost_usd.is_finite() || observed_cost_usd <= 0.0 {
+        return Err(CodexWeeklyValueError::NoPricedUsageInWindow);
+    }
+
+    let scale = 100.0 / quota.used_pct;
+    let estimated_weekly_value_usd = observed_cost_usd * scale;
+    let estimated_weekly_tokens = observed_tokens as f64 * scale;
+    if !estimated_weekly_value_usd.is_finite() || !estimated_weekly_tokens.is_finite() {
+        return Err(CodexWeeklyValueError::NonFiniteEstimate);
+    }
+
+    Ok(CodexWeeklyValueEstimate {
+        observed_at: quota.observed_at,
+        window_started_at: quota.resets_at - Duration::minutes(quota.window_minutes),
+        resets_at: quota.resets_at,
+        used_pct: quota.used_pct,
+        observed_cost_usd,
+        estimated_weekly_value_usd,
+        observed_tokens,
+        estimated_weekly_tokens,
+        valid_entries: usage.valid_entries,
+        dedup_skipped_entries: usage.dedup_skipped_entries,
+    })
 }
 
 /// Summarize local token usage and estimated cost.

--- a/src/source/codex/mod.rs
+++ b/src/source/codex/mod.rs
@@ -6,7 +6,9 @@
 mod config;
 mod parser;
 mod quota;
+mod quota_value;
 
 pub(crate) use config::{CodexScope, CodexSource};
 pub use quota::{CodexQuotaError, CodexQuotaStatus, CodexWeeklyQuota};
 pub(crate) use quota::{load_weekly_quota, load_weekly_quota_from_home};
+pub(crate) use quota_value::load_weekly_window_usage_from_home;

--- a/src/source/codex/parser.rs
+++ b/src/source/codex/parser.rs
@@ -272,6 +272,7 @@ struct CodexParseContext<'a> {
     debug: bool,
     identity: CodexFileIdentity,
     scope: CodexScope,
+    missing_model: &'static str,
 }
 
 struct CodexParseState {
@@ -309,6 +310,20 @@ pub(super) fn parse_codex_file_with_scope(
     debug: bool,
     scope: CodexScope,
 ) -> ParseOutput {
+    parse_codex_file(path, timezone, debug, scope, "gpt-5")
+}
+
+pub(super) fn parse_codex_file_for_quota(path: &Path, timezone: Timezone) -> ParseOutput {
+    parse_codex_file(path, timezone, false, CodexScope::All, "unknown-model")
+}
+
+fn parse_codex_file(
+    path: &Path,
+    timezone: Timezone,
+    debug: bool,
+    scope: CodexScope,
+    missing_model: &'static str,
+) -> ParseOutput {
     let identity = CodexFileIdentity::from_path(path);
     let context = CodexParseContext {
         path,
@@ -316,6 +331,7 @@ pub(super) fn parse_codex_file_with_scope(
         debug,
         identity,
         scope,
+        missing_model,
     };
     let file = match open_codex_file(&context) {
         Ok(file) => file,
@@ -452,7 +468,7 @@ fn process_event_message(
         return;
     };
 
-    let model = resolve_entry_model(payload, state);
+    let model = resolve_entry_model(payload, state, context.missing_model);
     push_codex_entry(timestamp, utc_dt, total, delta, model, context, state);
 }
 
@@ -566,7 +582,11 @@ fn parse_entry_timestamp(
     }
 }
 
-fn resolve_entry_model(payload: &Payload<'_>, state: &mut CodexParseState) -> String {
+fn resolve_entry_model(
+    payload: &Payload<'_>,
+    state: &mut CodexParseState,
+    missing_model: &str,
+) -> String {
     if let Some(parsed_model) = extract_model_ref(payload) {
         let parsed_model = parsed_model.to_string();
         state.current_model = Some(parsed_model.clone());
@@ -575,7 +595,7 @@ fn resolve_entry_model(payload: &Payload<'_>, state: &mut CodexParseState) -> St
         state
             .current_model
             .clone()
-            .unwrap_or_else(|| "gpt-5".to_string())
+            .unwrap_or_else(|| missing_model.to_string())
     }
 }
 

--- a/src/source/codex/quota.rs
+++ b/src/source/codex/quota.rs
@@ -96,6 +96,11 @@ pub enum CodexQuotaError {
         #[source]
         source: io::Error,
     },
+
+    #[error(
+        "failed to estimate weekly value because {count} Codex usage records could not be parsed"
+    )]
+    UsageParse { count: usize },
 }
 
 #[derive(Debug, Clone)]
@@ -177,7 +182,7 @@ pub(crate) fn load_weekly_quota_from_home(
     load_weekly_quota_from_files_at(files, Utc::now())
 }
 
-fn validate_sessions_dir(sessions_dir: &Path) -> Result<(), CodexQuotaError> {
+pub(super) fn validate_sessions_dir(sessions_dir: &Path) -> Result<(), CodexQuotaError> {
     match fs::symlink_metadata(sessions_dir) {
         Ok(metadata) if metadata.file_type().is_symlink() => {
             Err(CodexQuotaError::SessionDiscovery {
@@ -204,7 +209,7 @@ fn validate_sessions_dir(sessions_dir: &Path) -> Result<(), CodexQuotaError> {
     }
 }
 
-fn discover_quota_files(sessions_dir: &Path) -> Result<Vec<PathBuf>, CodexQuotaError> {
+pub(super) fn discover_quota_files(sessions_dir: &Path) -> Result<Vec<PathBuf>, CodexQuotaError> {
     let mut pending = vec![sessions_dir.to_path_buf()];
     let mut files = Vec::new();
     while let Some(directory) = pending.pop() {
@@ -245,7 +250,7 @@ fn load_weekly_quota_from_files_at(
     build_report(&latest, now)
 }
 
-fn recent_codex_files(
+pub(super) fn recent_codex_files(
     files: Vec<PathBuf>,
     now: DateTime<Utc>,
 ) -> Result<Vec<PathBuf>, CodexQuotaError> {

--- a/src/source/codex/quota_value.rs
+++ b/src/source/codex/quota_value.rs
@@ -9,8 +9,7 @@ use rayon::prelude::*;
 use crate::core::{DedupAccumulator, Stats};
 use crate::utils::Timezone;
 
-use super::config::CodexScope;
-use super::parser::{codex_sessions_dir_candidate, parse_codex_file_with_scope};
+use super::parser::{codex_sessions_dir_candidate, parse_codex_file_for_quota};
 use super::quota::{
     CodexQuotaError, CodexWeeklyQuota, discover_quota_files, recent_codex_files,
     validate_sessions_dir,
@@ -54,7 +53,7 @@ fn load_weekly_window_usage_from_files(
         files
             .par_iter()
             .map(|path| {
-                let parsed = parse_codex_file_with_scope(path, utc, false, CodexScope::All);
+                let parsed = parse_codex_file_for_quota(path, utc);
                 let mut partial = DedupAccumulator::new();
                 partial.extend(parsed.entries.into_iter().filter(|entry| {
                     entry.timestamp_ms >= since_ms && entry.timestamp_ms <= until_ms
@@ -181,5 +180,18 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(error, CodexQuotaError::UsageParse { count: 1 }));
+    }
+
+    #[test]
+    fn missing_model_metadata_stays_unpriceable() {
+        let line =
+            usage_event("2026-08-21T00:00:00Z", 100, 100).replace("\"model\":\"gpt-5\",", "");
+        let file = write_log(&[&line]);
+
+        let usage =
+            load_weekly_window_usage_from_files(&quota(), &[file.path().to_path_buf()]).unwrap();
+
+        assert!(usage.models.contains_key("unknown-model"));
+        assert!(!usage.models.contains_key("gpt-5"));
     }
 }

--- a/src/source/codex/quota_value.rs
+++ b/src/source/codex/quota_value.rs
@@ -1,0 +1,185 @@
+//! Exact-window Codex usage input for weekly value estimation.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use chrono::{Duration, Utc};
+use rayon::prelude::*;
+
+use crate::core::{DedupAccumulator, Stats};
+use crate::utils::Timezone;
+
+use super::config::CodexScope;
+use super::parser::{codex_sessions_dir_candidate, parse_codex_file_with_scope};
+use super::quota::{
+    CodexQuotaError, CodexWeeklyQuota, discover_quota_files, recent_codex_files,
+    validate_sessions_dir,
+};
+
+#[derive(Debug)]
+pub(crate) struct CodexWindowUsage {
+    pub(crate) stats: Stats,
+    pub(crate) models: HashMap<String, Stats>,
+    pub(crate) valid_entries: i64,
+    pub(crate) dedup_skipped_entries: i64,
+}
+
+pub(crate) fn load_weekly_window_usage_from_home(
+    quota: &CodexWeeklyQuota,
+    codex_home: Option<&Path>,
+) -> Result<CodexWindowUsage, CodexQuotaError> {
+    let sessions_dir = resolve_sessions_dir(codex_home)?;
+    validate_sessions_dir(&sessions_dir)?;
+    let files = recent_codex_files(discover_quota_files(&sessions_dir)?, Utc::now())?;
+    load_weekly_window_usage_from_files(quota, &files)
+}
+
+fn resolve_sessions_dir(codex_home: Option<&Path>) -> Result<PathBuf, CodexQuotaError> {
+    codex_home.map_or_else(
+        || codex_sessions_dir_candidate().ok_or(CodexQuotaError::SnapshotNotFound),
+        |home| Ok(home.join("sessions")),
+    )
+}
+
+fn load_weekly_window_usage_from_files(
+    quota: &CodexWeeklyQuota,
+    files: &[PathBuf],
+) -> Result<CodexWindowUsage, CodexQuotaError> {
+    let window_started_at = quota.resets_at - Duration::minutes(quota.window_minutes);
+    let since_ms = window_started_at.timestamp_millis();
+    let until_ms = quota.observed_at.timestamp_millis();
+    let utc = Timezone::Named(chrono_tz::UTC);
+
+    let (accumulator, parse_errors) =
+        files
+            .par_iter()
+            .map(|path| {
+                let parsed = parse_codex_file_with_scope(path, utc, false, CodexScope::All);
+                let mut partial = DedupAccumulator::new();
+                partial.extend(parsed.entries.into_iter().filter(|entry| {
+                    entry.timestamp_ms >= since_ms && entry.timestamp_ms <= until_ms
+                }));
+                (partial, parsed.errors)
+            })
+            .reduce(
+                || (DedupAccumulator::new(), 0usize),
+                |(mut accumulator, errors), (partial, partial_errors)| {
+                    accumulator.merge(partial);
+                    (accumulator, errors.saturating_add(partial_errors))
+                },
+            );
+
+    if parse_errors > 0 {
+        return Err(CodexQuotaError::UsageParse {
+            count: parse_errors,
+        });
+    }
+
+    let (entries, dedup_skipped_entries) = accumulator.finalize();
+    let valid_entries = entries.len() as i64;
+    let mut stats = Stats::default();
+    let mut models = HashMap::new();
+    for entry in entries {
+        let entry_stats = entry.to_stats();
+        stats.add(&entry_stats);
+        models
+            .entry(entry.model)
+            .or_insert_with(Stats::default)
+            .add(&entry_stats);
+    }
+
+    Ok(CodexWindowUsage {
+        stats,
+        models,
+        valid_entries,
+        dedup_skipped_entries,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write as _;
+
+    use chrono::DateTime;
+    use serde_json::json;
+    use tempfile::NamedTempFile;
+
+    use super::*;
+    use crate::source::CodexQuotaStatus;
+
+    fn quota() -> CodexWeeklyQuota {
+        CodexWeeklyQuota {
+            observed_at: "2026-08-22T00:00:00Z".parse::<DateTime<_>>().unwrap(),
+            resets_at: "2026-08-27T00:00:00Z".parse::<DateTime<_>>().unwrap(),
+            estimated_depletion_at: None,
+            window_minutes: 10_080,
+            used_pct: 25.0,
+            remaining_pct: 75.0,
+            projected_pct_at_reset: 80.0,
+            status: CodexQuotaStatus::OnTrack,
+        }
+    }
+
+    fn usage_event(timestamp: &str, total_input: i64, delta_input: i64) -> String {
+        json!({
+            "timestamp": timestamp,
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "model": "gpt-5",
+                "info": {
+                    "total_token_usage": {
+                        "input_tokens": total_input,
+                        "cached_input_tokens": 0,
+                        "output_tokens": 0,
+                        "reasoning_output_tokens": 0,
+                        "total_tokens": total_input,
+                    },
+                    "last_token_usage": {
+                        "input_tokens": delta_input,
+                        "cached_input_tokens": 0,
+                        "output_tokens": 0,
+                        "reasoning_output_tokens": 0,
+                        "total_tokens": delta_input,
+                    }
+                }
+            }
+        })
+        .to_string()
+    }
+
+    fn write_log(lines: &[&str]) -> NamedTempFile {
+        let mut file = NamedTempFile::new().unwrap();
+        for line in lines {
+            writeln!(file, "{line}").unwrap();
+        }
+        file
+    }
+
+    #[test]
+    fn usage_is_aligned_to_exact_provider_window_and_observation() {
+        let before = usage_event("2026-08-19T23:59:59Z", 100, 100);
+        let at_start = usage_event("2026-08-20T00:00:00Z", 300, 200);
+        let at_observation = usage_event("2026-08-22T00:00:00Z", 600, 300);
+        let after = usage_event("2026-08-22T00:00:01Z", 1_000, 400);
+        let file = write_log(&[&before, &at_start, &at_observation, &after]);
+
+        let usage =
+            load_weekly_window_usage_from_files(&quota(), &[file.path().to_path_buf()]).unwrap();
+
+        assert_eq!(usage.valid_entries, 2);
+        assert_eq!(usage.stats.total_tokens(), 500);
+        assert_eq!(usage.models["gpt-5"].total_tokens(), 500);
+    }
+
+    #[test]
+    fn malformed_usage_fails_value_estimate_closed() {
+        let valid = usage_event("2026-08-21T00:00:00Z", 100, 100);
+        let file = write_log(&[&valid, "{malformed"]);
+
+        let error = load_weekly_window_usage_from_files(&quota(), &[file.path().to_path_buf()])
+            .unwrap_err();
+
+        assert!(matches!(error, CodexQuotaError::UsageParse { count: 1 }));
+    }
+}

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -113,6 +113,7 @@ pub(crate) trait Source: Send + Sync {
 /// Box type for dynamic dispatch
 pub(crate) type BoxedSource = Box<dyn Source>;
 
+pub(crate) use codex::load_weekly_window_usage_from_home;
 pub use codex::{CodexQuotaError, CodexQuotaStatus, CodexWeeklyQuota};
 pub(crate) use codex::{CodexScope, CodexSource, load_weekly_quota, load_weekly_quota_from_home};
 

--- a/tests/cli_codex_quota.rs
+++ b/tests/cli_codex_quota.rs
@@ -38,6 +38,23 @@ fn quota_event(
             "type": "event_msg",
             "payload": {
                 "type": "token_count",
+                "info": {
+                    "total_token_usage": {
+                        "input_tokens": 1_000_000,
+                        "cached_input_tokens": 200_000,
+                        "output_tokens": 100_000,
+                        "reasoning_output_tokens": 50_000,
+                        "total_tokens": 1_100_000,
+                    },
+                    "last_token_usage": {
+                        "input_tokens": 1_000_000,
+                        "cached_input_tokens": 200_000,
+                        "output_tokens": 100_000,
+                        "reasoning_output_tokens": 50_000,
+                        "total_tokens": 1_100_000,
+                    },
+                    "model": "gpt-5",
+                },
                 "rate_limits": rate_limits,
             },
         })
@@ -64,12 +81,14 @@ fn quota_and_codex_quota_return_the_same_json() {
     let codex_home = root.join("codex-home");
     let resets_at = write_current_quota_fixture(&codex_home);
 
-    let (top_ok, top_stdout, top_stderr) =
-        run_ccstats(&["quota", "--json"], &[("CODEX_HOME", &codex_home)]);
+    let (top_ok, top_stdout, top_stderr) = run_ccstats(
+        &["quota", "--json", "--offline"],
+        &[("CODEX_HOME", &codex_home)],
+    );
     assert!(top_ok, "stderr: {}", String::from_utf8_lossy(&top_stderr));
 
     let (nested_ok, nested_stdout, nested_stderr) = run_ccstats(
-        &["codex", "quota", "--json"],
+        &["codex", "quota", "--json", "--offline"],
         &[("CODEX_HOME", &codex_home)],
     );
     assert!(
@@ -92,6 +111,21 @@ fn quota_and_codex_quota_return_the_same_json() {
         resets_at.to_rfc3339_opts(SecondsFormat::Secs, true)
     );
     assert!(value["estimated_depletion_at"].is_string());
+    assert_eq!(value["value_estimate"]["kind"], "api_equivalent");
+    let estimate = &value["value_estimate"];
+    let observed_cost = estimate["observed_cost_usd"].as_f64().unwrap();
+    let weekly_value = estimate["estimated_weekly_value_usd"].as_f64().unwrap();
+    let observed_tokens = estimate["observed_tokens"].as_f64().unwrap();
+    let weekly_tokens = estimate["estimated_weekly_tokens"].as_f64().unwrap();
+    assert!(observed_cost > 0.0);
+    assert!((weekly_value / observed_cost - 4.0).abs() < 0.001);
+    assert!(observed_tokens > 0.0);
+    assert!((weekly_tokens / observed_tokens - 4.0).abs() < f64::EPSILON);
+    assert_eq!(
+        estimate["window_started_at"],
+        (resets_at - Duration::minutes(10_080)).to_rfc3339_opts(SecondsFormat::Secs, true)
+    );
+    assert!(value["value_estimate_error"].is_null());
 
     let _ = fs::remove_dir_all(root);
 }
@@ -102,15 +136,43 @@ fn quota_csv_exposes_stable_columns() {
     let codex_home = root.join("codex-home");
     write_current_quota_fixture(&codex_home);
 
-    let (ok, stdout, stderr) = run_ccstats(&["quota", "--csv"], &[("CODEX_HOME", &codex_home)]);
+    let (ok, stdout, stderr) = run_ccstats(
+        &["quota", "--csv", "--offline"],
+        &[("CODEX_HOME", &codex_home)],
+    );
     assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
     let csv = String::from_utf8(stdout).unwrap();
     let lines: Vec<_> = csv.lines().collect();
     assert_eq!(
         lines[0],
-        "source,window,window_minutes,used_pct,remaining_pct,projected_pct_at_reset,status,observed_at,resets_at,estimated_depletion_at"
+        "source,window,window_minutes,used_pct,remaining_pct,projected_pct_at_reset,status,observed_at,resets_at,estimated_depletion_at,observed_cost_usd,estimated_weekly_value_usd,observed_tokens,estimated_weekly_tokens,value_window_started_at,value_estimate_error"
     );
     assert!(lines[1].starts_with("codex,weekly,10080,25.00,75.00,175.00,likely_exhausted"));
+    let columns: Vec<_> = lines[1].split(',').collect();
+    let observed_cost: f64 = columns[10].parse().unwrap();
+    let weekly_value: f64 = columns[11].parse().unwrap();
+    let observed_tokens: f64 = columns[12].parse().unwrap();
+    let weekly_tokens: f64 = columns[13].parse().unwrap();
+    assert!((weekly_value / observed_cost - 4.0).abs() < 0.001);
+    assert!((weekly_tokens / observed_tokens - 4.0).abs() < f64::EPSILON);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn quota_no_cost_omits_value_estimate() {
+    let root = unique_temp_dir("codex-quota-no-cost");
+    let codex_home = root.join("codex-home");
+    write_current_quota_fixture(&codex_home);
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &["quota", "--json", "--no-cost", "--offline"],
+        &[("CODEX_HOME", &codex_home)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let value: Value = serde_json::from_slice(&stdout).unwrap();
+    assert!(value.get("value_estimate").is_none());
+    assert!(value.get("value_estimate_error").is_none());
 
     let _ = fs::remove_dir_all(root);
 }

--- a/tests/cli_codex_quota.rs
+++ b/tests/cli_codex_quota.rs
@@ -174,6 +174,36 @@ fn quota_no_cost_omits_value_estimate() {
     assert!(value.get("value_estimate").is_none());
     assert!(value.get("value_estimate_error").is_none());
 
+    let (csv_ok, csv_stdout, csv_stderr) = run_ccstats(
+        &["quota", "--csv", "--no-cost", "--offline"],
+        &[("CODEX_HOME", &codex_home)],
+    );
+    assert!(csv_ok, "stderr: {}", String::from_utf8_lossy(&csv_stderr));
+    let csv = String::from_utf8(csv_stdout).unwrap();
+    assert_eq!(
+        csv.lines().next().unwrap(),
+        "source,window,window_minutes,used_pct,remaining_pct,projected_pct_at_reset,status,observed_at,resets_at,estimated_depletion_at"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn quota_rejects_non_usd_currency() {
+    let root = unique_temp_dir("codex-quota-currency");
+    let codex_home = root.join("codex-home");
+    write_current_quota_fixture(&codex_home);
+
+    let (ok, _stdout, stderr) = run_ccstats(
+        &["quota", "--currency", "EUR", "--offline"],
+        &[("CODEX_HOME", &codex_home)],
+    );
+    assert!(!ok);
+    assert!(
+        String::from_utf8_lossy(&stderr)
+            .contains("--currency is not supported for quota estimates")
+    );
+
     let _ = fs::remove_dir_all(root);
 }
 

--- a/tests/sdk_integration.rs
+++ b/tests/sdk_integration.rs
@@ -4,9 +4,10 @@ use std::sync::Mutex;
 
 use ccstats::{
     CodexQuotaError, CodexQuotaStatus, CostSummary, MultiSummaryOptions, SummaryOptions,
-    UsageRange, UsageSource, load_codex_weekly_quota, summarize_cost, summarize_cost_ranges,
+    UsageRange, UsageSource, estimate_codex_weekly_value, load_codex_weekly_quota, summarize_cost,
+    summarize_cost_ranges,
 };
-use chrono::{Datelike, Days, Duration, NaiveDate, Utc};
+use chrono::{Datelike, Days, Duration, NaiveDate, Timelike, Utc};
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
 
@@ -50,6 +51,65 @@ fn sdk_loads_codex_weekly_quota_from_explicit_home() {
         serialized["projected_pct_at_reset"],
         report.projected_pct_at_reset
     );
+}
+
+#[test]
+fn sdk_estimates_codex_weekly_api_equivalent_value() {
+    let root = tempfile::tempdir().expect("temp dir");
+    let codex_home = root.path().join("codex-home");
+    let session_file = codex_home.join("sessions").join("quota-and-usage.jsonl");
+    let observed_at = (Utc::now() - Duration::hours(1))
+        .with_nanosecond(0)
+        .expect("valid timestamp");
+    let resets_at = observed_at + Duration::days(6);
+    let event = serde_json::json!({
+        "timestamp": observed_at.to_rfc3339(),
+        "type": "event_msg",
+        "payload": {
+            "type": "token_count",
+            "info": {
+                "total_token_usage": {
+                    "input_tokens": 1_000_000,
+                    "cached_input_tokens": 200_000,
+                    "output_tokens": 100_000,
+                    "reasoning_output_tokens": 50_000,
+                    "total_tokens": 1_100_000,
+                },
+                "last_token_usage": {
+                    "input_tokens": 1_000_000,
+                    "cached_input_tokens": 200_000,
+                    "output_tokens": 100_000,
+                    "reasoning_output_tokens": 50_000,
+                    "total_tokens": 1_100_000,
+                },
+                "model": "gpt-5",
+            },
+            "rate_limits": {
+                "secondary": {
+                    "used_percent": 25.0,
+                    "window_minutes": 10_080,
+                    "resets_at": resets_at.timestamp(),
+                }
+            }
+        }
+    });
+    write_file(&session_file, &format!("{event}\n"));
+
+    let estimate =
+        estimate_codex_weekly_value(Some(&codex_home), true, false).expect("estimate weekly value");
+
+    assert_eq!(estimate.observed_at, observed_at);
+    assert_eq!(
+        estimate.window_started_at,
+        resets_at - Duration::minutes(10_080)
+    );
+    assert_eq!(estimate.observed_tokens, 1_100_000);
+    assert!(estimate.observed_cost_usd > 0.0);
+    assert!(
+        (estimate.estimated_weekly_value_usd / estimate.observed_cost_usd - 4.0).abs()
+            < f64::EPSILON
+    );
+    assert_eq!(estimate.estimated_weekly_tokens, 4_400_000.0);
 }
 
 #[test]


### PR DESCRIPTION
Closes #109

## Summary
- align local Codex token usage to the exact provider weekly window
- estimate full-week API-equivalent USD value and tokens from the reported used percentage
- expose the estimate through the CLI table, JSON, CSV, and a typed Rust SDK API
- preserve official quota output with an explicit estimate error when usage or pricing is unavailable
- allow `--no-cost` to omit the estimate

## Formula
`estimated weekly value = observed window cost / (used_pct / 100)`

The output explicitly labels dollar and token figures as local API-pricing estimates, not official provider allowances.

## Verification
- `cargo fmt --check`
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- real local Codex quota/session logs via `cargo run --quiet -- --offline quota --no-color`