### PR TITLE
feat: expose exact Codex value window SDK

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,8 @@
 //! The public SDK entry points are [`summarize_cost`] and
 //! [`summarize_cost_ranges`] for cost analytics, [`load_codex_weekly_quota`]
 //! for provider-authoritative Codex quota pace,
-//! [`estimate_codex_weekly_value`] for an API-equivalent weekly estimate, plus
+//! [`estimate_codex_weekly_value`] and [`estimate_codex_weekly_value_for_window`]
+//! for API-equivalent weekly estimates, plus
 //! [`summarize_cost_with_cli_config`] and
 //! [`summarize_cost_ranges_with_cli_config`] for CLI-aligned config defaults.
 //! The binary target calls [`run_cli`] to preserve the existing command-line
@@ -35,10 +36,11 @@ mod utils;
 
 pub use sdk::{
     CodexQuotaError, CodexQuotaStatus, CodexWeeklyQuota, CodexWeeklyValueError,
-    CodexWeeklyValueEstimate, CostSummary, ModelCostSummary, MultiCostSummary, MultiSummaryOptions,
-    SdkError, SummaryOptions, TokenBreakdown, UsageRange, UsageSource, estimate_codex_weekly_value,
-    load_codex_weekly_quota, summarize_cost, summarize_cost_ranges,
-    summarize_cost_ranges_with_cli_config, summarize_cost_with_cli_config,
+    CodexWeeklyValueEstimate, CodexWeeklyValueWindow, CodexWeeklyValueWindowError, CostSummary,
+    ModelCostSummary, MultiCostSummary, MultiSummaryOptions, SdkError, SummaryOptions,
+    TokenBreakdown, UsageRange, UsageSource, estimate_codex_weekly_value,
+    estimate_codex_weekly_value_for_window, load_codex_weekly_quota, summarize_cost,
+    summarize_cost_ranges, summarize_cost_ranges_with_cli_config, summarize_cost_with_cli_config,
 };
 
 use chrono::{NaiveDate, Utc};

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -1,13 +1,13 @@
 #![allow(clippy::module_name_repetitions)]
 
 mod batch;
+mod codex_weekly;
 
 use std::cmp::Ordering;
 use std::collections::HashMap;
-use std::path::Path;
 use std::str::FromStr;
 
-use chrono::{Datelike, Days, Duration, NaiveDate, Utc};
+use chrono::{Datelike, Days, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -17,9 +17,7 @@ use crate::pricing::{
     CurrencyConverter, PricingDb, calculate_cost, calculate_estimated_proxy_cost, model_cost_kind,
     sum_estimated_proxy_model_costs, sum_model_costs,
 };
-use crate::source::{
-    Source, get_source, load_daily, load_weekly_quota_from_home, load_weekly_window_usage_from_home,
-};
+use crate::source::{Source, get_source, load_daily};
 use crate::utils::Timezone;
 
 pub use crate::source::{CodexQuotaError, CodexQuotaStatus, CodexWeeklyQuota};
@@ -27,6 +25,12 @@ pub use crate::source::{CodexQuotaError, CodexQuotaStatus, CodexWeeklyQuota};
 pub use batch::{
     MultiCostSummary, MultiSummaryOptions, summarize_cost_ranges,
     summarize_cost_ranges_with_cli_config,
+};
+pub(crate) use codex_weekly::estimate_codex_weekly_value_with_pricing;
+pub use codex_weekly::{
+    CodexWeeklyValueError, CodexWeeklyValueEstimate, CodexWeeklyValueWindow,
+    CodexWeeklyValueWindowError, estimate_codex_weekly_value,
+    estimate_codex_weekly_value_for_window, load_codex_weekly_quota,
 };
 
 /// Supported local usage sources.
@@ -227,49 +231,6 @@ pub struct CostSummary {
     pub elapsed_ms: f64,
 }
 
-/// API-equivalent value inferred for the active Codex weekly quota window.
-///
-/// This is an approximation based on local token pricing and the current
-/// model/cache mix. It is not an official dollar allowance from the provider.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct CodexWeeklyValueEstimate {
-    pub observed_at: chrono::DateTime<Utc>,
-    pub window_started_at: chrono::DateTime<Utc>,
-    pub resets_at: chrono::DateTime<Utc>,
-    pub used_pct: f64,
-    pub observed_cost_usd: f64,
-    pub estimated_weekly_value_usd: f64,
-    pub observed_tokens: i64,
-    pub estimated_weekly_tokens: f64,
-    pub valid_entries: i64,
-    pub dedup_skipped_entries: i64,
-}
-
-/// Errors returned while estimating Codex weekly API-equivalent value.
-#[derive(Debug, Error)]
-pub enum CodexWeeklyValueError {
-    #[error(transparent)]
-    Quota(#[from] CodexQuotaError),
-
-    #[error("cannot estimate weekly value while the provider-reported used percentage is zero")]
-    ZeroUsagePercentage,
-
-    #[error("no Codex token usage matched the active weekly quota window")]
-    NoUsageInWindow,
-
-    #[error("cannot price Codex models in the active weekly window: {models}")]
-    UnpricedModels { models: String },
-
-    #[error("no positive API-equivalent cost was available for the active weekly window")]
-    NoPricedUsageInWindow,
-
-    #[error("failed to load pricing data for the weekly value estimate: {message}")]
-    Pricing { message: String },
-
-    #[error("the weekly value calculation produced a non-finite result")]
-    NonFiniteEstimate,
-}
-
 /// Errors returned by the public SDK API.
 #[derive(Debug, Error)]
 pub enum SdkError {
@@ -281,104 +242,6 @@ pub enum SdkError {
 
     #[error("{0}")]
     Configuration(String),
-}
-
-/// Load the newest provider-authoritative Codex weekly quota snapshot.
-///
-/// Pass an explicit Codex home to avoid process-global environment discovery.
-/// The home must contain a `sessions` directory and is never replaced by a
-/// fallback path. Passing `None` honors `CODEX_HOME` before `~/.codex`.
-///
-/// # Errors
-///
-/// Returns an error when the sessions directory or a usable weekly snapshot
-/// cannot be found, a session file cannot be inspected or read, or the newest
-/// snapshot is stale or malformed.
-pub fn load_codex_weekly_quota(
-    codex_home: Option<&Path>,
-) -> Result<CodexWeeklyQuota, CodexQuotaError> {
-    load_weekly_quota_from_home(codex_home)
-}
-
-/// Estimate the API-equivalent dollar value represented by the active Codex
-/// weekly quota.
-///
-/// Local token usage is aligned to the exact provider window, from
-/// `resets_at - window_minutes` through the quota snapshot's `observed_at`.
-/// The estimate divides that observed cost and token count by the
-/// provider-reported used fraction.
-///
-/// # Errors
-///
-/// Returns an error when the quota snapshot or matching usage cannot be read,
-/// the used percentage is zero, any matched model cannot be priced, or pricing
-/// data is unavailable.
-pub fn estimate_codex_weekly_value(
-    codex_home: Option<&Path>,
-    offline: bool,
-    strict_pricing: bool,
-) -> Result<CodexWeeklyValueEstimate, CodexWeeklyValueError> {
-    let quota = load_weekly_quota_from_home(codex_home)?;
-    let pricing_db = PricingDb::try_load_quiet(offline, strict_pricing).map_err(|error| {
-        CodexWeeklyValueError::Pricing {
-            message: error.to_string(),
-        }
-    })?;
-    estimate_codex_weekly_value_with_pricing(&quota, codex_home, &pricing_db)
-}
-
-pub(crate) fn estimate_codex_weekly_value_with_pricing(
-    quota: &CodexWeeklyQuota,
-    codex_home: Option<&Path>,
-    pricing_db: &PricingDb,
-) -> Result<CodexWeeklyValueEstimate, CodexWeeklyValueError> {
-    if quota.used_pct <= 0.0 {
-        return Err(CodexWeeklyValueError::ZeroUsagePercentage);
-    }
-
-    let usage = load_weekly_window_usage_from_home(quota, codex_home)?;
-    let observed_tokens = usage.stats.total_tokens();
-    if usage.valid_entries == 0 || observed_tokens <= 0 {
-        return Err(CodexWeeklyValueError::NoUsageInWindow);
-    }
-
-    let mut unpriced_models: Vec<_> = usage
-        .models
-        .iter()
-        .filter(|(model, stats)| !calculate_cost(stats, model, pricing_db).is_finite())
-        .map(|(model, _)| model.clone())
-        .collect();
-    unpriced_models.sort();
-    if !unpriced_models.is_empty() {
-        return Err(CodexWeeklyValueError::UnpricedModels {
-            models: unpriced_models.join(", "),
-        });
-    }
-
-    let observed_cost_usd = sum_model_costs(&usage.models, pricing_db);
-    if !observed_cost_usd.is_finite() || observed_cost_usd <= 0.0 {
-        return Err(CodexWeeklyValueError::NoPricedUsageInWindow);
-    }
-
-    let scale = 100.0 / quota.used_pct;
-    let estimated_weekly_value_usd = observed_cost_usd * scale;
-    let estimated_weekly_tokens = observed_tokens as f64 * scale;
-    if !estimated_weekly_value_usd.is_finite() || !estimated_weekly_tokens.is_finite() {
-        return Err(CodexWeeklyValueError::NonFiniteEstimate);
-    }
-
-    Ok(CodexWeeklyValueEstimate {
-        observed_at: quota.observed_at,
-        window_started_at: quota.resets_at - Duration::minutes(quota.window_minutes),
-        resets_at: quota.resets_at,
-        used_pct: quota.used_pct,
-        observed_cost_usd,
-        estimated_weekly_value_usd,
-        observed_tokens,
-        estimated_weekly_tokens,
-        valid_entries: usage.valid_entries,
-        dedup_skipped_entries: usage.dedup_skipped_entries,
-    })
 }
 
 /// Summarize local token usage and estimated cost.

--- a/src/sdk/codex_weekly.rs
+++ b/src/sdk/codex_weekly.rs
@@ -1,0 +1,308 @@
+use std::path::Path;
+
+use chrono::{Duration, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::pricing::{PricingDb, calculate_cost, sum_model_costs};
+use crate::source::{
+    CodexQuotaError, CodexWeeklyQuota, load_weekly_quota_from_home,
+    load_weekly_window_usage_from_home,
+};
+
+/// API-equivalent value inferred for the active Codex weekly quota window.
+///
+/// This is an approximation based on local token pricing and the current
+/// model/cache mix. It is not an official dollar allowance from the provider.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CodexWeeklyValueEstimate {
+    pub observed_at: chrono::DateTime<Utc>,
+    pub window_started_at: chrono::DateTime<Utc>,
+    pub resets_at: chrono::DateTime<Utc>,
+    pub used_pct: f64,
+    pub observed_cost_usd: f64,
+    pub estimated_weekly_value_usd: f64,
+    pub observed_tokens: i64,
+    pub estimated_weekly_tokens: f64,
+    pub valid_entries: i64,
+    pub dedup_skipped_entries: i64,
+}
+
+/// Provider-authoritative window used to align a Codex weekly value estimate.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CodexWeeklyValueWindow {
+    pub observed_at: chrono::DateTime<Utc>,
+    pub resets_at: chrono::DateTime<Utc>,
+    pub window_minutes: i64,
+    pub used_pct: f64,
+}
+
+impl From<&CodexWeeklyQuota> for CodexWeeklyValueWindow {
+    fn from(quota: &CodexWeeklyQuota) -> Self {
+        Self {
+            observed_at: quota.observed_at,
+            resets_at: quota.resets_at,
+            window_minutes: quota.window_minutes,
+            used_pct: quota.used_pct,
+        }
+    }
+}
+
+/// Errors returned while estimating Codex weekly API-equivalent value.
+#[derive(Debug, Error)]
+pub enum CodexWeeklyValueError {
+    #[error(transparent)]
+    Quota(#[from] CodexQuotaError),
+
+    #[error("cannot estimate weekly value while the provider-reported used percentage is zero")]
+    ZeroUsagePercentage,
+
+    #[error("no Codex token usage matched the active weekly quota window")]
+    NoUsageInWindow,
+
+    #[error("cannot price Codex models in the active weekly window: {models}")]
+    UnpricedModels { models: String },
+
+    #[error("no positive API-equivalent cost was available for the active weekly window")]
+    NoPricedUsageInWindow,
+
+    #[error("failed to load pricing data for the weekly value estimate: {message}")]
+    Pricing { message: String },
+
+    #[error("the weekly value calculation produced a non-finite result")]
+    NonFiniteEstimate,
+}
+
+/// Errors returned by the explicit-window Codex value API.
+#[derive(Debug, Error)]
+pub enum CodexWeeklyValueWindowError {
+    #[error("cannot estimate weekly value from an invalid provider window: {reason}")]
+    InvalidWindow { reason: &'static str },
+
+    #[error(transparent)]
+    Estimate(#[from] CodexWeeklyValueError),
+}
+
+/// Load the newest provider-authoritative Codex weekly quota snapshot.
+///
+/// Pass an explicit Codex home to avoid process-global environment discovery.
+/// The home must contain a `sessions` directory and is never replaced by a
+/// fallback path. Passing `None` honors `CODEX_HOME` before `~/.codex`.
+///
+/// # Errors
+///
+/// Returns an error when the sessions directory or a usable weekly snapshot
+/// cannot be found, a session file cannot be inspected or read, or the newest
+/// snapshot is stale or malformed.
+pub fn load_codex_weekly_quota(
+    codex_home: Option<&Path>,
+) -> Result<CodexWeeklyQuota, CodexQuotaError> {
+    load_weekly_quota_from_home(codex_home)
+}
+
+/// Estimate the API-equivalent dollar value represented by the active Codex
+/// weekly quota discovered from local session logs.
+///
+/// # Errors
+///
+/// Returns an error when the quota snapshot or matching usage cannot be read,
+/// the used percentage is zero, any matched model cannot be priced, or pricing
+/// data is unavailable.
+pub fn estimate_codex_weekly_value(
+    codex_home: Option<&Path>,
+    offline: bool,
+    strict_pricing: bool,
+) -> Result<CodexWeeklyValueEstimate, CodexWeeklyValueError> {
+    let quota = load_weekly_quota_from_home(codex_home)?;
+    let pricing_db = PricingDb::try_load_quiet(offline, strict_pricing).map_err(|error| {
+        CodexWeeklyValueError::Pricing {
+            message: error.to_string(),
+        }
+    })?;
+    estimate_codex_weekly_value_with_pricing(&quota, codex_home, &pricing_db)
+}
+
+/// Estimate Codex API-equivalent value against an explicit provider window.
+///
+/// Use this when the authoritative rate-limit response is newer than the
+/// quota snapshot stored in local Codex session logs. Usage is read from the
+/// exact timestamp interval and malformed matching logs fail closed.
+///
+/// # Errors
+///
+/// Returns an error when the window is invalid, matching usage cannot be read,
+/// any matched model cannot be priced, or pricing data is unavailable.
+pub fn estimate_codex_weekly_value_for_window(
+    window: &CodexWeeklyValueWindow,
+    codex_home: Option<&Path>,
+    offline: bool,
+    strict_pricing: bool,
+) -> Result<CodexWeeklyValueEstimate, CodexWeeklyValueWindowError> {
+    validate_window(window)?;
+    let pricing_db = PricingDb::try_load_quiet(offline, strict_pricing).map_err(|error| {
+        CodexWeeklyValueError::Pricing {
+            message: error.to_string(),
+        }
+    })?;
+    estimate_codex_weekly_value_for_window_with_pricing(window, codex_home, &pricing_db)
+        .map_err(Into::into)
+}
+
+fn validate_window(window: &CodexWeeklyValueWindow) -> Result<(), CodexWeeklyValueWindowError> {
+    if !window.used_pct.is_finite() || !(0.0..=100.0).contains(&window.used_pct) {
+        return Err(CodexWeeklyValueWindowError::InvalidWindow {
+            reason: "used percentage must be finite and between 0 and 100",
+        });
+    }
+    if window.used_pct == 0.0 {
+        return Err(CodexWeeklyValueWindowError::InvalidWindow {
+            reason: "used percentage must be greater than zero",
+        });
+    }
+    let duration = Duration::try_minutes(window.window_minutes).ok_or(
+        CodexWeeklyValueWindowError::InvalidWindow {
+            reason: "window length is outside the supported range",
+        },
+    )?;
+    if duration <= Duration::zero() {
+        return Err(CodexWeeklyValueWindowError::InvalidWindow {
+            reason: "window length must be positive",
+        });
+    }
+    let window_started_at = window.resets_at.checked_sub_signed(duration).ok_or(
+        CodexWeeklyValueWindowError::InvalidWindow {
+            reason: "window start is outside the supported timestamp range",
+        },
+    )?;
+    if window.observed_at < window_started_at || window.observed_at >= window.resets_at {
+        return Err(CodexWeeklyValueWindowError::InvalidWindow {
+            reason: "observation must fall inside the active window",
+        });
+    }
+    let now = Utc::now();
+    if window.observed_at > now + Duration::minutes(5)
+        || now - window.observed_at > Duration::hours(24)
+    {
+        return Err(CodexWeeklyValueWindowError::InvalidWindow {
+            reason: "observation must describe the current provider window",
+        });
+    }
+    Ok(())
+}
+
+pub(crate) fn estimate_codex_weekly_value_with_pricing(
+    quota: &CodexWeeklyQuota,
+    codex_home: Option<&Path>,
+    pricing_db: &PricingDb,
+) -> Result<CodexWeeklyValueEstimate, CodexWeeklyValueError> {
+    estimate_codex_weekly_value_for_window_with_pricing(
+        &CodexWeeklyValueWindow::from(quota),
+        codex_home,
+        pricing_db,
+    )
+}
+
+fn estimate_codex_weekly_value_for_window_with_pricing(
+    window: &CodexWeeklyValueWindow,
+    codex_home: Option<&Path>,
+    pricing_db: &PricingDb,
+) -> Result<CodexWeeklyValueEstimate, CodexWeeklyValueError> {
+    if window.used_pct <= 0.0 {
+        return Err(CodexWeeklyValueError::ZeroUsagePercentage);
+    }
+    let duration = Duration::try_minutes(window.window_minutes)
+        .ok_or(CodexWeeklyValueError::NonFiniteEstimate)?;
+    let window_started_at = window
+        .resets_at
+        .checked_sub_signed(duration)
+        .ok_or(CodexWeeklyValueError::NonFiniteEstimate)?;
+
+    let usage =
+        load_weekly_window_usage_from_home(window.observed_at, window_started_at, codex_home)?;
+    let observed_tokens = usage.stats.total_tokens();
+    if usage.valid_entries == 0 || observed_tokens <= 0 {
+        return Err(CodexWeeklyValueError::NoUsageInWindow);
+    }
+
+    let mut unpriced_models: Vec<_> = usage
+        .models
+        .iter()
+        .filter(|(model, stats)| !calculate_cost(stats, model, pricing_db).is_finite())
+        .map(|(model, _)| model.clone())
+        .collect();
+    unpriced_models.sort();
+    if !unpriced_models.is_empty() {
+        return Err(CodexWeeklyValueError::UnpricedModels {
+            models: unpriced_models.join(", "),
+        });
+    }
+
+    let observed_cost_usd = sum_model_costs(&usage.models, pricing_db);
+    if !observed_cost_usd.is_finite() || observed_cost_usd <= 0.0 {
+        return Err(CodexWeeklyValueError::NoPricedUsageInWindow);
+    }
+
+    let scale = 100.0 / window.used_pct;
+    let estimated_weekly_value_usd = observed_cost_usd * scale;
+    let estimated_weekly_tokens = observed_tokens as f64 * scale;
+    if !estimated_weekly_value_usd.is_finite() || !estimated_weekly_tokens.is_finite() {
+        return Err(CodexWeeklyValueError::NonFiniteEstimate);
+    }
+
+    Ok(CodexWeeklyValueEstimate {
+        observed_at: window.observed_at,
+        window_started_at,
+        resets_at: window.resets_at,
+        used_pct: window.used_pct,
+        observed_cost_usd,
+        estimated_weekly_value_usd,
+        observed_tokens,
+        estimated_weekly_tokens,
+        valid_entries: usage.valid_entries,
+        dedup_skipped_entries: usage.dedup_skipped_entries,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn window() -> CodexWeeklyValueWindow {
+        let observed_at = Utc::now() - Duration::hours(1);
+        CodexWeeklyValueWindow {
+            observed_at,
+            resets_at: observed_at + Duration::days(6),
+            window_minutes: 10_080,
+            used_pct: 25.0,
+        }
+    }
+
+    #[test]
+    fn explicit_window_rejects_extreme_duration_without_panicking() {
+        let error = validate_window(&CodexWeeklyValueWindow {
+            window_minutes: i64::MAX,
+            ..window()
+        })
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            CodexWeeklyValueWindowError::InvalidWindow { .. }
+        ));
+    }
+
+    #[test]
+    fn explicit_window_rejects_invalid_percentages() {
+        for used_pct in [-1.0, f64::INFINITY, f64::NEG_INFINITY, f64::NAN] {
+            let error = validate_window(&CodexWeeklyValueWindow {
+                used_pct,
+                ..window()
+            })
+            .unwrap_err();
+            assert!(matches!(
+                error,
+                CodexWeeklyValueWindowError::InvalidWindow { .. }
+            ));
+        }
+    }
+}

--- a/src/source/codex/parser.rs
+++ b/src/source/codex/parser.rs
@@ -458,6 +458,9 @@ fn process_event_message(
         return;
     }
     let Some(timestamp) = raw_entry.timestamp else {
+        if payload.info.is_some() {
+            state.parse_errors += 1;
+        }
         return;
     };
     let Some(info) = &payload.info else { return };

--- a/src/source/codex/quota.rs
+++ b/src/source/codex/quota.rs
@@ -255,6 +255,13 @@ pub(super) fn recent_codex_files(
     now: DateTime<Utc>,
 ) -> Result<Vec<PathBuf>, CodexQuotaError> {
     let cutoff = now - Duration::minutes(WEEKLY_WINDOW_MINUTES + DISCOVERY_MARGIN_MINUTES);
+    codex_files_since(files, cutoff)
+}
+
+pub(super) fn codex_files_since(
+    files: Vec<PathBuf>,
+    cutoff: DateTime<Utc>,
+) -> Result<Vec<PathBuf>, CodexQuotaError> {
     files
         .into_iter()
         .filter_map(|path| {

--- a/src/source/codex/quota_value.rs
+++ b/src/source/codex/quota_value.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use chrono::{Duration, Utc};
+use chrono::{DateTime, Utc};
 use rayon::prelude::*;
 
 use crate::core::{DedupAccumulator, Stats};
@@ -11,8 +11,7 @@ use crate::utils::Timezone;
 
 use super::parser::{codex_sessions_dir_candidate, parse_codex_file_for_quota};
 use super::quota::{
-    CodexQuotaError, CodexWeeklyQuota, discover_quota_files, recent_codex_files,
-    validate_sessions_dir,
+    CodexQuotaError, codex_files_since, discover_quota_files, validate_sessions_dir,
 };
 
 #[derive(Debug)]
@@ -24,13 +23,14 @@ pub(crate) struct CodexWindowUsage {
 }
 
 pub(crate) fn load_weekly_window_usage_from_home(
-    quota: &CodexWeeklyQuota,
+    observed_at: DateTime<Utc>,
+    window_started_at: DateTime<Utc>,
     codex_home: Option<&Path>,
 ) -> Result<CodexWindowUsage, CodexQuotaError> {
     let sessions_dir = resolve_sessions_dir(codex_home)?;
     validate_sessions_dir(&sessions_dir)?;
-    let files = recent_codex_files(discover_quota_files(&sessions_dir)?, Utc::now())?;
-    load_weekly_window_usage_from_files(quota, &files)
+    let files = codex_files_since(discover_quota_files(&sessions_dir)?, window_started_at)?;
+    load_weekly_window_usage_from_files(observed_at, window_started_at, &files)
 }
 
 fn resolve_sessions_dir(codex_home: Option<&Path>) -> Result<PathBuf, CodexQuotaError> {
@@ -41,32 +41,34 @@ fn resolve_sessions_dir(codex_home: Option<&Path>) -> Result<PathBuf, CodexQuota
 }
 
 fn load_weekly_window_usage_from_files(
-    quota: &CodexWeeklyQuota,
+    observed_at: DateTime<Utc>,
+    window_started_at: DateTime<Utc>,
     files: &[PathBuf],
 ) -> Result<CodexWindowUsage, CodexQuotaError> {
-    let window_started_at = quota.resets_at - Duration::minutes(quota.window_minutes);
-    let since_ms = window_started_at.timestamp_millis();
-    let until_ms = quota.observed_at.timestamp_millis();
     let utc = Timezone::Named(chrono_tz::UTC);
 
-    let (accumulator, parse_errors) =
-        files
-            .par_iter()
-            .map(|path| {
-                let parsed = parse_codex_file_for_quota(path, utc);
-                let mut partial = DedupAccumulator::new();
-                partial.extend(parsed.entries.into_iter().filter(|entry| {
-                    entry.timestamp_ms >= since_ms && entry.timestamp_ms <= until_ms
-                }));
-                (partial, parsed.errors)
-            })
-            .reduce(
-                || (DedupAccumulator::new(), 0usize),
-                |(mut accumulator, errors), (partial, partial_errors)| {
-                    accumulator.merge(partial);
-                    (accumulator, errors.saturating_add(partial_errors))
-                },
-            );
+    let (accumulator, parse_errors) = files
+        .par_iter()
+        .map(|path| {
+            let parsed = parse_codex_file_for_quota(path, utc);
+            let mut partial = DedupAccumulator::new();
+            partial.extend(parsed.entries.into_iter().filter(|entry| {
+                entry
+                    .timestamp
+                    .parse::<DateTime<Utc>>()
+                    .is_ok_and(|timestamp| {
+                        timestamp >= window_started_at && timestamp <= observed_at
+                    })
+            }));
+            (partial, parsed.errors)
+        })
+        .reduce(
+            || (DedupAccumulator::new(), 0usize),
+            |(mut accumulator, errors), (partial, partial_errors)| {
+                accumulator.merge(partial);
+                (accumulator, errors.saturating_add(partial_errors))
+            },
+        );
 
     if parse_errors > 0 {
         return Err(CodexQuotaError::UsageParse {
@@ -99,12 +101,12 @@ fn load_weekly_window_usage_from_files(
 mod tests {
     use std::io::Write as _;
 
-    use chrono::DateTime;
+    use chrono::{DateTime, Duration};
     use serde_json::json;
     use tempfile::NamedTempFile;
 
     use super::*;
-    use crate::source::CodexQuotaStatus;
+    use crate::source::{CodexQuotaStatus, CodexWeeklyQuota};
 
     fn quota() -> CodexWeeklyQuota {
         CodexWeeklyQuota {
@@ -157,14 +159,19 @@ mod tests {
 
     #[test]
     fn usage_is_aligned_to_exact_provider_window_and_observation() {
-        let before = usage_event("2026-08-19T23:59:59Z", 100, 100);
+        let before = usage_event("2026-08-19T23:59:59.999999500Z", 100, 100);
         let at_start = usage_event("2026-08-20T00:00:00Z", 300, 200);
         let at_observation = usage_event("2026-08-22T00:00:00Z", 600, 300);
-        let after = usage_event("2026-08-22T00:00:01Z", 1_000, 400);
+        let after = usage_event("2026-08-22T00:00:00.000000500Z", 1_000, 400);
         let file = write_log(&[&before, &at_start, &at_observation, &after]);
 
-        let usage =
-            load_weekly_window_usage_from_files(&quota(), &[file.path().to_path_buf()]).unwrap();
+        let quota = quota();
+        let usage = load_weekly_window_usage_from_files(
+            quota.observed_at,
+            quota.resets_at - Duration::minutes(quota.window_minutes),
+            &[file.path().to_path_buf()],
+        )
+        .unwrap();
 
         assert_eq!(usage.valid_entries, 2);
         assert_eq!(usage.stats.total_tokens(), 500);
@@ -176,8 +183,13 @@ mod tests {
         let valid = usage_event("2026-08-21T00:00:00Z", 100, 100);
         let file = write_log(&[&valid, "{malformed"]);
 
-        let error = load_weekly_window_usage_from_files(&quota(), &[file.path().to_path_buf()])
-            .unwrap_err();
+        let quota = quota();
+        let error = load_weekly_window_usage_from_files(
+            quota.observed_at,
+            quota.resets_at - Duration::minutes(quota.window_minutes),
+            &[file.path().to_path_buf()],
+        )
+        .unwrap_err();
 
         assert!(matches!(error, CodexQuotaError::UsageParse { count: 1 }));
     }
@@ -188,8 +200,13 @@ mod tests {
             usage_event("2026-08-21T00:00:00Z", 100, 100).replace("\"model\":\"gpt-5\",", "");
         let file = write_log(&[&line]);
 
-        let usage =
-            load_weekly_window_usage_from_files(&quota(), &[file.path().to_path_buf()]).unwrap();
+        let quota = quota();
+        let usage = load_weekly_window_usage_from_files(
+            quota.observed_at,
+            quota.resets_at - Duration::minutes(quota.window_minutes),
+            &[file.path().to_path_buf()],
+        )
+        .unwrap();
 
         assert!(usage.models.contains_key("unknown-model"));
         assert!(!usage.models.contains_key("gpt-5"));

--- a/tests/sdk_integration.rs
+++ b/tests/sdk_integration.rs
@@ -3,9 +3,10 @@ use std::path::Path;
 use std::sync::Mutex;
 
 use ccstats::{
-    CodexQuotaError, CodexQuotaStatus, CostSummary, MultiSummaryOptions, SummaryOptions,
-    UsageRange, UsageSource, estimate_codex_weekly_value, load_codex_weekly_quota, summarize_cost,
-    summarize_cost_ranges,
+    CodexQuotaError, CodexQuotaStatus, CodexWeeklyValueError, CodexWeeklyValueWindow,
+    CodexWeeklyValueWindowError, CostSummary, MultiSummaryOptions, SummaryOptions, UsageRange,
+    UsageSource, estimate_codex_weekly_value, estimate_codex_weekly_value_for_window,
+    load_codex_weekly_quota, summarize_cost, summarize_cost_ranges,
 };
 use chrono::{Datelike, Days, Duration, NaiveDate, Timelike, Utc};
 
@@ -110,6 +111,127 @@ fn sdk_estimates_codex_weekly_api_equivalent_value() {
             < f64::EPSILON
     );
     assert_eq!(estimate.estimated_weekly_tokens, 4_400_000.0);
+}
+
+#[test]
+fn sdk_estimates_codex_value_for_an_explicit_exact_window() {
+    let root = tempfile::tempdir().expect("temp dir");
+    let codex_home = root.path().join("codex-home");
+    let session_file = codex_home.join("sessions").join("usage.jsonl");
+    let observed_at = (Utc::now() - Duration::hours(1))
+        .with_nanosecond(0)
+        .expect("valid timestamp");
+    let resets_at = observed_at + Duration::days(6);
+    let before_window = observed_at - Duration::days(8);
+    let in_window = observed_at - Duration::hours(12);
+    let usage_event = |timestamp, total: i64, delta: i64| {
+        serde_json::json!({
+            "timestamp": timestamp,
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "total_token_usage": {
+                        "input_tokens": total,
+                        "cached_input_tokens": 0,
+                        "output_tokens": 0,
+                        "reasoning_output_tokens": 0,
+                        "total_tokens": total,
+                    },
+                    "last_token_usage": {
+                        "input_tokens": delta,
+                        "cached_input_tokens": 0,
+                        "output_tokens": 0,
+                        "reasoning_output_tokens": 0,
+                        "total_tokens": delta,
+                    },
+                    "model": "gpt-5",
+                }
+            }
+        })
+    };
+    write_file(
+        &session_file,
+        &format!(
+            "{}\n{}\n",
+            usage_event(before_window, 500_000, 500_000),
+            usage_event(in_window, 1_500_000, 1_000_000),
+        ),
+    );
+    let window = CodexWeeklyValueWindow {
+        observed_at,
+        resets_at,
+        window_minutes: 10_080,
+        used_pct: 25.0,
+    };
+
+    let estimate = estimate_codex_weekly_value_for_window(&window, Some(&codex_home), true, false)
+        .expect("estimate explicit weekly window");
+
+    assert_eq!(estimate.observed_tokens, 1_000_000);
+    assert_eq!(estimate.used_pct, 25.0);
+    assert_eq!(estimate.estimated_weekly_tokens, 4_000_000.0);
+}
+
+#[test]
+fn sdk_explicit_window_rejects_usage_without_a_timestamp() {
+    let root = tempfile::tempdir().expect("temp dir");
+    let codex_home = root.path().join("codex-home");
+    let session_file = codex_home.join("sessions").join("usage.jsonl");
+    let observed_at = (Utc::now() - Duration::hours(1))
+        .with_nanosecond(0)
+        .expect("valid timestamp");
+    let resets_at = observed_at + Duration::days(6);
+    let valid = serde_json::json!({
+        "timestamp": observed_at - Duration::minutes(1),
+        "type": "event_msg",
+        "payload": {
+            "type": "token_count",
+            "info": {
+                "last_token_usage": {
+                    "input_tokens": 1_000_000,
+                    "cached_input_tokens": 0,
+                    "output_tokens": 0,
+                    "reasoning_output_tokens": 0,
+                    "total_tokens": 1_000_000,
+                },
+                "model": "gpt-5",
+            }
+        }
+    });
+    let missing_timestamp = serde_json::json!({
+        "type": "event_msg",
+        "payload": {
+            "type": "token_count",
+            "info": {
+                "last_token_usage": {
+                    "input_tokens": 500_000,
+                    "cached_input_tokens": 0,
+                    "output_tokens": 0,
+                    "reasoning_output_tokens": 0,
+                    "total_tokens": 500_000,
+                },
+                "model": "gpt-5",
+            }
+        }
+    });
+    write_file(&session_file, &format!("{valid}\n{missing_timestamp}\n"));
+    let window = CodexWeeklyValueWindow {
+        observed_at,
+        resets_at,
+        window_minutes: 10_080,
+        used_pct: 25.0,
+    };
+
+    let error = estimate_codex_weekly_value_for_window(&window, Some(&codex_home), true, false)
+        .expect_err("missing usage timestamp must fail closed");
+
+    assert!(matches!(
+        error,
+        CodexWeeklyValueWindowError::Estimate(CodexWeeklyValueError::Quota(
+            CodexQuotaError::UsageParse { count: 1 }
+        ))
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## What

- Add an explicit provider-window SDK entry point for Codex weekly value estimates.
- Reuse exact timestamp filtering, pricing, deduplication, and parse-error rejection.
- Keep the existing convenience API and error type compatible.

## Why

QuotaBar needs to estimate against a newer provider-authoritative 7-day window when the local CLI quota snapshot describes a different window.

Closes #111

## Test Plan

- [x] `cargo check` passes
- [x] `cargo test` passes (579 unit tests plus all integration suites)
- [x] Exact timestamp, invalid-window, extreme-duration, and malformed-record coverage