### PR TITLE
fix: preserve complete Grok tokens with API cost coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ ccstats daily --source cur
 
 ## Quick Start (Grok)
 
-Grok support reads each `shell.turn.inference_done` record from `~/.grok/logs/unified.jsonl`. It reports uncached input, cached prompt, completion, and reasoning tokens, then calculates Grok 4.5/4.6 USD cost per inference using xAI's short- or long-context price for the whole request. Observed records are kept in an atomic ccstats ledger because Grok trims the live log in place.
+Grok support reports complete, globally deduplicated token totals from session `turn_completed.usage` records. It separately prices each observed `shell.turn.inference_done` record using xAI's short- or long-context API rate for the whole request. Because Grok trims `unified.jsonl`, the output includes priced-token coverage and marks the API-equivalent cost as a lower bound when inference history is incomplete.
 
 ```bash
 # Install
@@ -371,13 +371,14 @@ ccstats daily --source gx
 
 By default, ccstats uses:
 
-- `~/.grok/logs/unified.jsonl` for per-inference token records
+- `~/.grok/sessions/**/updates.jsonl` for complete per-turn token totals
+- `~/.grok/logs/unified.jsonl` for per-inference API-equivalent pricing
 - `~/.grok/sessions/**/summary.json` for model, project, and session metadata
 - the platform cache directory under `ccstats/grok/<source-root>/inference-v1.jsonl` for the durable, deduplicated ledger
 
-For Grok 4.5 and 4.6, requests below 200k prompt tokens use the short-context rates. Requests at or above 200k use the long-context input, cached-input, and output rates for the entire inference. `completion_tokens` already includes reasoning, so ccstats separates the displayed fields without charging reasoning twice. Rates follow the [xAI pricing reference](https://docs.x.ai/developers/pricing).
+For Grok 4.5 and 4.6, requests below 200k prompt tokens use the short-context rates. Requests at or above 200k use the long-context input, cached-input, and output rates for the entire inference. `completion_tokens` already includes reasoning, so ccstats does not charge reasoning twice. Rates follow the [xAI pricing reference](https://docs.x.ai/developers/pricing).
 
-If `unified.jsonl` is unavailable, ccstats retains the older session `turn_completed.usage` and context-snapshot fallback for installations that do not emit inference telemetry.
+Structured period output includes `api_equivalent_cost_coverage` with `total_tokens`, `priced_tokens`, `percent`, `complete`, and `cost_is_lower_bound`. If a session has no `turn_completed.usage`, ccstats retains its explicitly labeled `estimated_proxy` context-snapshot fallback.
 
 You can override the Grok home directory with `GROK_HOME`:
 
@@ -387,9 +388,9 @@ GROK_HOME="/path/to/.grok" ccstats grok
 
 Current limitations:
 
-- The durable ledger starts when ccstats first observes an inference. It cannot recover records Grok trimmed before the first run.
-- Session fallback totals use the fields available in those files and can differ from the Grok Build weekly allowance.
-- Grok models without a published ccstats per-inference tier fall back to the normal pricing resolver.
+- The durable ledger starts when ccstats first observes an inference. It cannot recover records Grok trimmed before the first run or between ccstats runs, so incomplete API-equivalent cost is reported as a lower bound.
+- `turn_completed.usage.costUsdTicks` is not used as an API-equivalent price.
+- Grok models without a published ccstats per-inference tier remain unpriced and reduce priced-token coverage.
 - Grok 5-hour billing blocks are not supported.
 
 ### Kimi Code
@@ -577,7 +578,7 @@ Warning: ignored <N> malformed records
 | OpenAI Codex | `~/.codex/sessions/` | `CODEX_HOME` | Reasoning Tokens |
 | All Sources | Multiple | Source-specific env vars | Combined daily/weekly/monthly/today/statusline summaries |
 | Cursor | Cursor usage API | `CURSOR_API_KEY` / `CURSOR_SESSION_TOKEN` | Per-event tokens, cache tokens, recorded `chargedCents` |
-| Grok | `~/.grok/logs/unified.jsonl` | `GROK_HOME` | Per-inference usage, Projects, Cache / reasoning tokens, 200k pricing tier, durable ledger |
+| Grok | `~/.grok/sessions/`, `~/.grok/logs/unified.jsonl` | `GROK_HOME` | Complete turn tokens, per-inference API pricing, coverage metadata, Projects, Cache / reasoning tokens, 200k pricing tier |
 | Kimi Code | `~/.kimi-code/sessions/` | `KIMI_CODE_HOME` | Per-turn usage records, Projects, Cache tokens |
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ ccstats daily --source cur
 
 ## Quick Start (Grok)
 
-Grok support reports complete, globally deduplicated token totals from session `turn_completed.usage` records. It separately prices each observed `shell.turn.inference_done` record using xAI's short- or long-context API rate for the whole request. Because Grok trims `unified.jsonl`, the output includes priced-token coverage and marks the API-equivalent cost as a lower bound when inference history is incomplete.
+Grok support reports complete, globally deduplicated token totals from session `turn_completed.usage` records. It separately prices each observed `shell.turn.inference_done` record using xAI's short- or long-context API rate for the whole request. Because Grok trims `unified.jsonl`, the output includes priced-token coverage and marks the API-equivalent cost as a lower bound when inference history is incomplete and no `estimated_proxy` contribution is included.
 
 ```bash
 # Install
@@ -388,7 +388,7 @@ GROK_HOME="/path/to/.grok" ccstats grok
 
 Current limitations:
 
-- The durable ledger starts when ccstats first observes an inference. It cannot recover records Grok trimmed before the first run or between ccstats runs, so incomplete API-equivalent cost is reported as a lower bound.
+- The durable ledger starts when ccstats first observes an inference. It cannot recover records Grok trimmed before the first run or between ccstats runs, so incomplete API-equivalent cost is reported as a lower bound only when no `estimated_proxy` contribution is included.
 - `turn_completed.usage.costUsdTicks` is not used as an API-equivalent price.
 - Grok models without a published ccstats per-inference tier remain unpriced and reduce priced-token coverage.
 - Grok 5-hour billing blocks are not supported.

--- a/src/app.rs
+++ b/src/app.rs
@@ -523,7 +523,9 @@ fn render_period_result(
                     cost_mode,
                 },
             );
-            cost_coverage::print_note(cost_coverage);
+            if ctx.cli.show_cost() {
+                cost_coverage::print_note(cost_coverage);
+            }
             if let Some(budget) = monthly_budget {
                 let reports = monthly_budget_reports(
                     &result.day_stats,
@@ -662,12 +664,18 @@ fn handle_all_period(command: SourceCommand, ctx: &CommandContext<'_>) {
         print_no_data_hint("All Sources", "usage");
         return;
     }
+    let cost_coverage = all_sources()
+        .filter_map(|source| source.cost_coverage(ctx.filter, ctx.timezone))
+        .reduce(|left, right| CostCoverage {
+            total_tokens: left.total_tokens.saturating_add(right.total_tokens),
+            priced_tokens: left.priced_tokens.saturating_add(right.priced_tokens),
+        });
     render_period_result(
         &result,
         period,
         &caps,
         None,
-        None,
+        cost_coverage,
         ctx,
         CostDisplayMode::RealOnly,
     );

--- a/src/app.rs
+++ b/src/app.rs
@@ -425,10 +425,10 @@ fn render_period_result(
     period: Period,
     caps: &Capabilities,
     codex_scope: Option<CodexScope>,
-    cost_coverage: Option<CostCoverage>,
     ctx: &CommandContext<'_>,
     cost_mode: CostDisplayMode,
 ) {
+    let cost_coverage = CostCoverage::from_stats(result.day_stats.values().map(|day| &day.stats));
     let monthly_budget = (period == Period::Month)
         .then_some(ctx.cli.monthly_budget)
         .flatten();
@@ -494,7 +494,7 @@ fn render_period_result(
                 );
                 json = add_monthly_budget_to_json(&json, &reports);
             }
-            json = cost_coverage::annotate_json(&json, cost_coverage);
+            json = cost_coverage::annotate_json(&json, &result.day_stats, period);
             json = codex_scope::annotate_json(&json, codex_scope);
             print_json(&json, ctx.jq_filter);
         }
@@ -565,7 +565,6 @@ fn handle_period(
         period,
         caps,
         codex_scope_for_source(source, ctx),
-        source.cost_coverage(ctx.filter, ctx.timezone),
         ctx,
         CostDisplayMode::Total,
     );
@@ -664,21 +663,7 @@ fn handle_all_period(command: SourceCommand, ctx: &CommandContext<'_>) {
         print_no_data_hint("All Sources", "usage");
         return;
     }
-    let cost_coverage = all_sources()
-        .filter_map(|source| source.cost_coverage(ctx.filter, ctx.timezone))
-        .reduce(|left, right| CostCoverage {
-            total_tokens: left.total_tokens.saturating_add(right.total_tokens),
-            priced_tokens: left.priced_tokens.saturating_add(right.priced_tokens),
-        });
-    render_period_result(
-        &result,
-        period,
-        &caps,
-        None,
-        cost_coverage,
-        ctx,
-        CostDisplayMode::RealOnly,
-    );
+    render_period_result(&result, period, &caps, None, ctx, CostDisplayMode::RealOnly);
 }
 
 /// Handle aggregate commands across every registered data source.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,6 @@
-use std::fmt::Write as _;
+mod codex_scope;
+mod cost_coverage;
+
 use std::time::Instant;
 
 use crate::cli::{Cli, SourceCommand, TopDimension};
@@ -20,8 +22,8 @@ use crate::output::{
 };
 use crate::pricing::{CostDisplayMode, PricingDb};
 use crate::source::{
-    Capabilities, CodexScope, Source, all_capabilities, all_sources, load_blocks, load_daily,
-    load_projects, load_sessions, load_tool_calls,
+    Capabilities, CodexScope, CostCoverage, Source, all_capabilities, all_sources, load_blocks,
+    load_daily, load_projects, load_sessions, load_tool_calls,
 };
 use crate::utils::{Timezone, filter_json};
 
@@ -68,47 +70,6 @@ fn source_label(source: &dyn Source, ctx: &CommandContext<'_>) -> String {
     }
 }
 
-fn annotate_json_codex_scope(json: &str, scope: Option<CodexScope>) -> String {
-    let Some(scope) = scope else {
-        return json.to_string();
-    };
-    let Ok(mut value) = serde_json::from_str::<serde_json::Value>(json) else {
-        return json.to_string();
-    };
-
-    match &mut value {
-        serde_json::Value::Array(rows) => {
-            for row in rows {
-                if let serde_json::Value::Object(object) = row {
-                    object.insert(
-                        "codex_scope".to_string(),
-                        serde_json::Value::String(scope.as_str().to_string()),
-                    );
-                }
-            }
-        }
-        serde_json::Value::Object(object) => {
-            object.insert(
-                "codex_scope".to_string(),
-                serde_json::Value::String(scope.as_str().to_string()),
-            );
-        }
-        _ => {}
-    }
-
-    serde_json::to_string(&value).unwrap_or_else(|_| json.to_string())
-}
-
-fn annotate_csv_codex_scope(mut csv: String, scope: Option<CodexScope>) -> String {
-    if let Some(scope) = scope {
-        if !csv.ends_with('\n') {
-            csv.push('\n');
-        }
-        let _ = writeln!(csv, "# codex_scope,{}", scope.as_str());
-    }
-    csv
-}
-
 fn print_codex_scope_note(scope: Option<CodexScope>) {
     if let Some(scope) = scope {
         println!("\n  Codex scope: {}", scope.as_str());
@@ -146,7 +107,7 @@ fn render_session(sessions: &[SessionStats], source: &dyn Source, ctx: &CommandC
                 source.capabilities().has_cache_read,
                 ctx.currency,
             );
-            print!("{}", annotate_csv_codex_scope(csv, scope));
+            print!("{}", codex_scope::annotate_csv(csv, scope));
         }
         OutputFormat::Json => {
             let json = output_session_json(
@@ -157,7 +118,7 @@ fn render_session(sessions: &[SessionStats], source: &dyn Source, ctx: &CommandC
                 source.capabilities().has_cache_read,
                 ctx.currency,
             );
-            let json = annotate_json_codex_scope(&json, scope);
+            let json = codex_scope::annotate_json(&json, scope);
             print_json(&json, ctx.jq_filter);
         }
         OutputFormat::Table => {
@@ -313,7 +274,7 @@ fn handle_top(
                 options.supports_cache_read,
                 ctx.currency,
             );
-            print!("{}", annotate_csv_codex_scope(csv, options.codex_scope));
+            print!("{}", codex_scope::annotate_csv(csv, options.codex_scope));
         }
         OutputFormat::Json => {
             let json = output_top_json(
@@ -324,7 +285,7 @@ fn handle_top(
                 options.supports_cache_read,
                 ctx.currency,
             );
-            let json = annotate_json_codex_scope(&json, options.codex_scope);
+            let json = codex_scope::annotate_json(&json, options.codex_scope);
             print_json(&json, ctx.jq_filter);
         }
         OutputFormat::Table => print_top_table(
@@ -443,7 +404,7 @@ fn handle_statusline(source: &dyn Source, ctx: &CommandContext<'_>) {
             Some(result.data_quality()),
             CostDisplayMode::Total,
         );
-        let json = annotate_json_codex_scope(&json, scope);
+        let json = codex_scope::annotate_json(&json, scope);
         print_json(&json, ctx.jq_filter);
     } else {
         print_statusline(
@@ -464,6 +425,7 @@ fn render_period_result(
     period: Period,
     caps: &Capabilities,
     codex_scope: Option<CodexScope>,
+    cost_coverage: Option<CostCoverage>,
     ctx: &CommandContext<'_>,
     cost_mode: CostDisplayMode,
 ) {
@@ -504,7 +466,8 @@ fn render_period_result(
                     cost_mode,
                 )
             };
-            print!("{}", annotate_csv_codex_scope(csv, codex_scope));
+            let csv = cost_coverage::annotate_csv(csv, cost_coverage);
+            print!("{}", codex_scope::annotate_csv(csv, codex_scope));
         }
         OutputFormat::Json => {
             let mut json = output_period_json_with_quality(
@@ -531,7 +494,8 @@ fn render_period_result(
                 );
                 json = add_monthly_budget_to_json(&json, &reports);
             }
-            json = annotate_json_codex_scope(&json, codex_scope);
+            json = cost_coverage::annotate_json(&json, cost_coverage);
+            json = codex_scope::annotate_json(&json, codex_scope);
             print_json(&json, ctx.jq_filter);
         }
         OutputFormat::Table => {
@@ -559,6 +523,7 @@ fn render_period_result(
                     cost_mode,
                 },
             );
+            cost_coverage::print_note(cost_coverage);
             if let Some(budget) = monthly_budget {
                 let reports = monthly_budget_reports(
                     &result.day_stats,
@@ -598,6 +563,7 @@ fn handle_period(
         period,
         caps,
         codex_scope_for_source(source, ctx),
+        source.cost_coverage(ctx.filter, ctx.timezone),
         ctx,
         CostDisplayMode::Total,
     );
@@ -681,6 +647,30 @@ fn load_all_daily(ctx: &CommandContext<'_>, quiet: bool) -> (LoadResult, Capabil
 
     combined.elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
     (combined, caps)
+}
+
+fn handle_all_period(command: SourceCommand, ctx: &CommandContext<'_>) {
+    let period = match command {
+        SourceCommand::Daily | SourceCommand::Today => Period::Day,
+        SourceCommand::Weekly => Period::Week,
+        SourceCommand::Monthly => Period::Month,
+        _ => return,
+    };
+
+    let (result, caps) = load_all_daily(ctx, false);
+    if result.day_stats.is_empty() && !should_render_empty_structured_result(&result, ctx) {
+        print_no_data_hint("All Sources", "usage");
+        return;
+    }
+    render_period_result(
+        &result,
+        period,
+        &caps,
+        None,
+        None,
+        ctx,
+        CostDisplayMode::RealOnly,
+    );
 }
 
 /// Handle aggregate commands across every registered data source.
@@ -771,17 +761,5 @@ pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandCo
         | SourceCommand::Monthly => {}
     }
 
-    let period = match command {
-        SourceCommand::Daily | SourceCommand::Today => Period::Day,
-        SourceCommand::Weekly => Period::Week,
-        SourceCommand::Monthly => Period::Month,
-        _ => return,
-    };
-
-    let (result, caps) = load_all_daily(ctx, false);
-    if result.day_stats.is_empty() && !should_render_empty_structured_result(&result, ctx) {
-        print_no_data_hint("All Sources", "usage");
-        return;
-    }
-    render_period_result(&result, period, &caps, None, ctx, CostDisplayMode::RealOnly);
+    handle_all_period(command, ctx);
 }

--- a/src/app/codex_scope.rs
+++ b/src/app/codex_scope.rs
@@ -1,0 +1,44 @@
+use std::fmt::Write as _;
+
+use crate::source::CodexScope;
+
+pub(crate) fn annotate_json(json: &str, scope: Option<CodexScope>) -> String {
+    let Some(scope) = scope else {
+        return json.to_string();
+    };
+    let Ok(mut value) = serde_json::from_str::<serde_json::Value>(json) else {
+        return json.to_string();
+    };
+
+    match &mut value {
+        serde_json::Value::Array(rows) => {
+            for row in rows {
+                if let serde_json::Value::Object(object) = row {
+                    object.insert(
+                        "codex_scope".to_string(),
+                        serde_json::Value::String(scope.as_str().to_string()),
+                    );
+                }
+            }
+        }
+        serde_json::Value::Object(object) => {
+            object.insert(
+                "codex_scope".to_string(),
+                serde_json::Value::String(scope.as_str().to_string()),
+            );
+        }
+        _ => {}
+    }
+
+    serde_json::to_string(&value).unwrap_or_else(|_| json.to_string())
+}
+
+pub(crate) fn annotate_csv(mut csv: String, scope: Option<CodexScope>) -> String {
+    if let Some(scope) = scope {
+        if !csv.ends_with('\n') {
+            csv.push('\n');
+        }
+        let _ = writeln!(csv, "# codex_scope,{}", scope.as_str());
+    }
+    csv
+}

--- a/src/app/cost_coverage.rs
+++ b/src/app/cost_coverage.rs
@@ -1,26 +1,47 @@
+use std::collections::HashMap;
 use std::fmt::Write as _;
 
+use crate::core::DayStats;
+use crate::output::{Period, aggregate_day_stats_by_period};
 use crate::source::CostCoverage;
 
-pub(crate) fn annotate_json(json: &str, coverage: Option<CostCoverage>) -> String {
-    let Some(coverage) = coverage else {
-        return json.to_string();
-    };
-    let Ok(mut value) = serde_json::from_str::<serde_json::Value>(json) else {
-        return json.to_string();
-    };
-    let metadata = serde_json::json!({
+fn metadata(coverage: CostCoverage) -> serde_json::Value {
+    serde_json::json!({
         "total_tokens": coverage.total_tokens,
         "priced_tokens": coverage.priced_tokens,
         "percent": coverage.percent(),
         "complete": !coverage.is_partial(),
-        "cost_is_lower_bound": coverage.is_partial(),
-    });
+        "cost_is_lower_bound": coverage.cost_is_lower_bound(),
+    })
+}
+
+pub(crate) fn annotate_json(
+    json: &str,
+    day_stats: &HashMap<String, DayStats>,
+    period: Period,
+) -> String {
+    let Ok(mut value) = serde_json::from_str::<serde_json::Value>(json) else {
+        return json.to_string();
+    };
+    let aggregated;
+    let rows_by_key = if period == Period::Day {
+        day_stats
+    } else {
+        aggregated = aggregate_day_stats_by_period(day_stats, period);
+        &aggregated
+    };
     if let serde_json::Value::Array(rows) = &mut value {
         for row in rows {
-            if let serde_json::Value::Object(object) = row {
-                object.insert("api_equivalent_cost_coverage".to_string(), metadata.clone());
-            }
+            let Some(key) = row.get(period.label()).and_then(serde_json::Value::as_str) else {
+                continue;
+            };
+            let Some(coverage) = rows_by_key
+                .get(key)
+                .and_then(|row| CostCoverage::from_stats(std::iter::once(&row.stats)))
+            else {
+                continue;
+            };
+            row["api_equivalent_cost_coverage"] = metadata(coverage);
         }
     }
     serde_json::to_string(&value).unwrap_or_else(|_| json.to_string())
@@ -38,7 +59,7 @@ pub(crate) fn annotate_csv(mut csv: String, coverage: Option<CostCoverage>) -> S
             coverage.priced_tokens,
             coverage.percent(),
             !coverage.is_partial(),
-            coverage.is_partial()
+            coverage.cost_is_lower_bound()
         );
     }
     csv
@@ -48,7 +69,7 @@ pub(crate) fn print_note(coverage: Option<CostCoverage>) {
     let Some(coverage) = coverage else {
         return;
     };
-    if coverage.is_partial() {
+    if coverage.cost_is_lower_bound() {
         println!(
             "\n  API-equivalent cost coverage: {} / {} tokens ({:.2}%); displayed cost is a lower bound.",
             coverage.priced_tokens,
@@ -61,16 +82,29 @@ pub(crate) fn print_note(coverage: Option<CostCoverage>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::{CostTokens, Stats};
+
+    fn day(total_tokens: i64, priced_tokens: i64, estimated_proxy_tokens: i64) -> DayStats {
+        DayStats {
+            stats: Stats {
+                input_tokens: total_tokens,
+                api_equivalent_priced_tokens: priced_tokens,
+                api_equivalent_coverage_tokens: total_tokens,
+                estimated_proxy: CostTokens {
+                    input_tokens: estimated_proxy_tokens,
+                    count: i64::from(estimated_proxy_tokens > 0),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
 
     #[test]
     fn json_marks_partial_api_cost_as_lower_bound() {
-        let output = annotate_json(
-            r#"[{"date":"2026-08-24"}]"#,
-            Some(CostCoverage {
-                total_tokens: 200,
-                priced_tokens: 100,
-            }),
-        );
+        let day_stats = HashMap::from([("2026-08-24".to_string(), day(200, 100, 0))]);
+        let output = annotate_json(r#"[{"date":"2026-08-24"}]"#, &day_stats, Period::Day);
         let value: serde_json::Value = serde_json::from_str(&output).expect("valid json");
         let coverage = &value[0]["api_equivalent_cost_coverage"];
         assert_eq!(coverage["total_tokens"], 200);
@@ -78,5 +112,35 @@ mod tests {
         assert_eq!(coverage["percent"], 50.0);
         assert_eq!(coverage["complete"], false);
         assert_eq!(coverage["cost_is_lower_bound"], true);
+    }
+
+    #[test]
+    fn snapshot_only_estimate_is_not_labeled_a_lower_bound() {
+        let day_stats = HashMap::from([("2026-08-24".to_string(), day(200, 0, 200))]);
+        let output = annotate_json(
+            r#"[{"date":"2026-08-24","total_tokens":200,"estimated_cost":0.1}]"#,
+            &day_stats,
+            Period::Day,
+        );
+        let value: serde_json::Value = serde_json::from_str(&output).expect("valid json");
+
+        assert_eq!(
+            value[0]["api_equivalent_cost_coverage"]["cost_is_lower_bound"],
+            false
+        );
+    }
+
+    #[test]
+    fn json_does_not_copy_range_coverage_into_empty_period_rows() {
+        let day_stats = HashMap::from([("2026-08-24".to_string(), day(200, 100, 0))]);
+        let output = annotate_json(
+            r#"[{"date":"2026-08-24","total_tokens":200},{"date":"2026-08-25","total_tokens":0}]"#,
+            &day_stats,
+            Period::Day,
+        );
+        let value: serde_json::Value = serde_json::from_str(&output).expect("valid json");
+
+        assert!(value[0].get("api_equivalent_cost_coverage").is_some());
+        assert!(value[1].get("api_equivalent_cost_coverage").is_none());
     }
 }

--- a/src/app/cost_coverage.rs
+++ b/src/app/cost_coverage.rs
@@ -1,0 +1,82 @@
+use std::fmt::Write as _;
+
+use crate::source::CostCoverage;
+
+pub(crate) fn annotate_json(json: &str, coverage: Option<CostCoverage>) -> String {
+    let Some(coverage) = coverage else {
+        return json.to_string();
+    };
+    let Ok(mut value) = serde_json::from_str::<serde_json::Value>(json) else {
+        return json.to_string();
+    };
+    let metadata = serde_json::json!({
+        "total_tokens": coverage.total_tokens,
+        "priced_tokens": coverage.priced_tokens,
+        "percent": coverage.percent(),
+        "complete": !coverage.is_partial(),
+        "cost_is_lower_bound": coverage.is_partial(),
+    });
+    if let serde_json::Value::Array(rows) = &mut value {
+        for row in rows {
+            if let serde_json::Value::Object(object) = row {
+                object.insert("api_equivalent_cost_coverage".to_string(), metadata.clone());
+            }
+        }
+    }
+    serde_json::to_string(&value).unwrap_or_else(|_| json.to_string())
+}
+
+pub(crate) fn annotate_csv(mut csv: String, coverage: Option<CostCoverage>) -> String {
+    if let Some(coverage) = coverage {
+        if !csv.ends_with('\n') {
+            csv.push('\n');
+        }
+        let _ = writeln!(
+            csv,
+            "# api_equivalent_cost_coverage,{},{},{:.2},{},{}",
+            coverage.total_tokens,
+            coverage.priced_tokens,
+            coverage.percent(),
+            !coverage.is_partial(),
+            coverage.is_partial()
+        );
+    }
+    csv
+}
+
+pub(crate) fn print_note(coverage: Option<CostCoverage>) {
+    let Some(coverage) = coverage else {
+        return;
+    };
+    if coverage.is_partial() {
+        println!(
+            "\n  API-equivalent cost coverage: {} / {} tokens ({:.2}%); displayed cost is a lower bound.",
+            coverage.priced_tokens,
+            coverage.total_tokens,
+            coverage.percent()
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_marks_partial_api_cost_as_lower_bound() {
+        let output = annotate_json(
+            r#"[{"date":"2026-08-24"}]"#,
+            Some(CostCoverage {
+                total_tokens: 200,
+                priced_tokens: 100,
+            }),
+        );
+        let value: serde_json::Value = serde_json::from_str(&output).expect("valid json");
+        let coverage = &value[0]["api_equivalent_cost_coverage"];
+        assert_eq!(coverage["total_tokens"], 200);
+        assert_eq!(coverage["priced_tokens"], 100);
+        assert_eq!(coverage["percent"], 50.0);
+        assert_eq!(coverage["complete"], false);
+        assert_eq!(coverage["cost_is_lower_bound"], true);
+    }
+}

--- a/src/core/aggregator.rs
+++ b/src/core/aggregator.rs
@@ -281,6 +281,8 @@ mod tests {
             endpoint: Endpoint::Unknown,
             call_count: 1,
             recorded_cost_usd: None,
+            api_equivalent_priced_tokens: 0,
+            api_equivalent_coverage_tokens: 0,
         }
     }
 
@@ -511,6 +513,8 @@ mod tests {
                 endpoint: Endpoint::Unknown,
                 call_count: 1,
                 recorded_cost_usd: None,
+                api_equivalent_priced_tokens: 0,
+                api_equivalent_coverage_tokens: 0,
             },
             RawEntry {
                 timestamp: "2025-01-01T08:00:00Z".to_string(),
@@ -532,6 +536,8 @@ mod tests {
                 endpoint: Endpoint::Unknown,
                 call_count: 1,
                 recorded_cost_usd: None,
+                api_equivalent_priced_tokens: 0,
+                api_equivalent_coverage_tokens: 0,
             },
             RawEntry {
                 timestamp: "2025-01-01T20:00:00Z".to_string(),
@@ -553,6 +559,8 @@ mod tests {
                 endpoint: Endpoint::Unknown,
                 call_count: 1,
                 recorded_cost_usd: None,
+                api_equivalent_priced_tokens: 0,
+                api_equivalent_coverage_tokens: 0,
             },
         ];
         let result = aggregate_sessions(entries);

--- a/src/core/aggregator_endpoint_tests.rs
+++ b/src/core/aggregator_endpoint_tests.rs
@@ -26,6 +26,8 @@ fn entry(model: &str, endpoint: Endpoint, input: i64) -> RawEntry {
         endpoint,
         call_count: 1,
         recorded_cost_usd: None,
+        api_equivalent_priced_tokens: 0,
+        api_equivalent_coverage_tokens: 0,
     }
 }
 

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -29,6 +29,12 @@ pub(crate) struct Stats {
     /// Number of source records that contributed `recorded_cost_usd`.
     #[serde(default)]
     pub(crate) recorded_cost_entries: i64,
+    /// Tokens covered by exact API-equivalent request telemetry.
+    #[serde(default)]
+    pub(crate) api_equivalent_priced_tokens: i64,
+    /// Usage tokens eligible for API-equivalent coverage reporting.
+    #[serde(default)]
+    pub(crate) api_equivalent_coverage_tokens: i64,
     /// Tokens that still need local pricing (records without a provider cost).
     #[serde(default)]
     pub(crate) priced_tokens: CostTokens,
@@ -52,6 +58,12 @@ impl Stats {
         self.recorded_cost_entries = self
             .recorded_cost_entries
             .saturating_add(other.recorded_cost_entries);
+        self.api_equivalent_priced_tokens = self
+            .api_equivalent_priced_tokens
+            .saturating_add(other.api_equivalent_priced_tokens);
+        self.api_equivalent_coverage_tokens = self
+            .api_equivalent_coverage_tokens
+            .saturating_add(other.api_equivalent_coverage_tokens);
         self.priced_tokens.add(&other.priced_tokens);
     }
 
@@ -179,6 +191,14 @@ pub(crate) struct CostTokens {
 }
 
 impl CostTokens {
+    pub(crate) fn total_tokens(self) -> i64 {
+        self.input_tokens
+            .saturating_add(self.output_tokens)
+            .saturating_add(self.reasoning_tokens)
+            .saturating_add(self.cache_creation)
+            .saturating_add(self.cache_read)
+    }
+
     pub(crate) fn add(&mut self, other: &Self) {
         self.input_tokens = self.input_tokens.saturating_add(other.input_tokens);
         self.output_tokens = self.output_tokens.saturating_add(other.output_tokens);
@@ -321,6 +341,12 @@ pub(crate) struct RawEntry {
     /// Provider-reported USD cost for this record, when the source logs one.
     #[serde(default)]
     pub(crate) recorded_cost_usd: Option<f64>,
+    /// Tokens represented by exact API-equivalent request telemetry.
+    #[serde(default)]
+    pub(crate) api_equivalent_priced_tokens: i64,
+    /// Usage tokens eligible for API-equivalent coverage reporting.
+    #[serde(default)]
+    pub(crate) api_equivalent_coverage_tokens: i64,
 }
 
 fn default_call_count() -> i64 {
@@ -345,6 +371,8 @@ impl RawEntry {
             estimated_proxy: CostTokens::default(),
             recorded_cost_usd: 0.0,
             recorded_cost_entries: 0,
+            api_equivalent_priced_tokens: self.api_equivalent_priced_tokens.max(0),
+            api_equivalent_coverage_tokens: self.api_equivalent_coverage_tokens.max(0),
             priced_tokens: CostTokens::default(),
         };
         if self.cost_kind == CostKind::EstimatedProxy {
@@ -625,6 +653,8 @@ mod tests {
             endpoint: Endpoint::Unknown,
             call_count: 1,
             recorded_cost_usd: None,
+            api_equivalent_priced_tokens: 0,
+            api_equivalent_coverage_tokens: 0,
         };
         let s = entry.to_stats();
         assert_eq!(s.input_tokens, 100);
@@ -661,6 +691,8 @@ mod tests {
             endpoint: Endpoint::Unknown,
             call_count: 5,
             recorded_cost_usd: Some(1.25),
+            api_equivalent_priced_tokens: 0,
+            api_equivalent_coverage_tokens: 0,
         };
         let stats = entry.to_stats();
         assert_eq!(stats.count, 5);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,12 +35,13 @@ mod sources_cmd;
 mod utils;
 
 pub use sdk::{
-    CodexQuotaError, CodexQuotaStatus, CodexWeeklyQuota, CodexWeeklyValueError,
-    CodexWeeklyValueEstimate, CodexWeeklyValueWindow, CodexWeeklyValueWindowError, CostSummary,
-    ModelCostSummary, MultiCostSummary, MultiSummaryOptions, SdkError, SummaryOptions,
-    TokenBreakdown, UsageRange, UsageSource, estimate_codex_weekly_value,
-    estimate_codex_weekly_value_for_window, load_codex_weekly_quota, summarize_cost,
-    summarize_cost_ranges, summarize_cost_ranges_with_cli_config, summarize_cost_with_cli_config,
+    ApiEquivalentCostCoverage, CodexQuotaError, CodexQuotaStatus, CodexWeeklyQuota,
+    CodexWeeklyValueError, CodexWeeklyValueEstimate, CodexWeeklyValueWindow,
+    CodexWeeklyValueWindowError, CostSummary, ModelCostSummary, MultiCostSummary,
+    MultiSummaryOptions, SdkError, SummaryOptions, TokenBreakdown, UsageRange, UsageSource,
+    estimate_codex_weekly_value, estimate_codex_weekly_value_for_window, load_codex_weekly_quota,
+    summarize_cost, summarize_cost_ranges, summarize_cost_ranges_with_cli_config,
+    summarize_cost_with_cli_config,
 };
 
 use chrono::{NaiveDate, Utc};

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -39,7 +39,7 @@ pub(crate) use csv::{
 pub(crate) use endpoints::{EndpointTableOptions, output_endpoint_json, print_endpoint_table};
 pub(crate) use format::NumberFormat;
 pub(crate) use json::output_period_json_with_quality;
-pub(crate) use period::Period;
+pub(crate) use period::{Period, aggregate_day_stats_by_period};
 pub(crate) use project::{ProjectTableOptions, output_project_json, print_project_table};
 pub(crate) use quota::{
     QuotaValueEstimate, output_quota_csv, output_quota_json, print_quota_table,

--- a/src/pricing/cost.rs
+++ b/src/pricing/cost.rs
@@ -44,11 +44,10 @@ fn combine_recorded_and_priced(recorded_usd: f64, priced: f64, priced_tokens: Co
 
 pub(crate) fn calculate_cost(stats: &Stats, model: &str, pricing_db: &PricingDb) -> f64 {
     if stats.recorded_cost_entries > 0 {
-        let priced = stats.priced_tokens.saturating_sub(&stats.estimated_proxy);
         combine_recorded_and_priced(
             stats.recorded_cost_usd,
-            calculate_token_cost(priced, model, pricing_db),
-            priced,
+            calculate_token_cost(stats.priced_tokens, model, pricing_db),
+            stats.priced_tokens,
         )
     } else {
         calculate_token_cost(stats.cost_tokens(), model, pricing_db)
@@ -412,9 +411,9 @@ mod tests {
     }
 
     #[test]
-    fn recorded_cost_does_not_include_overlapping_proxy_estimate() {
+    fn recorded_cost_preserves_unrelated_proxy_estimate_after_aggregation() {
         let db = pricing_db_with("fable-5", fable_pricing());
-        let estimated_proxy = CostTokens {
+        let unrelated_proxy = CostTokens {
             input_tokens: 1_000_000,
             count: 1,
             ..Default::default()
@@ -424,12 +423,11 @@ mod tests {
             count: 1,
             recorded_cost_entries: 1,
             recorded_cost_usd: 2.5,
-            priced_tokens: estimated_proxy,
-            estimated_proxy,
+            priced_tokens: unrelated_proxy,
+            estimated_proxy: unrelated_proxy,
             ..Default::default()
         };
 
-        assert!((calculate_cost(&stats, "fable-5", &db) - 2.5).abs() < 1e-12);
-        assert!((calculate_estimated_proxy_cost(&stats, "fable-5", &db) - 10.0).abs() < 1e-12);
+        assert!((calculate_cost(&stats, "fable-5", &db) - 12.5).abs() < 1e-12);
     }
 }

--- a/src/pricing/cost.rs
+++ b/src/pricing/cost.rs
@@ -44,10 +44,11 @@ fn combine_recorded_and_priced(recorded_usd: f64, priced: f64, priced_tokens: Co
 
 pub(crate) fn calculate_cost(stats: &Stats, model: &str, pricing_db: &PricingDb) -> f64 {
     if stats.recorded_cost_entries > 0 {
+        let priced = stats.priced_tokens.saturating_sub(&stats.estimated_proxy);
         combine_recorded_and_priced(
             stats.recorded_cost_usd,
-            calculate_token_cost(stats.priced_tokens, model, pricing_db),
-            stats.priced_tokens,
+            calculate_token_cost(priced, model, pricing_db),
+            priced,
         )
     } else {
         calculate_token_cost(stats.cost_tokens(), model, pricing_db)
@@ -408,5 +409,27 @@ mod tests {
             pricing_source_for_model_stats("fable-5", &stats, &db),
             PricingSource::Mixed
         );
+    }
+
+    #[test]
+    fn recorded_cost_does_not_include_overlapping_proxy_estimate() {
+        let db = pricing_db_with("fable-5", fable_pricing());
+        let estimated_proxy = CostTokens {
+            input_tokens: 1_000_000,
+            count: 1,
+            ..Default::default()
+        };
+        let stats = Stats {
+            input_tokens: 1_000_000,
+            count: 1,
+            recorded_cost_entries: 1,
+            recorded_cost_usd: 2.5,
+            priced_tokens: estimated_proxy,
+            estimated_proxy,
+            ..Default::default()
+        };
+
+        assert!((calculate_cost(&stats, "fable-5", &db) - 2.5).abs() < 1e-12);
+        assert!((calculate_estimated_proxy_cost(&stats, "fable-5", &db) - 10.0).abs() < 1e-12);
     }
 }

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -225,7 +225,7 @@ impl From<CostCoverage> for ApiEquivalentCostCoverage {
             priced_tokens: coverage.priced_tokens,
             percent: coverage.percent(),
             complete: !coverage.is_partial(),
-            cost_is_lower_bound: coverage.is_partial(),
+            cost_is_lower_bound: coverage.cost_is_lower_bound(),
         }
     }
 }
@@ -292,7 +292,7 @@ pub fn summarize_cost(options: SummaryOptions) -> Result<CostSummary, SdkError> 
     );
 
     let result = load_daily(source, &filter, timezone, true, false);
-    let cost_coverage = source.cost_coverage(&filter, timezone);
+    let cost_coverage = CostCoverage::from_stats(result.day_stats.values().map(|day| &day.stats));
     Ok(build_cost_summary(
         options.source,
         source,

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -17,7 +17,7 @@ use crate::pricing::{
     CurrencyConverter, PricingDb, calculate_cost, calculate_estimated_proxy_cost, model_cost_kind,
     sum_estimated_proxy_model_costs, sum_model_costs,
 };
-use crate::source::{Source, get_source, load_daily};
+use crate::source::{CostCoverage, Source, get_source, load_daily};
 use crate::utils::Timezone;
 
 pub use crate::source::{CodexQuotaError, CodexQuotaStatus, CodexWeeklyQuota};
@@ -208,6 +208,28 @@ pub struct ModelCostSummary {
     pub tokens: TokenBreakdown,
 }
 
+/// Coverage of API-equivalent pricing for sources with partial request telemetry.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ApiEquivalentCostCoverage {
+    pub total_tokens: i64,
+    pub priced_tokens: i64,
+    pub percent: f64,
+    pub complete: bool,
+    pub cost_is_lower_bound: bool,
+}
+
+impl From<CostCoverage> for ApiEquivalentCostCoverage {
+    fn from(coverage: CostCoverage) -> Self {
+        Self {
+            total_tokens: coverage.total_tokens,
+            priced_tokens: coverage.priced_tokens,
+            percent: coverage.percent(),
+            complete: !coverage.is_partial(),
+            cost_is_lower_bound: coverage.is_partial(),
+        }
+    }
+}
+
 /// Structured usage and cost summary for SDK consumers.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CostSummary {
@@ -223,6 +245,7 @@ pub struct CostSummary {
     pub estimated_cost: Option<f64>,
     pub estimated_cost_usd: Option<f64>,
     pub cost_kind: String,
+    pub api_equivalent_cost_coverage: Option<ApiEquivalentCostCoverage>,
     pub tokens: TokenBreakdown,
     pub models: Vec<ModelCostSummary>,
     pub valid_entries: i64,
@@ -269,6 +292,7 @@ pub fn summarize_cost(options: SummaryOptions) -> Result<CostSummary, SdkError> 
     );
 
     let result = load_daily(source, &filter, timezone, true, false);
+    let cost_coverage = source.cost_coverage(&filter, timezone);
     Ok(build_cost_summary(
         options.source,
         source,
@@ -279,6 +303,7 @@ pub fn summarize_cost(options: SummaryOptions) -> Result<CostSummary, SdkError> 
         &pricing_db,
         currency.as_ref(),
         &currency_code,
+        cost_coverage,
     ))
 }
 
@@ -344,6 +369,7 @@ pub(in crate::sdk) fn build_cost_summary(
     pricing_db: &PricingDb,
     currency: Option<&CurrencyConverter>,
     currency_code: &str,
+    cost_coverage: Option<CostCoverage>,
 ) -> CostSummary {
     let (stats, models) = merge_days(&result.day_stats);
     let cost_usd = finite_cost(sum_model_costs(&models, pricing_db));
@@ -364,6 +390,7 @@ pub(in crate::sdk) fn build_cost_summary(
         estimated_cost: convert_cost(estimated_cost_usd, currency),
         estimated_cost_usd,
         cost_kind: model_cost_kind(&models).as_str().to_string(),
+        api_equivalent_cost_coverage: cost_coverage.map(Into::into),
         tokens: TokenBreakdown::from_stats(&stats, supports_cache_read),
         models: summarize_models(&models, pricing_db, currency, supports_cache_read),
         valid_entries: result.valid,

--- a/src/sdk/batch.rs
+++ b/src/sdk/batch.rs
@@ -12,7 +12,7 @@ use crate::config::Config;
 use crate::consts::DATE_FORMAT;
 use crate::core::{DateFilter, DedupAccumulator, LoadResult, RawEntry, aggregate_daily};
 use crate::pricing::PricingDb;
-use crate::source::{Source, get_source};
+use crate::source::{CostCoverage, Source, get_source};
 use crate::utils::Timezone;
 
 /// Options for [`summarize_cost_ranges`].
@@ -111,7 +111,8 @@ pub fn summarize_cost_ranges(options: MultiSummaryOptions) -> Result<MultiCostSu
         .into_iter()
         .zip(results.iter())
         .map(|(range, result)| {
-            let cost_coverage = source.cost_coverage(&range.filter, timezone);
+            let cost_coverage =
+                CostCoverage::from_stats(result.day_stats.values().map(|day| &day.stats));
             build_cost_summary(
                 usage_source,
                 source,
@@ -237,11 +238,7 @@ fn load_daily_ranges(
     ranges
         .iter()
         .map(|range| {
-            let mut result = aggregate_entries_for_filter(
-                &entries,
-                &range.filter,
-                source.capabilities().needs_dedup,
-            );
+            let mut result = aggregate_entries_for_filter(&entries, &range.filter, source);
             result.parse_errors = parse_errors;
             result.elapsed_ms = elapsed_ms;
             result
@@ -264,7 +261,7 @@ fn normalize_entry_date(entry: &mut RawEntry, timezone: Timezone) -> Option<Naiv
 fn aggregate_entries_for_filter(
     entries: &[RawEntry],
     filter: &DateFilter,
-    needs_dedup: bool,
+    source: &dyn Source,
 ) -> LoadResult {
     let filtered: Vec<_> = entries
         .iter()
@@ -279,11 +276,11 @@ fn aggregate_entries_for_filter(
         return LoadResult::default();
     }
 
-    if needs_dedup {
+    if source.capabilities().needs_dedup {
         let mut accumulator = DedupAccumulator::new();
         accumulator.extend(filtered);
         let (deduped, skipped) = accumulator.finalize();
-        return load_result_from_entries(deduped, skipped);
+        return load_result_from_entries(source.finalize_entries(deduped), skipped);
     }
 
     load_result_from_entries(filtered, 0)
@@ -366,6 +363,8 @@ mod tests {
                     endpoint: crate::core::Endpoint::Unknown,
                     call_count: 1,
                     recorded_cost_usd: None,
+                    api_equivalent_priced_tokens: 15,
+                    api_equivalent_coverage_tokens: 15,
                 }],
                 errors: 0,
             }
@@ -461,6 +460,14 @@ mod tests {
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].valid, 2);
         assert_eq!(results[1].valid, 2);
+        assert_eq!(
+            CostCoverage::from_stats(results[0].day_stats.values().map(|day| &day.stats)),
+            Some(CostCoverage {
+                total_tokens: 30,
+                priced_tokens: 30,
+                estimated_proxy: 0,
+            })
+        );
     }
 
     #[test]

--- a/src/sdk/batch.rs
+++ b/src/sdk/batch.rs
@@ -111,6 +111,7 @@ pub fn summarize_cost_ranges(options: MultiSummaryOptions) -> Result<MultiCostSu
         .into_iter()
         .zip(results.iter())
         .map(|(range, result)| {
+            let cost_coverage = source.cost_coverage(&range.filter, timezone);
             build_cost_summary(
                 usage_source,
                 source,
@@ -121,6 +122,7 @@ pub fn summarize_cost_ranges(options: MultiSummaryOptions) -> Result<MultiCostSu
                 &pricing_db,
                 currency.as_ref(),
                 &currency_code,
+                cost_coverage,
             )
         })
         .collect();

--- a/src/source/claude/parser.rs
+++ b/src/source/claude/parser.rs
@@ -337,6 +337,8 @@ fn parse_entry_with_debug(
         endpoint,
         call_count: 1,
         recorded_cost_usd: None,
+        api_equivalent_priced_tokens: 0,
+        api_equivalent_coverage_tokens: 0,
     })
 }
 

--- a/src/source/codex/parser.rs
+++ b/src/source/codex/parser.rs
@@ -636,6 +636,8 @@ fn push_codex_entry(
         endpoint: crate::core::Endpoint::Unknown,
         call_count: 1,
         recorded_cost_usd: None,
+        api_equivalent_priced_tokens: 0,
+        api_equivalent_coverage_tokens: 0,
     });
 }
 

--- a/src/source/cursor/parser.rs
+++ b/src/source/cursor/parser.rs
@@ -201,6 +201,8 @@ fn entry_from_event(event: &Value, ordinal: usize, timezone: Timezone) -> Option
         endpoint: crate::core::Endpoint::Unknown,
         call_count: 1,
         recorded_cost_usd,
+        api_equivalent_priced_tokens: 0,
+        api_equivalent_coverage_tokens: 0,
     })
 }
 

--- a/src/source/grok/config.rs
+++ b/src/source/grok/config.rs
@@ -4,10 +4,11 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::source::{Capabilities, ParseOutput, Source};
+use crate::core::DateFilter;
+use crate::source::{Capabilities, CostCoverage, ParseOutput, Source};
 use crate::utils::Timezone;
 
-use super::unified::{find_grok_files, parse_grok_file_with_debug};
+use super::unified::{cost_coverage, find_grok_files, parse_grok_file_with_debug};
 
 /// Grok data source.
 pub(crate) struct GrokSource;
@@ -56,5 +57,9 @@ impl Source for GrokSource {
 
     fn parse_file(&self, path: &Path, timezone: Timezone, debug: bool) -> ParseOutput {
         parse_grok_file_with_debug(path, timezone, debug)
+    }
+
+    fn cost_coverage(&self, filter: &DateFilter, timezone: Timezone) -> Option<CostCoverage> {
+        cost_coverage(filter, timezone)
     }
 }

--- a/src/source/grok/config.rs
+++ b/src/source/grok/config.rs
@@ -2,13 +2,14 @@
 //!
 //! Defines the `GrokSource` implementation of the Source trait.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-use crate::core::DateFilter;
-use crate::source::{Capabilities, CostCoverage, ParseOutput, Source};
+use crate::core::{CostKind, RawEntry};
+use crate::source::{Capabilities, ParseOutput, Source};
 use crate::utils::Timezone;
 
-use super::unified::{cost_coverage, find_grok_files, parse_grok_file_with_debug};
+use super::unified::{find_grok_files, parse_grok_file_with_debug};
 
 /// Grok data source.
 pub(crate) struct GrokSource;
@@ -59,7 +60,77 @@ impl Source for GrokSource {
         parse_grok_file_with_debug(path, timezone, debug)
     }
 
-    fn cost_coverage(&self, filter: &DateFilter, timezone: Timezone) -> Option<CostCoverage> {
-        cost_coverage(filter, timezone)
+    fn finalize_entries(&self, entries: Vec<RawEntry>) -> Vec<RawEntry> {
+        let priced_sessions: HashSet<_> = entries
+            .iter()
+            .filter(|entry| entry.api_equivalent_priced_tokens > 0)
+            .map(|entry| entry.session_id.clone())
+            .collect();
+        entries
+            .into_iter()
+            .map(|mut entry| {
+                if entry.cost_kind == CostKind::EstimatedProxy
+                    && priced_sessions.contains(&entry.session_id)
+                {
+                    entry.cost_kind = CostKind::Real;
+                    entry.recorded_cost_usd = Some(0.0);
+                }
+                entry
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::{CostKind, Endpoint, RawEntry};
+
+    fn entry(session_id: &str, cost_kind: CostKind, priced_tokens: i64) -> RawEntry {
+        RawEntry {
+            timestamp: "2026-08-21T05:42:00Z".to_string(),
+            timestamp_ms: 0,
+            date_str: "2026-08-21".to_string(),
+            message_id: Some(format!("{session_id}:{priced_tokens}")),
+            session_key: session_id.to_string(),
+            session_id: session_id.to_string(),
+            project_path: String::new(),
+            model: "grok-4.6".to_string(),
+            input_tokens: i64::from(cost_kind == CostKind::EstimatedProxy) * 100,
+            output_tokens: 0,
+            cache_creation: 0,
+            cache_creation_1h: 0,
+            cache_read: 0,
+            reasoning_tokens: 0,
+            stop_reason: Some("complete".to_string()),
+            cost_kind,
+            endpoint: Endpoint::Unknown,
+            call_count: 1,
+            recorded_cost_usd: (priced_tokens > 0).then_some(0.1),
+            api_equivalent_priced_tokens: priced_tokens,
+            api_equivalent_coverage_tokens: i64::from(cost_kind == CostKind::EstimatedProxy) * 100,
+        }
+    }
+
+    #[test]
+    fn overlap_suppression_is_session_local() {
+        let source = GrokSource::new();
+        let entries = vec![
+            entry("priced", CostKind::EstimatedProxy, 0),
+            entry("priced", CostKind::Real, 110),
+            entry("snapshot-only", CostKind::EstimatedProxy, 0),
+        ];
+
+        let result = source.finalize_entries(entries);
+
+        assert_eq!(result.len(), 3);
+        assert!(
+            result
+                .iter()
+                .any(|entry| entry.session_id == "snapshot-only")
+        );
+        assert!(!result.iter().any(|entry| {
+            entry.session_id == "priced" && entry.cost_kind == CostKind::EstimatedProxy
+        }));
     }
 }

--- a/src/source/grok/parser.rs
+++ b/src/source/grok/parser.rs
@@ -73,11 +73,9 @@ struct UpdateEnvelope {
 }
 
 fn get_grok_sessions_dir() -> Option<PathBuf> {
-    if let Ok(grok_home) = env::var(GROK_HOME_ENV) {
+    if let Some(grok_home) = env::var_os(GROK_HOME_ENV) {
         let path = PathBuf::from(grok_home).join(SESSIONS_SUBDIR);
-        if path.is_dir() {
-            return Some(path);
-        }
+        return path.is_dir().then_some(path);
     }
 
     let home = dirs::home_dir()?;

--- a/src/source/grok/parser.rs
+++ b/src/source/grok/parser.rs
@@ -428,6 +428,8 @@ fn parse_grok_session_file(
             endpoint: crate::core::Endpoint::Unknown,
             call_count: 1,
             recorded_cost_usd: None,
+            api_equivalent_priced_tokens: 0,
+            api_equivalent_coverage_tokens: total_tokens,
         }],
         errors,
     }

--- a/src/source/grok/parser.rs
+++ b/src/source/grok/parser.rs
@@ -304,10 +304,28 @@ fn hex_value(byte: u8) -> Option<u8> {
     }
 }
 
+#[cfg(test)]
 pub(super) fn parse_grok_session_file_with_debug(
     path: &Path,
     timezone: Timezone,
     debug: bool,
+) -> ParseOutput {
+    parse_grok_session_file(path, timezone, debug, true)
+}
+
+pub(super) fn parse_grok_usage_file_with_debug(
+    path: &Path,
+    timezone: Timezone,
+    debug: bool,
+) -> ParseOutput {
+    parse_grok_session_file(path, timezone, debug, false)
+}
+
+fn parse_grok_session_file(
+    path: &Path,
+    timezone: Timezone,
+    debug: bool,
+    use_server_cost: bool,
 ) -> ParseOutput {
     let Some(session_dir) = path.parent() else {
         return ParseOutput {
@@ -342,7 +360,7 @@ pub(super) fn parse_grok_session_file_with_debug(
         session_id: session_id.clone(),
     };
 
-    let usage = super::usage::parse_turn_completed_usage(
+    let mut usage = super::usage::parse_turn_completed_usage(
         &session_dir.join(UPDATES_FILE),
         timezone,
         debug,
@@ -350,6 +368,14 @@ pub(super) fn parse_grok_session_file_with_debug(
     );
     errors += usage.errors;
     if usage.saw_usage_record {
+        if !use_server_cost {
+            // The API-equivalent cost comes exclusively from per-inference
+            // telemetry. A zero recorded cost keeps complete turn tokens in
+            // the usage total without pricing them a second time.
+            for entry in &mut usage.entries {
+                entry.recorded_cost_usd = Some(0.0);
+            }
+        }
         return ParseOutput {
             entries: usage.entries,
             errors,

--- a/src/source/grok/unified.rs
+++ b/src/source/grok/unified.rs
@@ -16,8 +16,8 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::consts::{DATE_FORMAT, UNKNOWN};
-use crate::core::{CostKind, DateFilter, DedupAccumulator, RawEntry};
-use crate::source::{CostCoverage, ParseOutput};
+use crate::core::{CostKind, RawEntry};
+use crate::source::ParseOutput;
 use crate::utils::Timezone;
 
 const APP_CACHE_DIR: &str = "ccstats";
@@ -523,93 +523,16 @@ fn records_to_parse_output(
                 endpoint: crate::core::Endpoint::Unknown,
                 call_count: 0,
                 recorded_cost_usd,
+                api_equivalent_priced_tokens: if recorded_cost_usd.is_some() {
+                    prompt_tokens.saturating_add(completion_tokens)
+                } else {
+                    0
+                },
+                api_equivalent_coverage_tokens: 0,
             })
         })
         .collect();
     ParseOutput { entries, errors }
-}
-
-pub(super) fn cost_coverage(filter: &DateFilter, timezone: Timezone) -> Option<CostCoverage> {
-    cost_coverage_from_files(&find_grok_files(), filter, timezone)
-}
-
-fn cost_coverage_from_files(
-    files: &[PathBuf],
-    filter: &DateFilter,
-    timezone: Timezone,
-) -> Option<CostCoverage> {
-    let mut usage = DedupAccumulator::new();
-    let mut priced_tokens = 0_i64;
-
-    for path in files {
-        match path.file_name().and_then(|name| name.to_str()) {
-            Some(LEDGER_FILE) => {
-                let Ok(records) = load_ledger(path) else {
-                    continue;
-                };
-                priced_tokens = priced_tokens.saturating_add(priced_tokens_in_records(
-                    records.into_values(),
-                    filter,
-                    timezone,
-                ));
-            }
-            Some(UNIFIED_LOG) => {
-                let sessions_dir = grok_home()
-                    .map(|home| home.join("sessions"))
-                    .unwrap_or_default();
-                let Ok(records) = read_inference_records(path, &sessions_dir) else {
-                    continue;
-                };
-                priced_tokens = priced_tokens
-                    .saturating_add(priced_tokens_in_records(records, filter, timezone));
-            }
-            _ => {
-                let parsed = super::parser::parse_grok_usage_file_with_debug(path, timezone, false);
-                usage.extend(parsed.entries.into_iter().filter(|entry| {
-                    chrono::NaiveDate::parse_from_str(&entry.date_str, DATE_FORMAT)
-                        .is_ok_and(|date| filter.contains(date))
-                }));
-            }
-        }
-    }
-
-    let (entries, _) = usage.finalize();
-    let total_tokens = entries.into_iter().fold(0_i64, |total, entry| {
-        total.saturating_add(entry.to_stats().total_tokens())
-    });
-    if total_tokens == 0 && priced_tokens == 0 {
-        None
-    } else {
-        Some(CostCoverage {
-            total_tokens,
-            priced_tokens,
-        })
-    }
-}
-
-fn priced_tokens_in_records(
-    records: impl IntoIterator<Item = InferenceRecord>,
-    filter: &DateFilter,
-    timezone: Timezone,
-) -> i64 {
-    records.into_iter().fold(0_i64, |total, record| {
-        let Ok(utc_dt) = record.timestamp.parse::<DateTime<Utc>>() else {
-            return total;
-        };
-        let date = timezone.to_fixed_offset(utc_dt).date_naive();
-        if !filter.contains(date) {
-            return total;
-        }
-        let prompt_tokens = record.prompt_tokens.max(0);
-        let cache_read = record.cached_prompt_tokens.clamp(0, prompt_tokens);
-        let completion_tokens = record.completion_tokens.max(0);
-        if api_cost_usd(&record.model, prompt_tokens, cache_read, completion_tokens).is_none() {
-            return total;
-        }
-        total
-            .saturating_add(prompt_tokens)
-            .saturating_add(completion_tokens)
-    })
 }
 
 #[cfg(test)]

--- a/src/source/grok/unified.rs
+++ b/src/source/grok/unified.rs
@@ -16,8 +16,8 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::consts::{DATE_FORMAT, UNKNOWN};
-use crate::core::{CostKind, RawEntry};
-use crate::source::ParseOutput;
+use crate::core::{CostKind, DateFilter, DedupAccumulator, RawEntry};
+use crate::source::{CostCoverage, ParseOutput};
 use crate::utils::Timezone;
 
 const APP_CACHE_DIR: &str = "ccstats";
@@ -163,21 +163,23 @@ pub(super) fn find_grok_files() -> Vec<PathBuf> {
     let source_path = grok_home.join("logs").join(UNIFIED_LOG);
     let sessions_dir = grok_home.join("sessions");
     let ledger_path = ledger_path(&grok_home);
+    let mut files = super::parser::find_grok_files();
 
     if source_path.is_file() {
-        if let Some(path) = ledger_path.as_deref() {
-            return vec![sync_or_select_grok_file(&source_path, path, &sessions_dir)];
-        }
-        return vec![source_path];
-    }
-
-    if let Some(path) = ledger_path
+        files.push(if let Some(path) = ledger_path.as_deref() {
+            sync_or_select_grok_file(&source_path, path, &sessions_dir)
+        } else {
+            source_path
+        });
+    } else if let Some(path) = ledger_path
         && path.is_file()
     {
-        return vec![path];
+        files.push(path);
     }
 
-    super::parser::find_grok_files()
+    files.sort();
+    files.dedup();
+    files
 }
 
 fn sync_or_select_grok_file(
@@ -211,7 +213,7 @@ pub(super) fn parse_grok_file_with_debug(
     match path.file_name().and_then(|name| name.to_str()) {
         Some(LEDGER_FILE) => parse_ledger_file(path, timezone, debug),
         Some(UNIFIED_LOG) => parse_live_unified_file(path, timezone, debug),
-        _ => super::parser::parse_grok_session_file_with_debug(path, timezone, debug),
+        _ => super::parser::parse_grok_usage_file_with_debug(path, timezone, debug),
     }
 }
 
@@ -486,10 +488,7 @@ fn records_to_parse_output(
             };
             let prompt_tokens = record.prompt_tokens.max(0);
             let cache_read = record.cached_prompt_tokens.clamp(0, prompt_tokens);
-            let input_tokens = prompt_tokens.saturating_sub(cache_read);
             let completion_tokens = record.completion_tokens.max(0);
-            let reasoning_tokens = record.reasoning_tokens.clamp(0, completion_tokens);
-            let output_tokens = completion_tokens.saturating_sub(reasoning_tokens);
             let recorded_cost_usd =
                 api_cost_usd(&record.model, prompt_tokens, cache_read, completion_tokens);
             let date_str = timezone
@@ -510,21 +509,107 @@ fn records_to_parse_output(
                 },
                 project_path: record.project_path,
                 model: record.model,
-                input_tokens,
-                output_tokens,
+                // Complete usage comes from turn_completed records. These
+                // inference entries contribute only their exact request-boundary
+                // API-equivalent cost, otherwise captured tokens are counted twice.
+                input_tokens: 0,
+                output_tokens: 0,
                 cache_creation: 0,
                 cache_creation_1h: 0,
-                cache_read,
-                reasoning_tokens,
+                cache_read: 0,
+                reasoning_tokens: 0,
                 stop_reason: Some("inference_done".to_string()),
                 cost_kind: CostKind::Real,
                 endpoint: crate::core::Endpoint::Unknown,
-                call_count: 1,
+                call_count: 0,
                 recorded_cost_usd,
             })
         })
         .collect();
     ParseOutput { entries, errors }
+}
+
+pub(super) fn cost_coverage(filter: &DateFilter, timezone: Timezone) -> Option<CostCoverage> {
+    cost_coverage_from_files(&find_grok_files(), filter, timezone)
+}
+
+fn cost_coverage_from_files(
+    files: &[PathBuf],
+    filter: &DateFilter,
+    timezone: Timezone,
+) -> Option<CostCoverage> {
+    let mut usage = DedupAccumulator::new();
+    let mut priced_tokens = 0_i64;
+
+    for path in files {
+        match path.file_name().and_then(|name| name.to_str()) {
+            Some(LEDGER_FILE) => {
+                let Ok(records) = load_ledger(path) else {
+                    continue;
+                };
+                priced_tokens = priced_tokens.saturating_add(priced_tokens_in_records(
+                    records.into_values(),
+                    filter,
+                    timezone,
+                ));
+            }
+            Some(UNIFIED_LOG) => {
+                let sessions_dir = grok_home()
+                    .map(|home| home.join("sessions"))
+                    .unwrap_or_default();
+                let Ok(records) = read_inference_records(path, &sessions_dir) else {
+                    continue;
+                };
+                priced_tokens = priced_tokens
+                    .saturating_add(priced_tokens_in_records(records, filter, timezone));
+            }
+            _ => {
+                let parsed = super::parser::parse_grok_usage_file_with_debug(path, timezone, false);
+                usage.extend(parsed.entries.into_iter().filter(|entry| {
+                    chrono::NaiveDate::parse_from_str(&entry.date_str, DATE_FORMAT)
+                        .is_ok_and(|date| filter.contains(date))
+                }));
+            }
+        }
+    }
+
+    let (entries, _) = usage.finalize();
+    let total_tokens = entries.into_iter().fold(0_i64, |total, entry| {
+        total.saturating_add(entry.to_stats().total_tokens())
+    });
+    if total_tokens == 0 && priced_tokens == 0 {
+        None
+    } else {
+        Some(CostCoverage {
+            total_tokens,
+            priced_tokens,
+        })
+    }
+}
+
+fn priced_tokens_in_records(
+    records: impl IntoIterator<Item = InferenceRecord>,
+    filter: &DateFilter,
+    timezone: Timezone,
+) -> i64 {
+    records.into_iter().fold(0_i64, |total, record| {
+        let Ok(utc_dt) = record.timestamp.parse::<DateTime<Utc>>() else {
+            return total;
+        };
+        let date = timezone.to_fixed_offset(utc_dt).date_naive();
+        if !filter.contains(date) {
+            return total;
+        }
+        let prompt_tokens = record.prompt_tokens.max(0);
+        let cache_read = record.cached_prompt_tokens.clamp(0, prompt_tokens);
+        let completion_tokens = record.completion_tokens.max(0);
+        if api_cost_usd(&record.model, prompt_tokens, cache_read, completion_tokens).is_none() {
+            return total;
+        }
+        total
+            .saturating_add(prompt_tokens)
+            .saturating_add(completion_tokens)
+    })
 }
 
 #[cfg(test)]
@@ -612,11 +697,8 @@ mod tests {
         assert_eq!(parsed.errors, 0);
         assert_eq!(parsed.entries.len(), 1);
         let entry = &parsed.entries[0];
-        assert_eq!(entry.input_tokens, 316);
-        assert_eq!(entry.cache_read, 148_224);
-        assert_eq!(entry.output_tokens, 407);
-        assert_eq!(entry.reasoning_tokens, 949);
-        assert_eq!(entry.to_stats().total_tokens(), 149_896);
+        assert_eq!(entry.to_stats().total_tokens(), 0);
+        assert_eq!(entry.call_count, 0);
         assert!((entry.recorded_cost_usd.expect("calculated cost") - 0.082_88).abs() < 1e-12);
     }
 
@@ -648,14 +730,18 @@ mod tests {
         let parsed = parse_ledger_file(&ledger_path, tz(), true);
         assert_eq!(parsed.errors, 0);
         assert_eq!(parsed.entries.len(), 2);
-        assert_eq!(
+        assert!(
             parsed
                 .entries
                 .iter()
-                .map(|entry| entry.input_tokens + entry.cache_read)
-                .sum::<i64>(),
-            300
+                .all(|entry| entry.to_stats().total_tokens() == 0)
         );
+        let cost: f64 = parsed
+            .entries
+            .iter()
+            .filter_map(|entry| entry.recorded_cost_usd)
+            .sum();
+        assert!((cost - 0.000_48).abs() < 1e-12);
     }
 
     #[test]
@@ -686,9 +772,7 @@ mod tests {
         let parsed = parse_ledger_file(&selected, tz(), true);
         assert_eq!(parsed.errors, 0);
         assert_eq!(parsed.entries.len(), 1);
-        assert_eq!(
-            parsed.entries[0].input_tokens + parsed.entries[0].cache_read,
-            100
-        );
+        assert_eq!(parsed.entries[0].to_stats().total_tokens(), 0);
+        assert!((parsed.entries[0].recorded_cost_usd.unwrap() - 0.000_185).abs() < 1e-12);
     }
 }

--- a/src/source/grok/usage.rs
+++ b/src/source/grok/usage.rs
@@ -15,7 +15,7 @@ use chrono::{DateTime, Utc};
 use serde::Deserialize;
 
 use crate::consts::DATE_FORMAT;
-use crate::core::{CostKind, RawEntry};
+use crate::core::{CostKind, RawEntry, source_wide_message_id};
 use crate::utils::Timezone;
 
 use super::parser::{GrokSessionContext, first_non_empty};
@@ -213,11 +213,14 @@ fn parse_turn_line(
     let event_id = params
         .and_then(|params| params.meta.as_ref())
         .and_then(|meta| meta.event_id.as_deref());
-    let base_message_id = first_non_empty(&[event_id, prompt_id]).unwrap_or_else(|| {
-        let mut hasher = DefaultHasher::new();
-        line.hash(&mut hasher);
-        format!("turn:{:016x}", hasher.finish())
-    });
+    let base_message_id = first_non_empty(&[event_id])
+        .map(|event_id| source_wide_message_id("grok", &event_id))
+        .or_else(|| first_non_empty(&[prompt_id]))
+        .unwrap_or_else(|| {
+            let mut hasher = DefaultHasher::new();
+            line.hash(&mut hasher);
+            format!("turn:{:016x}", hasher.finish())
+        });
     let stop_reason = update.and_then(|update| update.stop_reason.clone());
 
     let total_usage = normalize_usage(&usage.tokens);
@@ -426,7 +429,10 @@ mod tests {
         assert_eq!(entry.reasoning_tokens, 1145);
         assert_eq!(entry.call_count, 5);
         assert_eq!(entry.date_str, "2026-04-16");
-        assert_eq!(entry.message_id.as_deref(), Some("e1:grok-4.5-build"));
+        assert_eq!(
+            entry.message_id.as_deref(),
+            Some("source-wide:grok:e1:grok-4.5-build")
+        );
         assert_eq!(entry.stop_reason.as_deref(), Some("end_turn"));
         assert_eq!(entry.cost_kind, CostKind::Real);
         assert_eq!(entry.recorded_cost_usd, Some(0.13816));

--- a/src/source/grok/usage.rs
+++ b/src/source/grok/usage.rs
@@ -187,6 +187,15 @@ fn looks_like_turn_completed_record(line: &str) -> bool {
         })
 }
 
+fn coverage_tokens(usage: &NormalizedUsage) -> i64 {
+    usage
+        .input_tokens
+        .saturating_add(usage.output_tokens)
+        .saturating_add(usage.reasoning_tokens)
+        .saturating_add(usage.cache_creation)
+        .saturating_add(usage.cache_read)
+}
+
 fn parse_turn_line(
     line: &str,
     timezone: Timezone,
@@ -287,6 +296,8 @@ fn parse_turn_line(
             endpoint: crate::core::Endpoint::Unknown,
             call_count: normalized.call_count,
             recorded_cost_usd: normalized.recorded_cost_usd,
+            api_equivalent_priced_tokens: 0,
+            api_equivalent_coverage_tokens: coverage_tokens(&normalized),
         });
     }
     Ok(Some(entries).filter(|entries| !entries.is_empty()))

--- a/src/source/kimi/parser.rs
+++ b/src/source/kimi/parser.rs
@@ -285,6 +285,8 @@ fn parse_usage_line(
         endpoint: crate::core::Endpoint::Unknown,
         call_count: 1,
         recorded_cost_usd: None,
+        api_equivalent_priced_tokens: 0,
+        api_equivalent_coverage_tokens: 0,
     })
 }
 

--- a/src/source/loader.rs
+++ b/src/source/loader.rs
@@ -215,7 +215,7 @@ impl<'a> DataLoader<'a> {
         match result {
             Some((accumulator, parse_errors)) => {
                 let (entries, skipped) = accumulator.finalize();
-                (entries, skipped, parse_errors)
+                (self.source.finalize_entries(entries), skipped, parse_errors)
             }
             None => (Vec::new(), 0, 0),
         }
@@ -579,6 +579,8 @@ mod tests {
             endpoint: crate::core::Endpoint::Unknown,
             call_count: 1,
             recorded_cost_usd: None,
+            api_equivalent_priced_tokens: 0,
+            api_equivalent_coverage_tokens: 0,
         }
     }
 

--- a/src/source/loader_quality_tests.rs
+++ b/src/source/loader_quality_tests.rs
@@ -63,6 +63,8 @@ fn entry(id: &str, input_tokens: i64) -> RawEntry {
         endpoint: crate::core::Endpoint::Unknown,
         call_count: 1,
         recorded_cost_usd: None,
+        api_equivalent_priced_tokens: 0,
+        api_equivalent_coverage_tokens: 0,
     }
 }
 

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -13,7 +13,7 @@ mod registry;
 
 use std::path::{Path, PathBuf};
 
-use crate::core::{DateFilter, RawEntry, ToolCall};
+use crate::core::{DateFilter, RawEntry, Stats, ToolCall};
 use crate::utils::Timezone;
 
 /// Coverage of a locally calculated API-equivalent cost.
@@ -21,9 +21,26 @@ use crate::utils::Timezone;
 pub(crate) struct CostCoverage {
     pub(crate) total_tokens: i64,
     pub(crate) priced_tokens: i64,
+    pub(crate) estimated_proxy: i64,
 }
 
 impl CostCoverage {
+    pub(crate) fn from_stats<'a>(stats: impl IntoIterator<Item = &'a Stats>) -> Option<Self> {
+        let mut coverage = Self::default();
+        for stats in stats {
+            coverage.total_tokens = coverage
+                .total_tokens
+                .saturating_add(stats.api_equivalent_coverage_tokens);
+            coverage.priced_tokens = coverage
+                .priced_tokens
+                .saturating_add(stats.api_equivalent_priced_tokens);
+            coverage.estimated_proxy = coverage
+                .estimated_proxy
+                .saturating_add(stats.estimated_proxy.total_tokens());
+        }
+        (coverage.total_tokens > 0 || coverage.priced_tokens > 0).then_some(coverage)
+    }
+
     pub(crate) fn percent(self) -> f64 {
         if self.total_tokens <= 0 {
             0.0
@@ -35,6 +52,10 @@ impl CostCoverage {
 
     pub(crate) fn is_partial(self) -> bool {
         self.total_tokens <= 0 || self.priced_tokens != self.total_tokens
+    }
+
+    pub(crate) fn cost_is_lower_bound(self) -> bool {
+        self.is_partial() && self.estimated_proxy == 0
     }
 }
 
@@ -121,9 +142,8 @@ pub(crate) trait Source: Send + Sync {
     /// Parse a single file into raw entries and diagnostics.
     fn parse_file(&self, path: &Path, timezone: Timezone, debug: bool) -> ParseOutput;
 
-    /// Coverage metadata when a source prices only observed request records.
-    fn cost_coverage(&self, _filter: &DateFilter, _timezone: Timezone) -> Option<CostCoverage> {
-        None
+    fn finalize_entries(&self, entries: Vec<RawEntry>) -> Vec<RawEntry> {
+        entries
     }
 
     /// Find files that may contain tool-call records for this source.
@@ -174,6 +194,7 @@ mod cost_coverage_tests {
         let coverage = CostCoverage {
             total_tokens: 0,
             priced_tokens: 120,
+            estimated_proxy: 0,
         };
 
         assert!(coverage.is_partial());

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -34,7 +34,7 @@ impl CostCoverage {
     }
 
     pub(crate) fn is_partial(self) -> bool {
-        self.priced_tokens < self.total_tokens
+        self.total_tokens <= 0 || self.priced_tokens != self.total_tokens
     }
 }
 
@@ -163,4 +163,20 @@ pub(crate) fn load_endpoints(
     timezone: Timezone,
 ) -> Vec<crate::core::EndpointStats> {
     loader::DataLoader::new(source, false, false).load_endpoints(filter, timezone)
+}
+
+#[cfg(test)]
+mod cost_coverage_tests {
+    use super::CostCoverage;
+
+    #[test]
+    fn priced_tokens_without_a_total_are_incomplete() {
+        let coverage = CostCoverage {
+            total_tokens: 0,
+            priced_tokens: 120,
+        };
+
+        assert!(coverage.is_partial());
+        assert!(coverage.percent().abs() < f64::EPSILON);
+    }
 }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -16,6 +16,28 @@ use std::path::{Path, PathBuf};
 use crate::core::{DateFilter, RawEntry, ToolCall};
 use crate::utils::Timezone;
 
+/// Coverage of a locally calculated API-equivalent cost.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub(crate) struct CostCoverage {
+    pub(crate) total_tokens: i64,
+    pub(crate) priced_tokens: i64,
+}
+
+impl CostCoverage {
+    pub(crate) fn percent(self) -> f64 {
+        if self.total_tokens <= 0 {
+            0.0
+        } else {
+            self.priced_tokens.max(0).min(self.total_tokens) as f64 / self.total_tokens as f64
+                * 100.0
+        }
+    }
+
+    pub(crate) fn is_partial(self) -> bool {
+        self.priced_tokens < self.total_tokens
+    }
+}
+
 /// Parse result for a single source file.
 #[derive(Debug, Default)]
 pub(crate) struct ParseOutput {
@@ -98,6 +120,11 @@ pub(crate) trait Source: Send + Sync {
 
     /// Parse a single file into raw entries and diagnostics.
     fn parse_file(&self, path: &Path, timezone: Timezone, debug: bool) -> ParseOutput;
+
+    /// Coverage metadata when a source prices only observed request records.
+    fn cost_coverage(&self, _filter: &DateFilter, _timezone: Timezone) -> Option<CostCoverage> {
+        None
+    }
 
     /// Find files that may contain tool-call records for this source.
     fn find_tool_call_files(&self) -> Vec<PathBuf> {

--- a/tests/cli_grok_cursor.rs
+++ b/tests/cli_grok_cursor.rs
@@ -76,7 +76,7 @@ fn write_grok_turn_session(grok_home: &Path) {
         r#"{
   "created_at": "2026-08-15T09:00:00Z",
   "updated_at": "2026-08-17T10:00:00Z",
-  "current_model_id": "grok-build",
+  "current_model_id": "grok-4.5-build",
   "git_root_dir": "/tmp/grok-project/"
 }"#,
     );
@@ -85,6 +85,13 @@ fn write_grok_turn_session(grok_home: &Path) {
         r#"{"timestamp":1786838400,"method":"_x.ai/session/update","params":{"sessionId":"grok-turn-session","update":{"sessionUpdate":"turn_completed","prompt_id":"p1","stop_reason":"end_turn","usage":{"inputTokens":100,"outputTokens":20,"cachedReadTokens":40,"reasoningTokens":5,"modelCalls":3,"costUsdTicks":20000000000,"modelUsage":{"grok-4.5-build":{"inputTokens":100,"outputTokens":20,"cachedReadTokens":40,"reasoningTokens":5,"modelCalls":3,"costUsdTicks":20000000000}}}},"_meta":{"eventId":"e1","agentTimestampMs":1786838400000}}}
 {"timestamp":1786924800,"method":"_x.ai/session/update","params":{"sessionId":"grok-turn-session","update":{"sessionUpdate":"turn_completed","prompt_id":"p2","usage":{"inputTokens":50,"outputTokens":10,"cachedReadTokens":10,"reasoningTokens":2,"modelCalls":2,"costUsdTicks":5000000000,"modelUsage":{"grok-4.5-build":{"inputTokens":50,"outputTokens":10,"cachedReadTokens":10,"reasoningTokens":2,"modelCalls":2,"costUsdTicks":5000000000}}}},"_meta":{"agentTimestampMs":1786924800000}}}
 "#,
+    );
+}
+
+fn write_partial_grok_inference_log(grok_home: &Path) {
+    write_file(
+        &grok_home.join("logs/unified.jsonl"),
+        r#"{"ts":"2026-08-16T00:00:00Z","sid":"grok-turn-session","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":100,"cached_prompt_tokens":40,"completion_tokens":20,"reasoning_tokens":5}}"#,
     );
 }
 
@@ -129,6 +136,66 @@ fn assert_close(actual: f64, expected: f64) {
         (actual - expected).abs() < 0.000_001,
         "expected {expected}, got {actual}"
     );
+}
+
+#[test]
+fn grok_keeps_complete_turn_tokens_and_marks_partial_api_cost() {
+    let root = unique_temp_dir("grok-api-cost-coverage");
+    let grok_home = root.join("grok-home");
+    write_grok_turn_session(&grok_home);
+    write_partial_grok_inference_log(&grok_home);
+
+    let args = [
+        "grok",
+        "monthly",
+        "-j",
+        "-O",
+        "--timezone",
+        "UTC",
+        "--since",
+        "2026-08-16",
+        "--until",
+        "2026-08-17",
+    ];
+    let env = [("GROK_HOME", grok_home.as_path()), ("HOME", root.as_path())];
+    let (ok, stdout, stderr) = run_ccstats(&args, &env);
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    let row = &json.as_array().expect("array output")[0];
+    assert_eq!(row["total_tokens"].as_i64(), Some(180));
+    assert_close(row["cost"].as_f64().unwrap(), 0.000_252);
+    let coverage = &row["api_equivalent_cost_coverage"];
+    assert_eq!(coverage["total_tokens"].as_i64(), Some(180));
+    assert_eq!(coverage["priced_tokens"].as_i64(), Some(120));
+    assert_close(coverage["percent"].as_f64().unwrap(), 66.666_666_666_666_66);
+    assert_eq!(coverage["complete"].as_bool(), Some(false));
+    assert_eq!(coverage["cost_is_lower_bound"].as_bool(), Some(true));
+
+    let table_args = [
+        "grok",
+        "monthly",
+        "-O",
+        "--timezone",
+        "UTC",
+        "--since",
+        "2026-08-16",
+        "--until",
+        "2026-08-17",
+    ];
+    let (ok, stdout, stderr) = run_ccstats(&table_args, &env);
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let table = String::from_utf8(stdout).expect("utf8 table");
+    assert!(
+        table.contains("120 / 180 tokens (66.67%)"),
+        "table: {table}"
+    );
+    assert!(
+        table.contains("displayed cost is a lower bound"),
+        "table: {table}"
+    );
+
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -543,7 +610,7 @@ fn grok_source_falls_back_to_updates_when_signals_missing() {
 }
 
 #[test]
-fn grok_daily_json_reads_turn_completed_usage_by_event_date() {
+fn grok_daily_json_uses_turn_tokens_without_treating_cost_ticks_as_api_price() {
     let root = unique_temp_dir("grok-turn-usage");
     let grok_home = root.join("grok-home");
     write_grok_turn_session(&grok_home);
@@ -575,13 +642,17 @@ fn grok_daily_json_reads_turn_completed_usage_by_event_date() {
     assert_eq!(arr[0]["cache_read_tokens"].as_i64(), Some(40));
     assert_eq!(arr[0]["total_tokens"].as_i64(), Some(120));
     assert_close(arr[0]["cache_hit_rate"].as_f64().unwrap(), 40.0);
-    assert_close(arr[0]["cost"].as_f64().unwrap(), 2.0);
+    assert_close(arr[0]["cost"].as_f64().unwrap(), 0.0);
     assert_eq!(arr[0]["pricing_source"].as_str(), Some("recorded"));
     assert!(arr[0].get("cost_kind").is_none() || arr[0]["cost_kind"].is_null());
     assert_eq!(
         arr[0]["models"].as_array().unwrap()[0].as_str(),
         Some("grok-4.5-build")
     );
+    let coverage = &arr[0]["api_equivalent_cost_coverage"];
+    assert_eq!(coverage["total_tokens"].as_i64(), Some(120));
+    assert_eq!(coverage["priced_tokens"].as_i64(), Some(0));
+    assert_eq!(coverage["cost_is_lower_bound"].as_bool(), Some(true));
 
     let _ = fs::remove_dir_all(root);
 }
@@ -618,7 +689,7 @@ fn grok_daily_table_counts_model_calls_not_sessions() {
 }
 
 #[test]
-fn all_sources_includes_grok_server_cost_in_real_total() {
+fn all_sources_does_not_treat_grok_cost_ticks_as_api_price() {
     let root = unique_temp_dir("all-sources-grok-real");
     let grok_home = root.join("grok-home");
     write_claude_session(&root);
@@ -645,7 +716,7 @@ fn all_sources_includes_grok_server_cost_in_real_total() {
     let json: Value = serde_json::from_slice(&stdout).expect("json");
     let arr = json.as_array().expect("array output");
     assert_eq!(arr.len(), 1);
-    assert_close(arr[0]["cost"].as_f64().unwrap(), 2.0);
+    assert_close(arr[0]["cost"].as_f64().unwrap(), 0.0);
     assert!(arr[0].get("estimated_cost").is_none() || arr[0]["estimated_cost"].is_null());
 
     let _ = fs::remove_dir_all(root);

--- a/tests/cli_grok_cursor.rs
+++ b/tests/cli_grok_cursor.rs
@@ -244,11 +244,7 @@ fn grok_does_not_add_snapshot_estimate_to_inference_cost() {
     let row = &json.as_array().expect("array output")[0];
     assert_eq!(row["total_tokens"].as_i64(), Some(1500));
     assert_close(row["cost"].as_f64().expect("inference cost"), 0.000_175);
-    assert!(
-        row["estimated_cost"]
-            .as_f64()
-            .is_some_and(|cost| cost > 0.0)
-    );
+    assert!(row.get("estimated_cost").is_none());
 
     let _ = fs::remove_dir_all(root);
 }
@@ -289,7 +285,7 @@ fn explicit_grok_home_never_reads_default_sessions() {
 }
 
 #[test]
-fn all_sources_preserves_partial_grok_cost_coverage() {
+fn all_sources_reports_grok_cost_coverage_per_period() {
     let root = unique_temp_dir("all-sources-grok-coverage");
     let grok_home = root.join("grok-home");
     write_grok_turn_session(&grok_home);
@@ -315,10 +311,23 @@ fn all_sources_preserves_partial_grok_cost_coverage() {
     assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
 
     let json: Value = serde_json::from_slice(&stdout).expect("json");
-    let coverage = &json.as_array().expect("array output")[0]["api_equivalent_cost_coverage"];
-    assert_eq!(coverage["total_tokens"].as_i64(), Some(180));
-    assert_eq!(coverage["priced_tokens"].as_i64(), Some(120));
-    assert_eq!(coverage["cost_is_lower_bound"].as_bool(), Some(true));
+    let rows = json.as_array().expect("array output");
+    let first = rows
+        .iter()
+        .find(|row| row["date"] == "2026-08-16")
+        .expect("first day");
+    let second = rows
+        .iter()
+        .find(|row| row["date"] == "2026-08-17")
+        .expect("second day");
+    let first_coverage = &first["api_equivalent_cost_coverage"];
+    assert_eq!(first_coverage["total_tokens"].as_i64(), Some(120));
+    assert_eq!(first_coverage["priced_tokens"].as_i64(), Some(120));
+    assert_eq!(first_coverage["cost_is_lower_bound"].as_bool(), Some(false));
+    let second_coverage = &second["api_equivalent_cost_coverage"];
+    assert_eq!(second_coverage["total_tokens"].as_i64(), Some(60));
+    assert_eq!(second_coverage["priced_tokens"].as_i64(), Some(0));
+    assert_eq!(second_coverage["cost_is_lower_bound"].as_bool(), Some(true));
 
     let _ = fs::remove_dir_all(root);
 }

--- a/tests/cli_grok_cursor.rs
+++ b/tests/cli_grok_cursor.rs
@@ -95,6 +95,25 @@ fn write_partial_grok_inference_log(grok_home: &Path) {
     );
 }
 
+fn write_grok_snapshot_with_inference(grok_home: &Path) {
+    let session_dir = grok_home
+        .join("sessions")
+        .join("%2Ftmp%2Fgrok-project")
+        .join("grok-snapshot-session");
+    write_file(
+        &session_dir.join("signals.json"),
+        r#"{"contextTokensUsed":1500,"primaryModelId":"grok-4.5-build"}"#,
+    );
+    write_file(
+        &session_dir.join("summary.json"),
+        r#"{"updated_at":"2026-08-16T10:00:00Z","current_model_id":"grok-4.5-build"}"#,
+    );
+    write_file(
+        &grok_home.join("logs/unified.jsonl"),
+        r#"{"ts":"2026-08-16T10:00:00Z","sid":"grok-snapshot-session","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":100,"cached_prompt_tokens":50,"completion_tokens":10,"reasoning_tokens":0}}"#,
+    );
+}
+
 fn write_grok_update_only_session(grok_home: &Path) {
     let session_dir = grok_home
         .join("sessions")
@@ -192,6 +211,144 @@ fn grok_keeps_complete_turn_tokens_and_marks_partial_api_cost() {
     );
     assert!(
         table.contains("displayed cost is a lower bound"),
+        "table: {table}"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn grok_does_not_add_snapshot_estimate_to_inference_cost() {
+    let root = unique_temp_dir("grok-snapshot-inference-cost");
+    let grok_home = root.join("grok-home");
+    write_grok_snapshot_with_inference(&grok_home);
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "grok",
+            "daily",
+            "-j",
+            "-O",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-08-16",
+            "--until",
+            "2026-08-16",
+        ],
+        &[("GROK_HOME", &grok_home), ("HOME", &root)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    let row = &json.as_array().expect("array output")[0];
+    assert_eq!(row["total_tokens"].as_i64(), Some(1500));
+    assert_close(row["cost"].as_f64().expect("inference cost"), 0.000_175);
+    assert!(
+        row["estimated_cost"]
+            .as_f64()
+            .is_some_and(|cost| cost > 0.0)
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn explicit_grok_home_never_reads_default_sessions() {
+    let root = unique_temp_dir("grok-home-isolation");
+    let explicit_home = root.join("isolated-grok-home");
+    write_grok_turn_session(&root.join(".grok"));
+    write_file(
+        &explicit_home.join("logs/unified.jsonl"),
+        r#"{"ts":"2026-08-16T00:00:00Z","sid":"isolated-session","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":100,"cached_prompt_tokens":40,"completion_tokens":20,"reasoning_tokens":5}}"#,
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "grok",
+            "daily",
+            "-j",
+            "-O",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-08-16",
+            "--until",
+            "2026-08-16",
+        ],
+        &[("GROK_HOME", &explicit_home), ("HOME", &root)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    let row = &json.as_array().expect("array output")[0];
+    assert_eq!(row["total_tokens"].as_i64(), Some(0));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn all_sources_preserves_partial_grok_cost_coverage() {
+    let root = unique_temp_dir("all-sources-grok-coverage");
+    let grok_home = root.join("grok-home");
+    write_grok_turn_session(&grok_home);
+    write_partial_grok_inference_log(&grok_home);
+    write_claude_session_at(&root, "2026-08-16T12:00:00Z");
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "--source",
+            "all",
+            "-j",
+            "-O",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-08-16",
+            "--until",
+            "2026-08-17",
+        ],
+        &[("GROK_HOME", &grok_home), ("HOME", &root)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    let coverage = &json.as_array().expect("array output")[0]["api_equivalent_cost_coverage"];
+    assert_eq!(coverage["total_tokens"].as_i64(), Some(180));
+    assert_eq!(coverage["priced_tokens"].as_i64(), Some(120));
+    assert_eq!(coverage["cost_is_lower_bound"].as_bool(), Some(true));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn no_cost_table_omits_api_cost_lower_bound_note() {
+    let root = unique_temp_dir("grok-no-cost-coverage-note");
+    let grok_home = root.join("grok-home");
+    write_grok_turn_session(&grok_home);
+    write_partial_grok_inference_log(&grok_home);
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "grok",
+            "daily",
+            "-O",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-08-16",
+            "--until",
+            "2026-08-17",
+        ],
+        &[("GROK_HOME", &grok_home), ("HOME", &root)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let table = String::from_utf8(stdout).expect("utf8 table");
+    assert!(
+        !table.contains("displayed cost is a lower bound"),
         "table: {table}"
     );
 

--- a/tests/sdk_integration.rs
+++ b/tests/sdk_integration.rs
@@ -667,15 +667,6 @@ fn sdk_summarizes_grok_context_tokens_without_running_cli() {
     })
     .expect("summarize grok");
 
-    match previous_grok_home {
-        Some(value) => unsafe {
-            std::env::set_var("GROK_HOME", value);
-        },
-        None => unsafe {
-            std::env::remove_var("GROK_HOME");
-        },
-    }
-
     assert_eq!(summary.source, UsageSource::Grok);
     assert_eq!(summary.source_name, "grok");
     assert_eq!(summary.valid_entries, 1);
@@ -692,5 +683,41 @@ fn sdk_summarizes_grok_context_tokens_without_running_cli() {
     assert_eq!(
         summary.models[0].estimated_cost_usd,
         summary.models[0].cost_usd
+    );
+
+    let single_json = serde_json::to_value(&summary).expect("serialize single Grok summary");
+    assert_eq!(
+        single_json["api_equivalent_cost_coverage"]["total_tokens"],
+        1500
+    );
+    assert_eq!(
+        single_json["api_equivalent_cost_coverage"]["priced_tokens"],
+        0
+    );
+
+    let batch = summarize_cost_ranges(MultiSummaryOptions {
+        source: UsageSource::Grok,
+        ranges: vec![UsageRange::DateRange {
+            since: Some(NaiveDate::from_ymd_opt(2026, 2, 6).unwrap()),
+            until: Some(NaiveDate::from_ymd_opt(2026, 2, 6).unwrap()),
+        }],
+        timezone: Some("UTC".to_string()),
+        offline: true,
+        strict_pricing: false,
+        currency: None,
+    })
+    .expect("summarize Grok batch");
+    match previous_grok_home {
+        Some(value) => unsafe {
+            std::env::set_var("GROK_HOME", value);
+        },
+        None => unsafe {
+            std::env::remove_var("GROK_HOME");
+        },
+    }
+    let batch_json = serde_json::to_value(&batch).expect("serialize batch Grok summary");
+    assert_eq!(
+        batch_json["summaries"][0]["api_equivalent_cost_coverage"]["total_tokens"],
+        1500
     );
 }


### PR DESCRIPTION
## What

- keep globally deduplicated `turn_completed.usage` as the complete Grok token source
- use `inference_done` records only for request-boundary API-equivalent pricing, without counting their tokens twice
- ignore `costUsdTicks` for API-equivalent cost
- expose selected-range priced-token coverage in JSON/CSV and mark partial table cost as a lower bound
- deduplicate provider `eventId` values across forked sessions while keeping prompt-only IDs session-scoped

## Why

Grok trims `unified.jsonl`, so the durable inference ledger can cover only part of a requested period. Using it for both tokens and cost silently undercounts usage. Session turn totals are complete but do not retain the per-inference 200k pricing boundary. The two streams must therefore remain separate and report their coverage explicitly.

Closes #113

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo deny check`
- [x] `cargo test` (580 unit tests plus all integration tests)
- [x] live Grok log check for 2026-08-24 through 2026-08-30: 1,209,656,903 complete tokens, 641,201,672 priced tokens, 53.0069% coverage, $628.081192 API-equivalent lower bound