### PR TITLE
feat(sources): add OpenCode and Pi accounting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,7 @@ dependencies = [
  "dirs",
  "glob",
  "rayon",
+ "rusqlite",
  "serde",
  "serde_json",
  "tempfile",
@@ -384,6 +385,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,6 +423,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -456,7 +475,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -464,6 +483,27 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
+dependencies = [
+ "hashbrown 0.17.1",
+]
 
 [[package]]
 name = "heck"
@@ -676,6 +716,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,6 +856,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -905,6 +962,31 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsqlite-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.40.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -1048,6 +1130,18 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -1293,6 +1387,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ dirs = "6.0.0"
 ureq = { version = "3.2.0", features = ["json"] }
 thiserror = "2"
 toml = "1.0.0"
+rusqlite = { version = "0.40.2", features = ["bundled"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![ccstats token and cost analytics card](docs/branding/readme-card.png)
 
-`ccstats` is a fast CLI for token and cost usage analytics across 11 local AI coding-agent data sources.
+`ccstats` is a fast CLI for token and cost usage analytics across 13 local AI coding-agent data sources.
 
 Search keywords: `claude code usage stats`, `codex usage stats`, `cursor usage stats`, `token usage cli`, `ai token cost tracker`.
 
@@ -21,6 +21,7 @@ Search keywords: `claude code usage stats`, `codex usage stats`, `cursor usage s
 - Kimi Code support (`~/.kimi-code/sessions/`)
 - Gemini CLI, Amp, and Qwen Code support
 - Cline CLI plus Cline, Roo Code, and Kilo Code VS Code extension support
+- OpenCode SQLite and Pi coding-agent JSONL support
 - Daily/weekly/monthly/project/session views
 - Top-N leaderboard ranking models or projects by cost share
 - Optional model-level token and cost breakdown
@@ -136,14 +137,17 @@ ccstats daily --source qwen
 ccstats daily --source cline
 ccstats daily --source roocode
 ccstats daily --source kilocode
+ccstats daily --source opencode
+ccstats daily --source pi
 ```
 
 Gemini reads both chat JSON and headless JSONL usage. Amp reconciles its usage
 ledger with assistant-message usage without double counting. Qwen reads its
 native usage ledger and separates cached input from uncached input. Cline reads
 both CLI sessions and its VS Code extension task logs; Roo Code and Kilo Code
-use the same extension-log algorithm. Client-side credit or reported-cost
-fields are not imported, so cost remains ccstats' model pricing estimate.
+use the same extension-log algorithm. OpenCode and Pi preserve positive
+client-recorded USD cost; sources without authoritative per-call cost continue
+to use ccstats' model pricing estimate.
 
 ## Crate Documentation
 
@@ -493,6 +497,8 @@ ccstats daily --source qwen
 ccstats daily --source cline
 ccstats daily --source roocode
 ccstats daily --source kilocode
+ccstats daily --source opencode
+ccstats daily --source pi
 
 # Offline mode (use cached pricing)
 ccstats today -O
@@ -554,7 +560,7 @@ Supported keys:
 | `timezone` | string | IANA timezone such as `UTC` or `Asia/Shanghai` |
 | `locale` | string | Locale used for number formatting, such as `en` or `de` |
 | `currency` | string | Currency code such as `USD`, `CNY`, or `EUR` |
-| `source` | string | Source name or alias such as `claude`, `codex`, `gemini`, `amp`, `qwen`, `cline`, `roocode`, `kilocode`, or `all` |
+| `source` | string | Source name or alias such as `claude`, `codex`, `gemini`, `amp`, `qwen`, `cline`, `opencode`, `pi`, or `all` |
 
 Source root env overrides are independent of config keys:
 
@@ -569,6 +575,8 @@ Source root env overrides are independent of config keys:
 | Amp | `XDG_DATA_HOME` | User data root containing `amp/threads/` | `~/.local/share` |
 | Qwen Code | `QWEN_RUNTIME_DIR`, then `QWEN_HOME` | Qwen root containing `usage/` | `~/.qwen` |
 | Cline CLI | `CLINE_SESSION_DATA_DIR` | Cline session directory | `~/.cline/data/sessions` |
+| OpenCode | `OPENCODE_DB`; data root follows `XDG_DATA_HOME` | Exact database path, or relative name inside the OpenCode data directory | Platform data directory under `opencode/opencode*.db` |
+| Pi | `PI_CODING_AGENT_SESSION_DIR`, then `PI_CODING_AGENT_DIR` | Exact sessions directory, or agent directory containing `sessions/` | `~/.pi/agent/sessions` |
 
 Cline also recognizes `CLINE_DATA_DIR` and `CLINE_DIR`. Roo Code and Kilo Code
 currently use their standard local directories.
@@ -594,8 +602,8 @@ cache_read / (input + cache_creation + cache_read) * 100
 Table output uses one decimal place and a `%` suffix. JSON uses the numeric
 `cache_hit_rate` field, while CSV uses a two-decimal `cache_hit_rate` column.
 Claude, Codex, Cursor, Grok, Kimi Code, Gemini CLI, Amp, Qwen Code, Cline, Roo
-Code, and Kilo Code expose the required cache-read metric. Mixed `--source all`
-output reports the aggregate rate across all selected usage.
+Code, Kilo Code, OpenCode, and Pi expose the required cache-read metric. Mixed
+`--source all` output reports the aggregate rate across all selected usage.
 
 ### Parsing Warnings
 
@@ -621,6 +629,8 @@ Warning: ignored <N> malformed records
 | Cline | `~/.cline/data/sessions/` and VS Code global storage | `CLINE_SESSION_DATA_DIR`, `CLINE_DATA_DIR`, `CLINE_DIR` | CLI and extension sessions, Projects, Cache tokens |
 | Roo Code | VS Code global storage | — | Extension task usage, Cache tokens |
 | Kilo Code | VS Code global storage | — | Extension task usage, Cache tokens |
+| OpenCode | Platform data directory under `opencode/opencode*.db` | `OPENCODE_DB`, `XDG_DATA_HOME` | Projects, reasoning/cache tokens, recorded cost, cross-schema deduplication |
+| Pi | `~/.pi/agent/sessions/**/*.jsonl` | `PI_CODING_AGENT_SESSION_DIR`, `PI_CODING_AGENT_DIR` | Projects, assistant + summary usage, cache tokens, branch-copy deduplication |
 
 ## Architecture
 

--- a/docs/algorithm/authoritative-token-accounting.md
+++ b/docs/algorithm/authoritative-token-accounting.md
@@ -33,7 +33,7 @@ ccstats 启动时先读取可选的 TOML 配置文件，再根据命令行参数
 | `timezone` | string | IANA 时区，例如 `UTC` / `Asia/Shanghai` |
 | `locale` | string | 数字格式 locale，例如 `en` / `de` |
 | `currency` | string | 货币代码，例如 `USD` / `CNY` / `EUR` |
-| `source` | string | `claude` / `codex` / `cursor` / `grok` / `kimi` / `gemini` / `amp` / `qwen` / `cline` / `roocode` / `kilocode` / `all` 或别名 |
+| `source` | string | `claude` / `codex` / `cursor` / `grok` / `kimi` / `gemini` / `amp` / `qwen` / `cline` / `roocode` / `kilocode` / `opencode` / `pi` / `all` 或别名 |
 
 示例：
 
@@ -61,6 +61,8 @@ cost = "show"
 | Amp | `XDG_DATA_HOME` | 包含 `amp/threads/` 的用户数据根目录 | `~/.local/share` |
 | Qwen Code | `QWEN_RUNTIME_DIR`，其次 `QWEN_HOME` | 包含 `usage/` 的 Qwen 根目录 | `~/.qwen` |
 | Cline CLI | `CLINE_SESSION_DATA_DIR`，另支持 `CLINE_DATA_DIR`、`CLINE_DIR` | Cline session 目录或数据根目录 | `~/.cline/data/sessions` |
+| OpenCode | `OPENCODE_DB`，数据根目录遵循 `XDG_DATA_HOME` | 数据库绝对路径，或 OpenCode 数据目录内的相对文件名 | 平台 data dir 下的 `opencode/opencode*.db` |
+| Pi | `PI_CODING_AGENT_SESSION_DIR`，其次 `PI_CODING_AGENT_DIR` | sessions 目录，或包含 `sessions/` 的 agent 目录 | `~/.pi/agent/sessions` |
 
 ---
 
@@ -283,6 +285,59 @@ cache_read         ← cachedTokens
 官方 total fallback 是 `inputTokens + outputTokens + thoughtsTokens`，不会再次加 `cachedTokens`，这也是 cache 属于 input 子集的直接证据。ledger 的 UUID 表示独立调用，不做流式去重。
 
 未知 schema、无效时间、缺少身份字段、负 token 或 `cachedTokens > inputTokens` 会计入解析错误并跳过，不会生成错误统计。
+
+---
+
+## OpenCode
+
+### 数据库与双 schema
+
+OpenCode 默认写入平台 data directory 下的 `opencode/opencode.db`；非标准安装 channel 可能写入 `opencode-<channel>.db`。`OPENCODE_DB` 可指定绝对路径，或指定 OpenCode data directory 内的相对文件名。
+
+当前数据库可能同时包含两代消息表：
+
+- `message`：role、`modelID`、`providerID` 位于 JSON payload。
+- `session_message`：role 位于表的 `type` 列，model/provider 位于 payload 的 `model` 对象。
+
+两表中的 assistant payload 都持久化已经归一化的独立 token 桶：
+
+```text
+input_tokens       ← tokens.input
+output_tokens      ← tokens.output
+reasoning_tokens   ← tokens.reasoning
+cache_creation     ← tokens.cache.write
+cache_read         ← tokens.cache.read
+```
+
+OpenCode 写入端已经从 inclusive input 中扣除了 cache read/write，并从 output 中扣除了 reasoning；ccstats 不再次减法。正的 `cost` 保存为 client-recorded USD，零值视为缺少可用价格并允许价格层估算。
+
+同一个消息可能同时存在于两张表或多个 channel 数据库。ccstats 使用 source-wide message ID 去重，优先完成记录；session directory 用于项目聚合。损坏 JSON、负 token、无效时间或数据库读取失败都会计入 parse error。
+
+---
+
+## Pi
+
+### JSONL 与独立调用
+
+Pi 默认写入 `~/.pi/agent/sessions/<encoded-cwd>/*.jsonl`。显式 `PI_CODING_AGENT_SESSION_DIR` 优先，其次是 `PI_CODING_AGENT_DIR/sessions`。
+
+统计三类带 usage 的真实 LLM 调用：
+
+1. assistant message；
+2. compaction summary；
+3. branch summary。
+
+```text
+input_tokens       ← usage.input
+output_tokens      ← usage.output
+reasoning_tokens   ← 0
+cache_creation     ← usage.cacheWrite
+cache_read         ← usage.cacheRead
+```
+
+Pi 官方定义明确说明 `usage.reasoning` 已包含在 `usage.output` 中，所以不能再放入 additive reasoning 桶。summary 记录没有自己的 model 字段时，使用此前最近一次 `model_change` 或 assistant 明确记录的模型；仍无法确定时明确归入 `unknown`。
+
+Pi 的“创建分支 session”会把已有路径复制到新 JSONL，但保留原 entry ID。ccstats 以 source-wide entry ID 去重，既保留新分支之后产生的调用，也不会把复制的历史再次计费。正的 `usage.cost.total` 保存为 client-recorded USD。
 
 ---
 

--- a/docs/research/provider-algorithm-audit-2026-08-31.md
+++ b/docs/research/provider-algorithm-audit-2026-08-31.md
@@ -9,6 +9,8 @@
 3. ccstats 的统一 token 桶必须互不重叠。每个 parser 在边界处完成一次归一化，聚合和价格层不得再次猜测。
 4. 本轮确认两个需要修复的问题：Qwen 应改读官方 usage ledger 并分离 cache；Codex 应同时扫描 `sessions` 和 `archived_sessions`。
 5. 最新 ccstats 已把 Cursor 切到 usage events API，把 Grok 切到逐推理 usage ledger；这两者不再使用旧的本地 SQLite/上下文快照算法。但 Cursor endpoint 仍是未公开稳定协议，provider event cost 也不等同于最终发票。
+6. Tokscale 在固定提交中登记 52 个 client，ccstats 本批实现前登记 11 个 source；41 的原始差额不等于 41 个独立算法。OpenCode、MiMo Code、Kilo CLI 共享一个 SQLite 消息族，Pi、GJC、Senpi、Kimchi、Prime Agent、Oh My Pi 共享一个 JSONL 消息族，另有在线 quota、headless capture 和社交提交等不同系统边界。
+7. OpenCode 与 Pi 已取得当前官方写入端源码证据，可以进入实现。Pi 官方还会给 compaction / branch summary 保存独立 usage，Tokscale 当前普通 Pi parser 未统计这两类真实调用；ccstats 应补上而不是继承这个遗漏。
 
 ## 证据等级
 
@@ -35,6 +37,8 @@
 | [tkntracker](https://github.com/junaiddshaukat/tkntracker/tree/63cf913c02fcb337f134df37752ad50496f95f17) | `63cf913` | Qwen 官方 usage ledger 路径和广泛的轻量采集器 |
 | [rust-agtop](https://github.com/collectiveai-team/rust-agtop/tree/73f8f99bd1932e956cfdad19a4afe9f154a285f6) | `73f8f99` | Gemini telemetry 优先的实时进程观测 |
 | [token-history](https://github.com/keli-wen/token-history/tree/2351bb6ae4606dc0c364abe184ba9ba498ba447c) | `2351bb6` | 以现有 CLI 为输入的历史采集和可视化管线 |
+| [OpenCode](https://github.com/anomalyco/opencode/tree/10765ff2a9da8c3b88e4de873aa383a49c318912) | `10765ff` | 当前 SQLite 路径、v1/v2 message schema、cache 与 cost 归一化 |
+| [Pi](https://github.com/earendil-works/pi/tree/853a80d26c90a14c1886f0ebb8ffaae133ca2185) | `853a80d` | 当前 JSONL session schema、usage/cost 语义、目录环境变量 |
 
 官方 schema 证据：
 
@@ -42,6 +46,25 @@
 - [Qwen Code `TokenUsageRecord`](https://github.com/QwenLM/qwen-code/blob/3aa1b14624789797b33bffad3d70190ce41cedce/packages/core/src/services/tokenUsageService.ts) 是当前原生 usage ledger。其 total fallback 为 `input + output + thoughts`，没有再次加 cached，证明 cached 是 input 的子集。
 - [Qwen Code `Storage`](https://github.com/QwenLM/qwen-code/blob/3aa1b14624789797b33bffad3d70190ce41cedce/packages/core/src/config/storage.ts) 给出 `QWEN_RUNTIME_DIR > QWEN_HOME > ~/.qwen` 的根目录优先级。
 - [Cline `SessionUsageMetadata`](https://github.com/cline/cline/blob/48d63852745460ff0fa3dfcc0457bbe2493841de/sdk/packages/core/src/types/sessions.ts) 定义 `inputTokens`、`outputTokens`、`cacheReadTokens`、`cacheWriteTokens` 和 `totalCost`。
+- [OpenCode `SessionMessage.Assistant`](https://github.com/anomalyco/opencode/blob/10765ff2a9da8c3b88e4de873aa383a49c318912/packages/schema/src/session-message.ts) 定义 nested `model`、独立 token 桶、可选 recorded cost 与毫秒时间；[`session/sql.ts`](https://github.com/anomalyco/opencode/blob/10765ff2a9da8c3b88e4de873aa383a49c318912/packages/core/src/session/sql.ts) 证明当前数据库同时存在 `message` 与 `session_message` 两代消息表。
+- [OpenCode `getUsage`](https://github.com/anomalyco/opencode/blob/10765ff2a9da8c3b88e4de873aa383a49c318912/packages/opencode/src/session/session.ts) 会先从 AI SDK inclusive input 中扣除 cache read/write，并把 reasoning 从 output 中扣除；持久化后的五个桶已经互不重叠，consumer 不应再次做减法。
+- [Pi `Usage`](https://github.com/earendil-works/pi/blob/853a80d26c90a14c1886f0ebb8ffaae133ca2185/packages/ai/src/types.ts) 明确 `reasoning` 是 `output` 的子集，而 `totalTokens` 等于 input、output、cache read、cache write 之和；因此 reasoning 只能作为说明，不能再加入 ccstats 的 additive reasoning 桶。
+- [Pi session schema](https://github.com/earendil-works/pi/blob/853a80d26c90a14c1886f0ebb8ffaae133ca2185/packages/coding-agent/src/core/session-manager.ts) 证明 assistant message、compaction 与 branch summary 都可能携带 usage；后两者是独立 LLM 调用，不应静默丢弃。
+
+## Tokscale 52-client 差距分解
+
+Tokscale 的 registry 数量适合衡量发现覆盖面，不适合直接衡量算法数量。按实际数据所有权拆分如下：
+
+| 分组 | 代表 client | 算法关系 | ccstats 决策 |
+|---|---|---|---|
+| 已覆盖且已审计 | Claude、Codex、Cursor、Gemini、Amp、Kimi、Qwen、Cline、Roo、Kilo Code、Grok | 11 个现有 source | 保持逐来源证据，不回退为通用 extractor |
+| OpenCode SQLite 族 | OpenCode、MiMo Code、Kilo CLI | 同一消息 payload，路径、表版本、成本 provenance 有差异 | 先实现官方 OpenCode；fork 在取得当前写入端 fixture 后复用已验证映射 |
+| Pi JSONL 族 | Pi、GJC、Senpi、Kimchi、Prime Agent、Oh My Pi | 基础 assistant usage 相同；Prime 另有 child/aggregate reconciliation | 先实现官方 Pi 并覆盖 summary usage；fork 分别验证目录与额外记账 |
+| 官方可验证的下一批 | GitHub Copilot CLI、Goose | Copilot 是 OTel；Goose 是 SQLite | 下一批实现，不能与 premium request quota 混算 |
+| 独立本地格式候选 | Droid、OpenClaw、Mux、Crush、Hermes、Codebuff、Zed、Kiro、Trae、Warp、Junie、Augment 等 | JSONL、SQLite、IDE cache 混合 | 逐个取得官方 schema 或真实 fixture 后进入 |
+| 产品层而非 token parser | usage/quota、headless wrapper、profile、leaderboard、device/group、autosubmit、MCP | 系统边界不同 | 单列产品路线；不为追求 source 数量混入核心账本 |
+
+这意味着“全方位补齐”应分成两条可验证轨道：先补 authoritative local accounting，再补 quota/桌面/社区产品能力。把两者塞进同一个 parser PR 会让错误数字更难发现。
 
 ## 跨工具算法比较
 
@@ -90,7 +113,7 @@ total = fresh_input + cache_read + cache_write + visible_output + reasoning
 
 空文件和没有 usage 的合法事件可以跳过；无法读取、损坏 JSONL、非法时间戳导致有效 usage 丢失时必须增加 parse error。这样 CLI 才能把“不存在使用量”和“解析失败”区分开。
 
-## ccstats 当前 11 个来源审计
+## ccstats 实现前 11 个来源审计
 
 | 来源 | 数据路径与算法 | 证据状态 | 结论 |
 |---|---|---|---|
@@ -106,6 +129,13 @@ total = fresh_input + cache_read + cache_write + visible_output + reasoning
 | Roo Code | VS Code task `api_req_started`，读取最后 environment model | 推断/交叉验证 | 保持支持并在格式变化时用真实 fixture 更新 |
 | Kilo Code | 与 Roo/Cline extension task 格式相同 | 推断/交叉验证 | 保持支持；不要与 Kilo gateway 的在线 quota 混淆 |
 
+本批新增结果：
+
+| 来源 | 数据路径与算法 | 证据状态 | 结论 |
+|---|---|---|---|
+| OpenCode | 当前 SQLite `message` + `session_message`；五个桶已在写入端分离；跨表/跨 channel ID 去重 | 官方源码已验证 + Tokscale/ccusage 交叉验证 | 实现为第 12 个 source；保留项目、reasoning、cache 与正的 recorded cost |
+| Pi | JSONL assistant + compaction + branch summary；reasoning 属于 output 子集；branch copy 按 entry ID 去重 | 官方源码已验证 + Tokscale fixture 交叉验证 | 实现为第 13 个 source；补上 Tokscale 普通 Pi parser 未统计的 summary usage |
+
 ## 本轮采用、适配、拒绝决策
 
 ### 采用
@@ -119,6 +149,8 @@ total = fresh_input + cache_read + cache_write + visible_output + reasoning
 - Tokscale 的 Amp 双视图合并顺序。
 - Tokscale、Codeburn、Tokenleak 的 Gemini cache 归一化测试向量。
 - CodexBar 的“本地 cost”和“在线 quota”分层概念，但不引入其桌面账户管理层。
+- Tokscale 的 OpenCode 双表发现与跨表去重思路，但以当前 OpenCode 官方 schema 为字段语义权威。
+- Tokscale 的 Pi assistant 记录筛选；额外统计官方 schema 已证明的 compaction / branch summary usage。
 
 ### 拒绝
 
@@ -127,14 +159,14 @@ total = fresh_input + cache_read + cache_write + visible_output + reasoning
 - 根据 prompt/response 文本重新 tokenizer：模型 tokenizer、隐藏 system prompt、tool schema 和服务端缓存都不可完整重建。
 - 在没有验证 USD 单位和调用归属时导入 credits/reported cost：即使模型支持 provenance，也会把不同口径的值混在一起。
 
-## 后续数据源顺序
+## 后续数据源批次
 
 新增来源必须先取得官方 schema 或两个独立 fixture，再进入实现。建议顺序：
 
-1. OpenCode：官方 SQLite/JSON schema，且 ccusage、Tokscale、Codeburn、Tokenleak 都有独立实现，可充分交叉验证。
-2. GitHub Copilot：优先 OTEL 本地事件；必须区分 premium request quota 与模型 token。
-3. Pi：JSONL message usage 格式简单，多个项目已有 fixture。
-4. Droid、Kiro：先确认本地日志是否包含真实 token，而不是订阅额度或客户端 credits。
-5. Goose、Zed、Warp：SQLite/缓存格式需要版本化 fixture，不能只根据列名猜测。
+1. Batch 1：OpenCode + Pi + discovery→parse→aggregate→CLI 端到端矩阵。两者都有当前官方 schema，分别建立 SQLite 与 JSONL 的基准实现。
+2. Batch 2：GitHub Copilot CLI OTel + Goose SQLite。两者都有官方文档证明 token 数据落点。
+3. Batch 3：OpenCode/Pi fork family。逐个确认写入端版本、目录覆盖和 fork 特有的去重/child usage 后复用基准算法。
+4. Batch 4：Droid、Kiro、Zed、Warp 等独立格式。没有官方 schema 时必须取得匿名化真实 fixture 和第二实现交叉验证。
+5. Product track：桌面应用、quota、实时观测与多机器历史；与 authoritative token ledger 保持 provenance 隔离。
 
-每一个来源独立成 PR，包含官方证据链接、最小真实格式 fixture、RED/GREEN 测试记录、数据路径和已知限制。这样覆盖面可以持续增长，但不会用错误数字换取“支持数量”。
+每一批独立提交与 PR，包含官方证据链接、最小真实格式 fixture、RED/GREEN 测试记录、数据路径和已知限制。这样覆盖面可以持续增长，但不会用错误数字换取“支持数量”。

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -128,7 +128,7 @@ pub(crate) struct Cli {
     #[arg(long, global = true, value_name = "AMOUNT")]
     pub(crate) monthly_budget: Option<f64>,
 
-    /// Data source name or alias (e.g., "claude", "codex", "gemini", "amp", "qwen", "cline", "roocode", "kilocode", "all")
+    /// Data source name or alias (e.g., "claude", "codex", "gemini", "amp", "qwen", "cline", "opencode", "pi", "all")
     #[arg(long, global = true, value_name = "SOURCE")]
     pub(crate) source: Option<String>,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! `ccstats` is a local-first library and CLI for token and cost analytics from
 //! Claude Code, `OpenAI` Codex, Cursor, Grok, Kimi Code, Gemini CLI, Amp,
-//! Qwen Code, Cline, Roo Code, and Kilo Code session logs.
+//! Qwen Code, Cline, Roo Code, Kilo Code, `OpenCode`, and Pi session logs.
 //!
 //! The public SDK entry points are [`summarize_cost`] and
 //! [`summarize_cost_ranges`] for cost analytics, [`load_codex_weekly_quota`]

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -60,11 +60,15 @@ pub enum UsageSource {
     RooCode,
     /// Kilo Code VS Code extension task logs.
     KiloCode,
+    /// `OpenCode` messages in its local `SQLite` database.
+    OpenCode,
+    /// Pi coding-agent JSONL sessions.
+    Pi,
 }
 
 impl UsageSource {
     #[cfg(test)]
-    pub(crate) const VARIANTS: [Self; 11] = [
+    pub(crate) const VARIANTS: [Self; 13] = [
         UsageSource::Claude,
         UsageSource::Codex,
         UsageSource::Cursor,
@@ -76,6 +80,8 @@ impl UsageSource {
         UsageSource::Cline,
         UsageSource::RooCode,
         UsageSource::KiloCode,
+        UsageSource::OpenCode,
+        UsageSource::Pi,
     ];
 
     #[must_use]
@@ -92,6 +98,8 @@ impl UsageSource {
             UsageSource::Cline => "cline",
             UsageSource::RooCode => "roocode",
             UsageSource::KiloCode => "kilocode",
+            UsageSource::OpenCode => "opencode",
+            UsageSource::Pi => "pi",
         }
     }
 
@@ -108,6 +116,8 @@ impl UsageSource {
             "cline" => Some(UsageSource::Cline),
             "roocode" => Some(UsageSource::RooCode),
             "kilocode" => Some(UsageSource::KiloCode),
+            "opencode" => Some(UsageSource::OpenCode),
+            "pi" => Some(UsageSource::Pi),
             _ => None,
         }
     }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -13,6 +13,8 @@ mod gemini;
 mod grok;
 mod kimi;
 mod loader;
+mod opencode;
+mod pi;
 mod qwen;
 mod registry;
 

--- a/src/source/opencode.rs
+++ b/src/source/opencode.rs
@@ -1,0 +1,485 @@
+//! `OpenCode` local `SQLite` usage source.
+
+use std::env;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
+use serde::Deserialize;
+
+use crate::consts::DATE_FORMAT;
+use crate::core::{CostKind, Endpoint, RawEntry, source_wide_message_id};
+use crate::source::{Capabilities, ParseOutput, Source};
+use crate::utils::Timezone;
+
+const OPENCODE_DB_ENV: &str = "OPENCODE_DB";
+const XDG_DATA_HOME_ENV: &str = "XDG_DATA_HOME";
+
+pub(crate) struct OpenCodeSource;
+
+impl OpenCodeSource {
+    pub(crate) const fn new() -> Self {
+        Self
+    }
+}
+
+impl Source for OpenCodeSource {
+    fn name(&self) -> &'static str {
+        "opencode"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "OpenCode"
+    }
+
+    fn aliases(&self) -> &'static [&'static str] {
+        &["oc"]
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            has_projects: true,
+            has_billing_blocks: false,
+            has_reasoning_tokens: true,
+            has_cache_creation: true,
+            has_cache_read: true,
+            needs_dedup: true,
+            has_tool_calls: false,
+            has_endpoints: false,
+        }
+    }
+
+    fn find_files(&self) -> Vec<PathBuf> {
+        find_opencode_databases()
+    }
+
+    fn parse_file(&self, path: &Path, timezone: Timezone, debug: bool) -> ParseOutput {
+        parse_opencode_database(path, timezone, debug)
+    }
+}
+
+fn opencode_data_dir() -> Option<PathBuf> {
+    match env::var_os(XDG_DATA_HOME_ENV) {
+        Some(value) if !value.is_empty() => Some(PathBuf::from(value).join("opencode")),
+        Some(_) | None => dirs::data_dir().map(|path| path.join("opencode")),
+    }
+}
+
+fn find_opencode_databases() -> Vec<PathBuf> {
+    if let Some(configured) = env::var_os(OPENCODE_DB_ENV).filter(|value| !value.is_empty()) {
+        let configured = PathBuf::from(configured);
+        let path = if configured.is_absolute() {
+            configured
+        } else if let Some(data_dir) = opencode_data_dir() {
+            data_dir.join(configured)
+        } else {
+            return Vec::new();
+        };
+        return path.is_file().then_some(path).into_iter().collect();
+    }
+
+    let Some(data_dir) = opencode_data_dir() else {
+        return Vec::new();
+    };
+    let pattern = data_dir.join("opencode*.db");
+    let mut databases = glob::glob(&pattern.to_string_lossy())
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter(|path| path.is_file())
+        .collect::<Vec<_>>();
+    databases.sort();
+    databases.dedup();
+    databases
+}
+
+#[derive(Debug)]
+struct DatabaseMessage {
+    id: String,
+    session_id: String,
+    data: String,
+    project_path: Option<String>,
+    schema: MessageSchema,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum MessageSchema {
+    V1,
+    V2,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OpenCodeMessage {
+    role: Option<String>,
+    #[serde(rename = "modelID")]
+    model_id: Option<String>,
+    model: Option<OpenCodeModel>,
+    finish: Option<String>,
+    cost: Option<f64>,
+    tokens: OpenCodeTokens,
+    time: OpenCodeTime,
+    path: Option<OpenCodePath>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OpenCodeModel {
+    id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenCodeTokens {
+    input: i64,
+    output: i64,
+    reasoning: i64,
+    cache: OpenCodeCache,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenCodeCache {
+    read: i64,
+    write: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenCodeTime {
+    created: f64,
+    completed: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenCodePath {
+    root: Option<String>,
+}
+
+fn table_exists(connection: &Connection, table: &str) -> rusqlite::Result<bool> {
+    connection
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1",
+            params![table],
+            |_| Ok(()),
+        )
+        .optional()
+        .map(|row| row.is_some())
+}
+
+fn report_invalid_v1_json(
+    connection: &Connection,
+    output: &mut ParseOutput,
+    debug: bool,
+    path: &Path,
+) {
+    match connection.query_row(
+        "SELECT COUNT(*) FROM message WHERE NOT json_valid(data)",
+        [],
+        |row| row.get::<_, i64>(0),
+    ) {
+        Ok(invalid) if invalid > 0 => {
+            output.errors = output
+                .errors
+                .saturating_add(usize::try_from(invalid).unwrap_or(usize::MAX));
+            if debug {
+                eprintln!(
+                    "Ignored {invalid} invalid JSON rows in {} table message",
+                    path.display()
+                );
+            }
+        }
+        Ok(_) => {}
+        Err(error) => {
+            output.errors += 1;
+            if debug {
+                eprintln!(
+                    "Failed to validate {} table message: {error}",
+                    path.display()
+                );
+            }
+        }
+    }
+}
+
+fn read_table(
+    connection: &Connection,
+    schema: MessageSchema,
+    output: &mut ParseOutput,
+    debug: bool,
+    path: &Path,
+    timezone: Timezone,
+) -> bool {
+    let (table, query) = match schema {
+        MessageSchema::V1 => (
+            "message",
+            "SELECT m.id, m.session_id, m.data, NULLIF(s.directory, '')
+             FROM message m
+             LEFT JOIN session s ON s.id = m.session_id
+             WHERE json_valid(m.data)
+               AND json_extract(m.data, '$.role') = 'assistant'",
+        ),
+        MessageSchema::V2 => (
+            "session_message",
+            "SELECT sm.id, sm.session_id, sm.data, NULLIF(s.directory, '')
+             FROM session_message sm
+             LEFT JOIN session s ON s.id = sm.session_id
+             WHERE sm.type = 'assistant'",
+        ),
+    };
+
+    match table_exists(connection, table) {
+        Ok(false) => return false,
+        Err(error) => {
+            output.errors += 1;
+            if debug {
+                eprintln!(
+                    "Failed to inspect {} table {table}: {error}",
+                    path.display()
+                );
+            }
+            return false;
+        }
+        Ok(true) => {}
+    }
+
+    if matches!(schema, MessageSchema::V1) {
+        report_invalid_v1_json(connection, output, debug, path);
+    }
+
+    let mut statement = match connection.prepare(query) {
+        Ok(statement) => statement,
+        Err(error) => {
+            output.errors += 1;
+            if debug {
+                eprintln!("Failed to query {} table {table}: {error}", path.display());
+            }
+            return true;
+        }
+    };
+    let rows = match statement.query_map([], |row| {
+        Ok(DatabaseMessage {
+            id: row.get(0)?,
+            session_id: row.get(1)?,
+            data: row.get(2)?,
+            project_path: row.get(3)?,
+            schema,
+        })
+    }) {
+        Ok(rows) => rows,
+        Err(error) => {
+            output.errors += 1;
+            if debug {
+                eprintln!("Failed to read {} table {table}: {error}", path.display());
+            }
+            return true;
+        }
+    };
+
+    for row in rows {
+        match row {
+            Ok(row) => match entry_from_database_message(&row, timezone) {
+                Ok(Some(entry)) => output.entries.push(entry),
+                Ok(None) => {}
+                Err(error) => {
+                    output.errors += 1;
+                    if debug {
+                        eprintln!(
+                            "Invalid OpenCode message {} in {}: {error}",
+                            row.id,
+                            path.display()
+                        );
+                    }
+                }
+            },
+            Err(error) => {
+                output.errors += 1;
+                if debug {
+                    eprintln!("Invalid row in {} table {table}: {error}", path.display());
+                }
+            }
+        }
+    }
+    true
+}
+
+fn finite_millis(value: f64) -> Result<i64, &'static str> {
+    if !value.is_finite() || value <= 0.0 || value > i64::MAX as f64 {
+        return Err("invalid time.created");
+    }
+    Ok(value as i64)
+}
+
+fn entry_from_database_message(
+    row: &DatabaseMessage,
+    timezone: Timezone,
+) -> Result<Option<RawEntry>, &'static str> {
+    let message: OpenCodeMessage =
+        serde_json::from_str(&row.data).map_err(|_| "invalid message JSON")?;
+    if matches!(row.schema, MessageSchema::V1) && message.role.as_deref() != Some("assistant") {
+        return Ok(None);
+    }
+
+    let model = message
+        .model_id
+        .as_deref()
+        .or_else(|| message.model.as_ref().map(|model| model.id.as_str()))
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+        .ok_or("missing model")?
+        .to_string();
+    let tokens = message.tokens;
+    if [
+        tokens.input,
+        tokens.output,
+        tokens.reasoning,
+        tokens.cache.read,
+        tokens.cache.write,
+    ]
+    .into_iter()
+    .any(|value| value < 0)
+    {
+        return Err("negative token count");
+    }
+    let recorded_cost_usd = message.cost.filter(|cost| cost.is_finite() && *cost > 0.0);
+    if tokens.input == 0
+        && tokens.output == 0
+        && tokens.reasoning == 0
+        && tokens.cache.read == 0
+        && tokens.cache.write == 0
+        && recorded_cost_usd.is_none()
+    {
+        return Ok(None);
+    }
+
+    let timestamp_ms = finite_millis(message.time.created)?;
+    let timestamp =
+        DateTime::<Utc>::from_timestamp_millis(timestamp_ms).ok_or("invalid time.created")?;
+    let project_path = row
+        .project_path
+        .as_deref()
+        .or_else(|| message.path.as_ref().and_then(|path| path.root.as_deref()))
+        .unwrap_or_default()
+        .to_string();
+    let completed = message
+        .time
+        .completed
+        .is_some_and(|completed| completed.is_finite() && completed >= message.time.created);
+    let stop_reason = message
+        .finish
+        .filter(|finish| !finish.trim().is_empty())
+        .or_else(|| completed.then_some("completed".to_string()));
+    Ok(Some(RawEntry {
+        timestamp: timestamp.to_rfc3339(),
+        timestamp_ms,
+        date_str: timezone
+            .to_fixed_offset(timestamp)
+            .date_naive()
+            .format(DATE_FORMAT)
+            .to_string(),
+        message_id: Some(source_wide_message_id("opencode", &row.id)),
+        session_key: format!("opencode::{}", row.session_id),
+        session_id: row.session_id.clone(),
+        project_path,
+        model,
+        input_tokens: tokens.input,
+        output_tokens: tokens.output,
+        cache_creation: tokens.cache.write,
+        cache_creation_1h: 0,
+        cache_read: tokens.cache.read,
+        reasoning_tokens: tokens.reasoning,
+        stop_reason,
+        cost_kind: CostKind::Real,
+        endpoint: Endpoint::Unknown,
+        call_count: 1,
+        recorded_cost_usd,
+    }))
+}
+
+fn parse_opencode_database(path: &Path, timezone: Timezone, debug: bool) -> ParseOutput {
+    let flags = OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX;
+    let connection = match Connection::open_with_flags(path, flags) {
+        Ok(connection) => connection,
+        Err(error) => {
+            if debug {
+                eprintln!(
+                    "Failed to open OpenCode database {}: {error}",
+                    path.display()
+                );
+            }
+            return ParseOutput {
+                entries: Vec::new(),
+                errors: 1,
+            };
+        }
+    };
+
+    let mut output = ParseOutput::default();
+    let has_v2 = read_table(
+        &connection,
+        MessageSchema::V2,
+        &mut output,
+        debug,
+        path,
+        timezone,
+    );
+    let has_v1 = read_table(
+        &connection,
+        MessageSchema::V1,
+        &mut output,
+        debug,
+        path,
+        timezone,
+    );
+    if !has_v1 && !has_v2 && output.errors == 0 {
+        output.errors = 1;
+        if debug {
+            eprintln!(
+                "OpenCode database {} has neither message table",
+                path.display()
+            );
+        }
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_v2_message_preserves_independent_buckets_and_recorded_cost() {
+        let row = DatabaseMessage {
+            id: "msg_1".to_string(),
+            session_id: "ses_1".to_string(),
+            project_path: Some("/tmp/project".to_string()),
+            schema: MessageSchema::V2,
+            data: r#"{"agent":"build","model":{"id":"gpt-5","providerID":"openai"},"finish":"stop","cost":0.25,"tokens":{"input":100,"output":20,"reasoning":5,"cache":{"read":30,"write":10}},"time":{"created":1788131045000,"completed":1788131046000}}"#.to_string(),
+        };
+
+        let entry = entry_from_database_message(&row, Timezone::Named(chrono_tz::UTC))
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(entry.input_tokens, 100);
+        assert_eq!(entry.output_tokens, 20);
+        assert_eq!(entry.reasoning_tokens, 5);
+        assert_eq!(entry.cache_read, 30);
+        assert_eq!(entry.cache_creation, 10);
+        assert_eq!(entry.recorded_cost_usd, Some(0.25));
+        assert_eq!(entry.project_path, "/tmp/project");
+    }
+
+    #[test]
+    fn malformed_usage_is_reported_instead_of_clamped() {
+        let row = DatabaseMessage {
+            id: "msg_bad".to_string(),
+            session_id: "ses_1".to_string(),
+            project_path: None,
+            schema: MessageSchema::V2,
+            data: r#"{"model":{"id":"gpt-5","providerID":"openai"},"tokens":{"input":-1,"output":2,"reasoning":0,"cache":{"read":0,"write":0}},"time":{"created":1788131045000}}"#.to_string(),
+        };
+
+        assert!(matches!(
+            entry_from_database_message(&row, Timezone::Named(chrono_tz::UTC)),
+            Err("negative token count")
+        ));
+    }
+}

--- a/src/source/opencode.rs
+++ b/src/source/opencode.rs
@@ -390,6 +390,8 @@ fn entry_from_database_message(
         endpoint: Endpoint::Unknown,
         call_count: 1,
         recorded_cost_usd,
+        api_equivalent_priced_tokens: 0,
+        api_equivalent_coverage_tokens: 0,
     }))
 }
 

--- a/src/source/pi.rs
+++ b/src/source/pi.rs
@@ -1,5 +1,6 @@
 //! Pi coding-agent JSONL usage source.
 
+use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::io::{BufRead, BufReader};
@@ -103,9 +104,9 @@ struct PiEntry {
     #[serde(rename = "type")]
     entry_type: String,
     id: String,
+    parent_id: Option<String>,
     timestamp: String,
     message: Option<PiMessage>,
-    provider: Option<String>,
     model_id: Option<String>,
     usage: Option<PiUsage>,
 }
@@ -114,7 +115,6 @@ struct PiEntry {
 #[serde(rename_all = "camelCase")]
 struct PiMessage {
     role: String,
-    provider: Option<String>,
     model: Option<String>,
     usage: Option<PiUsage>,
     stop_reason: Option<String>,
@@ -135,23 +135,6 @@ struct PiCost {
     total: f64,
 }
 
-#[derive(Debug, Default)]
-struct PiModelState {
-    provider: Option<String>,
-    model: Option<String>,
-}
-
-impl PiModelState {
-    fn update(&mut self, provider: Option<&str>, model: Option<&str>) {
-        if let Some(provider) = provider.map(str::trim).filter(|value| !value.is_empty()) {
-            self.provider = Some(provider.to_string());
-        }
-        if let Some(model) = model.map(str::trim).filter(|value| !value.is_empty()) {
-            self.model = Some(model.to_string());
-        }
-    }
-}
-
 struct PiUsageContext<'a> {
     entry_id: &'a str,
     timestamp: &'a str,
@@ -166,6 +149,9 @@ fn usage_entry(
     usage: PiUsage,
     context: PiUsageContext<'_>,
 ) -> Result<Option<RawEntry>, &'static str> {
+    if context.entry_id.trim().is_empty() {
+        return Err("empty entry id");
+    }
     if [
         usage.input,
         usage.output,
@@ -232,12 +218,27 @@ fn usage_entry(
 fn parse_entry(
     entry: PiEntry,
     header: &PiHeader,
-    model_state: &mut PiModelState,
+    lineage_models: &mut HashMap<String, String>,
     timezone: Timezone,
 ) -> Result<Option<RawEntry>, &'static str> {
+    let inherited_model = entry
+        .parent_id
+        .as_deref()
+        .and_then(|parent| lineage_models.get(parent))
+        .cloned();
+    if let Some(model) = inherited_model.as_ref() {
+        lineage_models.insert(entry.id.clone(), model.clone());
+    }
     match entry.entry_type.as_str() {
         "model_change" => {
-            model_state.update(entry.provider.as_deref(), entry.model_id.as_deref());
+            if let Some(model) = entry
+                .model_id
+                .map(|model| model.trim().to_string())
+                .filter(|model| !model.is_empty())
+                .or(inherited_model)
+            {
+                lineage_models.insert(entry.id, model);
+            }
             Ok(None)
         }
         "message" => {
@@ -250,7 +251,16 @@ fn parse_entry(
             let Some(usage) = message.usage else {
                 return Ok(None);
             };
-            model_state.update(message.provider.as_deref(), message.model.as_deref());
+            let model = message
+                .model
+                .as_deref()
+                .map(str::trim)
+                .filter(|model| !model.is_empty())
+                .map(str::to_string)
+                .or(inherited_model);
+            if let Some(model) = model.as_ref() {
+                lineage_models.insert(entry.id.clone(), model.clone());
+            }
             usage_entry(
                 usage,
                 PiUsageContext {
@@ -258,7 +268,7 @@ fn parse_entry(
                     timestamp: &entry.timestamp,
                     session_id: &header.id,
                     project_path: &header.cwd,
-                    model: message.model.as_deref(),
+                    model: model.as_deref(),
                     stop_reason: message
                         .stop_reason
                         .filter(|reason| !reason.trim().is_empty())
@@ -278,7 +288,7 @@ fn parse_entry(
                     timestamp: &entry.timestamp,
                     session_id: &header.id,
                     project_path: &header.cwd,
-                    model: model_state.model.as_deref(),
+                    model: inherited_model.as_deref(),
                     stop_reason: Some(entry.entry_type),
                     timezone,
                 },
@@ -356,7 +366,7 @@ fn parse_pi_entries(
     debug: bool,
 ) -> ParseOutput {
     let mut output = ParseOutput::default();
-    let mut model_state = PiModelState::default();
+    let mut lineage_models = HashMap::new();
     for (line_index, line) in lines {
         let line = match line {
             Ok(line) => line,
@@ -389,7 +399,7 @@ fn parse_pi_entries(
                 continue;
             }
         };
-        match parse_entry(entry, header, &mut model_state, timezone) {
+        match parse_entry(entry, header, &mut lineage_models, timezone) {
             Ok(Some(entry)) => output.entries.push(entry),
             Ok(None) => {}
             Err(error) => {
@@ -410,6 +420,8 @@ fn parse_pi_entries(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use tempfile::tempdir;
 
     #[test]
     fn reasoning_stays_inside_output_and_reported_cost_is_preserved() {
@@ -466,5 +478,59 @@ mod tests {
             ),
             Err("negative token count")
         ));
+    }
+
+    #[test]
+    fn empty_usage_entry_id_is_an_explicit_error() {
+        let usage = PiUsage {
+            input: 1,
+            output: 0,
+            cache_read: 0,
+            cache_write: 0,
+            cost: None,
+        };
+
+        assert!(matches!(
+            usage_entry(
+                usage,
+                PiUsageContext {
+                    entry_id: "",
+                    timestamp: "2026-08-31T03:00:00Z",
+                    session_id: "session-1",
+                    project_path: "/tmp/project",
+                    model: Some("gpt-5"),
+                    stop_reason: Some("stop".to_string()),
+                    timezone: Timezone::Named(chrono_tz::UTC),
+                },
+            ),
+            Err("empty entry id")
+        ));
+    }
+
+    #[test]
+    fn summary_model_follows_its_parent_lineage() {
+        let temp = tempdir().unwrap();
+        let path = temp.path().join("session.jsonl");
+        fs::write(
+            &path,
+            r#"{"type":"session","version":3,"id":"session-1","timestamp":"2026-08-31T03:00:00Z","cwd":"/tmp/project"}
+{"type":"model_change","id":"model-a","parentId":null,"timestamp":"2026-08-31T03:00:01Z","provider":"a","modelId":"model-a"}
+{"type":"message","id":"assistant-a","parentId":"model-a","timestamp":"2026-08-31T03:00:02Z","message":{"role":"assistant","provider":"a","model":"model-a","usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0}}}
+{"type":"model_change","id":"model-b","parentId":"assistant-a","timestamp":"2026-08-31T03:00:03Z","provider":"b","modelId":"model-b"}
+{"type":"message","id":"assistant-b","parentId":"model-b","timestamp":"2026-08-31T03:00:04Z","message":{"role":"assistant","provider":"b","model":"model-b","usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0}}}
+{"type":"branch_summary","id":"summary-a","parentId":"assistant-a","timestamp":"2026-08-31T03:00:05Z","usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0}}
+"#,
+        )
+        .unwrap();
+
+        let parsed = parse_pi_file(&path, Timezone::Named(chrono_tz::UTC), false);
+
+        assert_eq!(parsed.errors, 0);
+        let summary = parsed
+            .entries
+            .iter()
+            .find(|entry| entry.stop_reason.as_deref() == Some("branch_summary"))
+            .unwrap();
+        assert_eq!(summary.model, "model-a");
     }
 }

--- a/src/source/pi.rs
+++ b/src/source/pi.rs
@@ -212,6 +212,8 @@ fn usage_entry(
         endpoint: Endpoint::Unknown,
         call_count: 1,
         recorded_cost_usd,
+        api_equivalent_priced_tokens: 0,
+        api_equivalent_coverage_tokens: 0,
     }))
 }
 

--- a/src/source/pi.rs
+++ b/src/source/pi.rs
@@ -1,0 +1,470 @@
+//! Pi coding-agent JSONL usage source.
+
+use std::env;
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+use crate::consts::{DATE_FORMAT, UNKNOWN};
+use crate::core::{CostKind, Endpoint, RawEntry, source_wide_message_id};
+use crate::source::{Capabilities, ParseOutput, Source};
+use crate::utils::Timezone;
+
+const PI_AGENT_DIR_ENV: &str = "PI_CODING_AGENT_DIR";
+const PI_SESSION_DIR_ENV: &str = "PI_CODING_AGENT_SESSION_DIR";
+
+pub(crate) struct PiSource;
+
+impl PiSource {
+    pub(crate) const fn new() -> Self {
+        Self
+    }
+}
+
+impl Source for PiSource {
+    fn name(&self) -> &'static str {
+        "pi"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Pi"
+    }
+
+    fn aliases(&self) -> &'static [&'static str] {
+        &["pi-agent"]
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            has_projects: true,
+            has_billing_blocks: false,
+            // Pi documents reasoning as a subset of output.
+            has_reasoning_tokens: false,
+            has_cache_creation: true,
+            has_cache_read: true,
+            // Branching copies existing entry ids into a new session file.
+            needs_dedup: true,
+            has_tool_calls: false,
+            has_endpoints: false,
+        }
+    }
+
+    fn find_files(&self) -> Vec<PathBuf> {
+        find_pi_files()
+    }
+
+    fn parse_file(&self, path: &Path, timezone: Timezone, debug: bool) -> ParseOutput {
+        parse_pi_file(path, timezone, debug)
+    }
+}
+
+fn non_empty_env(name: &str) -> Option<PathBuf> {
+    env::var_os(name)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+fn pi_sessions_dir() -> Option<PathBuf> {
+    non_empty_env(PI_SESSION_DIR_ENV)
+        .or_else(|| non_empty_env(PI_AGENT_DIR_ENV).map(|root| root.join("sessions")))
+        .or_else(|| dirs::home_dir().map(|home| home.join(".pi/agent/sessions")))
+}
+
+fn find_pi_files() -> Vec<PathBuf> {
+    let Some(root) = pi_sessions_dir() else {
+        return Vec::new();
+    };
+    let patterns = [root.join("*.jsonl"), root.join("**").join("*.jsonl")];
+    let mut files = Vec::new();
+    for pattern in patterns {
+        if let Ok(matches) = glob::glob(&pattern.to_string_lossy()) {
+            files.extend(matches.flatten().filter(|path| path.is_file()));
+        }
+    }
+    files.sort();
+    files.dedup();
+    files
+}
+
+#[derive(Debug, Deserialize)]
+struct PiHeader {
+    #[serde(rename = "type")]
+    entry_type: String,
+    id: String,
+    cwd: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PiEntry {
+    #[serde(rename = "type")]
+    entry_type: String,
+    id: String,
+    timestamp: String,
+    message: Option<PiMessage>,
+    provider: Option<String>,
+    model_id: Option<String>,
+    usage: Option<PiUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PiMessage {
+    role: String,
+    provider: Option<String>,
+    model: Option<String>,
+    usage: Option<PiUsage>,
+    stop_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PiUsage {
+    input: i64,
+    output: i64,
+    cache_read: i64,
+    cache_write: i64,
+    cost: Option<PiCost>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PiCost {
+    total: f64,
+}
+
+#[derive(Debug, Default)]
+struct PiModelState {
+    provider: Option<String>,
+    model: Option<String>,
+}
+
+impl PiModelState {
+    fn update(&mut self, provider: Option<&str>, model: Option<&str>) {
+        if let Some(provider) = provider.map(str::trim).filter(|value| !value.is_empty()) {
+            self.provider = Some(provider.to_string());
+        }
+        if let Some(model) = model.map(str::trim).filter(|value| !value.is_empty()) {
+            self.model = Some(model.to_string());
+        }
+    }
+}
+
+struct PiUsageContext<'a> {
+    entry_id: &'a str,
+    timestamp: &'a str,
+    session_id: &'a str,
+    project_path: &'a str,
+    model: Option<&'a str>,
+    stop_reason: Option<String>,
+    timezone: Timezone,
+}
+
+fn usage_entry(
+    usage: PiUsage,
+    context: PiUsageContext<'_>,
+) -> Result<Option<RawEntry>, &'static str> {
+    if [
+        usage.input,
+        usage.output,
+        usage.cache_read,
+        usage.cache_write,
+    ]
+    .into_iter()
+    .any(|value| value < 0)
+    {
+        return Err("negative token count");
+    }
+    let recorded_cost_usd = usage
+        .cost
+        .map(|cost| cost.total)
+        .filter(|cost| cost.is_finite() && *cost > 0.0);
+    if usage.input == 0
+        && usage.output == 0
+        && usage.cache_read == 0
+        && usage.cache_write == 0
+        && recorded_cost_usd.is_none()
+    {
+        return Ok(None);
+    }
+
+    let timestamp = DateTime::parse_from_rfc3339(context.timestamp)
+        .map_err(|_| "invalid timestamp")?
+        .with_timezone(&Utc);
+    let model = context
+        .model
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+        .unwrap_or(UNKNOWN)
+        .to_string();
+
+    Ok(Some(RawEntry {
+        timestamp: timestamp.to_rfc3339(),
+        timestamp_ms: timestamp.timestamp_millis(),
+        date_str: context
+            .timezone
+            .to_fixed_offset(timestamp)
+            .date_naive()
+            .format(DATE_FORMAT)
+            .to_string(),
+        message_id: Some(source_wide_message_id("pi", context.entry_id)),
+        session_key: format!("pi::{}", context.session_id),
+        session_id: context.session_id.to_string(),
+        project_path: context.project_path.to_string(),
+        model,
+        input_tokens: usage.input,
+        // Pi explicitly documents reasoning as a subset of output.
+        output_tokens: usage.output,
+        cache_creation: usage.cache_write,
+        cache_creation_1h: 0,
+        cache_read: usage.cache_read,
+        reasoning_tokens: 0,
+        stop_reason: context.stop_reason,
+        cost_kind: CostKind::Real,
+        endpoint: Endpoint::Unknown,
+        call_count: 1,
+        recorded_cost_usd,
+    }))
+}
+
+fn parse_entry(
+    entry: PiEntry,
+    header: &PiHeader,
+    model_state: &mut PiModelState,
+    timezone: Timezone,
+) -> Result<Option<RawEntry>, &'static str> {
+    match entry.entry_type.as_str() {
+        "model_change" => {
+            model_state.update(entry.provider.as_deref(), entry.model_id.as_deref());
+            Ok(None)
+        }
+        "message" => {
+            let Some(message) = entry.message else {
+                return Err("message record is missing message");
+            };
+            if message.role != "assistant" {
+                return Ok(None);
+            }
+            let Some(usage) = message.usage else {
+                return Ok(None);
+            };
+            model_state.update(message.provider.as_deref(), message.model.as_deref());
+            usage_entry(
+                usage,
+                PiUsageContext {
+                    entry_id: &entry.id,
+                    timestamp: &entry.timestamp,
+                    session_id: &header.id,
+                    project_path: &header.cwd,
+                    model: message.model.as_deref(),
+                    stop_reason: message
+                        .stop_reason
+                        .filter(|reason| !reason.trim().is_empty())
+                        .or_else(|| Some("assistant".to_string())),
+                    timezone,
+                },
+            )
+        }
+        "compaction" | "branch_summary" => {
+            let Some(usage) = entry.usage else {
+                return Ok(None);
+            };
+            usage_entry(
+                usage,
+                PiUsageContext {
+                    entry_id: &entry.id,
+                    timestamp: &entry.timestamp,
+                    session_id: &header.id,
+                    project_path: &header.cwd,
+                    model: model_state.model.as_deref(),
+                    stop_reason: Some(entry.entry_type),
+                    timezone,
+                },
+            )
+        }
+        _ => Ok(None),
+    }
+}
+
+fn parse_pi_file(path: &Path, timezone: Timezone, debug: bool) -> ParseOutput {
+    let file = match fs::File::open(path) {
+        Ok(file) => file,
+        Err(error) => {
+            if debug {
+                eprintln!("Failed to open Pi session {}: {error}", path.display());
+            }
+            return ParseOutput {
+                entries: Vec::new(),
+                errors: 1,
+            };
+        }
+    };
+    let mut lines = BufReader::new(file).lines().enumerate();
+    let header = loop {
+        let Some((line_index, line)) = lines.next() else {
+            return ParseOutput::default();
+        };
+        let line = match line {
+            Ok(line) => line,
+            Err(error) => {
+                if debug {
+                    eprintln!(
+                        "Failed to read {} line {}: {error}",
+                        path.display(),
+                        line_index + 1
+                    );
+                }
+                return ParseOutput {
+                    entries: Vec::new(),
+                    errors: 1,
+                };
+            }
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<PiHeader>(&line) {
+            Ok(header)
+                if header.entry_type == "session"
+                    && !header.id.trim().is_empty()
+                    && !header.cwd.trim().is_empty() =>
+            {
+                break header;
+            }
+            Ok(_) | Err(_) => {
+                if debug {
+                    eprintln!("Invalid Pi session header in {}", path.display());
+                }
+                return ParseOutput {
+                    entries: Vec::new(),
+                    errors: 1,
+                };
+            }
+        }
+    };
+
+    parse_pi_entries(lines, &header, path, timezone, debug)
+}
+
+fn parse_pi_entries(
+    lines: impl Iterator<Item = (usize, std::io::Result<String>)>,
+    header: &PiHeader,
+    path: &Path,
+    timezone: Timezone,
+    debug: bool,
+) -> ParseOutput {
+    let mut output = ParseOutput::default();
+    let mut model_state = PiModelState::default();
+    for (line_index, line) in lines {
+        let line = match line {
+            Ok(line) => line,
+            Err(error) => {
+                output.errors += 1;
+                if debug {
+                    eprintln!(
+                        "Failed to read {} line {}: {error}",
+                        path.display(),
+                        line_index + 1
+                    );
+                }
+                continue;
+            }
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let entry = match serde_json::from_str::<PiEntry>(&line) {
+            Ok(entry) => entry,
+            Err(error) => {
+                output.errors += 1;
+                if debug {
+                    eprintln!(
+                        "Invalid Pi JSON in {} line {}: {error}",
+                        path.display(),
+                        line_index + 1
+                    );
+                }
+                continue;
+            }
+        };
+        match parse_entry(entry, header, &mut model_state, timezone) {
+            Ok(Some(entry)) => output.entries.push(entry),
+            Ok(None) => {}
+            Err(error) => {
+                output.errors += 1;
+                if debug {
+                    eprintln!(
+                        "Invalid Pi usage in {} line {}: {error}",
+                        path.display(),
+                        line_index + 1
+                    );
+                }
+            }
+        }
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reasoning_stays_inside_output_and_reported_cost_is_preserved() {
+        let usage = PiUsage {
+            input: 10,
+            output: 7,
+            cache_read: 3,
+            cache_write: 2,
+            cost: Some(PiCost { total: 0.125 }),
+        };
+
+        let entry = usage_entry(
+            usage,
+            PiUsageContext {
+                entry_id: "entry-1",
+                timestamp: "2026-08-31T03:00:00Z",
+                session_id: "session-1",
+                project_path: "/tmp/project",
+                model: Some("gpt-5"),
+                stop_reason: Some("stop".to_string()),
+                timezone: Timezone::Named(chrono_tz::UTC),
+            },
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(entry.output_tokens, 7);
+        assert_eq!(entry.reasoning_tokens, 0);
+        assert_eq!(entry.recorded_cost_usd, Some(0.125));
+    }
+
+    #[test]
+    fn negative_usage_is_an_explicit_error() {
+        let usage = PiUsage {
+            input: -1,
+            output: 0,
+            cache_read: 0,
+            cache_write: 0,
+            cost: None,
+        };
+
+        assert!(matches!(
+            usage_entry(
+                usage,
+                PiUsageContext {
+                    entry_id: "entry-1",
+                    timestamp: "2026-08-31T03:00:00Z",
+                    session_id: "session-1",
+                    project_path: "/tmp/project",
+                    model: Some("gpt-5"),
+                    stop_reason: Some("stop".to_string()),
+                    timezone: Timezone::Named(chrono_tz::UTC),
+                },
+            ),
+            Err("negative token count")
+        ));
+    }
+}

--- a/src/source/registry.rs
+++ b/src/source/registry.rs
@@ -13,6 +13,8 @@ use super::cursor::CursorSource;
 use super::gemini::GeminiSource;
 use super::grok::GrokSource;
 use super::kimi::KimiSource;
+use super::opencode::OpenCodeSource;
+use super::pi::PiSource;
 use super::qwen::QwenSource;
 use super::{BoxedSource, Source};
 
@@ -33,6 +35,8 @@ static SOURCES: LazyLock<Vec<BoxedSource>> = LazyLock::new(|| {
         Box::new(ClineSource::new()),
         Box::new(RooCodeSource::new()),
         Box::new(KiloCodeSource::new()),
+        Box::new(OpenCodeSource::new()),
+        Box::new(PiSource::new()),
     ]
 });
 
@@ -143,6 +147,8 @@ mod tests {
         assert!(get_source("grok").is_some());
         assert!(get_source("kilocode").is_some());
         assert!(get_source("kimi").is_some());
+        assert!(get_source("opencode").is_some());
+        assert!(get_source("pi").is_some());
         assert!(get_source("qwen").is_some());
         assert!(get_source("roocode").is_some());
         assert!(get_source("unknown").is_none());
@@ -275,7 +281,7 @@ mod tests {
     #[test]
     fn test_sources_count() {
         // Verify all built-in sources are registered
-        assert_eq!(SOURCES.len(), 11);
+        assert_eq!(SOURCES.len(), 13);
     }
 
     #[test]

--- a/tests/cli_opencode_pi.rs
+++ b/tests/cli_opencode_pi.rs
@@ -1,0 +1,206 @@
+mod common;
+
+use common::{run_ccstats, unique_temp_dir, write_file};
+use rusqlite::{Connection, params};
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+
+fn daily_json(source: &str, envs: &[(&str, &Path)]) -> Value {
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "--source",
+            source,
+            "--json",
+            "--offline",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-08-31",
+            "--until",
+            "2026-08-31",
+        ],
+        envs,
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    serde_json::from_slice(&stdout).expect("daily JSON")
+}
+
+fn create_opencode_db(path: &Path) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create OpenCode data dir");
+    }
+    let connection = Connection::open(path).expect("open fixture database");
+    connection
+        .execute_batch(
+            "
+            CREATE TABLE session (
+                id TEXT PRIMARY KEY,
+                directory TEXT NOT NULL,
+                title TEXT NOT NULL,
+                time_created INTEGER NOT NULL,
+                time_updated INTEGER NOT NULL
+            );
+            CREATE TABLE session_message (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                type TEXT NOT NULL,
+                seq INTEGER NOT NULL,
+                time_created INTEGER NOT NULL,
+                time_updated INTEGER NOT NULL,
+                data TEXT NOT NULL
+            );
+            CREATE TABLE message (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                time_created INTEGER NOT NULL,
+                time_updated INTEGER NOT NULL,
+                data TEXT NOT NULL
+            );
+            ",
+        )
+        .expect("create current OpenCode schema");
+    connection
+        .execute(
+            "INSERT INTO session
+             (id, directory, title, time_created, time_updated)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                "ses_e2e",
+                "/tmp/opencode-project",
+                "OpenCode E2E",
+                1_788_145_445_000_i64,
+                1_788_145_446_000_i64,
+            ],
+        )
+        .expect("insert session");
+    connection
+        .execute(
+            "INSERT INTO session_message
+             (id, session_id, type, seq, time_created, time_updated, data)
+             VALUES (?1, ?2, 'assistant', 1, ?3, ?4, ?5)",
+            params![
+                "msg_e2e",
+                "ses_e2e",
+                1_788_145_445_000_i64,
+                1_788_145_446_000_i64,
+                r#"{"agent":"build","model":{"id":"claude-sonnet-4","providerID":"anthropic"},"finish":"stop","cost":0.0123,"tokens":{"input":100,"output":20,"reasoning":5,"cache":{"read":30,"write":10}},"time":{"created":1788145445000,"completed":1788145446000}}"#,
+            ],
+        )
+        .expect("insert assistant message");
+    connection
+        .execute(
+            "INSERT INTO message
+             (id, session_id, time_created, time_updated, data)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                "msg_e2e",
+                "ses_e2e",
+                1_788_145_445_000_i64,
+                1_788_145_446_000_i64,
+                r#"{"role":"assistant","agent":"build","modelID":"claude-sonnet-4","providerID":"anthropic","finish":"stop","cost":0.0123,"tokens":{"input":100,"output":20,"reasoning":5,"cache":{"read":30,"write":10}},"time":{"created":1788145445000,"completed":1788145446000}}"#,
+            ],
+        )
+        .expect("insert mirrored v1 assistant message");
+}
+
+#[test]
+fn opencode_sqlite_reaches_daily_cli_with_all_token_buckets() {
+    let root = unique_temp_dir("opencode-e2e");
+    let db = root.join("opencode.db");
+    create_opencode_db(&db);
+
+    let json = daily_json("opencode", &[("OPENCODE_DB", &db), ("HOME", &root)]);
+    let rows = json.as_array().expect("array");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["date"].as_str(), Some("2026-08-31"));
+    assert_eq!(rows[0]["input_tokens"].as_i64(), Some(100));
+    assert_eq!(rows[0]["output_tokens"].as_i64(), Some(20));
+    assert_eq!(rows[0]["reasoning_tokens"].as_i64(), Some(5));
+    assert_eq!(rows[0]["cache_read_tokens"].as_i64(), Some(30));
+    assert_eq!(rows[0]["cache_creation_tokens"].as_i64(), Some(10));
+    assert_eq!(rows[0]["total_tokens"].as_i64(), Some(165));
+    assert_eq!(rows[0]["data_quality"]["valid_entries"].as_i64(), Some(1));
+    assert_eq!(
+        rows[0]["data_quality"]["dedup_skipped_entries"].as_i64(),
+        Some(1)
+    );
+    assert_eq!(rows[0]["data_quality"]["parse_errors"].as_u64(), Some(0));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn pi_jsonl_counts_assistant_and_summary_llm_calls_end_to_end() {
+    let root = unique_temp_dir("pi-e2e");
+    let sessions = root.join("pi-sessions");
+    let file = sessions.join("--tmp-pi-project--/2026-08-31_session.jsonl");
+    write_file(
+        &file,
+        r#"{"type":"session","version":3,"id":"pi-session","timestamp":"2026-08-31T03:00:00.000Z","cwd":"/tmp/pi-project"}
+{"type":"model_change","id":"model-1","parentId":null,"timestamp":"2026-08-31T03:00:01.000Z","provider":"openai","modelId":"gpt-5"}
+{"type":"message","id":"assistant-1","parentId":"model-1","timestamp":"2026-08-31T03:00:02.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-opus-4","usage":{"input":100,"output":20,"reasoning":7,"cacheRead":30,"cacheWrite":10,"totalTokens":160,"cost":{"input":0.1,"output":0.1,"cacheRead":0.02,"cacheWrite":0.03,"total":0.25}},"stopReason":"stop","timestamp":1788145202000}}
+{"type":"compaction","id":"compact-1","parentId":"assistant-1","timestamp":"2026-08-31T03:01:00.000Z","summary":"summary","firstKeptEntryId":"assistant-1","tokensBefore":160,"usage":{"input":40,"output":5,"cacheRead":2,"cacheWrite":3,"totalTokens":50,"cost":{"input":0.02,"output":0.02,"cacheRead":0.005,"cacheWrite":0.005,"total":0.05}}}
+{"type":"branch_summary","id":"branch-1","parentId":"compact-1","timestamp":"2026-08-31T03:02:00.000Z","fromId":"assistant-1","summary":"branch","usage":{"input":20,"output":4,"cacheRead":1,"cacheWrite":0,"totalTokens":25,"cost":{"input":0.01,"output":0.01,"cacheRead":0.005,"cacheWrite":0.0,"total":0.025}}}
+"#,
+    );
+    let branched = sessions.join("--tmp-pi-project--/2026-08-31_branched.jsonl");
+    fs::copy(&file, &branched).expect("copy Pi branch fixture");
+
+    let json = daily_json(
+        "pi",
+        &[("PI_CODING_AGENT_SESSION_DIR", &sessions), ("HOME", &root)],
+    );
+    let rows = json.as_array().expect("array");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["input_tokens"].as_i64(), Some(160));
+    assert_eq!(rows[0]["output_tokens"].as_i64(), Some(29));
+    assert_eq!(rows[0]["reasoning_tokens"].as_i64(), Some(0));
+    assert_eq!(rows[0]["cache_read_tokens"].as_i64(), Some(33));
+    assert_eq!(rows[0]["cache_creation_tokens"].as_i64(), Some(13));
+    assert_eq!(rows[0]["total_tokens"].as_i64(), Some(235));
+    assert_eq!(rows[0]["data_quality"]["valid_entries"].as_i64(), Some(3));
+    assert_eq!(
+        rows[0]["data_quality"]["dedup_skipped_entries"].as_i64(),
+        Some(3)
+    );
+    assert_eq!(rows[0]["data_quality"]["parse_errors"].as_u64(), Some(0));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn sources_listing_exposes_opencode_and_pi_capabilities() {
+    let root = unique_temp_dir("opencode-pi-sources");
+    let (ok, stdout, stderr) = run_ccstats(&["sources", "--json"], &[("HOME", &root)]);
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let rows: Value = serde_json::from_slice(&stdout).expect("sources JSON");
+    let rows = rows.as_array().expect("array");
+
+    let opencode = rows
+        .iter()
+        .find(|row| row["name"].as_str() == Some("opencode"))
+        .expect("OpenCode source");
+    assert_eq!(
+        opencode["capabilities"]["has_projects"].as_bool(),
+        Some(true)
+    );
+    assert_eq!(
+        opencode["capabilities"]["has_reasoning_tokens"].as_bool(),
+        Some(true)
+    );
+
+    let pi = rows
+        .iter()
+        .find(|row| row["name"].as_str() == Some("pi"))
+        .expect("Pi source");
+    assert_eq!(pi["capabilities"]["has_projects"].as_bool(), Some(true));
+    assert_eq!(
+        pi["capabilities"]["has_reasoning_tokens"].as_bool(),
+        Some(false)
+    );
+
+    let _ = fs::remove_dir_all(root);
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -12,6 +12,10 @@ const SOURCE_ENV_VARS: &[&str] = &[
     "CURSOR_SESSION_TOKEN",
     "GROK_HOME",
     "KIMI_CODE_HOME",
+    "OPENCODE_DB",
+    "PI_CODING_AGENT_DIR",
+    "PI_CODING_AGENT_SESSION_DIR",
+    "XDG_DATA_HOME",
 ];
 
 pub(crate) fn unique_temp_dir(prefix: &str) -> PathBuf {


### PR DESCRIPTION
## Summary
- add verified OpenCode SQLite accounting with independent token buckets, recorded cost, and cross-schema deduplication
- add Pi JSONL accounting for assistant, compaction, and branch-summary calls with branch-copy deduplication
- document authoritative algorithms, provenance, limitations, and environment overrides
- add end-to-end CLI fixtures for discovery, parsing, deduplication, aggregation, and source capabilities

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --locked`
- `cargo deny check`
- `cargo llvm-cov --tests --bins --lcov --output-path lcov.info`
- `cargo test --locked --test cli_opencode_pi`

Stacked on #115.