### PR TITLE
fix(grok): harden ledger reliability and exact windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,7 @@ dependencies = [
  "clap",
  "comfy-table",
  "dirs",
+ "fs4",
  "glob",
  "rayon",
  "serde",
@@ -418,6 +419,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs4"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ clap = { version = "4.5.58", features = ["derive"] }
 comfy-table = "7.2.2"
 rayon = "1.11.0"
 dirs = "6.0.0"
+fs4 = "1.1.0"
 ureq = { version = "3.2.0", features = ["json"] }
 thiserror = "2"
 toml = "1.0.0"

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ println!("today: ${:.2}", summary.cost_usd.unwrap_or(0.0));
 
 The SDK uses the same source registry, parsers, aggregation logic, pricing cache, and fallback pricing as the CLI. Use `summarize_cost_with_cli_config` when SDK output should follow the same persisted CLI defaults for timezone, offline pricing, strict pricing, and currency. Use `summarize_cost` when the caller wants fully explicit options. Returned summaries include total tokens, cache read/create tokens, cache hit rate, reasoning tokens, per-model breakdowns, `cost_usd`, and an optional converted `cost` when `SummaryOptions::currency` is set.
 
+Use `UsageRange::TimestampRange` with inclusive UTC `DateTime<Utc>` bounds when an app must align usage to an exact provider quota window instead of whole local dates.
+
 Codex weekly quota pace is also available as structured SDK data without
 spawning the CLI:
 
@@ -374,7 +376,7 @@ By default, ccstats uses:
 - `~/.grok/sessions/**/updates.jsonl` for complete per-turn token totals
 - `~/.grok/logs/unified.jsonl` for per-inference API-equivalent pricing
 - `~/.grok/sessions/**/summary.json` for model, project, and session metadata
-- the platform cache directory under `ccstats/grok/<source-root>/inference-v1.jsonl` for the durable, deduplicated ledger
+- the platform application-data directory under `ccstats/grok/<source-root>/inference-v1.jsonl` for the durable, deduplicated ledger
 
 For Grok 4.5 and 4.6, requests below 200k prompt tokens use the short-context rates. Requests at or above 200k use the long-context input, cached-input, and output rates for the entire inference. `completion_tokens` already includes reasoning, so ccstats does not charge reasoning twice. Rates follow the [xAI pricing reference](https://docs.x.ai/developers/pricing).
 

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -365,11 +365,42 @@ impl RawEntry {
 pub(crate) struct DateFilter {
     pub(crate) since: Option<chrono::NaiveDate>,
     pub(crate) until: Option<chrono::NaiveDate>,
+    pub(crate) since_timestamp_ms: Option<i64>,
+    pub(crate) until_timestamp_ms: Option<i64>,
 }
 
 impl DateFilter {
     pub(crate) fn new(since: Option<chrono::NaiveDate>, until: Option<chrono::NaiveDate>) -> Self {
-        Self { since, until }
+        Self {
+            since,
+            until,
+            since_timestamp_ms: None,
+            until_timestamp_ms: None,
+        }
+    }
+
+    pub(crate) fn with_timestamp_range(mut self, since: i64, until: i64) -> Self {
+        self.since_timestamp_ms = Some(since);
+        self.until_timestamp_ms = Some(until);
+        self
+    }
+
+    pub(crate) fn has_timestamp_range(&self) -> bool {
+        self.since_timestamp_ms.is_some() || self.until_timestamp_ms.is_some()
+    }
+
+    pub(crate) fn contains_timestamp(&self, timestamp_ms: i64) -> bool {
+        if let Some(since) = self.since_timestamp_ms
+            && timestamp_ms < since
+        {
+            return false;
+        }
+        if let Some(until) = self.until_timestamp_ms
+            && timestamp_ms > until
+        {
+            return false;
+        }
+        true
     }
 
     pub(crate) fn contains(&self, date: chrono::NaiveDate) -> bool {

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -395,6 +395,8 @@ pub(crate) struct DateFilter {
     pub(crate) until: Option<chrono::NaiveDate>,
     pub(crate) since_timestamp_ms: Option<i64>,
     pub(crate) until_timestamp_ms: Option<i64>,
+    since_timestamp: Option<chrono::DateTime<chrono::Utc>>,
+    until_timestamp: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 impl DateFilter {
@@ -404,12 +406,27 @@ impl DateFilter {
             until,
             since_timestamp_ms: None,
             until_timestamp_ms: None,
+            since_timestamp: None,
+            until_timestamp: None,
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn with_timestamp_range(mut self, since: i64, until: i64) -> Self {
         self.since_timestamp_ms = Some(since);
         self.until_timestamp_ms = Some(until);
+        self
+    }
+
+    pub(crate) fn with_exact_timestamp_range(
+        mut self,
+        since: chrono::DateTime<chrono::Utc>,
+        until: chrono::DateTime<chrono::Utc>,
+    ) -> Self {
+        self.since_timestamp_ms = Some(since.timestamp_millis());
+        self.until_timestamp_ms = Some(until.timestamp_millis());
+        self.since_timestamp = Some(since);
+        self.until_timestamp = Some(until);
         self
     }
 
@@ -429,6 +446,32 @@ impl DateFilter {
             return false;
         }
         true
+    }
+
+    pub(crate) fn contains_datetime(&self, timestamp: chrono::DateTime<chrono::Utc>) -> bool {
+        if let Some(since) = self.since_timestamp
+            && timestamp < since
+        {
+            return false;
+        }
+        if let Some(until) = self.until_timestamp
+            && timestamp > until
+        {
+            return false;
+        }
+        if self.since_timestamp.is_none() && self.until_timestamp.is_none() {
+            return self.contains_timestamp(timestamp.timestamp_millis());
+        }
+        true
+    }
+
+    pub(crate) fn contains_entry_timestamp(&self, timestamp: &str, timestamp_ms: i64) -> bool {
+        if self.since_timestamp.is_some() || self.until_timestamp.is_some() {
+            return timestamp
+                .parse::<chrono::DateTime<chrono::Utc>>()
+                .is_ok_and(|timestamp| self.contains_datetime(timestamp));
+        }
+        self.contains_timestamp(timestamp_ms)
     }
 
     pub(crate) fn contains(&self, date: chrono::NaiveDate) -> bool {

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -122,11 +122,9 @@ pub enum UsageRange {
 }
 
 impl UsageRange {
-    fn timestamp_bounds(&self) -> Option<(i64, i64)> {
+    fn timestamp_bounds(&self) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
         match self {
-            UsageRange::TimestampRange { since, until } => {
-                Some((since.timestamp_millis(), until.timestamp_millis()))
-            }
+            UsageRange::TimestampRange { since, until } => Some((*since, *until)),
             _ => None,
         }
     }
@@ -308,8 +306,8 @@ pub fn summarize_cost(options: SummaryOptions) -> Result<CostSummary, SdkError> 
     let today = timezone.to_fixed_offset(Utc::now()).date_naive();
     let (since, until) = options.range.resolve(today)?;
     let mut filter = DateFilter::new(since, until);
-    if let Some((since_timestamp_ms, until_timestamp_ms)) = options.range.timestamp_bounds() {
-        filter = filter.with_timestamp_range(since_timestamp_ms, until_timestamp_ms);
+    if let Some((since_timestamp, until_timestamp)) = options.range.timestamp_bounds() {
+        filter = filter.with_exact_timestamp_range(since_timestamp, until_timestamp);
     }
 
     let source = get_source(options.source.as_str()).ok_or_else(|| SdkError::InvalidSource {

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -7,7 +7,7 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::str::FromStr;
 
-use chrono::{Datelike, Days, NaiveDate, Utc};
+use chrono::{DateTime, Datelike, Days, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -98,7 +98,7 @@ impl FromStr for UsageSource {
     }
 }
 
-/// Date range to summarize.
+/// Date or exact UTC timestamp range to summarize.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum UsageRange {
@@ -114,9 +114,23 @@ pub enum UsageRange {
         since: Option<NaiveDate>,
         until: Option<NaiveDate>,
     },
+    /// Explicit inclusive UTC timestamp range.
+    TimestampRange {
+        since: DateTime<Utc>,
+        until: DateTime<Utc>,
+    },
 }
 
 impl UsageRange {
+    fn timestamp_bounds(&self) -> Option<(i64, i64)> {
+        match self {
+            UsageRange::TimestampRange { since, until } => {
+                Some((since.timestamp_millis(), until.timestamp_millis()))
+            }
+            _ => None,
+        }
+    }
+
     pub(in crate::sdk) fn resolve(
         &self,
         today: NaiveDate,
@@ -134,6 +148,15 @@ impl UsageRange {
                 (Some(start), Some(today))
             }
             UsageRange::DateRange { since, until } => (*since, *until),
+            UsageRange::TimestampRange { since, until } => {
+                if since > until {
+                    return Err(SdkError::InvalidTimestampRange {
+                        since: *since,
+                        until: *until,
+                    });
+                }
+                (Some(since.date_naive()), Some(until.date_naive()))
+            }
         };
 
         if let (Some(since), Some(until)) = range
@@ -154,7 +177,7 @@ impl UsageRange {
 pub struct SummaryOptions {
     /// Usage source to read.
     pub source: UsageSource,
-    /// Date range to summarize.
+    /// Date or exact UTC timestamp range to summarize.
     pub range: UsageRange,
     /// Optional timezone name, such as `UTC` or `Asia/Shanghai`.
     pub timezone: Option<String>,
@@ -240,6 +263,12 @@ pub enum SdkError {
     #[error("invalid date range: since {since} is after until {until}")]
     InvalidDateRange { since: NaiveDate, until: NaiveDate },
 
+    #[error("invalid timestamp range: since {since} is after until {until}")]
+    InvalidTimestampRange {
+        since: DateTime<Utc>,
+        until: DateTime<Utc>,
+    },
+
     #[error("{0}")]
     Configuration(String),
 }
@@ -249,13 +278,16 @@ pub enum SdkError {
 /// # Errors
 ///
 /// Returns an error when the source or timezone is invalid, or when an explicit
-/// date range has `since` after `until`.
+/// date or timestamp range has `since` after `until`.
 pub fn summarize_cost(options: SummaryOptions) -> Result<CostSummary, SdkError> {
     let timezone = Timezone::parse(options.timezone.as_deref())
         .map_err(|err| SdkError::Configuration(err.to_string()))?;
     let today = timezone.to_fixed_offset(Utc::now()).date_naive();
     let (since, until) = options.range.resolve(today)?;
-    let filter = DateFilter::new(since, until);
+    let mut filter = DateFilter::new(since, until);
+    if let Some((since_timestamp_ms, until_timestamp_ms)) = options.range.timestamp_bounds() {
+        filter = filter.with_timestamp_range(since_timestamp_ms, until_timestamp_ms);
+    }
 
     let source = get_source(options.source.as_str()).ok_or_else(|| SdkError::InvalidSource {
         name: options.source.as_str().to_string(),
@@ -292,7 +324,7 @@ pub fn summarize_cost(options: SummaryOptions) -> Result<CostSummary, SdkError> 
 /// # Errors
 ///
 /// Returns an error when the resolved source or timezone is invalid, or when an
-/// explicit date range has `since` after `until`.
+/// explicit date or timestamp range has `since` after `until`.
 pub fn summarize_cost_with_cli_config(options: SummaryOptions) -> Result<CostSummary, SdkError> {
     let config = load_cli_config()?;
     summarize_cost(apply_cli_config(options, &config))
@@ -539,6 +571,35 @@ mod tests {
         assert!(
             range
                 .resolve(NaiveDate::from_ymd_opt(2026, 5, 9).unwrap())
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn usage_range_accepts_exact_utc_timestamps_and_rejects_reversed_bounds() {
+        let payload = serde_json::json!({
+            "timestamp_range": {
+                "since": "2026-08-21T05:41:00Z",
+                "until": "2026-08-21T05:43:00Z"
+            }
+        });
+        let range: UsageRange = serde_json::from_value(payload.clone()).expect("timestamp range");
+
+        assert_eq!(
+            serde_json::to_value(&range).expect("serialize range"),
+            payload
+        );
+
+        let reversed: UsageRange = serde_json::from_value(serde_json::json!({
+            "timestamp_range": {
+                "since": "2026-08-21T05:43:00Z",
+                "until": "2026-08-21T05:41:00Z"
+            }
+        }))
+        .expect("deserialize reversed range");
+        assert!(
+            reversed
+                .resolve(NaiveDate::from_ymd_opt(2026, 8, 21).expect("valid date"))
                 .is_err()
         );
     }

--- a/src/sdk/batch.rs
+++ b/src/sdk/batch.rs
@@ -23,7 +23,7 @@ use crate::utils::Timezone;
 pub struct MultiSummaryOptions {
     /// Usage source to read.
     pub source: UsageSource,
-    /// Date ranges to summarize, preserving this order in the returned summaries.
+    /// Date or exact UTC timestamp ranges, preserving result order.
     pub ranges: Vec<UsageRange>,
     /// Optional timezone name, such as `UTC` or `Asia/Shanghai`.
     pub timezone: Option<String>,
@@ -78,7 +78,7 @@ struct ResolvedRange {
 /// # Errors
 ///
 /// Returns an error when no ranges are requested, when the source or timezone is
-/// invalid, or when any explicit date range has `since` after `until`.
+/// invalid, or when any explicit date or timestamp range is reversed.
 pub fn summarize_cost_ranges(options: MultiSummaryOptions) -> Result<MultiCostSummary, SdkError> {
     let start = Instant::now();
     let MultiSummaryOptions {
@@ -145,7 +145,7 @@ pub fn summarize_cost_ranges(options: MultiSummaryOptions) -> Result<MultiCostSu
 ///
 /// Returns an error when no ranges are requested, when the resolved source or
 /// timezone is invalid, or when any explicit date range has `since` after
-/// `until`.
+/// `until`, or when an exact timestamp range is reversed.
 pub fn summarize_cost_ranges_with_cli_config(
     options: MultiSummaryOptions,
 ) -> Result<MultiCostSummary, SdkError> {
@@ -184,18 +184,28 @@ fn resolve_ranges(ranges: &[UsageRange], today: NaiveDate) -> Result<Vec<Resolve
         .iter()
         .map(|range| {
             let (since, until) = range.resolve(today)?;
+            let mut filter = DateFilter::new(since, until);
+            if let Some((since_timestamp_ms, until_timestamp_ms)) = range.timestamp_bounds() {
+                filter = filter.with_timestamp_range(since_timestamp_ms, until_timestamp_ms);
+            }
             Ok(ResolvedRange {
                 range: range.clone(),
                 since,
                 until,
-                filter: DateFilter::new(since, until),
+                filter,
             })
         })
         .collect()
 }
 
-fn contains_any_range(date: NaiveDate, ranges: &[ResolvedRange]) -> bool {
-    ranges.iter().any(|range| range.filter.contains(date))
+fn contains_any_range(entry: &RawEntry, date: NaiveDate, ranges: &[ResolvedRange]) -> bool {
+    ranges.iter().any(|range| {
+        if range.filter.has_timestamp_range() {
+            range.filter.contains_timestamp(entry.timestamp_ms)
+        } else {
+            range.filter.contains(date)
+        }
+    })
 }
 
 fn load_daily_ranges(
@@ -208,6 +218,9 @@ fn load_daily_ranges(
     if files.is_empty() {
         return ranges.iter().map(|_| LoadResult::default()).collect();
     }
+    let needs_timestamp = ranges
+        .iter()
+        .any(|range| range.filter.has_timestamp_range());
 
     let (entries, parse_errors) = files
         .par_iter()
@@ -217,8 +230,15 @@ fn load_daily_ranges(
                 .entries
                 .into_iter()
                 .filter_map(|mut entry| {
+                    if needs_timestamp && entry.timestamp_ms == 0 {
+                        entry.timestamp_ms = entry
+                            .timestamp
+                            .parse::<DateTime<Utc>>()
+                            .ok()?
+                            .timestamp_millis();
+                    }
                     let date = normalize_entry_date(&mut entry, timezone)?;
-                    contains_any_range(date, ranges).then_some(entry)
+                    contains_any_range(&entry, date, ranges).then_some(entry)
                 })
                 .collect::<Vec<_>>();
             (entries, parsed.errors)
@@ -267,8 +287,12 @@ fn aggregate_entries_for_filter(
     let filtered: Vec<_> = entries
         .iter()
         .filter(|entry| {
-            NaiveDate::parse_from_str(&entry.date_str, DATE_FORMAT)
-                .is_ok_and(|date| filter.contains(date))
+            if filter.has_timestamp_range() {
+                filter.contains_timestamp(entry.timestamp_ms)
+            } else {
+                NaiveDate::parse_from_str(&entry.date_str, DATE_FORMAT)
+                    .is_ok_and(|date| filter.contains(date))
+            }
         })
         .cloned()
         .collect();
@@ -309,6 +333,34 @@ mod tests {
 
     fn d(year: i32, month: u32, day: u32) -> NaiveDate {
         NaiveDate::from_ymd_opt(year, month, day).unwrap()
+    }
+
+    fn entry_at(timestamp: &str) -> RawEntry {
+        let timestamp_ms = timestamp
+            .parse::<DateTime<Utc>>()
+            .expect("valid timestamp")
+            .timestamp_millis();
+        RawEntry {
+            timestamp: timestamp.to_string(),
+            timestamp_ms,
+            date_str: "2026-08-21".to_string(),
+            message_id: Some(timestamp.to_string()),
+            session_key: "session".to_string(),
+            session_id: "session".to_string(),
+            project_path: String::new(),
+            model: "grok-4.6".to_string(),
+            input_tokens: 10,
+            output_tokens: 0,
+            cache_creation: 0,
+            cache_creation_1h: 0,
+            cache_read: 0,
+            reasoning_tokens: 0,
+            stop_reason: Some("complete".to_string()),
+            cost_kind: crate::core::CostKind::Real,
+            endpoint: crate::core::Endpoint::Unknown,
+            call_count: 1,
+            recorded_cost_usd: Some(0.1),
+        }
     }
 
     struct CountingSource {
@@ -405,10 +457,11 @@ mod tests {
             d(2026, 12, 10),
         )
         .unwrap();
+        let entry = entry_at("2026-08-21T05:42:00Z");
 
-        assert!(contains_any_range(d(2026, 1, 10), &ranges));
-        assert!(!contains_any_range(d(2026, 6, 1), &ranges));
-        assert!(contains_any_range(d(2026, 12, 10), &ranges));
+        assert!(contains_any_range(&entry, d(2026, 1, 10), &ranges));
+        assert!(!contains_any_range(&entry, d(2026, 6, 1), &ranges));
+        assert!(contains_any_range(&entry, d(2026, 12, 10), &ranges));
     }
 
     #[test]
@@ -427,10 +480,33 @@ mod tests {
             d(2026, 5, 9),
         )
         .unwrap();
+        let entry = entry_at("2026-08-21T05:42:00Z");
 
-        assert!(contains_any_range(d(2020, 1, 1), &ranges));
-        assert!(!contains_any_range(d(2026, 5, 7), &ranges));
-        assert!(contains_any_range(d(2026, 12, 31), &ranges));
+        assert!(contains_any_range(&entry, d(2020, 1, 1), &ranges));
+        assert!(!contains_any_range(&entry, d(2026, 5, 7), &ranges));
+        assert!(contains_any_range(&entry, d(2026, 12, 31), &ranges));
+    }
+
+    #[test]
+    fn timestamp_range_filters_entries_within_the_same_day() {
+        let ranges = resolve_ranges(
+            &[UsageRange::TimestampRange {
+                since: "2026-08-21T05:41:00Z".parse().expect("valid since"),
+                until: "2026-08-21T05:43:00Z".parse().expect("valid until"),
+            }],
+            d(2026, 8, 21),
+        )
+        .expect("resolve timestamp range");
+        let entries = vec![
+            entry_at("2026-08-21T05:40:00Z"),
+            entry_at("2026-08-21T05:42:00Z"),
+            entry_at("2026-08-21T05:44:00Z"),
+        ];
+
+        let result = aggregate_entries_for_filter(&entries, &ranges[0].filter, false);
+
+        assert_eq!(result.valid, 1);
+        assert_eq!(result.day_stats["2026-08-21"].stats.input_tokens, 10);
     }
 
     #[test]

--- a/src/sdk/batch.rs
+++ b/src/sdk/batch.rs
@@ -188,8 +188,8 @@ fn resolve_ranges(ranges: &[UsageRange], today: NaiveDate) -> Result<Vec<Resolve
         .map(|range| {
             let (since, until) = range.resolve(today)?;
             let mut filter = DateFilter::new(since, until);
-            if let Some((since_timestamp_ms, until_timestamp_ms)) = range.timestamp_bounds() {
-                filter = filter.with_timestamp_range(since_timestamp_ms, until_timestamp_ms);
+            if let Some((since_timestamp, until_timestamp)) = range.timestamp_bounds() {
+                filter = filter.with_exact_timestamp_range(since_timestamp, until_timestamp);
             }
             Ok(ResolvedRange {
                 range: range.clone(),
@@ -204,7 +204,9 @@ fn resolve_ranges(ranges: &[UsageRange], today: NaiveDate) -> Result<Vec<Resolve
 fn contains_any_range(entry: &RawEntry, date: NaiveDate, ranges: &[ResolvedRange]) -> bool {
     ranges.iter().any(|range| {
         if range.filter.has_timestamp_range() {
-            range.filter.contains_timestamp(entry.timestamp_ms)
+            range
+                .filter
+                .contains_entry_timestamp(&entry.timestamp, entry.timestamp_ms)
         } else {
             range.filter.contains(date)
         }
@@ -217,7 +219,8 @@ fn load_daily_ranges(
     timezone: Timezone,
 ) -> Vec<LoadResult> {
     let start = Instant::now();
-    let files = source.find_files();
+    let discovery_filter = discovery_filter(ranges);
+    let files = source.find_files_for_filter(&discovery_filter, timezone);
     if files.is_empty() {
         return ranges.iter().map(|_| LoadResult::default()).collect();
     }
@@ -287,7 +290,7 @@ fn aggregate_entries_for_filter(
         .iter()
         .filter(|entry| {
             if filter.has_timestamp_range() {
-                filter.contains_timestamp(entry.timestamp_ms)
+                filter.contains_entry_timestamp(&entry.timestamp, entry.timestamp_ms)
             } else {
                 NaiveDate::parse_from_str(&entry.date_str, DATE_FORMAT)
                     .is_ok_and(|date| filter.contains(date))
@@ -310,6 +313,37 @@ fn aggregate_entries_for_filter(
     load_result_from_entries(filtered, 0)
 }
 
+fn discovery_filter(ranges: &[ResolvedRange]) -> DateFilter {
+    let since = ranges
+        .iter()
+        .all(|range| range.since.is_some())
+        .then(|| ranges.iter().filter_map(|range| range.since).min())
+        .flatten();
+    let until = ranges
+        .iter()
+        .all(|range| range.until.is_some())
+        .then(|| ranges.iter().filter_map(|range| range.until).max())
+        .flatten();
+    let mut filter = DateFilter::new(since, until);
+    if ranges
+        .iter()
+        .all(|range| range.filter.has_timestamp_range())
+        && let (Some(since), Some(until)) = (
+            ranges
+                .iter()
+                .filter_map(|range| range.range.timestamp_bounds().map(|bounds| bounds.0))
+                .min(),
+            ranges
+                .iter()
+                .filter_map(|range| range.range.timestamp_bounds().map(|bounds| bounds.1))
+                .max(),
+        )
+    {
+        filter = filter.with_exact_timestamp_range(since, until);
+    }
+    filter
+}
+
 fn load_result_from_entries(entries: Vec<RawEntry>, skipped: i64) -> LoadResult {
     let valid = entries.len() as i64;
     LoadResult {
@@ -325,7 +359,7 @@ fn load_result_from_entries(entries: Vec<RawEntry>, skipped: i64) -> LoadResult 
 mod tests {
     use super::*;
     use std::path::{Path, PathBuf};
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicI64, AtomicUsize, Ordering};
 
     use crate::core::RawEntry;
     use crate::source::{Capabilities, ParseOutput};
@@ -359,6 +393,8 @@ mod tests {
             endpoint: crate::core::Endpoint::Unknown,
             call_count: 1,
             recorded_cost_usd: Some(0.1),
+            api_equivalent_priced_tokens: 0,
+            api_equivalent_coverage_tokens: 0,
         }
     }
 
@@ -420,6 +456,56 @@ mod tests {
                 }],
                 errors: 0,
             }
+        }
+    }
+
+    struct BoundedSource {
+        unfiltered_calls: AtomicUsize,
+        filtered_calls: AtomicUsize,
+        since_ms: AtomicI64,
+        until_ms: AtomicI64,
+    }
+
+    impl Default for BoundedSource {
+        fn default() -> Self {
+            Self {
+                unfiltered_calls: AtomicUsize::new(0),
+                filtered_calls: AtomicUsize::new(0),
+                since_ms: AtomicI64::new(0),
+                until_ms: AtomicI64::new(0),
+            }
+        }
+    }
+
+    impl Source for BoundedSource {
+        fn name(&self) -> &'static str {
+            "bounded"
+        }
+
+        fn capabilities(&self) -> Capabilities {
+            Capabilities::default()
+        }
+
+        fn find_files(&self) -> Vec<PathBuf> {
+            self.unfiltered_calls.fetch_add(1, Ordering::SeqCst);
+            Vec::new()
+        }
+
+        fn find_files_for_filter(&self, filter: &DateFilter, _timezone: Timezone) -> Vec<PathBuf> {
+            self.filtered_calls.fetch_add(1, Ordering::SeqCst);
+            self.since_ms.store(
+                filter.since_timestamp_ms.unwrap_or_default(),
+                Ordering::SeqCst,
+            );
+            self.until_ms.store(
+                filter.until_timestamp_ms.unwrap_or_default(),
+                Ordering::SeqCst,
+            );
+            Vec::new()
+        }
+
+        fn parse_file(&self, _path: &Path, _timezone: Timezone, _debug: bool) -> ParseOutput {
+            ParseOutput::default()
         }
     }
 
@@ -504,7 +590,8 @@ mod tests {
             entry_at("2026-08-21T05:44:00Z"),
         ];
 
-        let result = aggregate_entries_for_filter(&entries, &ranges[0].filter, false);
+        let source = CountingSource::new(Vec::new());
+        let result = aggregate_entries_for_filter(&entries, &ranges[0].filter, &source);
 
         assert_eq!(result.valid, 1);
         assert_eq!(result.day_stats["2026-08-21"].stats.input_tokens, 10);
@@ -543,6 +630,45 @@ mod tests {
                 priced_tokens: 30,
                 estimated_proxy: 0,
             })
+        );
+    }
+
+    #[test]
+    fn timestamp_ranges_bound_shared_source_discovery() {
+        let source = BoundedSource::default();
+        let ranges = resolve_ranges(
+            &[
+                UsageRange::TimestampRange {
+                    since: "2026-08-21T05:00:00Z".parse().expect("valid since"),
+                    until: "2026-08-21T06:00:00Z".parse().expect("valid until"),
+                },
+                UsageRange::TimestampRange {
+                    since: "2026-08-21T08:00:00Z".parse().expect("valid since"),
+                    until: "2026-08-21T09:00:00Z".parse().expect("valid until"),
+                },
+            ],
+            d(2026, 8, 21),
+        )
+        .expect("resolve ranges");
+
+        let results = load_daily_ranges(&source, &ranges, Timezone::Named(chrono_tz::UTC));
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(source.unfiltered_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(source.filtered_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            source.since_ms.load(Ordering::SeqCst),
+            "2026-08-21T05:00:00Z"
+                .parse::<DateTime<Utc>>()
+                .expect("valid since")
+                .timestamp_millis()
+        );
+        assert_eq!(
+            source.until_ms.load(Ordering::SeqCst),
+            "2026-08-21T09:00:00Z"
+                .parse::<DateTime<Utc>>()
+                .expect("valid until")
+                .timestamp_millis()
         );
     }
 

--- a/src/source/cursor/parser.rs
+++ b/src/source/cursor/parser.rs
@@ -31,13 +31,17 @@ pub(super) fn find_cursor_files(filter: &DateFilter, timezone: Timezone) -> Vec<
     }
 
     if has_api_credentials() {
-        let start_ms = filter
-            .since
-            .and_then(|date| timezone.date_start_utc_millis(date));
-        let end_ms = filter.until.and_then(|date| {
-            date.succ_opt()
-                .and_then(|next| timezone.date_start_utc_millis(next))
-                .map(|next_start| next_start.saturating_sub(1))
+        let start_ms = filter.since_timestamp_ms.or_else(|| {
+            filter
+                .since
+                .and_then(|date| timezone.date_start_utc_millis(date))
+        });
+        let end_ms = filter.until_timestamp_ms.or_else(|| {
+            filter.until.and_then(|date| {
+                date.succ_opt()
+                    .and_then(|next| timezone.date_start_utc_millis(next))
+                    .map(|next_start| next_start.saturating_sub(1))
+            })
         });
         vec![PathBuf::from(format!(
             "{API_SENTINEL}|{}|{}",

--- a/src/source/grok/ledger_lock.rs
+++ b/src/source/grok/ledger_lock.rs
@@ -1,0 +1,26 @@
+use std::fs::{self, File, OpenOptions};
+use std::path::Path;
+
+use fs4::FileExt;
+
+const LEDGER_LOCK_FILE: &str = "inference-v1.lock";
+
+pub(super) fn acquire(ledger_path: &Path) -> Result<File, String> {
+    let parent = ledger_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)
+        .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+    let lock_path = parent.join(LEDGER_LOCK_FILE);
+    let lock = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .map_err(|error| format!("failed to open {}: {error}", lock_path.display()))?;
+    FileExt::lock(&lock)
+        .map_err(|error| format!("failed to lock {}: {error}", lock_path.display()))?;
+    Ok(lock)
+}

--- a/src/source/grok/mod.rs
+++ b/src/source/grok/mod.rs
@@ -4,6 +4,7 @@
 //! without unified inference telemetry still use session usage records.
 
 mod config;
+mod ledger_lock;
 mod parser;
 mod unified;
 mod usage;

--- a/src/source/grok/unified.rs
+++ b/src/source/grok/unified.rs
@@ -1,8 +1,8 @@
 //! Durable Grok inference usage from `logs/unified.jsonl`.
 //!
-//! Grok trims the head of its unified log in place. Before ccstats parses the
-//! file, it merges every inference record into an atomic, source-root-scoped
-//! ledger under the platform cache directory.
+//! Grok trims the head of its unified log in place. Before parsing, ccstats
+//! merges every inference record into an atomic, source-root-scoped
+//! ledger under the platform application-data directory.
 
 use std::collections::{BTreeMap, HashMap, hash_map::DefaultHasher};
 use std::env;
@@ -20,13 +20,14 @@ use crate::core::{CostKind, DateFilter, DedupAccumulator, RawEntry};
 use crate::source::{CostCoverage, ParseOutput};
 use crate::utils::Timezone;
 
-const APP_CACHE_DIR: &str = "ccstats";
+const APP_DATA_DIR: &str = "ccstats";
 const GROK_CACHE_DIR: &str = "grok";
 const GROK_HOME_ENV: &str = "GROK_HOME";
 const DEFAULT_GROK_DIR: &str = ".grok";
 const UNIFIED_LOG: &str = "unified.jsonl";
 const LEDGER_FILE: &str = "inference-v1.jsonl";
 const INFERENCE_DONE: &str = "shell.turn.inference_done";
+const MODEL_CHANGED: &str = "model changed";
 const LONG_CONTEXT_THRESHOLD: i64 = 200_000;
 
 #[derive(Debug, Deserialize, Default)]
@@ -46,6 +47,7 @@ struct InferenceContext {
     cached_prompt_tokens: Option<i64>,
     completion_tokens: Option<i64>,
     reasoning_tokens: Option<i64>,
+    model: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -147,9 +149,9 @@ fn source_root_hash(path: &Path) -> String {
 }
 
 fn ledger_path(grok_home: &Path) -> Option<PathBuf> {
-    dirs::cache_dir().map(|cache_dir| {
-        cache_dir
-            .join(APP_CACHE_DIR)
+    dirs::data_local_dir().map(|data_dir| {
+        data_dir
+            .join(APP_DATA_DIR)
             .join(GROK_CACHE_DIR)
             .join(source_root_hash(grok_home))
             .join(LEDGER_FILE)
@@ -190,15 +192,9 @@ fn sync_or_select_grok_file(
     match sync_ledger_at(source_path, ledger_path, sessions_dir) {
         Ok(records) if records > 0 => ledger_path.to_path_buf(),
         Ok(_) => source_path.to_path_buf(),
-        Err(error) if ledger_path.is_file() => {
-            eprintln!(
-                "Warning: failed to ingest the latest Grok inference log; using the last persisted ledger: {error}"
-            );
-            ledger_path.to_path_buf()
-        }
         Err(error) => {
             eprintln!(
-                "Warning: failed to persist Grok inference log; reading the live log only: {error}"
+                "Error: failed to persist the latest Grok inference log; reading it directly so the incomplete result is reported: {error}"
             );
             source_path.to_path_buf()
         }
@@ -222,6 +218,7 @@ fn sync_ledger_at(
     ledger_path: &Path,
     sessions_dir: &Path,
 ) -> Result<usize, String> {
+    let _lock = super::ledger_lock::acquire(ledger_path)?;
     let mut records = load_ledger(ledger_path)?;
     for record in read_inference_records(source_path, sessions_dir)? {
         records.insert(record.event_key.clone(), record);
@@ -267,6 +264,7 @@ fn read_inference_records(
     let file =
         File::open(path).map_err(|error| format!("failed to open {}: {error}", path.display()))?;
     let session_metadata = load_session_metadata(sessions_dir);
+    let mut active_models = HashMap::new();
     let mut records = Vec::new();
 
     for (line_index, line) in BufReader::new(file).lines().enumerate() {
@@ -277,7 +275,7 @@ fn read_inference_records(
                 line_index + 1
             )
         })?;
-        if !line.contains(INFERENCE_DONE) {
+        if !line.contains(INFERENCE_DONE) && !line.contains(MODEL_CHANGED) {
             continue;
         }
         let envelope: UnifiedEnvelope = serde_json::from_str(&line).map_err(|error| {
@@ -287,13 +285,37 @@ fn read_inference_records(
                 line_index + 1
             )
         })?;
-        if envelope.msg.as_deref() != Some(INFERENCE_DONE) {
-            continue;
+        match envelope.msg.as_deref() {
+            Some(MODEL_CHANGED) => {
+                let Some(session_id) = envelope.sid.as_deref().map(str::trim) else {
+                    continue;
+                };
+                let Some(model) = envelope
+                    .ctx
+                    .as_ref()
+                    .and_then(|ctx| ctx.model.as_deref())
+                    .map(str::trim)
+                    .filter(|model| !model.is_empty())
+                else {
+                    continue;
+                };
+                if !session_id.is_empty() {
+                    active_models.insert(session_id.to_string(), model.to_string());
+                }
+            }
+            Some(INFERENCE_DONE) => {
+                let record = normalize_inference(envelope, &session_metadata, &active_models)
+                    .map_err(|error| {
+                        format!(
+                            "invalid inference record {} line {}: {error}",
+                            path.display(),
+                            line_index + 1
+                        )
+                    })?;
+                records.push(record);
+            }
+            _ => {}
         }
-        let Some(record) = normalize_inference(envelope, &session_metadata) else {
-            continue;
-        };
-        records.push(record);
     }
     Ok(records)
 }
@@ -336,15 +358,16 @@ fn load_session_metadata(sessions_root: &Path) -> HashMap<String, SessionMetadat
 fn normalize_inference(
     envelope: UnifiedEnvelope,
     session_metadata: &HashMap<String, SessionMetadata>,
-) -> Option<InferenceRecord> {
-    let timestamp = envelope.ts?.trim().to_string();
-    DateTime::parse_from_rfc3339(&timestamp).ok()?;
-    let session_id = envelope.sid?.trim().to_string();
+    active_models: &HashMap<String, String>,
+) -> Result<InferenceRecord, &'static str> {
+    let timestamp = envelope.ts.ok_or("missing ts")?.trim().to_string();
+    DateTime::parse_from_rfc3339(&timestamp).map_err(|_| "invalid ts")?;
+    let session_id = envelope.sid.ok_or("missing sid")?.trim().to_string();
     if session_id.is_empty() {
-        return None;
+        return Err("empty sid");
     }
-    let ctx = envelope.ctx?;
-    let prompt_tokens = ctx.prompt_tokens?.max(0);
+    let ctx = envelope.ctx.ok_or("missing ctx")?;
+    let prompt_tokens = ctx.prompt_tokens.ok_or("missing prompt_tokens")?.max(0);
     let cached_prompt_tokens = ctx
         .cached_prompt_tokens
         .unwrap_or(0)
@@ -355,7 +378,7 @@ fn normalize_inference(
         .unwrap_or(0)
         .clamp(0, completion_tokens);
     let loop_index = ctx.loop_index.unwrap_or(0).max(0);
-    let metadata = session_metadata
+    let mut metadata = session_metadata
         .get(&session_id)
         .cloned()
         .unwrap_or_else(|| SessionMetadata {
@@ -363,9 +386,12 @@ fn normalize_inference(
             project_path: String::new(),
             model: "grok".to_string(),
         });
+    if let Some(model) = active_models.get(&session_id) {
+        metadata.model.clone_from(model);
+    }
     let event_key = format!("{session_id}:{timestamp}:{loop_index}");
 
-    Some(InferenceRecord {
+    Ok(InferenceRecord {
         event_key,
         timestamp,
         session_id,
@@ -566,8 +592,12 @@ fn cost_coverage_from_files(
             _ => {
                 let parsed = super::parser::parse_grok_usage_file_with_debug(path, timezone, false);
                 usage.extend(parsed.entries.into_iter().filter(|entry| {
-                    chrono::NaiveDate::parse_from_str(&entry.date_str, DATE_FORMAT)
-                        .is_ok_and(|date| filter.contains(date))
+                    if filter.has_timestamp_range() {
+                        filter.contains_timestamp(entry.timestamp_ms)
+                    } else {
+                        chrono::NaiveDate::parse_from_str(&entry.date_str, DATE_FORMAT)
+                            .is_ok_and(|date| filter.contains(date))
+                    }
                 }));
             }
         }
@@ -596,8 +626,13 @@ fn priced_tokens_in_records(
         let Ok(utc_dt) = record.timestamp.parse::<DateTime<Utc>>() else {
             return total;
         };
-        let date = timezone.to_fixed_offset(utc_dt).date_naive();
-        if !filter.contains(date) {
+        let in_range = if filter.has_timestamp_range() {
+            filter.contains_timestamp(utc_dt.timestamp_millis())
+        } else {
+            let date = timezone.to_fixed_offset(utc_dt).date_naive();
+            filter.contains(date)
+        };
+        if !in_range {
             return total;
         }
         let prompt_tokens = record.prompt_tokens.max(0);
@@ -646,6 +681,24 @@ mod tests {
         format!(
             r#"{{"ts":"{timestamp}","sid":"{session_id}","msg":"shell.turn.inference_done","ctx":{{"loop_index":{loop_index},"prompt_tokens":{prompt},"cached_prompt_tokens":{cached},"completion_tokens":{completion},"reasoning_tokens":{reasoning}}}}}"#
         )
+    }
+
+    fn model_changed_line(timestamp: &str, session_id: &str, model: &str) -> String {
+        format!(
+            r#"{{"ts":"{timestamp}","sid":"{session_id}","msg":"model changed","ctx":{{"model":"{model}"}}}}"#
+        )
+    }
+
+    #[test]
+    fn durable_ledger_uses_platform_data_directory() {
+        let grok_home = Path::new("/tmp/example-grok-home");
+        let path = ledger_path(grok_home).expect("platform data directory");
+        let data_dir = dirs::data_local_dir().expect("platform data directory");
+
+        assert!(path.starts_with(data_dir));
+        if let Some(cache_dir) = dirs::cache_dir() {
+            assert!(!path.starts_with(cache_dir));
+        }
     }
 
     #[test]
@@ -703,6 +756,53 @@ mod tests {
     }
 
     #[test]
+    fn rejects_inference_records_missing_required_fields() {
+        let root = tempdir().expect("temp dir");
+        let source_path = root.path().join("unified.jsonl");
+        let ledger_path = root.path().join("grok-inference.jsonl");
+        let sessions_dir = root.path().join("sessions");
+        fs::write(
+            &source_path,
+            r#"{"ts":"2026-08-21T05:42:57.046Z","sid":"session-1","msg":"shell.turn.inference_done","ctx":{}}"#,
+        )
+        .expect("write incomplete inference");
+
+        let error = sync_ledger_at(&source_path, &ledger_path, &sessions_dir)
+            .expect_err("missing prompt tokens must fail ingestion");
+
+        assert!(error.contains("prompt_tokens"));
+        assert!(!ledger_path.exists());
+    }
+
+    #[test]
+    fn attributes_each_inference_to_the_model_active_at_that_time() {
+        let root = tempdir().expect("temp dir");
+        let sessions_dir = root.path().join("sessions");
+        let source_path = root.path().join("unified.jsonl");
+        let ledger_path = root.path().join("grok-inference.jsonl");
+        write_session_summary(&sessions_dir, "session-1", "grok-4.6");
+        fs::write(
+            &source_path,
+            [
+                model_changed_line("2026-08-21T05:40:00Z", "session-1", "grok-4.5"),
+                inference_line("2026-08-21T05:41:00Z", "session-1", 1, 100, 0, 10, 0),
+                model_changed_line("2026-08-21T05:42:00Z", "session-1", "grok-4.6"),
+                inference_line("2026-08-21T05:43:00Z", "session-1", 2, 200, 0, 20, 0),
+            ]
+            .join("\n"),
+        )
+        .expect("write model changes and inferences");
+
+        sync_ledger_at(&source_path, &ledger_path, &sessions_dir).expect("sync ledger");
+        let parsed = parse_ledger_file(&ledger_path, tz(), true);
+
+        assert_eq!(parsed.errors, 0);
+        assert_eq!(parsed.entries.len(), 2);
+        assert_eq!(parsed.entries[0].model, "grok-4.5");
+        assert_eq!(parsed.entries[1].model, "grok-4.6");
+    }
+
+    #[test]
     fn ledger_deduplicates_and_survives_source_trimming() {
         let root = tempdir().expect("temp dir");
         let sessions_dir = root.path().join("sessions");
@@ -745,7 +845,7 @@ mod tests {
     }
 
     #[test]
-    fn malformed_live_tail_keeps_last_persisted_ledger_visible() {
+    fn malformed_live_tail_fails_closed_instead_of_returning_stale_ledger() {
         let root = tempdir().expect("temp dir");
         let sessions_dir = root.path().join("sessions");
         let source_path = root.path().join("unified.jsonl");
@@ -768,11 +868,12 @@ mod tests {
         .expect("write partial live record");
 
         let selected = sync_or_select_grok_file(&source_path, &ledger_path, &sessions_dir);
-        assert_eq!(selected, ledger_path);
-        let parsed = parse_ledger_file(&selected, tz(), true);
-        assert_eq!(parsed.errors, 0);
-        assert_eq!(parsed.entries.len(), 1);
-        assert_eq!(parsed.entries[0].to_stats().total_tokens(), 0);
-        assert!((parsed.entries[0].recorded_cost_usd.unwrap() - 0.000_185).abs() < 1e-12);
+        assert_eq!(selected, source_path);
+        let parsed = parse_grok_file_with_debug(&selected, tz(), true);
+        assert_eq!(parsed.errors, 1);
+        assert!(parsed.entries.is_empty());
     }
+
+    #[path = "lock_tests.rs"]
+    mod lock_tests;
 }

--- a/src/source/grok/unified.rs
+++ b/src/source/grok/unified.rs
@@ -26,6 +26,7 @@ const GROK_HOME_ENV: &str = "GROK_HOME";
 const DEFAULT_GROK_DIR: &str = ".grok";
 const UNIFIED_LOG: &str = "unified.jsonl";
 const LEDGER_FILE: &str = "inference-v1.jsonl";
+const SYNC_ERROR_FILE: &str = "inference-v1.sync-error";
 const INFERENCE_DONE: &str = "shell.turn.inference_done";
 const MODEL_CHANGED: &str = "model changed";
 const LONG_CONTEXT_THRESHOLD: i64 = 200_000;
@@ -194,9 +195,9 @@ fn sync_or_select_grok_file(
         Ok(_) => source_path.to_path_buf(),
         Err(error) => {
             eprintln!(
-                "Error: failed to persist the latest Grok inference log; reading it directly so the incomplete result is reported: {error}"
+                "Error: failed to persist the latest Grok inference log; incomplete result omitted: {error}"
             );
-            source_path.to_path_buf()
+            ledger_path.with_file_name(SYNC_ERROR_FILE)
         }
     }
 }
@@ -208,6 +209,10 @@ pub(super) fn parse_grok_file_with_debug(
 ) -> ParseOutput {
     match path.file_name().and_then(|name| name.to_str()) {
         Some(LEDGER_FILE) => parse_ledger_file(path, timezone, debug),
+        Some(SYNC_ERROR_FILE) => ParseOutput {
+            entries: Vec::new(),
+            errors: 1,
+        },
         Some(UNIFIED_LOG) => parse_live_unified_file(path, timezone, debug),
         _ => super::parser::parse_grok_usage_file_with_debug(path, timezone, debug),
     }
@@ -610,9 +615,25 @@ mod tests {
         let data_dir = dirs::data_local_dir().expect("platform data directory");
 
         assert!(path.starts_with(data_dir));
-        if let Some(cache_dir) = dirs::cache_dir() {
-            assert!(!path.starts_with(cache_dir));
-        }
+        assert_eq!(
+            path.file_name().and_then(|name| name.to_str()),
+            Some(LEDGER_FILE)
+        );
+        assert_eq!(
+            path.parent()
+                .and_then(Path::parent)
+                .and_then(Path::file_name)
+                .and_then(|name| name.to_str()),
+            Some(GROK_CACHE_DIR)
+        );
+        assert_eq!(
+            path.parent()
+                .and_then(Path::parent)
+                .and_then(Path::parent)
+                .and_then(Path::file_name)
+                .and_then(|name| name.to_str()),
+            Some(APP_DATA_DIR)
+        );
     }
 
     #[test]
@@ -635,158 +656,8 @@ mod tests {
         assert!((long - 0.196).abs() < 1e-12);
     }
 
-    #[test]
-    fn parses_completion_without_double_counting_reasoning() {
-        let root = tempdir().expect("temp dir");
-        let sessions_dir = root.path().join("sessions");
-        let source_path = root.path().join("unified.jsonl");
-        let ledger_path = root.path().join("grok-inference.jsonl");
-        write_session_summary(&sessions_dir, "session-1", "grok-4.6");
-        fs::write(
-            &source_path,
-            inference_line(
-                "2026-08-21T05:42:57.046Z",
-                "session-1",
-                1,
-                148_540,
-                148_224,
-                1_356,
-                949,
-            ),
-        )
-        .expect("write source");
-
-        assert_eq!(
-            sync_ledger_at(&source_path, &ledger_path, &sessions_dir).expect("sync ledger"),
-            1
-        );
-        let parsed = parse_ledger_file(&ledger_path, tz(), true);
-        assert_eq!(parsed.errors, 0);
-        assert_eq!(parsed.entries.len(), 1);
-        let entry = &parsed.entries[0];
-        assert_eq!(entry.to_stats().total_tokens(), 0);
-        assert_eq!(entry.call_count, 0);
-        assert!((entry.recorded_cost_usd.expect("calculated cost") - 0.082_88).abs() < 1e-12);
-    }
-
-    #[test]
-    fn rejects_inference_records_missing_required_fields() {
-        let root = tempdir().expect("temp dir");
-        let source_path = root.path().join("unified.jsonl");
-        let ledger_path = root.path().join("grok-inference.jsonl");
-        let sessions_dir = root.path().join("sessions");
-        fs::write(
-            &source_path,
-            r#"{"ts":"2026-08-21T05:42:57.046Z","sid":"session-1","msg":"shell.turn.inference_done","ctx":{}}"#,
-        )
-        .expect("write incomplete inference");
-
-        let error = sync_ledger_at(&source_path, &ledger_path, &sessions_dir)
-            .expect_err("missing prompt tokens must fail ingestion");
-
-        assert!(error.contains("prompt_tokens"));
-        assert!(!ledger_path.exists());
-    }
-
-    #[test]
-    fn attributes_each_inference_to_the_model_active_at_that_time() {
-        let root = tempdir().expect("temp dir");
-        let sessions_dir = root.path().join("sessions");
-        let source_path = root.path().join("unified.jsonl");
-        let ledger_path = root.path().join("grok-inference.jsonl");
-        write_session_summary(&sessions_dir, "session-1", "grok-4.6");
-        fs::write(
-            &source_path,
-            [
-                model_changed_line("2026-08-21T05:40:00Z", "session-1", "grok-4.5"),
-                inference_line("2026-08-21T05:41:00Z", "session-1", 1, 100, 0, 10, 0),
-                model_changed_line("2026-08-21T05:42:00Z", "session-1", "grok-4.6"),
-                inference_line("2026-08-21T05:43:00Z", "session-1", 2, 200, 0, 20, 0),
-            ]
-            .join("\n"),
-        )
-        .expect("write model changes and inferences");
-
-        sync_ledger_at(&source_path, &ledger_path, &sessions_dir).expect("sync ledger");
-        let parsed = parse_ledger_file(&ledger_path, tz(), true);
-
-        assert_eq!(parsed.errors, 0);
-        assert_eq!(parsed.entries.len(), 2);
-        assert_eq!(parsed.entries[0].model, "grok-4.5");
-        assert_eq!(parsed.entries[1].model, "grok-4.6");
-    }
-
-    #[test]
-    fn ledger_deduplicates_and_survives_source_trimming() {
-        let root = tempdir().expect("temp dir");
-        let sessions_dir = root.path().join("sessions");
-        let source_path = root.path().join("unified.jsonl");
-        let ledger_path = root.path().join("grok-inference.jsonl");
-        write_session_summary(&sessions_dir, "session-1", "grok-4.6");
-        let first = inference_line("2026-08-21T05:42:57.046Z", "session-1", 1, 100, 50, 10, 4);
-        let second = inference_line("2026-08-21T05:43:11.682Z", "session-1", 2, 200, 150, 20, 8);
-        fs::write(&source_path, format!("{first}\n{second}\n")).expect("write source");
-
-        assert_eq!(
-            sync_ledger_at(&source_path, &ledger_path, &sessions_dir).expect("first sync"),
-            2
-        );
-        assert_eq!(
-            sync_ledger_at(&source_path, &ledger_path, &sessions_dir).expect("repeat sync"),
-            2
-        );
-
-        fs::write(&source_path, format!("{second}\n")).expect("trim source head");
-        assert_eq!(
-            sync_ledger_at(&source_path, &ledger_path, &sessions_dir).expect("trimmed sync"),
-            2
-        );
-        let parsed = parse_ledger_file(&ledger_path, tz(), true);
-        assert_eq!(parsed.errors, 0);
-        assert_eq!(parsed.entries.len(), 2);
-        assert!(
-            parsed
-                .entries
-                .iter()
-                .all(|entry| entry.to_stats().total_tokens() == 0)
-        );
-        let cost: f64 = parsed
-            .entries
-            .iter()
-            .filter_map(|entry| entry.recorded_cost_usd)
-            .sum();
-        assert!((cost - 0.000_48).abs() < 1e-12);
-    }
-
-    #[test]
-    fn malformed_live_tail_fails_closed_instead_of_returning_stale_ledger() {
-        let root = tempdir().expect("temp dir");
-        let sessions_dir = root.path().join("sessions");
-        let source_path = root.path().join("unified.jsonl");
-        let ledger_path = root.path().join("grok-inference.jsonl");
-        write_session_summary(&sessions_dir, "session-1", "grok-4.6");
-        fs::write(
-            &source_path,
-            inference_line("2026-08-21T05:42:57.046Z", "session-1", 1, 100, 50, 10, 4),
-        )
-        .expect("write initial source");
-        assert_eq!(
-            sync_ledger_at(&source_path, &ledger_path, &sessions_dir).expect("initial sync"),
-            1
-        );
-
-        fs::write(
-            &source_path,
-            r#"{"msg":"shell.turn.inference_done","ctx":{"prompt_tokens":200"#,
-        )
-        .expect("write partial live record");
-
-        let selected = sync_or_select_grok_file(&source_path, &ledger_path, &sessions_dir);
-        assert_eq!(selected, source_path);
-        let parsed = parse_grok_file_with_debug(&selected, tz(), true);
-        assert_eq!(parsed.errors, 1);
-        assert!(parsed.entries.is_empty());
-    }
+    #[path = "behavior_tests.rs"]
+    mod behavior_tests;
 
     #[path = "lock_tests.rs"]
     mod lock_tests;

--- a/src/source/grok/unified/tests/behavior_tests.rs
+++ b/src/source/grok/unified/tests/behavior_tests.rs
@@ -1,0 +1,157 @@
+use super::*;
+
+#[test]
+fn parses_completion_without_double_counting_reasoning() {
+    let root = tempdir().expect("temp dir");
+    let sessions_dir = root.path().join("sessions");
+    let source_path = root.path().join("unified.jsonl");
+    let ledger_path = root.path().join("grok-inference.jsonl");
+    write_session_summary(&sessions_dir, "session-1", "grok-4.6");
+    fs::write(
+        &source_path,
+        inference_line(
+            "2026-08-21T05:42:57.046Z",
+            "session-1",
+            1,
+            148_540,
+            148_224,
+            1_356,
+            949,
+        ),
+    )
+    .expect("write source");
+
+    assert_eq!(
+        sync_ledger_at(&source_path, &ledger_path, &sessions_dir).expect("sync ledger"),
+        1
+    );
+    let parsed = parse_ledger_file(&ledger_path, tz(), true);
+    assert_eq!(parsed.errors, 0);
+    assert_eq!(parsed.entries.len(), 1);
+    let entry = &parsed.entries[0];
+    assert_eq!(entry.to_stats().total_tokens(), 0);
+    assert_eq!(entry.call_count, 0);
+    assert!((entry.recorded_cost_usd.expect("calculated cost") - 0.082_88).abs() < 1e-12);
+}
+
+#[test]
+fn rejects_inference_records_missing_required_fields() {
+    let root = tempdir().expect("temp dir");
+    let source_path = root.path().join("unified.jsonl");
+    let ledger_path = root.path().join("grok-inference.jsonl");
+    let sessions_dir = root.path().join("sessions");
+    fs::write(
+        &source_path,
+        r#"{"ts":"2026-08-21T05:42:57.046Z","sid":"session-1","msg":"shell.turn.inference_done","ctx":{}}"#,
+    )
+    .expect("write incomplete inference");
+
+    let error = sync_ledger_at(&source_path, &ledger_path, &sessions_dir)
+        .expect_err("missing prompt tokens must fail ingestion");
+
+    assert!(error.contains("prompt_tokens"));
+    assert!(!ledger_path.exists());
+}
+
+#[test]
+fn attributes_each_inference_to_the_model_active_at_that_time() {
+    let root = tempdir().expect("temp dir");
+    let sessions_dir = root.path().join("sessions");
+    let source_path = root.path().join("unified.jsonl");
+    let ledger_path = root.path().join("grok-inference.jsonl");
+    write_session_summary(&sessions_dir, "session-1", "grok-4.6");
+    fs::write(
+        &source_path,
+        [
+            model_changed_line("2026-08-21T05:40:00Z", "session-1", "grok-4.5"),
+            inference_line("2026-08-21T05:41:00Z", "session-1", 1, 100, 0, 10, 0),
+            model_changed_line("2026-08-21T05:42:00Z", "session-1", "grok-4.6"),
+            inference_line("2026-08-21T05:43:00Z", "session-1", 2, 200, 0, 20, 0),
+        ]
+        .join("\n"),
+    )
+    .expect("write model changes and inferences");
+
+    sync_ledger_at(&source_path, &ledger_path, &sessions_dir).expect("sync ledger");
+    let parsed = parse_ledger_file(&ledger_path, tz(), true);
+
+    assert_eq!(parsed.errors, 0);
+    assert_eq!(parsed.entries.len(), 2);
+    assert_eq!(parsed.entries[0].model, "grok-4.5");
+    assert_eq!(parsed.entries[1].model, "grok-4.6");
+}
+
+#[test]
+fn ledger_deduplicates_and_survives_source_trimming() {
+    let root = tempdir().expect("temp dir");
+    let sessions_dir = root.path().join("sessions");
+    let source_path = root.path().join("unified.jsonl");
+    let ledger_path = root.path().join("grok-inference.jsonl");
+    write_session_summary(&sessions_dir, "session-1", "grok-4.6");
+    let first = inference_line("2026-08-21T05:42:57.046Z", "session-1", 1, 100, 50, 10, 4);
+    let second = inference_line("2026-08-21T05:43:11.682Z", "session-1", 2, 200, 150, 20, 8);
+    fs::write(&source_path, format!("{first}\n{second}\n")).expect("write source");
+
+    assert_eq!(
+        sync_ledger_at(&source_path, &ledger_path, &sessions_dir).expect("first sync"),
+        2
+    );
+    assert_eq!(
+        sync_ledger_at(&source_path, &ledger_path, &sessions_dir).expect("repeat sync"),
+        2
+    );
+
+    fs::write(&source_path, format!("{second}\n")).expect("trim source head");
+    assert_eq!(
+        sync_ledger_at(&source_path, &ledger_path, &sessions_dir).expect("trimmed sync"),
+        2
+    );
+    let parsed = parse_ledger_file(&ledger_path, tz(), true);
+    assert_eq!(parsed.errors, 0);
+    assert_eq!(parsed.entries.len(), 2);
+    assert!(
+        parsed
+            .entries
+            .iter()
+            .all(|entry| entry.to_stats().total_tokens() == 0)
+    );
+    let cost: f64 = parsed
+        .entries
+        .iter()
+        .filter_map(|entry| entry.recorded_cost_usd)
+        .sum();
+    assert!((cost - 0.000_48).abs() < 1e-12);
+}
+
+#[test]
+fn malformed_live_tail_fails_closed_instead_of_returning_stale_ledger() {
+    let root = tempdir().expect("temp dir");
+    let sessions_dir = root.path().join("sessions");
+    let source_path = root.path().join("unified.jsonl");
+    let ledger_path = root.path().join("grok-inference.jsonl");
+    write_session_summary(&sessions_dir, "session-1", "grok-4.6");
+    fs::write(
+        &source_path,
+        inference_line("2026-08-21T05:42:57.046Z", "session-1", 1, 100, 50, 10, 4),
+    )
+    .expect("write initial source");
+    assert_eq!(
+        sync_ledger_at(&source_path, &ledger_path, &sessions_dir).expect("initial sync"),
+        1
+    );
+
+    fs::write(
+        &source_path,
+        r#"{"msg":"shell.turn.inference_done","ctx":{"prompt_tokens":200"#,
+    )
+    .expect("write partial live record");
+
+    let selected = sync_or_select_grok_file(&source_path, &ledger_path, &sessions_dir);
+    assert_eq!(
+        selected.file_name().and_then(|name| name.to_str()),
+        Some(SYNC_ERROR_FILE)
+    );
+    let parsed = parse_grok_file_with_debug(&selected, tz(), true);
+    assert_eq!(parsed.errors, 1);
+    assert!(parsed.entries.is_empty());
+}

--- a/src/source/grok/unified/tests/lock_tests.rs
+++ b/src/source/grok/unified/tests/lock_tests.rs
@@ -50,42 +50,22 @@ fn sync_waits_for_the_ledger_lock_before_merging() {
 }
 
 #[test]
-fn priced_token_coverage_honors_exact_timestamp_range() {
-    let records = [
-        InferenceRecord {
-            event_key: "first".to_string(),
-            timestamp: "2026-08-21T05:00:00Z".to_string(),
-            session_id: "session-1".to_string(),
-            session_key: "session-1".to_string(),
-            project_path: String::new(),
-            model: "grok-4.6".to_string(),
-            prompt_tokens: 100,
-            cached_prompt_tokens: 0,
-            completion_tokens: 10,
-            reasoning_tokens: 0,
-        },
-        InferenceRecord {
-            event_key: "second".to_string(),
-            timestamp: "2026-08-21T06:00:00Z".to_string(),
-            session_id: "session-1".to_string(),
-            session_key: "session-1".to_string(),
-            project_path: String::new(),
-            model: "grok-4.6".to_string(),
-            prompt_tokens: 200,
-            cached_prompt_tokens: 0,
-            completion_tokens: 20,
-            reasoning_tokens: 0,
-        },
-    ];
-    let since = "2026-08-21T05:30:00Z"
-        .parse::<DateTime<Utc>>()
-        .expect("valid since")
-        .timestamp_millis();
-    let until = "2026-08-21T06:30:00Z"
-        .parse::<DateTime<Utc>>()
-        .expect("valid until")
-        .timestamp_millis();
-    let filter = DateFilter::new(None, None).with_timestamp_range(since, until);
+fn valid_live_tail_reports_a_malformed_ledger_sync_failure() {
+    let root = tempdir().expect("temp dir");
+    let sessions_dir = root.path().join("sessions");
+    let source_path = root.path().join(UNIFIED_LOG);
+    let ledger_path = root.path().join(LEDGER_FILE);
+    write_session_summary(&sessions_dir, "session-1", "grok-4.6");
+    fs::write(
+        &source_path,
+        inference_line("2026-08-21T05:42:57.046Z", "session-1", 1, 100, 0, 10, 0),
+    )
+    .expect("write valid live source");
+    fs::write(&ledger_path, "{not valid ledger json}\n").expect("write malformed ledger");
 
-    assert_eq!(priced_tokens_in_records(records, &filter, tz()), 220);
+    let selected = sync_or_select_grok_file(&source_path, &ledger_path, &sessions_dir);
+    let parsed = parse_grok_file_with_debug(&selected, tz(), true);
+
+    assert_eq!(parsed.errors, 1);
+    assert!(parsed.entries.is_empty());
 }

--- a/src/source/grok/unified/tests/lock_tests.rs
+++ b/src/source/grok/unified/tests/lock_tests.rs
@@ -1,0 +1,91 @@
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+use fs4::FileExt;
+
+use super::*;
+
+#[test]
+fn sync_waits_for_the_ledger_lock_before_merging() {
+    let root = tempdir().expect("temp dir");
+    let sessions_dir = root.path().join("sessions");
+    let source_path = root.path().join("unified.jsonl");
+    let ledger_path = root.path().join(LEDGER_FILE);
+    let lock_path = root.path().join("inference-v1.lock");
+    write_session_summary(&sessions_dir, "session-1", "grok-4.6");
+    fs::write(
+        &source_path,
+        inference_line("2026-08-21T05:42:57.046Z", "session-1", 1, 100, 0, 10, 0),
+    )
+    .expect("write source");
+    let lock = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(lock_path)
+        .expect("open lock file");
+    FileExt::lock(&lock).expect("hold ledger lock");
+
+    let (sender, receiver) = mpsc::channel();
+    thread::spawn(move || {
+        sender
+            .send(sync_ledger_at(&source_path, &ledger_path, &sessions_dir))
+            .expect("send sync result");
+    });
+
+    assert!(matches!(
+        receiver.recv_timeout(Duration::from_millis(200)),
+        Err(mpsc::RecvTimeoutError::Timeout)
+    ));
+    FileExt::unlock(&lock).expect("release ledger lock");
+    assert_eq!(
+        receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("sync finishes after unlock")
+            .expect("sync succeeds"),
+        1
+    );
+}
+
+#[test]
+fn priced_token_coverage_honors_exact_timestamp_range() {
+    let records = [
+        InferenceRecord {
+            event_key: "first".to_string(),
+            timestamp: "2026-08-21T05:00:00Z".to_string(),
+            session_id: "session-1".to_string(),
+            session_key: "session-1".to_string(),
+            project_path: String::new(),
+            model: "grok-4.6".to_string(),
+            prompt_tokens: 100,
+            cached_prompt_tokens: 0,
+            completion_tokens: 10,
+            reasoning_tokens: 0,
+        },
+        InferenceRecord {
+            event_key: "second".to_string(),
+            timestamp: "2026-08-21T06:00:00Z".to_string(),
+            session_id: "session-1".to_string(),
+            session_key: "session-1".to_string(),
+            project_path: String::new(),
+            model: "grok-4.6".to_string(),
+            prompt_tokens: 200,
+            cached_prompt_tokens: 0,
+            completion_tokens: 20,
+            reasoning_tokens: 0,
+        },
+    ];
+    let since = "2026-08-21T05:30:00Z"
+        .parse::<DateTime<Utc>>()
+        .expect("valid since")
+        .timestamp_millis();
+    let until = "2026-08-21T06:30:00Z"
+        .parse::<DateTime<Utc>>()
+        .expect("valid until")
+        .timestamp_millis();
+    let filter = DateFilter::new(None, None).with_timestamp_range(since, until);
+
+    assert_eq!(priced_tokens_in_records(records, &filter, tz()), 220);
+}

--- a/src/source/loader.rs
+++ b/src/source/loader.rs
@@ -118,7 +118,7 @@ impl<'a> DataLoader<'a> {
                     };
                     entry.timestamp_ms = utc_dt.timestamp_millis();
                 }
-                if !filter.contains_timestamp(entry.timestamp_ms) {
+                if !filter.contains_entry_timestamp(&entry.timestamp, entry.timestamp_ms) {
                     continue;
                 }
                 if Self::parse_date_parts_fast(&entry.date_str).is_none() {

--- a/src/source/loader.rs
+++ b/src/source/loader.rs
@@ -111,6 +111,30 @@ impl<'a> DataLoader<'a> {
 
         let mut filtered = Vec::new();
         for mut entry in entries {
+            if filter.has_timestamp_range() {
+                if entry.timestamp_ms == 0 {
+                    let Ok(utc_dt) = entry.timestamp.parse::<DateTime<Utc>>() else {
+                        continue;
+                    };
+                    entry.timestamp_ms = utc_dt.timestamp_millis();
+                }
+                if !filter.contains_timestamp(entry.timestamp_ms) {
+                    continue;
+                }
+                if Self::parse_date_parts_fast(&entry.date_str).is_none() {
+                    let Some(utc_dt) = DateTime::<Utc>::from_timestamp_millis(entry.timestamp_ms)
+                    else {
+                        continue;
+                    };
+                    entry.date_str = timezone
+                        .to_fixed_offset(utc_dt)
+                        .date_naive()
+                        .format(DATE_FORMAT)
+                        .to_string();
+                }
+                filtered.push(entry);
+                continue;
+            }
             if Self::parse_date_parts_fast(&entry.date_str).is_some() {
                 if Self::date_str_in_filter(&entry.date_str, since_key, until_key) {
                     filtered.push(entry);
@@ -517,41 +541,6 @@ pub(crate) fn load_blocks(
     loader.load_blocks(filter, timezone)
 }
 
-/// Convenience function to load tool calls for a source with tool-call support.
-pub(crate) fn load_tool_calls(
-    source: &dyn Source,
-    filter: &DateFilter,
-    timezone: Timezone,
-) -> Vec<crate::core::ToolCall> {
-    if !source.capabilities().has_tool_calls {
-        return Vec::new();
-    }
-
-    let files = source.find_tool_call_files();
-    if files.is_empty() {
-        return Vec::new();
-    }
-
-    eprintln!("Scanning {} files for tool usage...", files.len());
-
-    let all_calls: Vec<crate::core::ToolCall> = files
-        .par_iter()
-        .flat_map(|path| {
-            let calls = source.parse_tool_call_file(path, timezone);
-            calls
-                .into_iter()
-                .filter(|c| {
-                    chrono::NaiveDate::parse_from_str(&c.date_str, crate::consts::DATE_FORMAT)
-                        .is_ok_and(|d| filter.contains(d))
-                })
-                .collect::<Vec<_>>()
-        })
-        .collect();
-
-    eprintln!("Found {} tool calls", all_calls.len());
-    all_calls
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -788,10 +777,6 @@ mod tests {
         assert_eq!(target.models["other-model"].input_tokens, 200);
     }
 }
-
-#[cfg(test)]
-#[path = "loader_tool_tests.rs"]
-mod loader_tool_tests;
 
 #[cfg(test)]
 #[path = "loader_quality_tests.rs"]

--- a/src/source/loader_quality_tests.rs
+++ b/src/source/loader_quality_tests.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use chrono::NaiveDate;
+use chrono::{DateTime, NaiveDate, Utc};
 
 use crate::core::{DateFilter, RawEntry};
 use crate::source::{Capabilities, ParseOutput, Source};
@@ -66,6 +66,17 @@ fn entry(id: &str, input_tokens: i64) -> RawEntry {
     }
 }
 
+fn entry_at(id: &str, timestamp: &str) -> RawEntry {
+    let mut entry = entry(id, 10);
+    entry.timestamp = timestamp.to_string();
+    entry.timestamp_ms = timestamp
+        .parse::<DateTime<Utc>>()
+        .expect("valid timestamp")
+        .timestamp_millis();
+    entry.date_str = "2026-08-21".to_string();
+    entry
+}
+
 fn filter() -> DateFilter {
     DateFilter::new(
         NaiveDate::from_ymd_opt(2026, 2, 6),
@@ -108,4 +119,38 @@ fn load_daily_dedup_reports_skipped_and_parse_errors() {
     assert_eq!(result.valid, 1);
     assert_eq!(result.skipped, 1);
     assert_eq!(result.parse_errors, 3);
+}
+
+#[test]
+fn load_daily_honors_exact_timestamp_bounds() {
+    let since = "2026-08-21T05:41:00Z"
+        .parse::<DateTime<Utc>>()
+        .expect("valid since")
+        .timestamp_millis();
+    let until = "2026-08-21T05:43:00Z"
+        .parse::<DateTime<Utc>>()
+        .expect("valid until")
+        .timestamp_millis();
+    let source = TestSource {
+        needs_dedup: false,
+        files: vec![(
+            PathBuf::from("grok-ledger.jsonl"),
+            {
+                let mut inside = entry_at("inside", "2026-08-21T05:42:00Z");
+                inside.date_str = "invalid".to_string();
+                vec![
+                    entry_at("before", "2026-08-21T05:40:00Z"),
+                    inside,
+                    entry_at("after", "2026-08-21T05:44:00Z"),
+                ]
+            },
+            0,
+        )],
+    };
+    let filter = DateFilter::new(None, None).with_timestamp_range(since, until);
+
+    let result = load_daily(&source, &filter, tz(), true, false);
+
+    assert_eq!(result.valid, 1);
+    assert_eq!(result.day_stats["2026-08-21"].stats.input_tokens, 10);
 }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -10,6 +10,7 @@ mod grok;
 mod kimi;
 mod loader;
 mod registry;
+mod tool_loader;
 
 use std::path::{Path, PathBuf};
 
@@ -152,7 +153,8 @@ pub(crate) fn all_capabilities() -> Capabilities {
 }
 
 // Re-export loader functions
-pub(crate) use loader::{load_blocks, load_daily, load_projects, load_sessions, load_tool_calls};
+pub(crate) use loader::{load_blocks, load_daily, load_projects, load_sessions};
+pub(crate) use tool_loader::load_tool_calls;
 
 /// Load per-endpoint stats (native vs proxy) for a source. Claude-only; other
 /// sources return empty. Lives here (not in `loader.rs`) to keep that file

--- a/src/source/tool_loader.rs
+++ b/src/source/tool_loader.rs
@@ -1,0 +1,44 @@
+use rayon::prelude::*;
+
+use crate::core::{DateFilter, ToolCall};
+use crate::source::Source;
+use crate::utils::Timezone;
+
+/// Load tool calls for a source with tool-call support.
+pub(crate) fn load_tool_calls(
+    source: &dyn Source,
+    filter: &DateFilter,
+    timezone: Timezone,
+) -> Vec<ToolCall> {
+    if !source.capabilities().has_tool_calls {
+        return Vec::new();
+    }
+
+    let files = source.find_tool_call_files();
+    if files.is_empty() {
+        return Vec::new();
+    }
+
+    eprintln!("Scanning {} files for tool usage...", files.len());
+
+    let all_calls = files
+        .par_iter()
+        .flat_map(|path| {
+            source
+                .parse_tool_call_file(path, timezone)
+                .into_iter()
+                .filter(|call| {
+                    chrono::NaiveDate::parse_from_str(&call.date_str, crate::consts::DATE_FORMAT)
+                        .is_ok_and(|date| filter.contains(date))
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<ToolCall>>();
+
+    eprintln!("Found {} tool calls", all_calls.len());
+    all_calls
+}
+
+#[cfg(test)]
+#[path = "loader_tool_tests.rs"]
+mod tests;

--- a/tests/sdk_integration.rs
+++ b/tests/sdk_integration.rs
@@ -666,6 +666,17 @@ fn sdk_summarizes_grok_context_tokens_without_running_cli() {
         ..SummaryOptions::default()
     })
     .expect("summarize grok");
+    let outside_window = summarize_cost(SummaryOptions {
+        source: UsageSource::Grok,
+        range: UsageRange::TimestampRange {
+            since: "2026-02-06T11:00:00Z".parse().expect("valid since"),
+            until: "2026-02-06T12:00:00Z".parse().expect("valid until"),
+        },
+        timezone: Some("UTC".to_string()),
+        offline: true,
+        ..SummaryOptions::default()
+    })
+    .expect("summarize exact Grok window");
 
     match previous_grok_home {
         Some(value) => unsafe {
@@ -693,4 +704,6 @@ fn sdk_summarizes_grok_context_tokens_without_running_cli() {
         summary.models[0].estimated_cost_usd,
         summary.models[0].cost_usd
     );
+    assert_eq!(outside_window.valid_entries, 0);
+    assert_eq!(outside_window.tokens.total_tokens, 0);
 }

--- a/tests/sdk_integration.rs
+++ b/tests/sdk_integration.rs
@@ -633,6 +633,57 @@ fn sdk_batch_respects_timezone_boundaries_like_single_range() {
 }
 
 #[test]
+fn sdk_exact_ranges_preserve_submillisecond_boundaries() {
+    let _guard = ENV_LOCK.lock().expect("env lock");
+    let root = tempfile::tempdir().expect("temp dir");
+    let codex_home = root.path().join("codex-home");
+    let session_file = codex_home.join("sessions").join("submillisecond.jsonl");
+    write_file(
+        &session_file,
+        r#"{"timestamp":"2026-08-21T05:41:00.000100Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":0,"output_tokens":10,"reasoning_output_tokens":0,"total_tokens":110},"last_token_usage":{"input_tokens":100,"cached_input_tokens":0,"output_tokens":10,"reasoning_output_tokens":0,"total_tokens":110},"model":"gpt-5"}}}
+"#,
+    );
+    let range = UsageRange::TimestampRange {
+        since: "2026-08-21T05:41:00.000200Z".parse().expect("valid since"),
+        until: "2026-08-21T05:41:00.000300Z".parse().expect("valid until"),
+    };
+    let previous_codex_home = std::env::var_os("CODEX_HOME");
+    unsafe {
+        std::env::set_var("CODEX_HOME", &codex_home);
+    }
+
+    let single = summarize_cost(SummaryOptions {
+        source: UsageSource::Codex,
+        range: range.clone(),
+        timezone: Some("UTC".to_string()),
+        offline: true,
+        ..SummaryOptions::default()
+    })
+    .expect("summarize exact range");
+    let batch = summarize_cost_ranges(MultiSummaryOptions {
+        source: UsageSource::Codex,
+        ranges: vec![range],
+        timezone: Some("UTC".to_string()),
+        offline: true,
+        strict_pricing: false,
+        currency: None,
+    })
+    .expect("summarize exact range batch");
+
+    match previous_codex_home {
+        Some(value) => unsafe {
+            std::env::set_var("CODEX_HOME", value);
+        },
+        None => unsafe {
+            std::env::remove_var("CODEX_HOME");
+        },
+    }
+
+    assert_eq!(single.valid_entries, 0);
+    assert_eq!(batch.summaries[0].valid_entries, 0);
+}
+
+#[test]
 fn sdk_summarizes_grok_context_tokens_without_running_cli() {
     let _guard = ENV_LOCK.lock().expect("env lock");
     let root = tempfile::tempdir().expect("temp dir");


### PR DESCRIPTION
## What

- Move the Grok inference ledger from cache storage to durable application data.
- Serialize concurrent ledger updates with a file lock.
- Fail clearly on malformed or truncated live/ledger data instead of returning stale or partial totals.
- Require the fields needed for reliable inference accounting and attribute each inference to the model active at that time.
- Add exact UTC timestamp windows to single and batch SDK queries, Cursor request bounds, and Grok cost coverage.
- Extract tool-log discovery from the already-large source loader.

## Why

#114 fixes the Grok complete-token/API-cost double-counting model. This follow-up hardens the persistence and ingestion paths around that model and makes exact quota windows available through the SDK.

This PR is stacked on #114. After #114 merges, it can be retargeted to `main`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-targets --all-features --quiet`

Closes #116
Depends on #114