### PR TITLE
feat: add MiMo, Kilo CLI, Senpi, and Kimchi usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,7 @@ dependencies = [
  "comfy-table",
  "dirs",
  "glob",
+ "jsonc-parser",
  "rayon",
  "rusqlite",
  "serde",
@@ -691,6 +692,15 @@ checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonc-parser"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0560e3f9a9a03ea6b6e90b41138c5db9e21526c99eb192c1a26c68176593285"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ ureq = { version = "3.2.0", features = ["json"] }
 thiserror = "2"
 toml = "1.0.0"
 rusqlite = { version = "0.40.2", features = ["bundled"] }
+jsonc-parser = { version = "0.33.1", features = ["serde"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![ccstats token and cost analytics card](docs/branding/readme-card.png)
 
-`ccstats` is a fast CLI for token and cost usage analytics across 15 local AI coding-agent data sources.
+`ccstats` is a fast CLI for token and cost usage analytics across 19 local AI coding-agent data sources.
 
 Search keywords: `claude code usage stats`, `codex usage stats`, `cursor usage stats`, `token usage cli`, `ai token cost tracker`.
 
@@ -21,7 +21,8 @@ Search keywords: `claude code usage stats`, `codex usage stats`, `cursor usage s
 - Kimi Code support (`~/.kimi-code/sessions/`)
 - Gemini CLI, Amp, and Qwen Code support
 - Cline CLI plus Cline, Roo Code, and Kilo Code VS Code extension support
-- OpenCode SQLite and Pi coding-agent JSONL support
+- OpenCode, MiMo Code, and Kilo CLI SQLite support
+- Pi, Senpi, and Kimchi coding-agent JSONL support
 - GitHub Copilot CLI OpenTelemetry and Goose per-call ledger support
 - Daily/weekly/monthly/project/session views
 - Top-N leaderboard ranking models or projects by cost share
@@ -139,7 +140,11 @@ ccstats daily --source cline
 ccstats daily --source roocode
 ccstats daily --source kilocode
 ccstats daily --source opencode
+ccstats daily --source mimocode
+ccstats daily --source kilo
 ccstats daily --source pi
+ccstats daily --source senpi
+ccstats daily --source kimchi
 ccstats daily --source copilot
 ccstats daily --source goose
 ```
@@ -148,8 +153,10 @@ Gemini reads both chat JSON and headless JSONL usage. Amp reconciles its usage
 ledger with assistant-message usage without double counting. Qwen reads its
 native usage ledger and separates cached input from uncached input. Cline reads
 both CLI sessions and its VS Code extension task logs; Roo Code and Kilo Code
-use the same extension-log algorithm. OpenCode, Pi, and provider-reported Goose
-ledger rows preserve positive client-recorded USD cost. Copilot's documented
+use the same extension-log algorithm. The OpenCode family reconciles dual
+schemas and fork-copied history; the Pi family counts each format's independent
+LLM calls without adding child rollups twice. Source-recorded OpenCode-family,
+Pi-family, and provider-reported Goose ledger costs retain their provenance. Copilot's documented
 monetary field has no published currency code, so it remains separate from
 ccstats' USD estimate instead of being mislabeled.
 
@@ -502,7 +509,11 @@ ccstats daily --source cline
 ccstats daily --source roocode
 ccstats daily --source kilocode
 ccstats daily --source opencode
+ccstats daily --source mimocode
+ccstats daily --source kilo
 ccstats daily --source pi
+ccstats daily --source senpi
+ccstats daily --source kimchi
 
 # Offline mode (use cached pricing)
 ccstats today -O
@@ -564,7 +575,7 @@ Supported keys:
 | `timezone` | string | IANA timezone such as `UTC` or `Asia/Shanghai` |
 | `locale` | string | Locale used for number formatting, such as `en` or `de` |
 | `currency` | string | Currency code such as `USD`, `CNY`, or `EUR` |
-| `source` | string | Source name or alias such as `claude`, `codex`, `gemini`, `cline`, `opencode`, `pi`, `copilot`, `goose`, or `all` |
+| `source` | string | Source name or alias such as `claude`, `codex`, `opencode`, `mimocode`, `kilo`, `pi`, `senpi`, `kimchi`, `copilot`, `goose`, or `all` |
 
 Source root env overrides are independent of config keys:
 
@@ -580,12 +591,19 @@ Source root env overrides are independent of config keys:
 | Qwen Code | `QWEN_RUNTIME_DIR`, then `QWEN_HOME` | Qwen root containing `usage/` | `~/.qwen` |
 | Cline CLI | `CLINE_SESSION_DATA_DIR` | Cline session directory | `~/.cline/data/sessions` |
 | OpenCode | `OPENCODE_DB`; data root follows `XDG_DATA_HOME` | Exact database path, or relative name inside the OpenCode data directory | Platform data directory under `opencode/opencode*.db` |
+| MiMo Code | `MIMOCODE_DB`; `MIMOCODE_HOME`; data root follows `XDG_DATA_HOME` | Exact database path, or MiMo home containing `data/` | `~/.local/share/mimocode/mimocode*.db` |
+| Kilo CLI | `KILO_DB`; data root follows `XDG_DATA_HOME` | Exact database path, or relative name inside the Kilo data directory | `~/.local/share/kilo/kilo*.db` plus legacy channel databases |
 | Pi | `PI_CODING_AGENT_SESSION_DIR`, then `PI_CODING_AGENT_DIR` | Exact sessions directory, or agent directory containing `sessions/` | `~/.pi/agent/sessions` |
+| Senpi | `SENPI_CODING_AGENT_SESSION_DIR`, then `SENPI_CODING_AGENT_DIR` | Exact sessions directory, or agent directory containing `sessions/`; `~` is expanded | Nearest project `.senpi/agent/sessions`, then `~/.senpi/agent/sessions` |
+| Kimchi | — | Fixed by the Kimchi launcher | `~/.config/kimchi/harness/sessions` |
 | GitHub Copilot CLI | `COPILOT_OTEL_FILE_EXPORTER_PATH` | Exact OTel JSONL exporter file | Also scans `~/.copilot/otel/**/*.jsonl` |
 | Goose | `GOOSE_PATH_ROOT`; data root follows `XDG_DATA_HOME` | Absolute Goose path root containing `data/sessions/sessions.db` | `~/.local/share/goose/sessions/sessions.db` |
 
 Cline also recognizes `CLINE_DATA_DIR` and `CLINE_DIR`. Roo Code and Kilo Code
 currently use their standard local directories.
+Senpi `settings.json`/`settings.jsonc` `sessionDir` is discovered automatically. If it was launched
+with the one-off `--session-dir` flag, set `SENPI_CODING_AGENT_SESSION_DIR` to
+that same directory for ccstats.
 
 ### Session CSV Columns
 
@@ -608,7 +626,8 @@ cache_read / (input + cache_creation + cache_read) * 100
 Table output uses one decimal place and a `%` suffix. JSON uses the numeric
 `cache_hit_rate` field, while CSV uses a two-decimal `cache_hit_rate` column.
 Claude, Codex, Cursor, Grok, Kimi Code, Gemini CLI, Amp, Qwen Code, Cline, Roo
-Code, Kilo Code, OpenCode, Pi, GitHub Copilot CLI, and Goose expose the required
+Code, Kilo Code, OpenCode, MiMo Code, Kilo CLI, Pi, Senpi, Kimchi, GitHub
+Copilot CLI, and Goose expose the required
 cache-read metric. Mixed `--source all` output reports the aggregate rate across
 all selected usage.
 
@@ -637,7 +656,11 @@ Warning: ignored <N> malformed records
 | Roo Code | VS Code global storage | — | Extension task usage, Cache tokens |
 | Kilo Code | VS Code global storage | — | Extension task usage, Cache tokens |
 | OpenCode | Platform data directory under `opencode/opencode*.db` | `OPENCODE_DB`, `XDG_DATA_HOME` | Projects, reasoning/cache tokens, recorded cost, cross-schema deduplication |
+| MiMo Code | `~/.local/share/mimocode/mimocode*.db` | `MIMOCODE_DB`, `MIMOCODE_HOME`, `XDG_DATA_HOME` | Projects, reasoning/cache tokens, recorded cost, fork-copy timestamp reconciliation |
+| Kilo CLI | `~/.local/share/kilo/kilo*.db` | `KILO_DB`, `XDG_DATA_HOME` | Current + legacy message schemas, recorded cost, fork-copy timestamp reconciliation |
 | Pi | `~/.pi/agent/sessions/**/*.jsonl` | `PI_CODING_AGENT_SESSION_DIR`, `PI_CODING_AGENT_DIR` | Projects, assistant + summary usage, cache tokens, branch-copy deduplication |
+| Senpi | `~/.senpi/agent/sessions/**/*.jsonl` | `SENPI_CODING_AGENT_SESSION_DIR`, `SENPI_CODING_AGENT_DIR` | Assistant, compaction, branch summary, and tool-result usage with branch-copy deduplication |
+| Kimchi | `~/.config/kimchi/harness/sessions/**/*.jsonl` | — | Child transcripts plus remote/missing-child `details.tokenUsage` fallback without rollup double counting |
 | GitHub Copilot CLI | `~/.copilot/otel/**/*.jsonl` | `COPILOT_OTEL_FILE_EXPORTER_PATH` | Per-request `chat` spans, reasoning/cache normalization, cross-file deduplication |
 | Goose | `~/.local/share/goose/sessions/sessions.db` | `GOOSE_PATH_ROOT`, `XDG_DATA_HOME` | Per-call ledger, Projects, cache tokens, provider-reported cost provenance |
 

--- a/docs/algorithm/authoritative-token-accounting.md
+++ b/docs/algorithm/authoritative-token-accounting.md
@@ -62,7 +62,11 @@ cost = "show"
 | Qwen Code | `QWEN_RUNTIME_DIR`，其次 `QWEN_HOME` | 包含 `usage/` 的 Qwen 根目录 | `~/.qwen` |
 | Cline CLI | `CLINE_SESSION_DATA_DIR`，另支持 `CLINE_DATA_DIR`、`CLINE_DIR` | Cline session 目录或数据根目录 | `~/.cline/data/sessions` |
 | OpenCode | `OPENCODE_DB`，数据根目录遵循 `XDG_DATA_HOME` | 数据库绝对路径，或 OpenCode 数据目录内的相对文件名 | 平台 data dir 下的 `opencode/opencode*.db` |
+| MiMo Code | `MIMOCODE_DB`；`MIMOCODE_HOME`；数据根目录遵循 `XDG_DATA_HOME` | 数据库绝对路径，或包含 `data/` 的 MiMo home | `~/.local/share/mimocode/mimocode*.db` |
+| Kilo CLI | `KILO_DB`，数据根目录遵循 `XDG_DATA_HOME` | 数据库绝对路径，或 Kilo data directory 内的相对文件名 | `~/.local/share/kilo/kilo*.db`，并扫描 legacy channel 数据库 |
 | Pi | `PI_CODING_AGENT_SESSION_DIR`，其次 `PI_CODING_AGENT_DIR` | sessions 目录，或包含 `sessions/` 的 agent 目录 | `~/.pi/agent/sessions` |
+| Senpi | `SENPI_CODING_AGENT_SESSION_DIR`，其次 `SENPI_CODING_AGENT_DIR` | sessions 目录，或包含 `sessions/` 的 agent 目录；展开 `~` | 最近的项目 `.senpi/agent/sessions`，其次 `~/.senpi/agent/sessions` |
+| Kimchi | 无 | launcher 固定目录 | `~/.config/kimchi/harness/sessions` |
 | GitHub Copilot CLI | `COPILOT_OTEL_FILE_EXPORTER_PATH` | OTel file exporter 的 JSONL 文件 | 另扫描 `~/.copilot/otel/**/*.jsonl` |
 | Goose | `GOOSE_PATH_ROOT`，数据根目录遵循 `XDG_DATA_HOME` | 包含 `data/sessions/sessions.db` 的绝对 path root | `~/.local/share/goose/sessions/sessions.db` |
 
@@ -315,6 +319,12 @@ OpenCode 写入端已经从 inclusive input 中扣除了 cache read/write，并�
 
 同一个消息可能同时存在于两张表或多个 channel 数据库。ccstats 使用 source-wide message ID 去重，优先完成记录；session directory 用于项目聚合。损坏 JSON、负 token、无效时间或数据库读取失败都会计入 parse error。
 
+### MiMo Code 与 Kilo CLI
+
+MiMo Code 和 Kilo CLI 复用 OpenCode 消息族的五个独立 token 桶，但目录、schema 和 fork 行为分别由各自当前源码确定。MiMo Code 读取 `message`；Kilo CLI 同时读取 legacy `message` 与当前 `session_message`。官方 fork 不持久化 parent ID，但复制消息会保留原 `message.time.created`，而新 session 有更晚的 `session.time_created`。ccstats 只把“消息早于所属 session”视为 copy 候选，并要求同数据库中同模型、同毫秒时间和同五桶的唯一原 session 同时存在才去重。directory 不参与 key，因为官方允许跨目录 fork；原 session 后来被删除时，两份以上相同 copy 仍归一为一份。这样保留 fork 后的新调用，也避免普通的相似调用被误删。
+
+MiMo Code 和 Kilo CLI 的持久化 `cost` 是来源记录值，可能来自上游响应或本地计算；ccstats 保留其 provenance，不把它描述成 provider 发票。与 OpenCode 不同，这两个 fork 的显式零值有格式语义并会保留。数据库 schema 缺失、session creation time 读取失败、非法成本或 token 会明确计入 parse error。
+
 ---
 
 ## Pi
@@ -323,11 +333,12 @@ OpenCode 写入端已经从 inclusive input 中扣除了 cache read/write，并�
 
 Pi 默认写入 `~/.pi/agent/sessions/<encoded-cwd>/*.jsonl`。显式 `PI_CODING_AGENT_SESSION_DIR` 优先，其次是 `PI_CODING_AGENT_DIR/sessions`。
 
-统计三类带 usage 的真实 LLM 调用：
+统计四类带 usage 的真实 LLM 调用：
 
 1. assistant message；
 2. compaction summary；
-3. branch summary。
+3. branch summary；
+4. `toolResult.message.usage` 中的子调用汇总。
 
 ```text
 input_tokens       ← usage.input
@@ -340,6 +351,12 @@ cache_read         ← usage.cacheRead
 Pi 官方定义明确说明 `usage.reasoning` 已包含在 `usage.output` 中，所以不能再放入 additive reasoning 桶。summary 记录没有自己的 model 字段时，使用此前最近一次 `model_change` 或 assistant 明确记录的模型；仍无法确定时明确归入 `unknown`。
 
 Pi 的“创建分支 session”会把已有路径复制到新 JSONL，但保留原 entry ID。ccstats 以 source-wide entry ID 去重，既保留新分支之后产生的调用，也不会把复制的历史再次计费。正的 `usage.cost.total` 保存为 client-recorded USD。
+
+### Senpi 与 Kimchi
+
+Senpi 使用 Pi v3 的四类 usage carrier 和相同的 branch-copy entry ID，因此沿用相同的 token 归一化与 source-wide 去重。发现顺序支持显式 session/agent env、从当前目录向上查找的非 symlink 项目 `.senpi/agent`、project/global `settings.jsonc` 或 `settings.json` 的 `sessionDir`，以及 home 默认目录；JSONC 支持 BOM、注释和尾逗号，project 的 null/空串会重置 global 值，路径会展开 `~`。一次性的 `--session-dir` 不会持久化，需把同值传给 `SENPI_CODING_AGENT_SESSION_DIR`。
+
+Kimchi 的 child transcript 是真实独立调用，而 parent tool result 的 `details.tokenUsage` 是同一 child 的累计回传。`details.sessionFile` 指向且 child 能通过正式 session/header/timestamp/cost 校验产出 `RawEntry` 时，ccstats 统计 child 并忽略 parent rollup；只有 header、无有效 usage、child 未落盘或 remote agent 没有 session file 时，统计 parent details 作为权威 fallback。Kimchi launcher 固定 session 路径，因此不暴露一个实际上不会生效的目录覆盖项。
 
 ---
 

--- a/docs/research/provider-algorithm-audit-2026-08-31.md
+++ b/docs/research/provider-algorithm-audit-2026-08-31.md
@@ -13,6 +13,7 @@
 7. OpenCode 与 Pi 已取得当前官方写入端源码证据，可以进入实现。Pi 官方还会给 compaction / branch summary 保存独立 usage，Tokscale 当前普通 Pi parser 未统计这两类真实调用；ccstats 应补上而不是继承这个遗漏。
 8. Copilot CLI 官方将一次 LLM 请求定义为一条 `chat` span；Tokscale 只从 input 扣 cache read、也不从 output 扣 reasoning，会重复计算 cache creation 与 reasoning。ccstats 同时拆除两个 inclusive 子集，并忽略 `invoke_agent` 汇总。
 9. Goose 最新权威数据是 schema v15+ `usage_ledger`。Tokscale 仍读取 session 累计快照、把整段用量记到 session 创建日，并用 total 差额猜 reasoning；ccstats 改读逐调用 ledger，保留 cache、项目、模型、时间和 cost provenance。
+10. MiMo Code、Kilo CLI、Senpi、Kimchi 已逐一核对当前写入端并实现；它们共享基础格式，但 fork 复制、双 schema、tool-result rollup 和目录语义不同。GJC、Prime Agent、Oh My Pi 已确认存在额外聚合层，不能作为普通 Pi 记录直接相加，当前明确不宣称支持。
 
 ## 证据等级
 
@@ -43,6 +44,13 @@
 | [Pi](https://github.com/earendil-works/pi/tree/853a80d26c90a14c1886f0ebb8ffaae133ca2185) | `853a80d` | 当前 JSONL session schema、usage/cost 语义、目录环境变量 |
 | [GitHub Copilot CLI](https://github.com/github/copilot-cli/tree/be82101e70f0253b57519bebb9cc9d0f6dfb2ed2) | `be82101` | 当前 OTel 版本与字段变更记录；公开仓库不含运行时源码 |
 | [Goose](https://github.com/aaif-goose/goose/tree/8ae4e4ba02836529790f47109b8785e8b42843a7) | `8ae4e4b` | 当前 SQLite schema、usage ledger、cache/cost 语义与路径 |
+| [MiMo Code](https://github.com/XiaomiMiMo/MiMo-Code/tree/be5af909aeccdeb1b707ac4c5f9214e6fe4b8d2b) | `be5af90` | OpenCode fork 的 DB 路径、message/session 时间、fork copy 与 cost 写入 |
+| [Kilo CLI](https://github.com/Kilo-Org/kilocode/tree/bbf6a278d791842ababfbc8d58f902cb0f6b9bf4) | `bbf6a27` | Kilo DB 路径、legacy/current 双表与 fork copy 行为 |
+| [Senpi](https://github.com/code-yeongyu/senpi/tree/7ac3cf302950a4b258421748f944ed1281007c4b) | `7ac3cf3` | Pi v3 session 目录、四类 usage carrier 与 branch copy |
+| [Kimchi](https://github.com/getkimchi/kimchi/tree/eacd20f15c2e2ed2b8d24fc52f08fa7638b8f759) | `eacd20f` | 固定 session 目录、child transcript 与 parent rollup 关系 |
+| [GJC](https://github.com/Yeachan-Heo/gajae-code/tree/7d23ed3d9e8cb6e5062ba2840462d59fe18eb784) | `7d23ed3` | 当前 v5 stats parser，证明其已偏离普通 Pi v3 |
+| [Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent/tree/c382f09856d4a8c8d2b765179657047d58691f25) | `c382f09` | parent aggregate、child transcript 与 fork aggregate 的 RLM 语义 |
+| [Oh My Pi](https://github.com/can1357/oh-my-pi/tree/969062200754ea02cfac922e5ebb8c608c079e15) | `9690622` | profile/XDG 路径、child transcript、parent task rollup 与 orchestration usage |
 
 官方 schema 证据：
 
@@ -56,6 +64,10 @@
 - [Pi session schema](https://github.com/earendil-works/pi/blob/853a80d26c90a14c1886f0ebb8ffaae133ca2185/packages/coding-agent/src/core/session-manager.ts) 证明 assistant message、compaction 与 branch summary 都可能携带 usage；后两者是独立 LLM 调用，不应静默丢弃。
 - [Copilot CLI OTel 官方文档](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference#opentelemetry-monitoring) 定义 file exporter、每请求一条 `chat` span、累计 `invoke_agent` span，以及当前 token/cache/cost 属性；[OpenTelemetry GenAI registry](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/) 定义 cache/reasoning detail bucket 的语义。
 - [Goose `Usage`](https://github.com/aaif-goose/goose/blob/8ae4e4ba02836529790f47109b8785e8b42843a7/crates/goose-provider-types/src/conversation/token_usage.rs) 明确 input 包含 cache read/write；[`session_manager`](https://github.com/aaif-goose/goose/blob/8ae4e4ba02836529790f47109b8785e8b42843a7/crates/goose/src/session/session_manager.rs) 定义 schema v16 `usage_ledger`、逐调用 model/time/cache/cost 与 session project。
+- [MiMo Code session schema](https://github.com/XiaomiMiMo/MiMo-Code/blob/be5af909aeccdeb1b707ac4c5f9214e6fe4b8d2b/packages/opencode/src/session/session.sql.ts) 与 [fork 实现](https://github.com/XiaomiMiMo/MiMo-Code/blob/be5af909aeccdeb1b707ac4c5f9214e6fe4b8d2b/packages/opencode/src/session/session.ts) 证明消息/session creation time；fork 会复制 usage、保留原消息时间并改写消息 ID，但不写 parent ID。
+- [Kilo CLI schema](https://github.com/Kilo-Org/kilocode/blob/bbf6a278d791842ababfbc8d58f902cb0f6b9bf4/packages/core/src/session/sql.ts) 同时定义 `message` 与 `session_message`，[fork 实现](https://github.com/Kilo-Org/kilocode/blob/bbf6a278d791842ababfbc8d58f902cb0f6b9bf4/packages/opencode/src/session/session.ts) 证明复制历史使用新 ID 且 copied cost 归零。
+- [Senpi session format](https://github.com/code-yeongyu/senpi/blob/7ac3cf302950a4b258421748f944ed1281007c4b/packages/coding-agent/docs/session-format.md) 与 [session manager](https://github.com/code-yeongyu/senpi/blob/7ac3cf302950a4b258421748f944ed1281007c4b/packages/coding-agent/src/core/session-manager.ts) 证明 assistant、compaction、branch summary、tool-result usage 和 branch-copy ID。
+- [Kimchi child writer](https://github.com/getkimchi/kimchi/blob/eacd20f15c2e2ed2b8d24fc52f08fa7638b8f759/src/extensions/agents/manager/session-file.ts) 与 [launcher](https://github.com/getkimchi/kimchi/blob/eacd20f15c2e2ed2b8d24fc52f08fa7638b8f759/src/entry.ts) 证明 child transcript 独立落盘、parent tool-result 只是 rollup，而且目录被 launcher 固定。
 
 ## Tokscale 52-client 差距分解
 
@@ -64,8 +76,8 @@ Tokscale 的 registry 数量适合衡量发现覆盖面，不适合直接衡量�
 | 分组 | 代表 client | 算法关系 | ccstats 决策 |
 |---|---|---|---|
 | 已覆盖且已审计 | Claude、Codex、Cursor、Gemini、Amp、Kimi、Qwen、Cline、Roo、Kilo Code、Grok | 11 个现有 source | 保持逐来源证据，不回退为通用 extractor |
-| OpenCode SQLite 族 | OpenCode、MiMo Code、Kilo CLI | 同一消息 payload，路径、表版本、成本 provenance 有差异 | 先实现官方 OpenCode；fork 在取得当前写入端 fixture 后复用已验证映射 |
-| Pi JSONL 族 | Pi、GJC、Senpi、Kimchi、Prime Agent、Oh My Pi | 基础 assistant usage 相同；Prime 另有 child/aggregate reconciliation | 先实现官方 Pi 并覆盖 summary usage；fork 分别验证目录与额外记账 |
+| OpenCode SQLite 族 | OpenCode、MiMo Code、Kilo CLI | 同一消息 payload，路径、表版本、成本 provenance 和 fork ID 有差异 | 三者已按各自当前 schema 实现；MiMo/Kilo 用 message/session creation time 识别复制历史 |
+| Pi JSONL 族 | Pi、GJC、Senpi、Kimchi、Prime Agent、Oh My Pi | 基础 assistant usage 相近；子调用与聚合层并不相同 | Pi/Senpi/Kimchi 已实现；GJC/Prime/OMP 等各自专用 reconciliation 后再接入 |
 | 本批新增的独立格式 | GitHub Copilot CLI、Goose | Copilot 是每调用 OTel span；Goose 是 SQLite usage ledger | 已实现，且不与 aggregate span、session snapshot 或 premium request quota 混算 |
 | 独立本地格式候选 | Droid、OpenClaw、Mux、Crush、Hermes、Codebuff、Zed、Kiro、Trae、Warp、Junie、Augment 等 | JSONL、SQLite、IDE cache 混合 | 逐个取得官方 schema 或真实 fixture 后进入 |
 | 产品层而非 token parser | usage/quota、headless wrapper、profile、leaderboard、device/group、autosubmit、MCP | 系统边界不同 | 单列产品路线；不为追求 source 数量混入核心账本 |
@@ -145,6 +157,10 @@ total = fresh_input + cache_read + cache_write + visible_output + reasoning
 | Pi | JSONL assistant + compaction + branch summary；reasoning 属于 output 子集；branch copy 按 entry ID 去重 | 官方源码已验证 + Tokscale fixture 交叉验证 | 实现为第 13 个 source；补上 Tokscale 普通 Pi parser 未统计的 summary usage |
 | GitHub Copilot CLI | OTel file exporter 的 per-request `chat` span；拆分 cache/reasoning inclusive bucket；trace/span 跨文件去重 | 官方文档已验证 + Tokscale current fixture 交叉验证 | 实现为第 14 个 source；不累计 `invoke_agent`，修复 Tokscale cache creation/reasoning 双计 |
 | Goose | schema v15+ `usage_ledger`；逐调用时间/model/cache/cost，join session project | 官方源码已验证 + Tokscale parser 对比 | 实现为第 15 个 source；不使用 session snapshot，不猜 reasoning，只接受 provider-reported cost provenance |
+| MiMo Code | OpenCode-family `message`；独立 token 桶；按 copy timestamp + model/five-bucket + unique original session 识别新 ID fork copy | 官方源码已验证 | 实现为第 16 个 source；支持跨目录与 original-deleted multi-copy fork，保留显式 recorded cost，包括零值 |
+| Kilo CLI | legacy `message` + current `session_message`；跨表 ID 和 fork lineage 去重 | 官方源码已验证 | 实现为第 17 个 source；同时覆盖当前/旧表，不把 copied-zero history 当新调用 |
+| Senpi | Pi v3 四类 usage carrier；branch copy 保留 entry ID；JSONC settings 合并 | 官方源码已验证 | 实现为第 18 个 source；统计 tool-result 子调用、跨分支去重并发现 project/global sessionDir |
+| Kimchi | parent `details.tokenUsage` + sibling child transcript；remote 没有 session file | 官方源码已验证 | 实现为第 19 个 source；含 usage 的本地 child 优先，header-only/缺失/remote 时 parent details fallback |
 
 ## 本轮采用、适配、拒绝决策
 
@@ -163,6 +179,8 @@ total = fresh_input + cache_read + cache_write + visible_output + reasoning
 - Tokscale 的 Pi assistant 记录筛选；额外统计官方 schema 已证明的 compaction / branch summary usage。
 - Copilot 使用 Tokscale 已观察到的 file-export JSONL 外形和 trace/span 去重思路，但记录选择与字段语义以当前 GitHub/OTel 文档为准。
 - Goose 采用官方 usage ledger，而不是适配 Tokscale 的 session aggregate query。
+- MiMo/Kilo 复用已验证的 OpenCode payload 映射，但分别适配官方路径、双表和 creation-time fork reconciliation。
+- Senpi 复用 Pi v3 的四类 usage carrier；Kimchi 在 sibling child 存在时关闭 parent rollup，缺失/remote 时解析 `details.tokenUsage`。
 
 ### 拒绝
 
@@ -172,6 +190,7 @@ total = fresh_input + cache_read + cache_write + visible_output + reasoning
 - 在没有验证 USD 单位和调用归属时导入 credits/reported cost：即使模型支持 provenance，也会把不同口径的值混在一起。
 - 把 Copilot `invoke_agent` 和 child `chat` 一起相加，或把未声明 currency 的 `github.copilot.cost` 直接标成 USD。
 - 把 Goose `total-input-output` 猜成 reasoning，或把累计 session snapshot 伪装成创建日的一次调用。
+- 把 GJC v5 当普通 Pi v3、把 Prime parent aggregate 与 child/fork transcript 全相加、或把 Oh My Pi task rollup 与 child transcript 全相加。三者需要独立 adapter 和 fixture，不能为增加来源数量静默双计。
 
 ## 后续数据源批次
 
@@ -179,7 +198,7 @@ total = fresh_input + cache_read + cache_write + visible_output + reasoning
 
 1. Batch 1（已完成）：OpenCode + Pi + discovery→parse→aggregate→CLI 端到端矩阵。
 2. Batch 2（已完成）：GitHub Copilot CLI OTel + Goose per-call SQLite ledger。
-3. Batch 3：OpenCode/Pi fork family。逐个确认写入端版本、目录覆盖和 fork 特有的去重/child usage 后复用基准算法。
+3. Batch 3（已完成）：MiMo Code、Kilo CLI、Senpi、Kimchi；逐个验证写入端、目录、fork/child reconciliation 和端到端输出。
 4. Batch 4：Droid、Kiro、Zed、Warp 等独立格式。没有官方 schema 时必须取得匿名化真实 fixture 和第二实现交叉验证。
 5. Product track：桌面应用、quota、实时观测与多机器历史；与 authoritative token ledger 保持 provenance 隔离。
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! `ccstats` is a local-first library and CLI for token and cost analytics from
 //! Claude Code, `OpenAI` Codex, Cursor, Grok, Kimi Code, Gemini CLI, Amp,
-//! Qwen Code, Cline, Roo Code, Kilo Code, `OpenCode`, Pi, GitHub Copilot CLI,
-//! and Goose session logs.
+//! Qwen Code, Cline, Roo Code, Kilo Code, `OpenCode`, `MiMo` Code, Kilo CLI, Pi,
+//! Senpi, Kimchi, GitHub Copilot CLI, and Goose session logs.
 //!
 //! The public SDK entry points are [`summarize_cost`] and
 //! [`summarize_cost_ranges`] for cost analytics, [`load_codex_weekly_quota`]

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -62,8 +62,16 @@ pub enum UsageSource {
     KiloCode,
     /// `OpenCode` messages in its local `SQLite` database.
     OpenCode,
+    /// `MiMo` Code messages in its local `SQLite` database.
+    MiMoCode,
+    /// Kilo CLI messages in its local `SQLite` database.
+    Kilo,
     /// Pi coding-agent JSONL sessions.
     Pi,
+    /// Senpi coding-agent JSONL sessions.
+    Senpi,
+    /// Kimchi harness JSONL sessions.
+    Kimchi,
     /// GitHub Copilot CLI `OpenTelemetry` JSONL spans.
     Copilot,
     /// Goose per-call usage ledger in its local `SQLite` database.
@@ -72,7 +80,7 @@ pub enum UsageSource {
 
 impl UsageSource {
     #[cfg(test)]
-    pub(crate) const VARIANTS: [Self; 15] = [
+    pub(crate) const VARIANTS: [Self; 19] = [
         UsageSource::Claude,
         UsageSource::Codex,
         UsageSource::Cursor,
@@ -85,7 +93,11 @@ impl UsageSource {
         UsageSource::RooCode,
         UsageSource::KiloCode,
         UsageSource::OpenCode,
+        UsageSource::MiMoCode,
+        UsageSource::Kilo,
         UsageSource::Pi,
+        UsageSource::Senpi,
+        UsageSource::Kimchi,
         UsageSource::Copilot,
         UsageSource::Goose,
     ];
@@ -105,7 +117,11 @@ impl UsageSource {
             UsageSource::RooCode => "roocode",
             UsageSource::KiloCode => "kilocode",
             UsageSource::OpenCode => "opencode",
+            UsageSource::MiMoCode => "mimocode",
+            UsageSource::Kilo => "kilo",
             UsageSource::Pi => "pi",
+            UsageSource::Senpi => "senpi",
+            UsageSource::Kimchi => "kimchi",
             UsageSource::Copilot => "copilot",
             UsageSource::Goose => "goose",
         }
@@ -125,7 +141,11 @@ impl UsageSource {
             "roocode" => Some(UsageSource::RooCode),
             "kilocode" => Some(UsageSource::KiloCode),
             "opencode" => Some(UsageSource::OpenCode),
+            "mimocode" => Some(UsageSource::MiMoCode),
+            "kilo" => Some(UsageSource::Kilo),
             "pi" => Some(UsageSource::Pi),
+            "senpi" => Some(UsageSource::Senpi),
+            "kimchi" => Some(UsageSource::Kimchi),
             "copilot" => Some(UsageSource::Copilot),
             "goose" => Some(UsageSource::Goose),
             _ => None,

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -16,7 +16,9 @@ mod grok;
 mod kimi;
 mod loader;
 mod opencode;
+mod opencode_fork;
 mod pi;
+mod pi_paths;
 mod qwen;
 mod registry;
 

--- a/src/source/opencode.rs
+++ b/src/source/opencode.rs
@@ -12,14 +12,46 @@ use crate::core::{CostKind, Endpoint, RawEntry, source_wide_message_id};
 use crate::source::{Capabilities, ParseOutput, Source};
 use crate::utils::Timezone;
 
+use super::opencode_fork::{read_session_creation_times, reconcile_fork_copies};
+
 const OPENCODE_DB_ENV: &str = "OPENCODE_DB";
+const MIMOCODE_DB_ENV: &str = "MIMOCODE_DB";
+const MIMOCODE_HOME_ENV: &str = "MIMOCODE_HOME";
+const KILO_DB_ENV: &str = "KILO_DB";
 const XDG_DATA_HOME_ENV: &str = "XDG_DATA_HOME";
 
 pub(crate) struct OpenCodeSource;
+pub(crate) struct MiMoCodeSource;
+pub(crate) struct KiloCliSource;
 
 impl OpenCodeSource {
     pub(crate) const fn new() -> Self {
         Self
+    }
+}
+
+impl MiMoCodeSource {
+    pub(crate) const fn new() -> Self {
+        Self
+    }
+}
+
+impl KiloCliSource {
+    pub(crate) const fn new() -> Self {
+        Self
+    }
+}
+
+fn opencode_capabilities() -> Capabilities {
+    Capabilities {
+        has_projects: true,
+        has_billing_blocks: false,
+        has_reasoning_tokens: true,
+        has_cache_creation: true,
+        has_cache_read: true,
+        needs_dedup: true,
+        has_tool_calls: false,
+        has_endpoints: false,
     }
 }
 
@@ -37,16 +69,7 @@ impl Source for OpenCodeSource {
     }
 
     fn capabilities(&self) -> Capabilities {
-        Capabilities {
-            has_projects: true,
-            has_billing_blocks: false,
-            has_reasoning_tokens: true,
-            has_cache_creation: true,
-            has_cache_read: true,
-            needs_dedup: true,
-            has_tool_calls: false,
-            has_endpoints: false,
-        }
+        opencode_capabilities()
     }
 
     fn find_files(&self) -> Vec<PathBuf> {
@@ -54,7 +77,68 @@ impl Source for OpenCodeSource {
     }
 
     fn parse_file(&self, path: &Path, timezone: Timezone, debug: bool) -> ParseOutput {
-        parse_opencode_database(path, timezone, debug)
+        parse_opencode_database(path, timezone, debug, ParseProfile::opencode())
+    }
+}
+
+impl Source for MiMoCodeSource {
+    fn name(&self) -> &'static str {
+        "mimocode"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "MiMo Code"
+    }
+
+    fn aliases(&self) -> &'static [&'static str] {
+        &["micode"]
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        opencode_capabilities()
+    }
+
+    fn find_files(&self) -> Vec<PathBuf> {
+        find_mimocode_databases()
+    }
+
+    fn parse_file(&self, path: &Path, timezone: Timezone, debug: bool) -> ParseOutput {
+        if mimocode_home_is_invalid() {
+            if debug {
+                eprintln!("MIMOCODE_HOME must be an absolute path");
+            }
+            return ParseOutput {
+                entries: Vec::new(),
+                errors: 1,
+            };
+        }
+        parse_opencode_database(path, timezone, debug, ParseProfile::mimocode())
+    }
+}
+
+impl Source for KiloCliSource {
+    fn name(&self) -> &'static str {
+        "kilo"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Kilo CLI"
+    }
+
+    fn aliases(&self) -> &'static [&'static str] {
+        &["kilo-cli"]
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        opencode_capabilities()
+    }
+
+    fn find_files(&self) -> Vec<PathBuf> {
+        find_kilo_databases()
+    }
+
+    fn parse_file(&self, path: &Path, timezone: Timezone, debug: bool) -> ParseOutput {
+        parse_opencode_database(path, timezone, debug, ParseProfile::kilo())
     }
 }
 
@@ -91,6 +175,131 @@ fn find_opencode_databases() -> Vec<PathBuf> {
     databases.sort();
     databases.dedup();
     databases
+}
+
+fn xdg_data_dir(application: &str) -> Option<PathBuf> {
+    env::var_os(XDG_DATA_HOME_ENV)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+        .or_else(|| dirs::home_dir().map(|home| home.join(".local/share")))
+        .map(|root| root.join(application))
+}
+
+fn find_family_databases(
+    db_env: &str,
+    data_dir: Option<PathBuf>,
+    patterns: &[&str],
+) -> Vec<PathBuf> {
+    if let Some(configured) = env::var_os(db_env).filter(|value| !value.is_empty()) {
+        let configured = PathBuf::from(configured);
+        let path = if configured.is_absolute() {
+            configured
+        } else if let Some(data_dir) = data_dir {
+            data_dir.join(configured)
+        } else {
+            return Vec::new();
+        };
+        return path.is_file().then_some(path).into_iter().collect();
+    }
+
+    let Some(data_dir) = data_dir else {
+        return Vec::new();
+    };
+    let mut databases = Vec::new();
+    for pattern in patterns {
+        let pattern = data_dir.join(pattern);
+        if let Ok(matches) = glob::glob(&pattern.to_string_lossy()) {
+            databases.extend(matches.flatten().filter(|path| path.is_file()));
+        }
+    }
+    databases.sort();
+    databases.dedup();
+    databases
+}
+
+fn find_mimocode_databases() -> Vec<PathBuf> {
+    if env::var_os(MIMOCODE_DB_ENV)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .is_some_and(|path| path.is_absolute())
+    {
+        return find_family_databases(MIMOCODE_DB_ENV, None, &["mimocode*.db"]);
+    }
+    let configured_home = env::var_os(MIMOCODE_HOME_ENV)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from);
+    let data_dir = match configured_home {
+        Some(root) if root.is_absolute() => Some(root.join("data")),
+        // Return a path that the parser will reject instead of silently reading
+        // an unrelated XDG database after an invalid explicit override.
+        Some(root) => return vec![root.join("data/mimocode.db")],
+        None => xdg_data_dir("mimocode"),
+    };
+    find_family_databases(MIMOCODE_DB_ENV, data_dir, &["mimocode*.db"])
+}
+
+fn mimocode_home_is_invalid() -> bool {
+    let database_is_absolute = env::var_os(MIMOCODE_DB_ENV)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .is_some_and(|path| path.is_absolute());
+    !database_is_absolute
+        && env::var_os(MIMOCODE_HOME_ENV)
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+            .is_some_and(|path| !path.is_absolute())
+}
+
+fn find_kilo_databases() -> Vec<PathBuf> {
+    find_family_databases(
+        KILO_DB_ENV,
+        xdg_data_dir("kilo"),
+        &["kilo*.db", "opencode-*.db"],
+    )
+}
+
+#[derive(Debug, Clone, Copy)]
+enum RecordedCostPolicy {
+    PositiveOnly,
+    AnyReported,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ParseProfile {
+    source: &'static str,
+    display_name: &'static str,
+    cost_policy: RecordedCostPolicy,
+    reconcile_fork_copies: bool,
+}
+
+impl ParseProfile {
+    const fn opencode() -> Self {
+        Self {
+            source: "opencode",
+            display_name: "OpenCode",
+            cost_policy: RecordedCostPolicy::PositiveOnly,
+            reconcile_fork_copies: false,
+        }
+    }
+
+    const fn mimocode() -> Self {
+        Self {
+            source: "mimocode",
+            display_name: "MiMo Code",
+            cost_policy: RecordedCostPolicy::AnyReported,
+            reconcile_fork_copies: true,
+        }
+    }
+
+    const fn kilo() -> Self {
+        Self {
+            source: "kilo",
+            display_name: "Kilo CLI",
+            cost_policy: RecordedCostPolicy::AnyReported,
+            reconcile_fork_copies: true,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -206,6 +415,7 @@ fn read_table(
     debug: bool,
     path: &Path,
     timezone: Timezone,
+    profile: ParseProfile,
 ) -> bool {
     let (table, query) = match schema {
         MessageSchema::V1 => (
@@ -275,14 +485,15 @@ fn read_table(
 
     for row in rows {
         match row {
-            Ok(row) => match entry_from_database_message(&row, timezone) {
+            Ok(row) => match entry_from_database_message(&row, timezone, profile) {
                 Ok(Some(entry)) => output.entries.push(entry),
                 Ok(None) => {}
                 Err(error) => {
                     output.errors += 1;
                     if debug {
                         eprintln!(
-                            "Invalid OpenCode message {} in {}: {error}",
+                            "Invalid {} message {} in {}: {error}",
+                            profile.display_name,
                             row.id,
                             path.display()
                         );
@@ -310,6 +521,7 @@ fn finite_millis(value: f64) -> Result<i64, &'static str> {
 fn entry_from_database_message(
     row: &DatabaseMessage,
     timezone: Timezone,
+    profile: ParseProfile,
 ) -> Result<Option<RawEntry>, &'static str> {
     let message: OpenCodeMessage =
         serde_json::from_str(&row.data).map_err(|_| "invalid message JSON")?;
@@ -338,7 +550,16 @@ fn entry_from_database_message(
     {
         return Err("negative token count");
     }
-    let recorded_cost_usd = message.cost.filter(|cost| cost.is_finite() && *cost > 0.0);
+    if message
+        .cost
+        .is_some_and(|cost| !cost.is_finite() || cost < 0.0)
+    {
+        return Err("invalid cost");
+    }
+    let recorded_cost_usd = match profile.cost_policy {
+        RecordedCostPolicy::PositiveOnly => message.cost.filter(|cost| *cost > 0.0),
+        RecordedCostPolicy::AnyReported => message.cost,
+    };
     if tokens.input == 0
         && tokens.output == 0
         && tokens.reasoning == 0
@@ -374,8 +595,8 @@ fn entry_from_database_message(
             .date_naive()
             .format(DATE_FORMAT)
             .to_string(),
-        message_id: Some(source_wide_message_id("opencode", &row.id)),
-        session_key: format!("opencode::{}", row.session_id),
+        message_id: Some(source_wide_message_id(profile.source, &row.id)),
+        session_key: format!("{}::{}", profile.source, row.session_id),
         session_id: row.session_id.clone(),
         project_path,
         model,
@@ -393,14 +614,20 @@ fn entry_from_database_message(
     }))
 }
 
-fn parse_opencode_database(path: &Path, timezone: Timezone, debug: bool) -> ParseOutput {
+fn parse_opencode_database(
+    path: &Path,
+    timezone: Timezone,
+    debug: bool,
+    profile: ParseProfile,
+) -> ParseOutput {
     let flags = OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX;
     let connection = match Connection::open_with_flags(path, flags) {
         Ok(connection) => connection,
         Err(error) => {
             if debug {
                 eprintln!(
-                    "Failed to open OpenCode database {}: {error}",
+                    "Failed to open {} database {}: {error}",
+                    profile.display_name,
                     path.display()
                 );
             }
@@ -411,6 +638,27 @@ fn parse_opencode_database(path: &Path, timezone: Timezone, debug: bool) -> Pars
         }
     };
 
+    let creation_times = if profile.reconcile_fork_copies {
+        match read_session_creation_times(&connection) {
+            Ok(creation_times) => creation_times,
+            Err(error) => {
+                if debug {
+                    eprintln!(
+                        "Failed to read {} session creation times {}: {error}",
+                        profile.display_name,
+                        path.display()
+                    );
+                }
+                return ParseOutput {
+                    entries: Vec::new(),
+                    errors: 1,
+                };
+            }
+        }
+    } else {
+        std::collections::HashMap::default()
+    };
+
     let mut output = ParseOutput::default();
     let has_v2 = read_table(
         &connection,
@@ -419,6 +667,7 @@ fn parse_opencode_database(path: &Path, timezone: Timezone, debug: bool) -> Pars
         debug,
         path,
         timezone,
+        profile,
     );
     let has_v1 = read_table(
         &connection,
@@ -427,15 +676,20 @@ fn parse_opencode_database(path: &Path, timezone: Timezone, debug: bool) -> Pars
         debug,
         path,
         timezone,
+        profile,
     );
     if !has_v1 && !has_v2 && output.errors == 0 {
         output.errors = 1;
         if debug {
             eprintln!(
-                "OpenCode database {} has neither message table",
+                "{} database {} has neither message table",
+                profile.display_name,
                 path.display()
             );
         }
+    }
+    if profile.reconcile_fork_copies {
+        reconcile_fork_copies(&mut output.entries, &creation_times);
     }
     output
 }
@@ -454,9 +708,13 @@ mod tests {
             data: r#"{"agent":"build","model":{"id":"gpt-5","providerID":"openai"},"finish":"stop","cost":0.25,"tokens":{"input":100,"output":20,"reasoning":5,"cache":{"read":30,"write":10}},"time":{"created":1788131045000,"completed":1788131046000}}"#.to_string(),
         };
 
-        let entry = entry_from_database_message(&row, Timezone::Named(chrono_tz::UTC))
-            .unwrap()
-            .unwrap();
+        let entry = entry_from_database_message(
+            &row,
+            Timezone::Named(chrono_tz::UTC),
+            ParseProfile::opencode(),
+        )
+        .unwrap()
+        .unwrap();
 
         assert_eq!(entry.input_tokens, 100);
         assert_eq!(entry.output_tokens, 20);
@@ -478,7 +736,11 @@ mod tests {
         };
 
         assert!(matches!(
-            entry_from_database_message(&row, Timezone::Named(chrono_tz::UTC)),
+            entry_from_database_message(
+                &row,
+                Timezone::Named(chrono_tz::UTC),
+                ParseProfile::opencode(),
+            ),
             Err("negative token count")
         ));
     }

--- a/src/source/opencode_fork.rs
+++ b/src/source/opencode_fork.rs
@@ -1,0 +1,124 @@
+//! Fork-copy reconciliation for OpenCode-family databases.
+
+use std::collections::{HashMap, HashSet};
+
+use rusqlite::Connection;
+
+use crate::core::RawEntry;
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct UsageFingerprint {
+    timestamp_ms: i64,
+    model: String,
+    input: i64,
+    output: i64,
+    reasoning: i64,
+    cache_read: i64,
+    cache_write: i64,
+}
+
+fn usage_fingerprint(entry: &RawEntry) -> UsageFingerprint {
+    UsageFingerprint {
+        timestamp_ms: entry.timestamp_ms,
+        model: entry.model.clone(),
+        input: entry.input_tokens,
+        output: entry.output_tokens,
+        reasoning: entry.reasoning_tokens,
+        cache_read: entry.cache_read,
+        cache_write: entry.cache_creation,
+    }
+}
+
+pub(super) fn read_session_creation_times(
+    connection: &Connection,
+) -> rusqlite::Result<HashMap<String, i64>> {
+    let mut statement = connection.prepare("SELECT id, time_created FROM session")?;
+    let rows = statement.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+    })?;
+    let mut creation_times = HashMap::new();
+    for row in rows {
+        let (session, created_at) = row?;
+        creation_times.insert(session, created_at);
+    }
+    Ok(creation_times)
+}
+
+pub(super) fn reconcile_fork_copies(
+    entries: &mut [RawEntry],
+    creation_times: &HashMap<String, i64>,
+) {
+    let mut groups = HashMap::<UsageFingerprint, Vec<usize>>::new();
+    for (index, entry) in entries.iter().enumerate() {
+        groups
+            .entry(usage_fingerprint(entry))
+            .or_default()
+            .push(index);
+    }
+
+    for indices in groups.into_values() {
+        let original_sessions = indices
+            .iter()
+            .filter_map(|index| {
+                let entry = &entries[*index];
+                creation_times
+                    .get(&entry.session_id)
+                    .filter(|created_at| entry.timestamp_ms >= **created_at)
+                    .map(|_| entry.session_id.clone())
+            })
+            .collect::<HashSet<_>>();
+        let has_copy = indices.iter().any(|index| {
+            let entry = &entries[*index];
+            creation_times
+                .get(&entry.session_id)
+                .is_some_and(|created_at| entry.timestamp_ms < *created_at)
+        });
+        if !has_copy || original_sessions.len() > 1 {
+            continue;
+        }
+        let copy_sessions = indices
+            .iter()
+            .filter_map(|index| {
+                let entry = &entries[*index];
+                creation_times
+                    .get(&entry.session_id)
+                    .filter(|created_at| entry.timestamp_ms < **created_at)
+                    .map(|_| entry.session_id.as_str())
+            })
+            .collect::<HashSet<_>>();
+        if original_sessions.is_empty() && copy_sessions.len() < 2 {
+            continue;
+        }
+
+        let representative = if let Some(original_session) = original_sessions.iter().next() {
+            indices
+                .iter()
+                .copied()
+                .filter(|index| entries[*index].session_id == *original_session)
+                .max_by(|left, right| {
+                    entries[*left]
+                        .recorded_cost_usd
+                        .unwrap_or(-1.0)
+                        .total_cmp(&entries[*right].recorded_cost_usd.unwrap_or(-1.0))
+                })
+        } else {
+            indices.iter().copied().max_by(|left, right| {
+                entries[*left]
+                    .recorded_cost_usd
+                    .unwrap_or(-1.0)
+                    .total_cmp(&entries[*right].recorded_cost_usd.unwrap_or(-1.0))
+            })
+        };
+        let Some(representative) = representative else {
+            continue;
+        };
+        let identity = entries[representative].message_id.clone();
+        for index in indices {
+            if index != representative {
+                entries[index].message_id.clone_from(&identity);
+                entries[index].stop_reason = None;
+                entries[index].recorded_cost_usd = None;
+            }
+        }
+    }
+}

--- a/src/source/pi.rs
+++ b/src/source/pi.rs
@@ -1,6 +1,5 @@
 //! Pi coding-agent JSONL usage source.
 
-use std::env;
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -13,14 +12,42 @@ use crate::core::{CostKind, Endpoint, RawEntry, source_wide_message_id};
 use crate::source::{Capabilities, ParseOutput, Source};
 use crate::utils::Timezone;
 
-const PI_AGENT_DIR_ENV: &str = "PI_CODING_AGENT_DIR";
-const PI_SESSION_DIR_ENV: &str = "PI_CODING_AGENT_SESSION_DIR";
+use super::pi_paths::{find_kimchi_files, find_pi_files, find_senpi_files};
 
 pub(crate) struct PiSource;
+pub(crate) struct SenpiSource;
+pub(crate) struct KimchiSource;
 
 impl PiSource {
     pub(crate) const fn new() -> Self {
         Self
+    }
+}
+
+impl SenpiSource {
+    pub(crate) const fn new() -> Self {
+        Self
+    }
+}
+
+impl KimchiSource {
+    pub(crate) const fn new() -> Self {
+        Self
+    }
+}
+
+fn pi_capabilities() -> Capabilities {
+    Capabilities {
+        has_projects: true,
+        has_billing_blocks: false,
+        // Pi-family formats document reasoning as a subset of output.
+        has_reasoning_tokens: false,
+        has_cache_creation: true,
+        has_cache_read: true,
+        // Branching copies existing entry ids into a new session file.
+        needs_dedup: true,
+        has_tool_calls: false,
+        has_endpoints: false,
     }
 }
 
@@ -38,18 +65,7 @@ impl Source for PiSource {
     }
 
     fn capabilities(&self) -> Capabilities {
-        Capabilities {
-            has_projects: true,
-            has_billing_blocks: false,
-            // Pi documents reasoning as a subset of output.
-            has_reasoning_tokens: false,
-            has_cache_creation: true,
-            has_cache_read: true,
-            // Branching copies existing entry ids into a new session file.
-            needs_dedup: true,
-            has_tool_calls: false,
-            has_endpoints: false,
-        }
+        pi_capabilities()
     }
 
     fn find_files(&self) -> Vec<PathBuf> {
@@ -57,36 +73,111 @@ impl Source for PiSource {
     }
 
     fn parse_file(&self, path: &Path, timezone: Timezone, debug: bool) -> ParseOutput {
-        parse_pi_file(path, timezone, debug)
+        parse_pi_file(path, timezone, debug, PiProfile::pi())
     }
 }
 
-fn non_empty_env(name: &str) -> Option<PathBuf> {
-    env::var_os(name)
-        .filter(|value| !value.is_empty())
-        .map(PathBuf::from)
+impl Source for SenpiSource {
+    fn name(&self) -> &'static str {
+        "senpi"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Senpi"
+    }
+
+    fn aliases(&self) -> &'static [&'static str] {
+        &[]
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        pi_capabilities()
+    }
+
+    fn find_files(&self) -> Vec<PathBuf> {
+        find_senpi_files()
+    }
+
+    fn parse_file(&self, path: &Path, timezone: Timezone, debug: bool) -> ParseOutput {
+        parse_pi_file(path, timezone, debug, PiProfile::senpi())
+    }
 }
 
-fn pi_sessions_dir() -> Option<PathBuf> {
-    non_empty_env(PI_SESSION_DIR_ENV)
-        .or_else(|| non_empty_env(PI_AGENT_DIR_ENV).map(|root| root.join("sessions")))
-        .or_else(|| dirs::home_dir().map(|home| home.join(".pi/agent/sessions")))
+impl Source for KimchiSource {
+    fn name(&self) -> &'static str {
+        "kimchi"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Kimchi"
+    }
+
+    fn aliases(&self) -> &'static [&'static str] {
+        &["kimchi-coding"]
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        pi_capabilities()
+    }
+
+    fn find_files(&self) -> Vec<PathBuf> {
+        find_kimchi_files()
+    }
+
+    fn parse_file(&self, path: &Path, timezone: Timezone, debug: bool) -> ParseOutput {
+        parse_pi_file(path, timezone, debug, PiProfile::kimchi())
+    }
 }
 
-fn find_pi_files() -> Vec<PathBuf> {
-    let Some(root) = pi_sessions_dir() else {
-        return Vec::new();
-    };
-    let patterns = [root.join("*.jsonl"), root.join("**").join("*.jsonl")];
-    let mut files = Vec::new();
-    for pattern in patterns {
-        if let Ok(matches) = glob::glob(&pattern.to_string_lossy()) {
-            files.extend(matches.flatten().filter(|path| path.is_file()));
+#[derive(Debug, Clone, Copy)]
+struct PiProfile {
+    source: &'static str,
+    display_name: &'static str,
+    count_message_tool_result_usage: bool,
+    count_kimchi_details_usage: bool,
+    suppress_linked_rollups: bool,
+}
+
+impl PiProfile {
+    const fn pi() -> Self {
+        Self {
+            source: "pi",
+            display_name: "Pi",
+            count_message_tool_result_usage: true,
+            count_kimchi_details_usage: false,
+            suppress_linked_rollups: false,
         }
     }
-    files.sort();
-    files.dedup();
-    files
+
+    const fn senpi() -> Self {
+        Self {
+            source: "senpi",
+            display_name: "Senpi",
+            count_message_tool_result_usage: true,
+            count_kimchi_details_usage: false,
+            suppress_linked_rollups: false,
+        }
+    }
+
+    const fn kimchi() -> Self {
+        Self {
+            source: "kimchi",
+            display_name: "Kimchi",
+            count_message_tool_result_usage: false,
+            count_kimchi_details_usage: true,
+            suppress_linked_rollups: true,
+        }
+    }
+
+    const fn kimchi_probe() -> Self {
+        Self {
+            source: "kimchi",
+            display_name: "Kimchi",
+            count_message_tool_result_usage: false,
+            count_kimchi_details_usage: true,
+            suppress_linked_rollups: false,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -118,6 +209,15 @@ struct PiMessage {
     model: Option<String>,
     usage: Option<PiUsage>,
     stop_reason: Option<String>,
+    details: Option<KimchiDetails>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct KimchiDetails {
+    model_name: Option<String>,
+    session_file: Option<String>,
+    token_usage: Option<PiUsage>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -153,6 +253,7 @@ impl PiModelState {
 }
 
 struct PiUsageContext<'a> {
+    source: &'a str,
     entry_id: &'a str,
     timestamp: &'a str,
     session_id: &'a str,
@@ -177,10 +278,11 @@ fn usage_entry(
     {
         return Err("negative token count");
     }
-    let recorded_cost_usd = usage
-        .cost
-        .map(|cost| cost.total)
-        .filter(|cost| cost.is_finite() && *cost > 0.0);
+    let recorded_cost_usd = match usage.cost.map(|cost| cost.total) {
+        Some(cost) if !cost.is_finite() || cost < 0.0 => return Err("invalid cost"),
+        Some(cost) if cost > 0.0 => Some(cost),
+        _ => None,
+    };
     if usage.input == 0
         && usage.output == 0
         && usage.cache_read == 0
@@ -209,8 +311,8 @@ fn usage_entry(
             .date_naive()
             .format(DATE_FORMAT)
             .to_string(),
-        message_id: Some(source_wide_message_id("pi", context.entry_id)),
-        session_key: format!("pi::{}", context.session_id),
+        message_id: Some(source_wide_message_id(context.source, context.entry_id)),
+        session_key: format!("{}::{}", context.source, context.session_id),
         session_id: context.session_id.to_string(),
         project_path: context.project_path.to_string(),
         model,
@@ -229,11 +331,54 @@ fn usage_entry(
     }))
 }
 
+fn linked_transcript_produces_entry(path: &Path) -> bool {
+    !parse_pi_file(
+        path,
+        Timezone::Named(chrono_tz::UTC),
+        false,
+        PiProfile::kimchi_probe(),
+    )
+    .entries
+    .is_empty()
+}
+
+fn tool_result_usage(
+    message: PiMessage,
+    path: &Path,
+    profile: PiProfile,
+) -> Option<(PiUsage, Option<String>)> {
+    if profile.count_message_tool_result_usage {
+        return message.usage.map(|usage| (usage, None));
+    }
+    if !profile.count_kimchi_details_usage {
+        return None;
+    }
+    let details = message.details?;
+    if profile.suppress_linked_rollups
+        && details.session_file.as_deref().is_some_and(|session_file| {
+            let session_file = Path::new(session_file);
+            let linked_file = if session_file.is_absolute() {
+                session_file.to_path_buf()
+            } else {
+                path.parent()
+                    .unwrap_or_else(|| Path::new(""))
+                    .join(session_file)
+            };
+            linked_transcript_produces_entry(&linked_file)
+        })
+    {
+        return None;
+    }
+    details.token_usage.map(|usage| (usage, details.model_name))
+}
+
 fn parse_entry(
     entry: PiEntry,
     header: &PiHeader,
+    path: &Path,
     model_state: &mut PiModelState,
     timezone: Timezone,
+    profile: PiProfile,
 ) -> Result<Option<RawEntry>, &'static str> {
     match entry.entry_type.as_str() {
         "model_change" => {
@@ -244,28 +389,50 @@ fn parse_entry(
             let Some(message) = entry.message else {
                 return Err("message record is missing message");
             };
-            if message.role != "assistant" {
-                return Ok(None);
+            match message.role.as_str() {
+                "assistant" => {
+                    let Some(usage) = message.usage else {
+                        return Ok(None);
+                    };
+                    model_state.update(message.provider.as_deref(), message.model.as_deref());
+                    usage_entry(
+                        usage,
+                        PiUsageContext {
+                            source: profile.source,
+                            entry_id: &entry.id,
+                            timestamp: &entry.timestamp,
+                            session_id: &header.id,
+                            project_path: &header.cwd,
+                            model: message.model.as_deref(),
+                            stop_reason: message
+                                .stop_reason
+                                .filter(|reason| !reason.trim().is_empty())
+                                .or_else(|| Some("assistant".to_string())),
+                            timezone,
+                        },
+                    )
+                }
+                "toolResult" => {
+                    let Some((usage, details_model)) = tool_result_usage(message, path, profile)
+                    else {
+                        return Ok(None);
+                    };
+                    usage_entry(
+                        usage,
+                        PiUsageContext {
+                            source: profile.source,
+                            entry_id: &entry.id,
+                            timestamp: &entry.timestamp,
+                            session_id: &header.id,
+                            project_path: &header.cwd,
+                            model: details_model.as_deref().or(model_state.model.as_deref()),
+                            stop_reason: Some("tool_result".to_string()),
+                            timezone,
+                        },
+                    )
+                }
+                _ => Ok(None),
             }
-            let Some(usage) = message.usage else {
-                return Ok(None);
-            };
-            model_state.update(message.provider.as_deref(), message.model.as_deref());
-            usage_entry(
-                usage,
-                PiUsageContext {
-                    entry_id: &entry.id,
-                    timestamp: &entry.timestamp,
-                    session_id: &header.id,
-                    project_path: &header.cwd,
-                    model: message.model.as_deref(),
-                    stop_reason: message
-                        .stop_reason
-                        .filter(|reason| !reason.trim().is_empty())
-                        .or_else(|| Some("assistant".to_string())),
-                    timezone,
-                },
-            )
         }
         "compaction" | "branch_summary" => {
             let Some(usage) = entry.usage else {
@@ -274,6 +441,7 @@ fn parse_entry(
             usage_entry(
                 usage,
                 PiUsageContext {
+                    source: profile.source,
                     entry_id: &entry.id,
                     timestamp: &entry.timestamp,
                     session_id: &header.id,
@@ -288,12 +456,16 @@ fn parse_entry(
     }
 }
 
-fn parse_pi_file(path: &Path, timezone: Timezone, debug: bool) -> ParseOutput {
+fn parse_pi_file(path: &Path, timezone: Timezone, debug: bool, profile: PiProfile) -> ParseOutput {
     let file = match fs::File::open(path) {
         Ok(file) => file,
         Err(error) => {
             if debug {
-                eprintln!("Failed to open Pi session {}: {error}", path.display());
+                eprintln!(
+                    "Failed to open {} session {}: {error}",
+                    profile.display_name,
+                    path.display()
+                );
             }
             return ParseOutput {
                 entries: Vec::new(),
@@ -335,7 +507,11 @@ fn parse_pi_file(path: &Path, timezone: Timezone, debug: bool) -> ParseOutput {
             }
             Ok(_) | Err(_) => {
                 if debug {
-                    eprintln!("Invalid Pi session header in {}", path.display());
+                    eprintln!(
+                        "Invalid {} session header in {}",
+                        profile.display_name,
+                        path.display()
+                    );
                 }
                 return ParseOutput {
                     entries: Vec::new(),
@@ -345,7 +521,7 @@ fn parse_pi_file(path: &Path, timezone: Timezone, debug: bool) -> ParseOutput {
         }
     };
 
-    parse_pi_entries(lines, &header, path, timezone, debug)
+    parse_pi_entries(lines, &header, path, timezone, debug, profile)
 }
 
 fn parse_pi_entries(
@@ -354,6 +530,7 @@ fn parse_pi_entries(
     path: &Path,
     timezone: Timezone,
     debug: bool,
+    profile: PiProfile,
 ) -> ParseOutput {
     let mut output = ParseOutput::default();
     let mut model_state = PiModelState::default();
@@ -389,14 +566,15 @@ fn parse_pi_entries(
                 continue;
             }
         };
-        match parse_entry(entry, header, &mut model_state, timezone) {
+        match parse_entry(entry, header, path, &mut model_state, timezone, profile) {
             Ok(Some(entry)) => output.entries.push(entry),
             Ok(None) => {}
             Err(error) => {
                 output.errors += 1;
                 if debug {
                     eprintln!(
-                        "Invalid Pi usage in {} line {}: {error}",
+                        "Invalid {} usage in {} line {}: {error}",
+                        profile.display_name,
                         path.display(),
                         line_index + 1
                     );
@@ -424,6 +602,7 @@ mod tests {
         let entry = usage_entry(
             usage,
             PiUsageContext {
+                source: "pi",
                 entry_id: "entry-1",
                 timestamp: "2026-08-31T03:00:00Z",
                 session_id: "session-1",
@@ -455,6 +634,7 @@ mod tests {
             usage_entry(
                 usage,
                 PiUsageContext {
+                    source: "pi",
                     entry_id: "entry-1",
                     timestamp: "2026-08-31T03:00:00Z",
                     session_id: "session-1",

--- a/src/source/pi_paths.rs
+++ b/src/source/pi_paths.rs
@@ -1,0 +1,156 @@
+//! Session discovery for Pi-family sources.
+
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const PI_AGENT_DIR_ENV: &str = "PI_CODING_AGENT_DIR";
+const PI_SESSION_DIR_ENV: &str = "PI_CODING_AGENT_SESSION_DIR";
+const SENPI_AGENT_DIR_ENV: &str = "SENPI_CODING_AGENT_DIR";
+const SENPI_SESSION_DIR_ENV: &str = "SENPI_CODING_AGENT_SESSION_DIR";
+
+enum SessionDirSetting {
+    Missing,
+    Reset,
+    Path(PathBuf),
+    Invalid(PathBuf),
+}
+
+fn non_empty_env(name: &str) -> Option<PathBuf> {
+    env::var_os(name)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .map(expand_home_path)
+}
+
+fn expand_home_path(path: PathBuf) -> PathBuf {
+    let value = path.to_string_lossy();
+    if value == "~" {
+        return dirs::home_dir().unwrap_or(path);
+    }
+    value
+        .strip_prefix("~/")
+        .or_else(|| value.strip_prefix(r"~\"))
+        .and_then(|suffix| dirs::home_dir().map(|home| home.join(suffix)))
+        .unwrap_or(path)
+}
+
+fn nearest_senpi_config_dir(require_agent: bool) -> Option<PathBuf> {
+    let home = dirs::home_dir()?;
+    let mut current = env::current_dir().ok()?;
+    for _ in 0..=100 {
+        if current == home {
+            return None;
+        }
+        let config = current.join(".senpi");
+        let agent = config.join("agent");
+        let is_real_directory = |path: &Path| {
+            fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_dir())
+        };
+        if is_real_directory(&config) && (!require_agent || is_real_directory(&agent)) {
+            return Some(config);
+        }
+        if !current.pop() {
+            return None;
+        }
+    }
+    None
+}
+
+fn settings_source(directory: &Path) -> Option<PathBuf> {
+    let jsonc = directory.join("settings.jsonc");
+    if jsonc.is_file() {
+        return Some(jsonc);
+    }
+    let json = directory.join("settings.json");
+    json.is_file().then_some(json)
+}
+
+fn read_session_dir_setting(directory: &Path) -> SessionDirSetting {
+    let Some(path) = settings_source(directory) else {
+        return SessionDirSetting::Missing;
+    };
+    let Ok(content) = fs::read_to_string(&path) else {
+        return SessionDirSetting::Invalid(path);
+    };
+    let content = content.trim_start_matches('\u{feff}');
+    let Ok(value) = jsonc_parser::parse_to_serde_value::<serde_json::Value>(
+        content,
+        &jsonc_parser::ParseOptions::default(),
+    ) else {
+        return SessionDirSetting::Invalid(path);
+    };
+    match value.get("sessionDir") {
+        None => SessionDirSetting::Missing,
+        Some(serde_json::Value::String(value)) if !value.is_empty() => {
+            let path = expand_home_path(PathBuf::from(value));
+            if path.is_absolute() {
+                SessionDirSetting::Path(path)
+            } else if let Ok(cwd) = env::current_dir() {
+                SessionDirSetting::Path(cwd.join(path))
+            } else {
+                SessionDirSetting::Invalid(directory.to_path_buf())
+            }
+        }
+        Some(serde_json::Value::String(_) | serde_json::Value::Null) => SessionDirSetting::Reset,
+        Some(_) => SessionDirSetting::Invalid(path),
+    }
+}
+
+fn senpi_sessions_dir() -> Result<PathBuf, PathBuf> {
+    if let Some(sessions) = non_empty_env(SENPI_SESSION_DIR_ENV) {
+        return Ok(sessions);
+    }
+    let project_config = nearest_senpi_config_dir(false);
+    let agent_dir = non_empty_env(SENPI_AGENT_DIR_ENV)
+        .or_else(|| nearest_senpi_config_dir(true).map(|config| config.join("agent")))
+        .or_else(|| dirs::home_dir().map(|home| home.join(".senpi/agent")))
+        .ok_or_else(|| PathBuf::from("senpi-settings-error.jsonl"))?;
+    let default = || agent_dir.join("sessions");
+    let setting = project_config
+        .as_deref()
+        .map_or(SessionDirSetting::Missing, read_session_dir_setting);
+    match setting {
+        SessionDirSetting::Path(path) => Ok(path),
+        SessionDirSetting::Reset => Ok(default()),
+        SessionDirSetting::Invalid(path) => Err(path),
+        SessionDirSetting::Missing => match read_session_dir_setting(&agent_dir) {
+            SessionDirSetting::Path(path) => Ok(path),
+            SessionDirSetting::Missing | SessionDirSetting::Reset => Ok(default()),
+            SessionDirSetting::Invalid(path) => Err(path),
+        },
+    }
+}
+
+fn find_family_files(root: &Path) -> Vec<PathBuf> {
+    let patterns = [root.join("*.jsonl"), root.join("**").join("*.jsonl")];
+    let mut files = Vec::new();
+    for pattern in patterns {
+        if let Ok(matches) = glob::glob(&pattern.to_string_lossy()) {
+            files.extend(matches.flatten().filter(|path| path.is_file()));
+        }
+    }
+    files.sort();
+    files.dedup();
+    files
+}
+
+pub(super) fn find_pi_files() -> Vec<PathBuf> {
+    let root = non_empty_env(PI_SESSION_DIR_ENV)
+        .or_else(|| non_empty_env(PI_AGENT_DIR_ENV).map(|root| root.join("sessions")))
+        .or_else(|| dirs::home_dir().map(|home| home.join(".pi/agent/sessions")));
+    root.as_deref().map(find_family_files).unwrap_or_default()
+}
+
+pub(super) fn find_senpi_files() -> Vec<PathBuf> {
+    match senpi_sessions_dir() {
+        Ok(root) => find_family_files(&root),
+        Err(settings_path) => vec![settings_path],
+    }
+}
+
+pub(super) fn find_kimchi_files() -> Vec<PathBuf> {
+    dirs::home_dir()
+        .map(|home| find_family_files(&home.join(".config/kimchi/harness/sessions")))
+        .unwrap_or_default()
+}

--- a/src/source/registry.rs
+++ b/src/source/registry.rs
@@ -15,8 +15,8 @@ use super::gemini::GeminiSource;
 use super::goose::GooseSource;
 use super::grok::GrokSource;
 use super::kimi::KimiSource;
-use super::opencode::OpenCodeSource;
-use super::pi::PiSource;
+use super::opencode::{KiloCliSource, MiMoCodeSource, OpenCodeSource};
+use super::pi::{KimchiSource, PiSource, SenpiSource};
 use super::qwen::QwenSource;
 use super::{BoxedSource, Source};
 
@@ -38,7 +38,11 @@ static SOURCES: LazyLock<Vec<BoxedSource>> = LazyLock::new(|| {
         Box::new(RooCodeSource::new()),
         Box::new(KiloCodeSource::new()),
         Box::new(OpenCodeSource::new()),
+        Box::new(MiMoCodeSource::new()),
+        Box::new(KiloCliSource::new()),
         Box::new(PiSource::new()),
+        Box::new(SenpiSource::new()),
+        Box::new(KimchiSource::new()),
         Box::new(CopilotSource::new()),
         Box::new(GooseSource::new()),
     ]
@@ -152,11 +156,15 @@ mod tests {
         assert!(get_source("grok").is_some());
         assert!(get_source("goose").is_some());
         assert!(get_source("kilocode").is_some());
+        assert!(get_source("kilo").is_some());
+        assert!(get_source("kimchi").is_some());
         assert!(get_source("kimi").is_some());
+        assert!(get_source("mimocode").is_some());
         assert!(get_source("opencode").is_some());
         assert!(get_source("pi").is_some());
         assert!(get_source("qwen").is_some());
         assert!(get_source("roocode").is_some());
+        assert!(get_source("senpi").is_some());
         assert!(get_source("unknown").is_none());
     }
 
@@ -287,7 +295,7 @@ mod tests {
     #[test]
     fn test_sources_count() {
         // Verify all built-in sources are registered
-        assert_eq!(SOURCES.len(), 15);
+        assert_eq!(SOURCES.len(), 19);
     }
 
     #[test]

--- a/tests/cli_mimocode_kilo.rs
+++ b/tests/cli_mimocode_kilo.rs
@@ -1,0 +1,331 @@
+mod common;
+
+use common::{run_ccstats, unique_temp_dir, write_file};
+use rusqlite::{Connection, params};
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+
+fn daily_json(source: &str, envs: &[(&str, &Path)]) -> Value {
+    daily_json_with_cost(source, envs, false)
+}
+
+fn daily_json_with_cost(source: &str, envs: &[(&str, &Path)], include_cost: bool) -> Value {
+    let mut args = vec![
+        "daily",
+        "--source",
+        source,
+        "--json",
+        "--offline",
+        "--timezone",
+        "UTC",
+        "--since",
+        "2026-08-31",
+        "--until",
+        "2026-08-31",
+    ];
+    if !include_cost {
+        args.push("--no-cost");
+    }
+    let (ok, stdout, stderr) = run_ccstats(&args, envs);
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    serde_json::from_slice(&stdout).expect("daily JSON")
+}
+
+fn insert_single_message(connection: &Connection, session: &str, message: &str) {
+    connection
+        .execute(
+            "INSERT INTO session (id, directory, parent_id, time_created)
+             VALUES (?1, '/tmp/discovery-project', NULL, 1788145400000)",
+            params![session],
+        )
+        .expect("insert discovery session");
+    connection
+        .execute(
+            "INSERT INTO message (id, session_id, data) VALUES ('discovery-message', ?1, ?2)",
+            params![session, message],
+        )
+        .expect("insert discovery message");
+}
+
+fn create_schema(connection: &Connection, include_v2: bool) {
+    connection
+        .execute_batch(
+            "CREATE TABLE session (
+                id TEXT PRIMARY KEY,
+                directory TEXT NOT NULL,
+                parent_id TEXT,
+                time_created INTEGER NOT NULL
+            );
+            CREATE TABLE message (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                data TEXT NOT NULL
+            );",
+        )
+        .expect("create OpenCode-family schema");
+    if include_v2 {
+        connection
+            .execute_batch(
+                "CREATE TABLE session_message (
+                    id TEXT PRIMARY KEY,
+                    session_id TEXT NOT NULL,
+                    type TEXT NOT NULL,
+                    data TEXT NOT NULL
+                );",
+            )
+            .expect("create v2 message schema");
+    }
+}
+
+fn assert_one_normalized_call(json: &Value, expected_dedup: i64) {
+    let rows = json.as_array().expect("array");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["input_tokens"].as_i64(), Some(100));
+    assert_eq!(rows[0]["output_tokens"].as_i64(), Some(20));
+    assert_eq!(rows[0]["reasoning_tokens"].as_i64(), Some(5));
+    assert_eq!(rows[0]["cache_read_tokens"].as_i64(), Some(30));
+    assert_eq!(rows[0]["cache_creation_tokens"].as_i64(), Some(10));
+    assert_eq!(rows[0]["total_tokens"].as_i64(), Some(165));
+    assert_eq!(rows[0]["data_quality"]["valid_entries"].as_i64(), Some(1));
+    assert_eq!(
+        rows[0]["data_quality"]["dedup_skipped_entries"].as_i64(),
+        Some(expected_dedup)
+    );
+    assert_eq!(rows[0]["data_quality"]["parse_errors"].as_u64(), Some(0));
+}
+
+#[test]
+fn mimocode_database_deduplicates_fork_copied_history() {
+    let root = unique_temp_dir("mimocode-e2e");
+    let db = root.join("mimocode.db");
+    write_file(&db, "");
+    let connection = Connection::open(&db).expect("open MiMo fixture database");
+    create_schema(&connection, false);
+    connection
+        .execute(
+            "INSERT INTO session (id, directory, parent_id, time_created) VALUES
+             ('parent', '/tmp/mimo-project', NULL, 1788145400000),
+             ('fork', '/tmp/mimo-fork-project', NULL, 1788145500000)",
+            [],
+        )
+        .expect("insert sessions");
+    let data = r#"{"role":"assistant","modelID":"mimo-v2.5-pro","providerID":"mimo","finish":"stop","cost":0.25,"tokens":{"input":100,"output":20,"reasoning":5,"cache":{"read":30,"write":10}},"time":{"created":1788145445000,"completed":1788145446000}}"#;
+    connection
+        .execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            params!["original-message", "parent", data],
+        )
+        .expect("insert original message");
+    connection
+        .execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            params!["copied-message", "fork", data],
+        )
+        .expect("insert copied message");
+    drop(connection);
+
+    let json = daily_json("mimocode", &[("MIMOCODE_DB", &db), ("HOME", &root)]);
+    assert_one_normalized_call(&json, 1);
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn kilo_database_reconciles_dual_schema_and_fork_copy() {
+    let root = unique_temp_dir("kilo-cli-e2e");
+    let db = root.join("kilo.db");
+    write_file(&db, "");
+    let connection = Connection::open(&db).expect("open Kilo fixture database");
+    create_schema(&connection, true);
+    connection
+        .execute(
+            "INSERT INTO session (id, directory, parent_id, time_created) VALUES
+             ('parent', '/tmp/kilo-project', NULL, 1788145400000),
+             ('fork', '/tmp/kilo-fork-project', NULL, 1788145500000),
+             ('fork-2', '/tmp/kilo-second-fork', NULL, 1788145600000)",
+            [],
+        )
+        .expect("insert sessions");
+    let legacy = r#"{"role":"assistant","modelID":"claude-sonnet-4","providerID":"anthropic","finish":"stop","cost":0.25,"tokens":{"input":100,"output":20,"reasoning":5,"cache":{"read":30,"write":10}},"time":{"created":1788145445000,"completed":1788145446000}}"#;
+    let current = r#"{"agent":"build","model":{"id":"claude-sonnet-4","providerID":"anthropic"},"finish":"stop","cost":0.25,"tokens":{"input":100,"output":20,"reasoning":5,"cache":{"read":30,"write":10}},"time":{"created":1788145445000,"completed":1788145446000}}"#;
+    let copied = r#"{"agent":"build","model":{"id":"claude-sonnet-4","providerID":"anthropic"},"finish":"stop","cost":0.0,"tokens":{"input":100,"output":20,"reasoning":5,"cache":{"read":30,"write":10}},"time":{"created":1788145445000,"completed":1788145446000}}"#;
+    connection
+        .execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, 'parent', ?2)",
+            params!["shared-message", legacy],
+        )
+        .expect("insert legacy projection");
+    connection
+        .execute(
+            "INSERT INTO session_message (id, session_id, type, data) VALUES (?1, 'parent', 'assistant', ?2)",
+            params!["shared-message", current],
+        )
+        .expect("insert current projection");
+    connection
+        .execute(
+            "INSERT INTO session_message (id, session_id, type, data) VALUES ('fork-copy', 'fork', 'assistant', ?1)",
+            params![copied],
+        )
+        .expect("insert fork copy");
+    connection
+        .execute(
+            "INSERT INTO session_message (id, session_id, type, data) VALUES ('fork-copy-2', 'fork-2', 'assistant', ?1)",
+            params![copied],
+        )
+        .expect("insert second fork copy");
+    drop(connection);
+
+    let json = daily_json("kilo", &[("KILO_DB", &db), ("HOME", &root)]);
+    assert_one_normalized_call(&json, 3);
+
+    let connection = Connection::open(&db).expect("reopen Kilo fixture database");
+    connection
+        .execute("DELETE FROM message WHERE session_id = 'parent'", [])
+        .expect("delete original legacy message");
+    connection
+        .execute(
+            "DELETE FROM session_message WHERE session_id = 'parent'",
+            [],
+        )
+        .expect("delete original current message");
+    connection
+        .execute("DELETE FROM session WHERE id = 'parent'", [])
+        .expect("delete original session");
+    drop(connection);
+    let copies_only = daily_json("kilo", &[("KILO_DB", &db), ("HOME", &root)]);
+    assert_one_normalized_call(&copies_only, 1);
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn sources_listing_exposes_mimocode_and_kilo_cli() {
+    let root = unique_temp_dir("mimocode-kilo-sources");
+    let (ok, stdout, stderr) = run_ccstats(&["sources", "--json"], &[("HOME", &root)]);
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let rows: Value = serde_json::from_slice(&stdout).expect("sources JSON");
+    let rows = rows.as_array().expect("array");
+    assert!(rows.iter().any(|row| row["name"] == "mimocode"));
+    assert!(rows.iter().any(|row| row["name"] == "kilo"));
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn mimocode_home_and_kilo_xdg_channel_databases_are_discovered() {
+    let root = unique_temp_dir("opencode-family-discovery");
+    let message = r#"{"role":"assistant","modelID":"verified-model","providerID":"verified","finish":"stop","cost":0.0,"tokens":{"input":100,"output":20,"reasoning":5,"cache":{"read":30,"write":10}},"time":{"created":1788145445000,"completed":1788145446000}}"#;
+
+    let mimocode_home = root.join("mimo-home");
+    let mimocode_db = mimocode_home.join("data/mimocode.db");
+    write_file(&mimocode_db, "");
+    let connection = Connection::open(&mimocode_db).expect("open discovered MiMo database");
+    create_schema(&connection, false);
+    insert_single_message(&connection, "mimo-discovery", message);
+    drop(connection);
+    assert_one_normalized_call(
+        &daily_json(
+            "mimocode",
+            &[("MIMOCODE_HOME", &mimocode_home), ("HOME", &root)],
+        ),
+        0,
+    );
+
+    let xdg = root.join("share");
+    let kilo_db = xdg.join("kilo/kilo-nightly.db");
+    write_file(&kilo_db, "");
+    let connection = Connection::open(&kilo_db).expect("open discovered Kilo database");
+    create_schema(&connection, false);
+    insert_single_message(&connection, "kilo-discovery", message);
+    drop(connection);
+    assert_one_normalized_call(
+        &daily_json("kilo", &[("XDG_DATA_HOME", &xdg), ("HOME", &root)]),
+        0,
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn mimocode_recorded_zero_cost_wins_and_invalid_cost_is_reported() {
+    let root = unique_temp_dir("mimocode-cost-e2e");
+    let db = root.join("mimocode.db");
+    write_file(&db, "");
+    let connection = Connection::open(&db).expect("open MiMo cost fixture database");
+    create_schema(&connection, false);
+    connection
+        .execute(
+            "INSERT INTO session (id, directory, parent_id, time_created)
+             VALUES ('cost-session', '/tmp/cost-project', NULL, 1788145400000)",
+            [],
+        )
+        .expect("insert cost session");
+    let zero = r#"{"role":"assistant","modelID":"gpt-5","providerID":"openai","finish":"stop","cost":0.0,"tokens":{"input":10,"output":2,"reasoning":0,"cache":{"read":0,"write":0}},"time":{"created":1788145445000,"completed":1788145446000}}"#;
+    let invalid = r#"{"role":"assistant","modelID":"gpt-5","providerID":"openai","finish":"stop","cost":-1.0,"tokens":{"input":999,"output":99,"reasoning":0,"cache":{"read":0,"write":0}},"time":{"created":1788145447000,"completed":1788145448000}}"#;
+    connection
+        .execute(
+            "INSERT INTO message (id, session_id, data) VALUES
+             ('zero-cost', 'cost-session', ?1),
+             ('invalid-cost', 'cost-session', ?2)",
+            params![zero, invalid],
+        )
+        .expect("insert cost messages");
+    drop(connection);
+
+    let json = daily_json_with_cost("mimocode", &[("MIMOCODE_DB", &db), ("HOME", &root)], true);
+    let row = &json.as_array().expect("array")[0];
+    assert_eq!(row["input_tokens"].as_i64(), Some(10));
+    assert_eq!(row["cost"].as_f64(), Some(0.0));
+    assert_eq!(row["data_quality"]["valid_entries"].as_i64(), Some(1));
+    assert_eq!(row["data_quality"]["parse_errors"].as_u64(), Some(1));
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn relative_mimocode_home_never_falls_back_to_xdg() {
+    let root = unique_temp_dir("mimocode-invalid-home");
+    let xdg = root.join("share");
+    let fallback_db = xdg.join("mimocode/mimocode.db");
+    write_file(&fallback_db, "");
+    let connection = Connection::open(&fallback_db).expect("open fallback database");
+    create_schema(&connection, false);
+    insert_single_message(
+        &connection,
+        "must-not-load",
+        r#"{"role":"assistant","modelID":"wrong-db","providerID":"test","finish":"stop","cost":0.0,"tokens":{"input":100,"output":20,"reasoning":5,"cache":{"read":30,"write":10}},"time":{"created":1788145445000,"completed":1788145446000}}"#,
+    );
+    drop(connection);
+    let relative_home = Path::new("invalid-relative-mimocode-home");
+    let relative_db = root.join(relative_home).join("data/mimocode.db");
+    write_file(&relative_db, "");
+    let connection = Connection::open(&relative_db).expect("open relative MiMo database");
+    create_schema(&connection, false);
+    insert_single_message(
+        &connection,
+        "relative-must-not-load",
+        r#"{"role":"assistant","modelID":"also-wrong","providerID":"test","finish":"stop","cost":0.0,"tokens":{"input":200,"output":40,"reasoning":10,"cache":{"read":60,"write":20}},"time":{"created":1788145445000,"completed":1788145446000}}"#,
+    );
+    drop(connection);
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "--source",
+            "mimocode",
+            "--json",
+            "--offline",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+        ],
+        &[
+            ("MIMOCODE_HOME", relative_home),
+            ("XDG_DATA_HOME", &xdg),
+            ("HOME", &root),
+            ("CCSTATS_TEST_CWD", &root),
+        ],
+    );
+    assert!(ok);
+    let rows = serde_json::from_slice::<Value>(&stdout).unwrap();
+    let row = &rows.as_array().expect("array")[0];
+    assert_eq!(row["data_quality"]["valid_entries"].as_i64(), Some(0));
+    assert_eq!(row["data_quality"]["parse_errors"].as_u64(), Some(1));
+    assert!(String::from_utf8_lossy(&stderr).contains("malformed"));
+    let _ = fs::remove_dir_all(root);
+}

--- a/tests/cli_opencode_pi.rs
+++ b/tests/cli_opencode_pi.rs
@@ -39,6 +39,7 @@ fn create_opencode_db(path: &Path) {
             CREATE TABLE session (
                 id TEXT PRIMARY KEY,
                 directory TEXT NOT NULL,
+                parent_id TEXT,
                 title TEXT NOT NULL,
                 time_created INTEGER NOT NULL,
                 time_updated INTEGER NOT NULL
@@ -65,8 +66,8 @@ fn create_opencode_db(path: &Path) {
     connection
         .execute(
             "INSERT INTO session
-             (id, directory, title, time_created, time_updated)
-             VALUES (?1, ?2, ?3, ?4, ?5)",
+             (id, directory, parent_id, title, time_created, time_updated)
+             VALUES (?1, ?2, NULL, ?3, ?4, ?5)",
             params![
                 "ses_e2e",
                 "/tmp/opencode-project",

--- a/tests/cli_pi_family.rs
+++ b/tests/cli_pi_family.rs
@@ -1,0 +1,293 @@
+mod common;
+
+use common::{run_ccstats, unique_temp_dir, write_file};
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+
+fn daily_json(source: &str, envs: &[(&str, &Path)]) -> Value {
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "--source",
+            source,
+            "--json",
+            "--offline",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-08-31",
+            "--until",
+            "2026-08-31",
+        ],
+        envs,
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    serde_json::from_slice(&stdout).expect("daily JSON")
+}
+
+#[test]
+fn senpi_counts_all_authoritative_usage_carriers_and_deduplicates_fork() {
+    let root = unique_temp_dir("senpi-e2e");
+    let sessions = root.join("sessions");
+    let original = sessions.join("--tmp-senpi--/original.jsonl");
+    let copied = sessions.join("--tmp-senpi--/fork.jsonl");
+    let header = r#"{"type":"session","version":3,"id":"senpi-original","timestamp":"2026-08-31T03:00:00Z","cwd":"/tmp/senpi"}"#;
+    let entries = r#"
+{"type":"model_change","id":"model","timestamp":"2026-08-31T03:00:01Z","provider":"anthropic","modelId":"claude-sonnet-4"}
+{"type":"message","id":"assistant","timestamp":"2026-08-31T03:00:02Z","message":{"role":"assistant","provider":"anthropic","model":"claude-sonnet-4","usage":{"input":10,"output":2,"cacheRead":3,"cacheWrite":1,"cost":{"total":0.01}},"stopReason":"stop"}}
+{"type":"compaction","id":"compaction","timestamp":"2026-08-31T03:00:03Z","usage":{"input":20,"output":4,"cacheRead":0,"cacheWrite":0,"cost":{"total":0.02}}}
+{"type":"branch_summary","id":"branch","timestamp":"2026-08-31T03:00:04Z","usage":{"input":30,"output":6,"cacheRead":0,"cacheWrite":0,"cost":{"total":0.03}}}
+{"type":"message","id":"tool-result","timestamp":"2026-08-31T03:00:05Z","message":{"role":"toolResult","usage":{"input":40,"output":8,"cacheRead":0,"cacheWrite":0,"cost":{"total":0.04}}}}
+"#;
+    let invalid_cost = r#"{"type":"message","id":"invalid-cost","timestamp":"2026-08-31T03:00:06Z","message":{"role":"assistant","provider":"anthropic","model":"claude-sonnet-4","usage":{"input":999,"output":99,"cacheRead":0,"cacheWrite":0,"cost":{"total":-1.0}},"stopReason":"stop"}}
+"#;
+    write_file(&original, &format!("{header}{entries}{invalid_cost}"));
+    write_file(
+        &copied,
+        &format!(
+            "{}{}",
+            r#"{"type":"session","version":3,"id":"senpi-fork","timestamp":"2026-08-31T03:00:10Z","cwd":"/tmp/senpi","parentSession":"senpi-original"}"#,
+            entries
+        ),
+    );
+
+    let json = daily_json(
+        "senpi",
+        &[
+            ("SENPI_CODING_AGENT_SESSION_DIR", &sessions),
+            ("HOME", &root),
+        ],
+    );
+    let row = &json.as_array().expect("array")[0];
+    assert_eq!(row["input_tokens"].as_i64(), Some(100));
+    assert_eq!(row["output_tokens"].as_i64(), Some(20));
+    assert_eq!(row["cache_read_tokens"].as_i64(), Some(3));
+    assert_eq!(row["cache_creation_tokens"].as_i64(), Some(1));
+    assert_eq!(row["data_quality"]["valid_entries"].as_i64(), Some(4));
+    assert_eq!(
+        row["data_quality"]["dedup_skipped_entries"].as_i64(),
+        Some(4)
+    );
+    assert_eq!(row["data_quality"]["parse_errors"].as_u64(), Some(1));
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn kimchi_counts_child_transcript_without_parent_tool_result_rollup() {
+    let root = unique_temp_dir("kimchi-e2e");
+    let sessions = root.join(".config/kimchi/harness/sessions/project");
+    let parent = sessions.join("parent.jsonl");
+    let child = sessions.join("2026-08-31T03-00-03-000Z_kimchi-child.jsonl");
+    let header_only_child = sessions.join("2026-08-31T03-00-06-000Z_header-only.jsonl");
+    let invalid_child = sessions.join("2026-08-31T03-00-07-000Z_invalid-child.jsonl");
+    let parent_line = serde_json::json!({
+        "type": "message",
+        "id": "child-rollup",
+        "timestamp": "2026-08-31T03:00:02Z",
+        "message": {
+            "role": "toolResult",
+            "details": {
+                "modelName": "kimchi-dev/kimi-k2.6",
+                "sessionFile": child.to_string_lossy(),
+                "tokenUsage": {"input": 900, "output": 90, "cacheRead": 0, "cacheWrite": 0}
+            }
+        }
+    });
+    let remote_line = serde_json::json!({
+        "type": "message",
+        "id": "remote-rollup",
+        "timestamp": "2026-08-31T03:00:05Z",
+        "message": {
+            "role": "toolResult",
+            "details": {
+                "modelName": "kimchi-dev/kimi-k2.6",
+                "tokenUsage": {"input": 40, "output": 8, "cacheRead": 0, "cacheWrite": 0}
+            }
+        }
+    });
+    let header_only_line = serde_json::json!({
+        "type": "message",
+        "id": "header-only-rollup",
+        "timestamp": "2026-08-31T03:00:06Z",
+        "message": {
+            "role": "toolResult",
+            "details": {
+                "modelName": "kimchi-dev/kimi-k2.6",
+                "sessionFile": header_only_child.to_string_lossy(),
+                "tokenUsage": {"input": 50, "output": 10, "cacheRead": 0, "cacheWrite": 0}
+            }
+        }
+    });
+    let invalid_child_line = serde_json::json!({
+        "type": "message",
+        "id": "invalid-child-rollup",
+        "timestamp": "2026-08-31T03:00:07Z",
+        "message": {
+            "role": "toolResult",
+            "details": {
+                "modelName": "kimchi-dev/kimi-k2.6",
+                "sessionFile": invalid_child.to_string_lossy(),
+                "tokenUsage": {"input": 60, "output": 12, "cacheRead": 0, "cacheWrite": 0}
+            }
+        }
+    });
+    write_file(
+        &parent,
+        &format!(
+            "{}\n{}\n{}\n{}\n{}\n{}\n",
+            r#"{"type":"session","version":3,"id":"kimchi-parent","timestamp":"2026-08-31T03:00:00Z","cwd":"/tmp/kimchi"}"#,
+            r#"{"type":"message","id":"parent-call","timestamp":"2026-08-31T03:00:01Z","message":{"role":"assistant","provider":"kimchi-dev","model":"kimi-k2.6","usage":{"input":10,"output":2,"cacheRead":0,"cacheWrite":0,"cost":{"total":0.01}},"stopReason":"stop"}}"#,
+            parent_line,
+            remote_line,
+            header_only_line,
+            invalid_child_line
+        ),
+    );
+    write_file(
+        &child,
+        &format!(
+            "{}\n{}\n",
+            serde_json::json!({
+                "type": "session",
+                "version": 3,
+                "id": "kimchi-child",
+                "timestamp": "2026-08-31T03:00:03Z",
+                "cwd": "/tmp/kimchi",
+                "parentSession": parent.to_string_lossy()
+            }),
+            r#"{"type":"message","id":"child-call","timestamp":"2026-08-31T03:00:04Z","message":{"role":"assistant","provider":"kimchi-dev","model":"kimi-k2.6","usage":{"input":20,"output":4,"cacheRead":3,"cacheWrite":1,"cost":{"total":0.02}},"stopReason":"stop"}}"#
+        ),
+    );
+    write_file(
+        &header_only_child,
+        &format!(
+            "{}\n",
+            serde_json::json!({
+                "type": "session",
+                "version": 3,
+                "id": "kimchi-header-only",
+                "timestamp": "2026-08-31T03:00:06Z",
+                "cwd": "/tmp/kimchi",
+                "parentSession": parent.to_string_lossy()
+            })
+        ),
+    );
+    write_file(
+        &invalid_child,
+        &format!(
+            "{}\n{}\n",
+            serde_json::json!({
+                "type": "session",
+                "version": 3,
+                "id": "kimchi-invalid-child",
+                "timestamp": "2026-08-31T03:00:07Z",
+                "cwd": "/tmp/kimchi",
+                "parentSession": parent.to_string_lossy()
+            }),
+            r#"{"type":"message","id":"invalid-child-call","timestamp":"not-a-time","message":{"role":"assistant","provider":"kimchi-dev","model":"kimi-k2.6","usage":{"input":999,"output":99,"cacheRead":0,"cacheWrite":0,"cost":{"total":-1.0}},"stopReason":"stop"}}"#
+        ),
+    );
+
+    let json = daily_json("kimchi", &[("HOME", &root)]);
+    let row = &json.as_array().expect("array")[0];
+    assert_eq!(row["input_tokens"].as_i64(), Some(180));
+    assert_eq!(row["output_tokens"].as_i64(), Some(36));
+    assert_eq!(row["cache_read_tokens"].as_i64(), Some(3));
+    assert_eq!(row["cache_creation_tokens"].as_i64(), Some(1));
+    assert_eq!(row["data_quality"]["valid_entries"].as_i64(), Some(5));
+    assert_eq!(row["data_quality"]["parse_errors"].as_u64(), Some(1));
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn sources_listing_exposes_senpi_and_kimchi() {
+    let root = unique_temp_dir("pi-family-sources");
+    let (ok, stdout, stderr) = run_ccstats(&["sources", "--json"], &[("HOME", &root)]);
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let rows: Value = serde_json::from_slice(&stdout).expect("sources JSON");
+    let rows = rows.as_array().expect("array");
+    assert!(rows.iter().any(|row| row["name"] == "senpi"));
+    assert!(rows.iter().any(|row| row["name"] == "kimchi"));
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn senpi_discovers_project_local_and_tilde_agent_directories() {
+    let root = unique_temp_dir("senpi-discovery");
+    let project = root.join("project");
+    let cwd = project.join("nested/worktree");
+    fs::create_dir_all(&cwd).expect("create project cwd");
+    let session = r#"{"type":"session","version":3,"id":"senpi-discovery","timestamp":"2026-08-31T03:00:00Z","cwd":"/tmp/senpi-discovery"}
+{"type":"message","id":"usage","timestamp":"2026-08-31T03:00:01Z","message":{"role":"assistant","provider":"test","model":"verified-model","usage":{"input":12,"output":3,"cacheRead":2,"cacheWrite":1},"stopReason":"stop"}}
+"#;
+    write_file(
+        &project.join(".senpi/agent/sessions/project/session.jsonl"),
+        session,
+    );
+    let project_json = daily_json("senpi", &[("HOME", &root), ("CCSTATS_TEST_CWD", &cwd)]);
+    let row = &project_json.as_array().expect("array")[0];
+    assert_eq!(row["input_tokens"].as_i64(), Some(12));
+    assert_eq!(row["output_tokens"].as_i64(), Some(3));
+
+    write_file(
+        &root.join("custom-agent/sessions/project/session.jsonl"),
+        session,
+    );
+    let tilde_json = daily_json(
+        "senpi",
+        &[
+            ("HOME", &root),
+            ("SENPI_CODING_AGENT_DIR", Path::new("~/custom-agent")),
+        ],
+    );
+    let row = &tilde_json.as_array().expect("array")[0];
+    assert_eq!(row["input_tokens"].as_i64(), Some(12));
+    assert_eq!(row["cache_read_tokens"].as_i64(), Some(2));
+
+    write_file(
+        &root.join("windows-style-agent/sessions/project/session.jsonl"),
+        session,
+    );
+    let windows_tilde_json = daily_json(
+        "senpi",
+        &[
+            ("HOME", &root),
+            (
+                "SENPI_CODING_AGENT_DIR",
+                Path::new(r"~\windows-style-agent"),
+            ),
+        ],
+    );
+    let row = &windows_tilde_json.as_array().expect("array")[0];
+    assert_eq!(row["input_tokens"].as_i64(), Some(12));
+
+    write_file(
+        &root.join(".senpi/agent/settings.jsonc"),
+        "\u{feff}{\n  // Senpi prefers JSONC when both formats exist.\n  \"sessionDir\": \"~/settings-sessions\",\n}\n",
+    );
+    write_file(&root.join("settings-sessions/session.jsonl"), session);
+    let settings_json = daily_json("senpi", &[("HOME", &root)]);
+    let row = &settings_json.as_array().expect("array")[0];
+    assert_eq!(row["input_tokens"].as_i64(), Some(12));
+    assert_eq!(row["cache_creation_tokens"].as_i64(), Some(1));
+
+    let reset_project = root.join("settings-reset-project/nested");
+    fs::create_dir_all(&reset_project).expect("create settings reset project");
+    write_file(
+        &root.join("settings-reset-project/.senpi/settings.jsonc"),
+        "{\n  // Project null resets the global sessionDir.\n  \"sessionDir\": null,\n}\n",
+    );
+    write_file(
+        &root.join(".senpi/agent/sessions/project/session.jsonl"),
+        &session.replace("\"input\":12", "\"input\":14"),
+    );
+    let reset_json = daily_json(
+        "senpi",
+        &[("HOME", &root), ("CCSTATS_TEST_CWD", &reset_project)],
+    );
+    let row = &reset_json.as_array().expect("array")[0];
+    assert_eq!(row["input_tokens"].as_i64(), Some(14));
+    let _ = fs::remove_dir_all(root);
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -14,9 +14,14 @@ const SOURCE_ENV_VARS: &[&str] = &[
     "GROK_HOME",
     "GOOSE_PATH_ROOT",
     "KIMI_CODE_HOME",
+    "KILO_DB",
+    "MIMOCODE_DB",
+    "MIMOCODE_HOME",
     "OPENCODE_DB",
     "PI_CODING_AGENT_DIR",
     "PI_CODING_AGENT_SESSION_DIR",
+    "SENPI_CODING_AGENT_DIR",
+    "SENPI_CODING_AGENT_SESSION_DIR",
     "XDG_DATA_HOME",
 ];
 
@@ -84,7 +89,11 @@ pub(crate) fn run_ccstats(args: &[&str], envs: &[(&str, &Path)]) -> (bool, Vec<u
         cmd.env_remove(key);
     }
     for (k, v) in envs {
-        cmd.env(k, v);
+        if *k == "CCSTATS_TEST_CWD" {
+            cmd.current_dir(v);
+        } else {
+            cmd.env(k, v);
+        }
     }
     let output = cmd.output().expect("run ccstats");
     (output.status.success(), output.stdout, output.stderr)


### PR DESCRIPTION
Stacked on #119.\n\n## What changed\n- add verified MiMo Code and Kilo CLI SQLite ingestion\n- reconcile OpenCode-fork copied history without relying on nonexistent parent lineage\n- add Senpi discovery for project/global directories and JSONC settings\n- add Kimchi child-transcript accounting with authoritative parent-rollup fallback\n- document verified algorithms and explicit accuracy boundaries for GJC, Prime Agent, and OMP\n- expand the source registry and SDK to 19 sources\n\n## Verification\n- cargo fmt --all\n- cargo clippy --all-targets --all-features -- -D warnings\n- 13 focused CLI end-to-end scenarios\n- cargo test --locked\n- cargo deny check (advisories, bans, licenses, and sources all pass; duplicate-version warnings remain)\n- cargo llvm-cov --tests --bins --lcov --output-path /tmp/ccstats-batch3-lcov.info\n- patch-tournament guard: 0 violations