### PR TITLE
feat: prepare ccstats for public adoption

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
 
   publish:
     name: Publish crate
-    needs: preflight
+    needs: [preflight, build]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -39,7 +39,7 @@ jobs:
 
       - name: Authenticate to crates.io
         id: crates-auth
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18
 
       - name: Publish crate
         run: cargo publish --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,6 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  contents: write
-
 jobs:
   preflight:
     name: Release preflight
@@ -26,6 +23,28 @@ jobs:
 
       - name: Package dry run
         run: cargo publish --dry-run --locked
+
+  publish:
+    name: Publish crate
+    needs: preflight
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.88.0
+
+      - name: Authenticate to crates.io
+        id: crates-auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Publish crate
+        run: cargo publish --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-auth.outputs.token }}
 
   build:
     name: Build ${{ matrix.target }}
@@ -93,8 +112,10 @@ jobs:
 
   release:
     name: Create Release
-    needs: build
+    needs: [build, publish]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
 
@@ -117,6 +138,13 @@ jobs:
       - name: Extract release version
         id: release-version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for crates.io artifact
+        run: >-
+          curl --fail --show-error --silent
+          --retry 12 --retry-all-errors --retry-delay 5
+          "https://static.crates.io/crates/ccstats/ccstats-${{ steps.release-version.outputs.version }}.crate"
+          --output /dev/null
 
       - name: Update Homebrew formula
         uses: mislav/bump-homebrew-formula-action@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-08-31
+
 ### Added
 - Expose provider-authoritative Codex weekly quota reports through the Rust SDK with typed data and errors.
+- Add `ccstats doctor` for read-only, machine-readable source setup diagnostics.
+- Document privacy boundaries, network access, and the release process.
 
 ### Changed
 - Calculate Grok 4.5 and 4.6 USD cost from per-inference `unified.jsonl` token records, including prompt-cache rates and the 200k-token whole-request pricing tier, instead of using `turn_completed.costUsdTicks` as the Grok Build weekly-allowance value.
+- Improve the README first-run path, positioning, installation maintenance, and package metadata.
 
 ### Fixed
 - Preserve Grok inference records in an atomic ccstats ledger so upstream head trimming does not remove usage that ccstats has already observed.
+- Publish crates.io through short-lived OIDC credentials before creating GitHub Releases or updating Homebrew.
 
 ## [0.5.0] - 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Expose provider-authoritative Codex weekly quota reports through the Rust SDK with typed data and errors.
+- Expand local usage support from 5 to 29 sources across nine provider batches: Gemini CLI, Amp, Qwen Code, Cline, Roo Code, and Kilo Code; OpenCode, MiMo Code, and Kilo CLI; Pi, Senpi, and Kimchi; Gajae Code, Prime Agent, and Oh My Pi; GitHub Copilot CLI and Goose; OpenClaw, Xum, and Hermes Agent; Reasonix and Vercel Fx; Unsloth Studio; and DeepSeek Harness.
 - Add `ccstats doctor` for read-only, machine-readable diagnostics across all 29 registered sources.
 - Document privacy boundaries, network access, and the release process.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Expose provider-authoritative Codex weekly quota reports through the Rust SDK with typed data and errors.
-- Add `ccstats doctor` for read-only, machine-readable source setup diagnostics.
+- Add `ccstats doctor` for read-only, machine-readable diagnostics across all 29 registered sources.
 - Document privacy boundaries, network access, and the release process.
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "ccstats"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "ccstats"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.88"
-description = "Fast token and cost usage statistics CLI for Claude Code, OpenAI Codex, Cursor, Grok, and Kimi Code"
+description = "Fast, local-first token and cost analytics for AI coding agents"
 license = "MIT"
 repository = "https://github.com/majiayu000/ccstats"
+homepage = "https://github.com/majiayu000/ccstats"
+documentation = "https://docs.rs/ccstats"
+readme = "README.md"
 keywords = ["claude", "codex", "cursor", "token", "usage"]
 categories = ["command-line-utilities"]
 

--- a/README.md
+++ b/README.md
@@ -1,56 +1,127 @@
 # ccstats
 
+[![CI](https://github.com/majiayu000/ccstats/actions/workflows/ci.yml/badge.svg)](https://github.com/majiayu000/ccstats/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/ccstats.svg)](https://crates.io/crates/ccstats)
+[![Crates.io Downloads](https://img.shields.io/crates/d/ccstats.svg)](https://crates.io/crates/ccstats)
 [![GitHub Release](https://img.shields.io/github/v/release/majiayu000/ccstats)](https://github.com/majiayu000/ccstats/releases)
+[![docs.rs](https://img.shields.io/docsrs/ccstats)](https://docs.rs/ccstats/latest/ccstats/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/majiayu000/ccstats/blob/main/LICENSE)
 
 ![ccstats token and cost analytics card](docs/branding/readme-card.png)
 
-`ccstats` is a fast CLI for token and cost usage analytics for Claude Code, OpenAI Codex, Cursor, Grok, and Kimi Code logs.
+`ccstats` is a fast, local-first CLI and Rust SDK for understanding token usage,
+cost, cache efficiency, and quota pace across Claude Code, OpenAI Codex,
+Cursor, Grok, and Kimi Code.
 
-Search keywords: `claude code usage stats`, `codex usage stats`, `cursor usage stats`, `token usage cli`, `ai token cost tracker`.
+One binary turns the usage metadata your coding agents already produce into
+terminal reports and structured JSON/CSV. No ccstats account or telemetry is
+required.
 
-## Highlights
+## 30-second start
 
-- Fast local analysis of usage JSONL logs
-- Claude Code support (`~/.claude/projects/`)
-- OpenAI Codex support (`~/.codex/sessions/`)
-- Codex weekly quota pace and reset estimates from provider snapshots
-- Cursor usage API support (`CURSOR_API_KEY` or `CURSOR_SESSION_TOKEN`)
-- Grok support (`~/.grok/sessions/`)
-- Kimi Code support (`~/.kimi-code/sessions/`)
-- Daily/weekly/monthly/project/session views
-- Top-N leaderboard ranking models or projects by cost share
-- Optional model-level token and cost breakdown
-- Reusable Rust SDK for embedding local usage and cost summaries in other apps
+```bash
+brew install majiayu000/tap/ccstats
+ccstats doctor
+ccstats daily --source all
+```
+
+`doctor` is read-only and never contacts remote providers. It shows which
+sources are detected, which API-backed sources are configured, and the exact
+setup step for anything missing.
+
+## Why ccstats
+
+- **Fast and portable** — a small Rust binary with no Node.js or Python runtime.
+- **Automation-ready** — table, JSON, CSV, jq filtering, statusline output, and
+  a reusable Rust SDK share the same accounting logic.
+- **Accuracy over guesswork** — source-aware deduplication, cache/reasoning token
+  handling, parse-quality metadata, strict pricing mode, and visible pricing
+  provenance.
+- **Useful beyond spend** — daily/weekly/monthly trends, projects, sessions,
+  top consumers, Claude tool usage, and Codex quota pace.
+- **Local-first** — local session data stays on the machine; network access is
+  bounded by feature and pricing refreshes can be disabled with `--offline`.
+
+ccstats is intentionally CLI-first. If your primary need is an always-visible
+menu-bar app, a graphical dashboard, gamification, or cloud leaderboards, a GUI
+tracker is a better fit. Choose ccstats when speed, scripting, reproducibility,
+and inspectable accounting rules matter most.
+
+## Supported sources
+
+| Source | Usage input | Start here |
+|--------|-------------|------------|
+| Claude Code | `~/.claude/projects/` | `ccstats today` |
+| OpenAI Codex | `~/.codex/sessions/` and local quota snapshots | `ccstats codex today` / `ccstats quota` |
+| Cursor | Official usage API or an explicit replay file | `ccstats today --source cursor` |
+| Grok | `~/.grok/logs/unified.jsonl` with session fallback | `ccstats grok today` |
+| Kimi Code | `~/.kimi-code/sessions/` wire logs | `ccstats kimi today` |
+
+Run `ccstats sources` for aliases and per-source capabilities, or `ccstats
+doctor --json` for machine-readable setup diagnostics.
+
+## Privacy and network access
+
+ccstats extracts usage metadata from known source locations. It does not store
+or upload prompt text, responses, or source-code content. Local parsing requires
+no ccstats account.
+
+Network access occurs only when a selected feature needs it:
+
+- pricing refresh downloads the public LiteLLM pricing catalog;
+- non-USD output downloads exchange rates;
+- Cursor usage calls Cursor's API with credentials supplied by the user.
+
+Use `--offline` to prevent pricing and exchange-rate refreshes. See the full
+[privacy and data-access reference](docs/PRIVACY.md) for files read, caches
+written, and endpoints contacted.
 
 ## Installation
 
 ### Homebrew (macOS/Linux)
+
 ```bash
 brew install majiayu000/tap/ccstats
 ```
 
 ### Cargo binstall (prebuilt binary)
+
 ```bash
 cargo binstall ccstats
 ```
 
 ### Cargo install (from source)
+
 ```bash
 cargo install ccstats
 ```
 
 ### Shell script
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/majiayu000/ccstats/main/install.sh | sh
 
 # Install a specific version
-curl -fsSL https://raw.githubusercontent.com/majiayu000/ccstats/main/install.sh | VERSION=v0.2.63 sh
+curl -fsSL https://raw.githubusercontent.com/majiayu000/ccstats/main/install.sh | VERSION=v0.5.0 sh
 ```
 
 ### Manual download
+
 Download prebuilt archives and SHA-256 checksums from [GitHub Releases](https://github.com/majiayu000/ccstats/releases).
+
+### Upgrade and uninstall
+
+```bash
+# Homebrew
+brew upgrade majiayu000/tap/ccstats
+
+# Cargo
+cargo install ccstats --locked --force
+
+# Uninstall Homebrew or Cargo installs
+brew uninstall ccstats
+cargo uninstall ccstats
+```
 
 ## Quick Start (Codex)
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ ccstats daily --source all
 ```
 
 `doctor` is read-only and never contacts remote providers. It shows which
-sources are detected, which API-backed sources are configured, and the exact
-setup step for anything missing.
+registered sources are detected or configured, plus a practical hint for
+missing sources.
 
 ## Why ccstats
 
@@ -46,7 +46,7 @@ menu-bar app, a graphical dashboard, gamification, or cloud leaderboards, a GUI
 tracker is a better fit. Choose ccstats when speed, scripting, reproducibility,
 and inspectable accounting rules matter most.
 
-## Supported sources
+## Start with common sources
 
 | Source | Usage input | Start here |
 |--------|-------------|------------|
@@ -56,8 +56,10 @@ and inspectable accounting rules matter most.
 | Grok | `~/.grok/logs/unified.jsonl` with session fallback | `ccstats grok today` |
 | Kimi Code | `~/.kimi-code/sessions/` wire logs | `ccstats kimi today` |
 
-Run `ccstats sources` for aliases and per-source capabilities, or `ccstats
-doctor --json` for machine-readable setup diagnostics.
+The complete registry contains 29 sources, including DeepSeek Harness. See the
+full [source table](#supported-data-sources) below. Run `ccstats sources` for
+aliases and per-source capabilities, or `ccstats doctor --json` for
+machine-readable setup diagnostics.
 
 ## Privacy and network access
 
@@ -714,8 +716,9 @@ Table output uses one decimal place and a `%` suffix. JSON uses the numeric
 Claude, Codex, Cursor, Grok, Kimi Code, Gemini CLI, Amp, Qwen Code, Cline, Roo
 Code, Kilo Code, OpenCode, MiMo Code, Kilo CLI, Pi, Senpi, Kimchi, Gajae Code,
 Prime Agent, Oh My Pi, GitHub Copilot CLI, Goose, OpenClaw, Xum, Hermes Agent,
-Reasonix, Vercel Fx, and DeepSeek Harness expose the required cache-read metric. Mixed `--source all` output
-reports the aggregate rate across all selected usage.
+Reasonix, Vercel Fx, Unsloth Studio, and DeepSeek Harness expose the required
+cache-read metric. Mixed `--source all` output reports the aggregate rate across
+all selected usage.
 
 ### Parsing Warnings
 
@@ -757,6 +760,7 @@ Warning: ignored <N> malformed records
 | Hermes Agent | `~/.hermes/state.db` | `HERMES_HOME` | Current per-model/task ledger plus session residual, Projects, exact API call counts, reasoning/cache tokens, actual/included cost provenance |
 | Reasonix | `~/.reasonix/stats/YYYY-MM-DD.jsonl` | `REASONIX_STATE_HOME`, `REASONIX_HOME` | Per-call/request aggregates, reasoning/cache normalization, occurrence-time complete USD valuations, isolated parse errors |
 | Vercel Fx | `~/.fx/usage.jsonl` plus canonical-session-validated recovery backlog | `HOME` | Profile-wide generation IDs, exact timestamps and costs, cache/reasoning normalization, duplicate/conflict detection, fail-closed sidecar recovery |
+| Unsloth Studio | `~/.unsloth/studio/studio.db` | `UNSLOTH_STUDIO_HOME`, `STUDIO_HOME` | Chat and API receipts, fork-copy reconciliation, project attribution, response-model precedence, independent reported totals |
 | DeepSeek Harness | `~/.dsh/sessions/<project>/<session>/session.jsonl[.zstd]` | `DSH_HOME` | Projects, retry-aware call accounting, cache/reasoning tokens, compaction calls, fork ownership, concatenated-zstd recovery |
 
 ## Architecture

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -7,16 +7,16 @@ source-code content.
 
 ## Local data read
 
-| Source | Default location | Override |
-|--------|------------------|----------|
-| Claude Code | `~/.claude/projects/` | `CLAUDE_CONFIG_DIR` |
-| OpenAI Codex | `~/.codex/sessions/` | `CODEX_HOME` |
-| Cursor | No local discovery; API or replay file only | `CURSOR_USAGE_FILE` |
-| Grok | `~/.grok/logs/unified.jsonl` and `~/.grok/sessions/` | `GROK_HOME` |
-| Kimi Code | `~/.kimi-code/sessions/` | `KIMI_CODE_HOME` |
+The 29 registered sources are Claude Code, OpenAI Codex, Cursor, Grok, Kimi
+Code, Gemini CLI, Amp, Qwen Code, Cline, Roo Code, Kilo Code, OpenCode, MiMo
+Code, Kilo CLI, Pi, Senpi, Kimchi, Gajae Code, Prime Agent, Oh My Pi, GitHub
+Copilot CLI, Goose, OpenClaw, Xum, Hermes Agent, Reasonix, Vercel Fx, Unsloth
+Studio, and DeepSeek Harness. Their default locations and overrides are listed
+in the README's complete supported-source table.
 
-`ccstats doctor` only checks these known locations and environment-variable
-presence. It does not parse session contents or contact remote services.
+`ccstats doctor` checks the registered sources' known locations and relevant
+environment-variable presence. It does not parse session contents or contact
+remote services.
 
 ## Network access
 

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -1,0 +1,55 @@
+# Privacy and data access
+
+ccstats is local-first and does not require an account. It extracts token,
+model, timestamp, project/session identity, tool-call, and cost metadata needed
+for reports. It does not persist or upload prompt text, model responses, or
+source-code content.
+
+## Local data read
+
+| Source | Default location | Override |
+|--------|------------------|----------|
+| Claude Code | `~/.claude/projects/` | `CLAUDE_CONFIG_DIR` |
+| OpenAI Codex | `~/.codex/sessions/` | `CODEX_HOME` |
+| Cursor | No local discovery; API or replay file only | `CURSOR_USAGE_FILE` |
+| Grok | `~/.grok/logs/unified.jsonl` and `~/.grok/sessions/` | `GROK_HOME` |
+| Kimi Code | `~/.kimi-code/sessions/` | `KIMI_CODE_HOME` |
+
+`ccstats doctor` only checks these known locations and environment-variable
+presence. It does not parse session contents or contact remote services.
+
+## Network access
+
+| Feature | Endpoint | Data sent |
+|---------|----------|-----------|
+| Pricing refresh | `raw.githubusercontent.com/BerriAI/litellm` | Standard HTTPS request; no session data |
+| Currency conversion | `open.er-api.com` | Requested USD rate catalog; no session data |
+| Cursor Admin usage | `api.cursor.com` | User-supplied API key and requested date range |
+| Cursor dashboard usage | `cursor.com` | User-supplied session token and requested date range |
+
+`--offline` disables pricing and exchange-rate downloads and uses cached data.
+It does not make Cursor local because Cursor is an API-backed source; use
+`CURSOR_USAGE_FILE` for an explicit offline replay.
+
+## Local data written
+
+ccstats writes only operational data needed to make repeated reports reliable:
+
+- pricing cache under the platform cache directory and exchange-rate cache
+  under `~/.cache/ccstats/`;
+- a Grok inference ledger under the ccstats cache directory because Grok may
+  trim its live log in place;
+- no prompt, response, or source-code archive.
+
+The optional TOML config is user-created. ccstats reads the first configured
+path documented in the README and fails clearly if that file is malformed.
+
+## Credentials
+
+Cursor credentials are read from `CURSOR_API_KEY` or `CURSOR_SESSION_TOKEN` and
+sent only to the corresponding Cursor endpoint. ccstats does not print them,
+write them to its cache, or include them in doctor JSON/CSV output.
+
+When reporting a bug, include `ccstats doctor --json` and the command's stderr.
+Do not attach session logs, environment dumps, config files containing secrets,
+or Cursor credentials.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,60 @@
+# Releasing ccstats
+
+Releases are tag-driven. A successful release publishes the crate first, then
+creates the multi-platform GitHub Release and updates the Homebrew formula.
+This ordering prevents the Homebrew formula from pointing at a crate version
+that does not exist.
+
+## One-time crates.io setup
+
+Open the `ccstats` crate settings on crates.io, add a GitHub trusted publisher,
+and use these values before creating a release tag:
+
+- Repository owner: `majiayu000`
+- Repository name: `ccstats`
+- Workflow filename: `release.yml`
+- Environment: leave blank (the workflow does not declare one)
+
+The workflow uses the official
+[`rust-lang/crates-io-auth-action`](https://github.com/rust-lang/crates-io-auth-action)
+to exchange GitHub OIDC identity for a short-lived crates.io token. Do not add
+a long-lived crates.io API token to GitHub Secrets.
+
+The existing `HOMEBREW_TAP_TOKEN` secret must retain permission to update
+`majiayu000/homebrew-tap`.
+
+## Release checklist
+
+1. Update the version in `Cargo.toml` and `Cargo.lock`.
+2. Move the relevant entries from `Unreleased` into a dated version section in
+   `CHANGELOG.md`.
+3. Run the same preflight checks used by CI:
+
+   ```bash
+   cargo fmt --all -- --check
+   cargo clippy --all-targets --all-features -- -D warnings
+   cargo test --all-targets --all-features
+   cargo deny check
+   cargo publish --dry-run --locked
+   ```
+
+4. Create and push the matching tag, for example `v0.5.1` for version `0.5.1`.
+5. Confirm every job in the Release workflow succeeds.
+
+## Public verification
+
+Verify the independently published surfaces instead of treating a green
+workflow as sufficient:
+
+```bash
+cargo search ccstats --limit 1
+gh release view v0.5.1 --repo majiayu000/ccstats
+brew update
+brew info majiayu000/tap/ccstats
+cargo binstall ccstats --no-confirm
+ccstats --version
+```
+
+crates.io indexing and Homebrew tap updates can lag briefly. The published
+version, release assets, and formula must all agree before announcing a
+release.

--- a/src/app.rs
+++ b/src/app.rs
@@ -612,6 +612,7 @@ pub(crate) fn handle_source_command(
     let caps = source.capabilities();
 
     match command {
+        SourceCommand::Doctor => return crate::doctor_cmd::handle_doctor(ctx),
         SourceCommand::Sources => return crate::sources_cmd::handle_sources(ctx),
         SourceCommand::Quota => return crate::quota_cmd::handle_quota(ctx),
         SourceCommand::Session => return handle_session(source, ctx),
@@ -686,6 +687,7 @@ fn load_all_daily(ctx: &CommandContext<'_>, quiet: bool) -> (LoadResult, Capabil
 /// Handle aggregate commands across every registered data source.
 pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandContext<'_>) {
     match command {
+        SourceCommand::Doctor => return crate::doctor_cmd::handle_doctor(ctx),
         SourceCommand::Sources => return crate::sources_cmd::handle_sources(ctx),
         SourceCommand::Quota => {
             eprintln!("Error: quota analysis only supports the Codex source");

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -17,6 +17,8 @@ pub(crate) enum TopDimension {
 /// Main CLI commands
 #[derive(Subcommand)]
 pub(crate) enum Commands {
+    /// Check source setup without contacting remote providers
+    Doctor,
     /// List available data sources and aliases
     Sources,
     /// Show daily usage (default)
@@ -127,6 +129,7 @@ pub(crate) enum KimiCommands {
 /// Normalized command that works across all sources
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SourceCommand {
+    Doctor,
     Sources,
     Daily,
     Weekly,
@@ -158,6 +161,7 @@ impl From<&Commands> for SourceCommand {
     #[allow(clippy::match_same_arms)] // Codex default intentionally maps to Daily
     fn from(cmd: &Commands) -> Self {
         match cmd {
+            Commands::Doctor => SourceCommand::Doctor,
             Commands::Sources => SourceCommand::Sources,
             Commands::Daily => SourceCommand::Daily,
             Commands::Weekly => SourceCommand::Weekly,
@@ -322,6 +326,13 @@ mod tests {
     fn parse_command_sources_has_no_source_hint() {
         let parsed = parse_command(Some(&Commands::Sources));
         assert_eq!(parsed.command, SourceCommand::Sources);
+        assert_eq!(parsed.source_hint, None);
+    }
+
+    #[test]
+    fn parse_command_doctor_has_no_source_hint() {
+        let parsed = parse_command(Some(&Commands::Doctor));
+        assert_eq!(parsed.command, SourceCommand::Doctor);
         assert_eq!(parsed.source_hint, None);
     }
 }

--- a/src/doctor_cmd.rs
+++ b/src/doctor_cmd.rs
@@ -1,0 +1,90 @@
+//! Read-only source diagnostics for first-run setup and troubleshooting.
+
+use crate::app::{CommandContext, print_json};
+use crate::output::{OutputFormat, csv_escape};
+use crate::source::{DiagnosticStatus, Source, SourceDiagnostic, all_sources};
+use serde_json::json;
+
+struct DiagnosticRow {
+    source: &'static dyn Source,
+    diagnostic: SourceDiagnostic,
+}
+
+pub(crate) fn handle_doctor(ctx: &CommandContext<'_>) {
+    let rows = all_sources()
+        .map(|source| DiagnosticRow {
+            source,
+            diagnostic: source.diagnose(),
+        })
+        .collect::<Vec<_>>();
+
+    match ctx.cli.output_format() {
+        OutputFormat::Table => render_table(&rows),
+        OutputFormat::Json => render_json(&rows, ctx),
+        OutputFormat::Csv => render_csv(&rows),
+    }
+}
+
+fn render_table(rows: &[DiagnosticRow]) {
+    println!("Source diagnostics (read-only; remote providers are not contacted):");
+    for row in rows {
+        println!(
+            "- {:<10} {:<16} {}",
+            row.diagnostic.status.as_str(),
+            row.source.display_name(),
+            row.diagnostic.detail
+        );
+        if row.diagnostic.status == DiagnosticStatus::Missing {
+            println!("  Setup: {}.", row.source.setup_hint());
+        }
+    }
+
+    if rows
+        .iter()
+        .all(|row| row.diagnostic.status != DiagnosticStatus::Detected)
+    {
+        println!(
+            "\nNo source data detected. Complete one setup step above, then rerun `ccstats doctor --json`."
+        );
+    } else {
+        println!("\nNext: run `ccstats daily --source all` for a combined report.");
+    }
+}
+
+fn render_json(rows: &[DiagnosticRow], ctx: &CommandContext<'_>) {
+    let payload = rows
+        .iter()
+        .map(|row| {
+            json!({
+                "name": row.source.name(),
+                "display_name": row.source.display_name(),
+                "status": row.diagnostic.status.as_str(),
+                "files": row.diagnostic.files,
+                "detail": row.diagnostic.detail,
+                "setup": row.source.setup_hint(),
+            })
+        })
+        .collect::<Vec<_>>();
+    match serde_json::to_string(&payload) {
+        Ok(json) => print_json(&json, ctx.jq_filter),
+        Err(error) => {
+            eprintln!("Error: failed to serialize doctor output: {error}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn render_csv(rows: &[DiagnosticRow]) {
+    println!("name,display_name,status,files,detail,setup");
+    for row in rows {
+        println!(
+            "{},{},{},{},{},{}",
+            csv_escape(row.source.name()),
+            csv_escape(row.source.display_name()),
+            row.diagnostic.status.as_str(),
+            row.diagnostic.files,
+            csv_escape(&row.diagnostic.detail),
+            csv_escape(row.source.setup_hint())
+        );
+    }
+}

--- a/src/doctor_cmd.rs
+++ b/src/doctor_cmd.rs
@@ -1,4 +1,4 @@
-//! Read-only source diagnostics for first-run setup and troubleshooting.
+//! Read-only registered source diagnostics for first-run troubleshooting.
 
 use crate::app::{CommandContext, print_json};
 use crate::output::{OutputFormat, csv_escape};
@@ -41,7 +41,7 @@ fn render_table(rows: &[DiagnosticRow]) {
 
     if rows
         .iter()
-        .all(|row| row.diagnostic.status != DiagnosticStatus::Detected)
+        .all(|row| row.diagnostic.status == DiagnosticStatus::Missing)
     {
         println!(
             "\nNo source data detected. Complete one setup step above, then rerun `ccstats doctor --json`."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,8 @@
 //! Claude Code, `OpenAI` Codex, Cursor, Grok, Kimi Code, Gemini CLI, Amp,
 //! Qwen Code, Cline, Roo Code, Kilo Code, `OpenCode`, `MiMo` Code, Kilo CLI, Pi,
 //! Senpi, Kimchi, Gajae Code, Prime Agent, Oh My Pi, GitHub Copilot CLI, Goose,
-//! `OpenClaw`, Xum, Hermes Agent, Reasonix, and Vercel Fx local usage data.
+//! `OpenClaw`, Xum, Hermes Agent, Reasonix, Vercel Fx, Unsloth Studio, and
+//! `DeepSeek Harness` local usage data.
 //!
 //! The public SDK entry points are [`summarize_cost`] and
 //! [`summarize_cost_ranges`] for cost analytics, [`load_codex_weekly_quota`]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ mod cli;
 mod config;
 mod consts;
 mod core;
+mod doctor_cmd;
 mod endpoints_cmd;
 mod error;
 mod output;
@@ -184,7 +185,7 @@ fn resolve_source_name<'a>(
     source_override: Option<&'a str>,
     source_cmd: SourceCommand,
 ) -> &'a str {
-    if source_cmd == SourceCommand::Sources {
+    if matches!(source_cmd, SourceCommand::Doctor | SourceCommand::Sources) {
         return "claude";
     }
 
@@ -325,7 +326,8 @@ pub fn run_cli() {
     let budget_as_of = until.map_or(today, |end| end.min(today));
     let filter = build_date_filter(source_cmd, today, since, until);
     let show_cost = cli.show_cost();
-    let needs_pricing = is_statusline || show_cost;
+    let metadata_only = matches!(source_cmd, SourceCommand::Doctor | SourceCommand::Sources);
+    let needs_pricing = !metadata_only && (is_statusline || show_cost);
     let pricing_db = load_pricing_db(&cli, needs_pricing, is_statusline);
     let source_name = resolve_source_name(
         parsed_command.source_hint,

--- a/src/output/format.rs
+++ b/src/output/format.rs
@@ -209,7 +209,7 @@ pub(super) fn right_cell(text: &str, color: Option<Color>, bold: bool) -> Cell {
 ///
 /// Wraps the value in double quotes and doubles any embedded quotes if the
 /// input contains a comma, double quote, newline, or carriage return.
-pub(super) fn csv_escape(s: &str) -> String {
+pub(crate) fn csv_escape(s: &str) -> String {
     if s.contains(',') || s.contains('"') || s.contains('\n') || s.contains('\r') {
         format!("\"{}\"", s.replace('"', "\"\""))
     } else {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -37,7 +37,7 @@ pub(crate) use csv::{
     output_period_csv_with_quality, output_project_csv, output_session_csv,
 };
 pub(crate) use endpoints::{EndpointTableOptions, output_endpoint_json, print_endpoint_table};
-pub(crate) use format::NumberFormat;
+pub(crate) use format::{NumberFormat, csv_escape};
 pub(crate) use json::output_period_json_with_quality;
 pub(crate) use period::Period;
 pub(crate) use project::{ProjectTableOptions, output_project_json, print_project_table};

--- a/src/output/quota.rs
+++ b/src/output/quota.rs
@@ -6,7 +6,8 @@ use crate::source::{CodexQuotaStatus, CodexWeeklyQuota};
 use crate::utils::Timezone;
 
 use super::format::{
-    NumberFormat, create_styled_table, format_compact, header_cell, right_cell, styled_cell,
+    NumberFormat, create_styled_table, csv_escape, format_compact, header_cell, right_cell,
+    styled_cell,
 };
 
 fn rounded_pct(value: f64) -> f64 {
@@ -65,14 +66,6 @@ pub(crate) fn output_quota_json(
     output.to_string()
 }
 
-fn csv_field(value: &str) -> String {
-    if value.contains([',', '"', '\n', '\r']) {
-        format!("\"{}\"", value.replace('"', "\"\""))
-    } else {
-        value.to_string()
-    }
-}
-
 pub(crate) fn output_quota_csv(
     report: &CodexWeeklyQuota,
     value_estimate: QuotaValueEstimate<'_>,
@@ -111,7 +104,7 @@ codex,weekly,{},{:.2},{:.2},{:.2},{},{},{},{}\n",
                 String::new(),
                 String::new(),
                 String::new(),
-                csv_field(&error.to_string()),
+                csv_escape(&error.to_string()),
             ),
         };
     format!(

--- a/src/source/claude/config.rs
+++ b/src/source/claude/config.rs
@@ -51,6 +51,10 @@ impl Source for ClaudeSource {
         }
     }
 
+    fn setup_hint(&self) -> &'static str {
+        "Run Claude Code once or set CLAUDE_CONFIG_DIR to its config root"
+    }
+
     fn find_files(&self) -> Vec<PathBuf> {
         find_claude_files()
     }

--- a/src/source/codex/config.rs
+++ b/src/source/codex/config.rs
@@ -91,6 +91,10 @@ impl Source for CodexSource {
         }
     }
 
+    fn setup_hint(&self) -> &'static str {
+        "Run OpenAI Codex once or set CODEX_HOME to its data root"
+    }
+
     fn find_files(&self) -> Vec<PathBuf> {
         find_codex_files()
     }

--- a/src/source/cursor/config.rs
+++ b/src/source/cursor/config.rs
@@ -63,10 +63,7 @@ impl Source for CursorSource {
             return if path.is_file() {
                 SourceDiagnostic::detected(1, "Cursor replay file is available")
             } else {
-                SourceDiagnostic::missing(format!(
-                    "CURSOR_USAGE_FILE does not point to a file: {}",
-                    path.display()
-                ))
+                SourceDiagnostic::missing("CURSOR_USAGE_FILE is set but does not point to a file")
             };
         }
 

--- a/src/source/cursor/config.rs
+++ b/src/source/cursor/config.rs
@@ -2,13 +2,15 @@
 //!
 //! Defines the `CursorSource` implementation of the Source trait.
 
+use std::env;
 use std::path::{Path, PathBuf};
 
 use crate::core::DateFilter;
-use crate::source::{Capabilities, ParseOutput, Source};
+use crate::source::{Capabilities, ParseOutput, Source, SourceDiagnostic};
 use crate::utils::Timezone;
 
-use super::parser::{find_cursor_files, parse_cursor_with_debug};
+use super::client::has_api_credentials;
+use super::parser::{USAGE_FILE_ENV, find_cursor_files, parse_cursor_with_debug};
 
 /// Cursor usage API data source.
 pub(crate) struct CursorSource;
@@ -48,6 +50,32 @@ impl Source for CursorSource {
             needs_dedup: false,
             has_tool_calls: false,
             has_endpoints: false,
+        }
+    }
+
+    fn setup_hint(&self) -> &'static str {
+        "Set CURSOR_API_KEY, CURSOR_SESSION_TOKEN, or CURSOR_USAGE_FILE"
+    }
+
+    fn diagnose(&self) -> SourceDiagnostic {
+        if let Some(path) = env::var_os(USAGE_FILE_ENV).filter(|path| !path.is_empty()) {
+            let path = PathBuf::from(path);
+            return if path.is_file() {
+                SourceDiagnostic::detected(1, "Cursor replay file is available")
+            } else {
+                SourceDiagnostic::missing(format!(
+                    "CURSOR_USAGE_FILE does not point to a file: {}",
+                    path.display()
+                ))
+            };
+        }
+
+        if has_api_credentials() {
+            SourceDiagnostic::configured(
+                "Cursor API credentials are set; the provider was not contacted",
+            )
+        } else {
+            SourceDiagnostic::missing("No Cursor API credentials or replay file found")
         }
     }
 

--- a/src/source/grok/config.rs
+++ b/src/source/grok/config.rs
@@ -4,10 +4,10 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::source::{Capabilities, ParseOutput, Source};
+use crate::source::{Capabilities, ParseOutput, Source, SourceDiagnostic};
 use crate::utils::Timezone;
 
-use super::unified::{find_grok_files, parse_grok_file_with_debug};
+use super::unified::{find_grok_files, grok_home, parse_grok_file_with_debug};
 
 /// Grok data source.
 pub(crate) struct GrokSource;
@@ -47,6 +47,31 @@ impl Source for GrokSource {
             needs_dedup: true,
             has_tool_calls: false,
             has_endpoints: false,
+        }
+    }
+
+    fn setup_hint(&self) -> &'static str {
+        "Run Grok once or set GROK_HOME to its data root"
+    }
+
+    fn diagnose(&self) -> SourceDiagnostic {
+        let Some(home) = grok_home() else {
+            return SourceDiagnostic::missing("Could not resolve the Grok data root");
+        };
+        let unified_log = home.join("logs/unified.jsonl");
+        if unified_log.is_file() {
+            return SourceDiagnostic::detected(1, "Found the Grok unified inference log");
+        }
+
+        let sessions_dir = home.join("sessions");
+        if !sessions_dir.is_dir() {
+            return SourceDiagnostic::missing("No Grok unified log or sessions directory found");
+        }
+        let files = super::parser::find_grok_files().len();
+        if files == 0 {
+            SourceDiagnostic::missing("The Grok sessions directory contains no usage records")
+        } else {
+            SourceDiagnostic::detected(files, format!("Found {files} Grok session file(s)"))
         }
     }
 

--- a/src/source/grok/unified.rs
+++ b/src/source/grok/unified.rs
@@ -134,7 +134,7 @@ fn api_cost_usd(
     )
 }
 
-fn grok_home() -> Option<PathBuf> {
+pub(super) fn grok_home() -> Option<PathBuf> {
     env::var_os(GROK_HOME_ENV)
         .map(PathBuf::from)
         .or_else(|| dirs::home_dir().map(|home| home.join(DEFAULT_GROK_DIR)))

--- a/src/source/kimi/config.rs
+++ b/src/source/kimi/config.rs
@@ -50,6 +50,10 @@ impl Source for KimiSource {
         }
     }
 
+    fn setup_hint(&self) -> &'static str {
+        "Run Kimi Code once or set KIMI_CODE_HOME to its data root"
+    }
+
     fn find_files(&self) -> Vec<PathBuf> {
         find_kimi_files()
     }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -23,6 +23,56 @@ pub(crate) struct ParseOutput {
     pub(crate) errors: usize,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DiagnosticStatus {
+    Detected,
+    Configured,
+    Missing,
+}
+
+impl DiagnosticStatus {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Detected => "detected",
+            Self::Configured => "configured",
+            Self::Missing => "missing",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SourceDiagnostic {
+    pub(crate) status: DiagnosticStatus,
+    pub(crate) files: usize,
+    pub(crate) detail: String,
+}
+
+impl SourceDiagnostic {
+    pub(crate) fn detected(files: usize, detail: impl Into<String>) -> Self {
+        Self {
+            status: DiagnosticStatus::Detected,
+            files,
+            detail: detail.into(),
+        }
+    }
+
+    pub(crate) fn configured(detail: impl Into<String>) -> Self {
+        Self {
+            status: DiagnosticStatus::Configured,
+            files: 0,
+            detail: detail.into(),
+        }
+    }
+
+    pub(crate) fn missing(detail: impl Into<String>) -> Self {
+        Self {
+            status: DiagnosticStatus::Missing,
+            files: 0,
+            detail: detail.into(),
+        }
+    }
+}
+
 /// Capabilities that a data source may support
 #[derive(Debug, Clone, Default)]
 #[allow(clippy::struct_excessive_bools)]
@@ -86,6 +136,22 @@ pub(crate) trait Source: Send + Sync {
 
     /// Capabilities of this source
     fn capabilities(&self) -> Capabilities;
+
+    /// Actionable setup guidance used by the read-only doctor command.
+    fn setup_hint(&self) -> &'static str {
+        "Run the source once so it creates local usage data"
+    }
+
+    /// Inspect whether this source can provide data without parsing logs or
+    /// contacting remote services.
+    fn diagnose(&self) -> SourceDiagnostic {
+        let files = self.find_files().len();
+        if files == 0 {
+            SourceDiagnostic::missing("No local usage files found")
+        } else {
+            SourceDiagnostic::detected(files, format!("Found {files} local usage file(s)"))
+        }
+    }
 
     /// Find all data files for this source
     fn find_files(&self) -> Vec<PathBuf>;

--- a/src/source/openclaw.rs
+++ b/src/source/openclaw.rs
@@ -7,8 +7,10 @@ use serde::Deserialize;
 
 use crate::consts::{DATE_FORMAT, UNKNOWN};
 use crate::core::{CostKind, Endpoint, RawEntry, source_wide_message_id};
-use crate::source::openclaw_store::{find_transcript_stores, load_transcripts};
-use crate::source::{Capabilities, ParseOutput, Source};
+use crate::source::openclaw_store::{
+    diagnose_transcript_stores, find_transcript_stores, load_transcripts,
+};
+use crate::source::{Capabilities, ParseOutput, Source, SourceDiagnostic};
 use crate::utils::Timezone;
 
 pub(crate) struct OpenClawSource;
@@ -38,6 +40,19 @@ impl Source for OpenClawSource {
             needs_dedup: true,
             has_tool_calls: false,
             has_endpoints: false,
+        }
+    }
+
+    fn diagnose(&self) -> SourceDiagnostic {
+        match diagnose_transcript_stores() {
+            Err(()) => {
+                SourceDiagnostic::missing("OpenClaw configuration could not be read or parsed")
+            }
+            Ok(0) => SourceDiagnostic::missing("No OpenClaw transcript stores found"),
+            Ok(files) => SourceDiagnostic::detected(
+                files,
+                format!("Found {files} OpenClaw transcript store(s)"),
+            ),
         }
     }
 

--- a/src/source/openclaw_store.rs
+++ b/src/source/openclaw_store.rs
@@ -14,11 +14,30 @@ const OPENCLAW_HOME_ENV: &str = "OPENCLAW_HOME";
 const OPENCLAW_STATE_DIR_ENV: &str = "OPENCLAW_STATE_DIR";
 
 pub(super) fn find_transcript_stores() -> Vec<PathBuf> {
+    let (mut paths, config_error) = transcript_store_discovery();
+    if let Some(config_path) = config_error {
+        paths.push(config_path);
+    }
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
+pub(super) fn diagnose_transcript_stores() -> Result<usize, ()> {
+    let (paths, config_error) = transcript_store_discovery();
+    if config_error.is_some() {
+        Err(())
+    } else {
+        Ok(paths.len())
+    }
+}
+
+fn transcript_store_discovery() -> (Vec<PathBuf>, Option<PathBuf>) {
     let Some(root) = state_dir() else {
-        return Vec::new();
+        return (Vec::new(), None);
     };
     let Some(home) = effective_home() else {
-        return Vec::new();
+        return (Vec::new(), None);
     };
     let mut paths = Vec::new();
     for pattern in [
@@ -34,13 +53,16 @@ pub(super) fn find_transcript_stores() -> Vec<PathBuf> {
                 .filter(|path| is_counted_transcript(path) || is_sqlite_store(path)),
         );
     }
-    match configured_stores(&root, &home) {
-        Ok(configured) => paths.extend(configured),
-        Err(config_path) => paths.push(config_path),
-    }
+    let config_error = match configured_stores(&root, &home) {
+        Ok(configured) => {
+            paths.extend(configured);
+            None
+        }
+        Err(config_path) => Some(config_path),
+    };
     paths.sort();
     paths.dedup();
-    paths
+    (paths, config_error)
 }
 
 pub(super) struct TranscriptLoad {

--- a/src/source/pi.rs
+++ b/src/source/pi.rs
@@ -10,10 +10,10 @@ use serde::Deserialize;
 
 use crate::consts::{DATE_FORMAT, UNKNOWN};
 use crate::core::{CostKind, Endpoint, RawEntry, source_wide_message_id};
-use crate::source::{Capabilities, ParseOutput, Source};
+use crate::source::{Capabilities, ParseOutput, Source, SourceDiagnostic};
 use crate::utils::Timezone;
 
-use super::pi_paths::{find_kimchi_files, find_pi_files, find_senpi_files};
+use super::pi_paths::{diagnose_senpi_files, find_kimchi_files, find_pi_files, find_senpi_files};
 
 pub(crate) struct PiSource;
 pub(crate) struct SenpiSource;
@@ -93,6 +93,17 @@ impl Source for SenpiSource {
 
     fn capabilities(&self) -> Capabilities {
         pi_capabilities()
+    }
+
+    fn diagnose(&self) -> SourceDiagnostic {
+        match diagnose_senpi_files() {
+            Err(()) => SourceDiagnostic::missing("Senpi configuration could not be read or parsed"),
+            Ok(0) => SourceDiagnostic::missing("No Senpi local usage files found"),
+            Ok(files) => SourceDiagnostic::detected(
+                files,
+                format!("Found {files} Senpi local usage file(s)"),
+            ),
+        }
     }
 
     fn find_files(&self) -> Vec<PathBuf> {

--- a/src/source/pi_fork_paths.rs
+++ b/src/source/pi_fork_paths.rs
@@ -277,7 +277,7 @@ pub(super) fn find_gjc_files() -> Vec<PathBuf> {
     find_jsonl(&root)
 }
 
-pub(super) fn find_prime_files() -> Vec<PathBuf> {
+fn discover_prime_files() -> (Vec<PathBuf>, bool) {
     let mut invalid_settings = Vec::new();
     let agent = env_path("PRIME_AGENT_CODING_AGENT_DIR")
         .or_else(|| dirs::home_dir().map(|home| home.join(".prime/agent")));
@@ -316,16 +316,26 @@ pub(super) fn find_prime_files() -> Vec<PathBuf> {
         }
     });
     let Some(root) = root else {
-        return Vec::new();
+        return (Vec::new(), false);
     };
     let mut files = find_jsonl(&root);
     if let Some(parent) = root.parent() {
         files.extend(find_jsonl(&parent.join("session-artifacts")));
     }
+    let has_invalid_settings = !invalid_settings.is_empty();
     files.extend(invalid_settings);
     files.sort();
     files.dedup();
-    files
+    (files, has_invalid_settings)
+}
+
+pub(super) fn find_prime_files() -> Vec<PathBuf> {
+    discover_prime_files().0
+}
+
+pub(super) fn diagnose_prime_files() -> Result<usize, ()> {
+    let (files, has_invalid_settings) = discover_prime_files();
+    (!has_invalid_settings).then_some(files.len()).ok_or(())
 }
 
 fn valid_omp_profile(profile: &str) -> bool {
@@ -382,10 +392,8 @@ fn profile_derived_agent(config: &Path, agent: &Path) -> bool {
     resolved_path(agent.to_path_buf()) == resolved_path(derived)
 }
 
-pub(super) fn find_omp_files() -> Vec<PathBuf> {
-    let Ok(profile) = omp_profile() else {
-        return vec![PathBuf::from("invalid-omp-profile.jsonl")];
-    };
+fn discover_omp_files() -> Result<Vec<PathBuf>, ()> {
+    let profile = omp_profile()?;
     let config = env::var("PI_CONFIG_DIR")
         .ok()
         .filter(|value| !value.is_empty())
@@ -422,7 +430,15 @@ pub(super) fn find_omp_files() -> Vec<PathBuf> {
             agent.map(|agent| agent.join("sessions"))
         }
     };
-    root.as_deref().map(find_jsonl).unwrap_or_default()
+    Ok(root.as_deref().map(find_jsonl).unwrap_or_default())
+}
+
+pub(super) fn find_omp_files() -> Vec<PathBuf> {
+    discover_omp_files().unwrap_or_else(|()| vec![PathBuf::from("invalid-omp-profile.jsonl")])
+}
+
+pub(super) fn diagnose_omp_files() -> Result<usize, ()> {
+    discover_omp_files().map(|files| files.len())
 }
 
 #[cfg(test)]

--- a/src/source/pi_forks.rs
+++ b/src/source/pi_forks.rs
@@ -7,13 +7,13 @@ use std::path::{Path, PathBuf};
 
 use crate::consts::{DATE_FORMAT, UNKNOWN};
 use crate::core::{CostKind, Endpoint, RawEntry, source_wide_message_id};
-use crate::source::{Capabilities, ParseOutput, Source};
+use crate::source::{Capabilities, ParseOutput, Source, SourceDiagnostic};
 use crate::utils::Timezone;
 use chrono::{DateTime, Utc};
 
 use super::pi_fork_paths::{
-    find_gjc_files, find_omp_files, find_prime_files, inherited_project_path,
-    linked_child_transcript, parent_transcript,
+    diagnose_omp_files, diagnose_prime_files, find_gjc_files, find_omp_files, find_prime_files,
+    inherited_project_path, linked_child_transcript, parent_transcript,
 };
 use super::pi_fork_schema::{
     ForkUsage, PrimeAttribution, SessionEntry, SessionHeader, SessionRecord,
@@ -97,7 +97,7 @@ fn capabilities(has_reasoning: bool) -> Capabilities {
 }
 
 macro_rules! source_impl {
-    ($source:ty, $name:literal, $display:literal, $aliases:expr, $profile:expr, $find:ident) => {
+    ($source:ty, $name:literal, $display:literal, $aliases:expr, $profile:expr, $find:ident, $diagnose:expr, $error:literal) => {
         impl Source for $source {
             fn name(&self) -> &'static str {
                 $name
@@ -113,6 +113,21 @@ macro_rules! source_impl {
 
             fn capabilities(&self) -> Capabilities {
                 capabilities($profile.has_reasoning)
+            }
+
+            fn diagnose(&self) -> SourceDiagnostic {
+                match ($diagnose)() {
+                    Err(()) => SourceDiagnostic::missing($error),
+                    Ok(0) => SourceDiagnostic::missing(concat!(
+                        "No ",
+                        $display,
+                        " local usage files found"
+                    )),
+                    Ok(files) => SourceDiagnostic::detected(
+                        files,
+                        format!("Found {files} {} local usage file(s)", $display),
+                    ),
+                }
             }
 
             fn find_files(&self) -> Vec<PathBuf> {
@@ -132,7 +147,9 @@ source_impl!(
     "Gajae Code",
     &["gajae-code"],
     ForkProfile::gjc(),
-    find_gjc_files
+    find_gjc_files,
+    || Ok(find_gjc_files().len()),
+    "Gajae Code configuration could not be read or parsed"
 );
 source_impl!(
     PrimeSource,
@@ -140,7 +157,9 @@ source_impl!(
     "Prime Agent",
     &["prime-agent"],
     ForkProfile::prime(),
-    find_prime_files
+    find_prime_files,
+    diagnose_prime_files,
+    "Prime Agent configuration could not be read or parsed"
 );
 source_impl!(
     OmpSource,
@@ -148,7 +167,9 @@ source_impl!(
     "Oh My Pi",
     &["oh-my-pi"],
     ForkProfile::omp(),
-    find_omp_files
+    find_omp_files,
+    diagnose_omp_files,
+    "OMP_PROFILE is invalid"
 );
 
 fn parse_timestamp(

--- a/src/source/pi_paths.rs
+++ b/src/source/pi_paths.rs
@@ -149,6 +149,12 @@ pub(super) fn find_senpi_files() -> Vec<PathBuf> {
     }
 }
 
+pub(super) fn diagnose_senpi_files() -> Result<usize, ()> {
+    senpi_sessions_dir()
+        .map(|root| find_family_files(&root).len())
+        .map_err(|_| ())
+}
+
 pub(super) fn find_kimchi_files() -> Vec<PathBuf> {
     dirs::home_dir()
         .map(|home| find_family_files(&home.join(".config/kimchi/harness/sessions")))

--- a/tests/cli_doctor.rs
+++ b/tests/cli_doctor.rs
@@ -1,0 +1,75 @@
+mod common;
+
+use std::{fs, path::Path};
+
+use common::{run_ccstats, unique_temp_dir, write_file};
+use serde_json::Value;
+
+#[test]
+fn doctor_reports_detected_and_configured_sources_without_exposing_credentials() {
+    let root = unique_temp_dir("doctor-diagnostics");
+    let claude_root = root.join("claude-home");
+    write_file(&claude_root.join("projects/example/session.jsonl"), "{}\n");
+    let cursor_key = Path::new("cursor-secret-must-not-appear");
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &["doctor", "--json"],
+        &[
+            ("HOME", &root),
+            ("CLAUDE_CONFIG_DIR", &claude_root),
+            ("CURSOR_API_KEY", cursor_key),
+        ],
+    );
+
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    assert!(
+        stderr.is_empty(),
+        "stderr: {}",
+        String::from_utf8_lossy(&stderr)
+    );
+    let output = String::from_utf8(stdout).expect("utf8 output");
+    assert!(!output.contains("cursor-secret-must-not-appear"));
+
+    let rows: Value = serde_json::from_str(&output).expect("doctor json");
+    let rows = rows.as_array().expect("array output");
+    assert_eq!(rows.len(), 5);
+
+    let claude = rows
+        .iter()
+        .find(|row| row["name"] == "claude")
+        .expect("Claude diagnostic");
+    assert_eq!(claude["status"], "detected");
+    assert_eq!(claude["files"], 1);
+
+    let cursor = rows
+        .iter()
+        .find(|row| row["name"] == "cursor")
+        .expect("Cursor diagnostic");
+    assert_eq!(cursor["status"], "configured");
+    assert_eq!(cursor["files"], 0);
+    assert!(
+        cursor["detail"]
+            .as_str()
+            .is_some_and(|detail| detail.contains("not contacted"))
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn doctor_table_gives_a_next_step_when_no_sources_are_detected() {
+    let root = unique_temp_dir("doctor-empty");
+    let (ok, stdout, stderr) = run_ccstats(&["doctor"], &[("HOME", &root)]);
+
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    assert!(
+        stderr.is_empty(),
+        "stderr: {}",
+        String::from_utf8_lossy(&stderr)
+    );
+    let output = String::from_utf8(stdout).expect("utf8 output");
+    assert!(output.contains("No source data detected"));
+    assert!(output.contains("ccstats doctor --json"));
+
+    let _ = fs::remove_dir_all(root);
+}

--- a/tests/cli_doctor.rs
+++ b/tests/cli_doctor.rs
@@ -133,6 +133,84 @@ fn doctor_reports_openclaw_config_errors_instead_of_detecting_the_sentinel() {
 }
 
 #[test]
+fn doctor_reports_senpi_config_errors_instead_of_detecting_the_sentinel() {
+    let root = unique_temp_dir("doctor-senpi-config");
+    write_file(&root.join(".senpi/settings.jsonc"), "{broken");
+    let (ok, stdout, stderr) = run_ccstats(
+        &["doctor", "--json"],
+        &[("HOME", &root), ("CCSTATS_TEST_CWD", &root)],
+    );
+
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let rows: Value = serde_json::from_slice(&stdout).expect("doctor json");
+    let senpi = rows
+        .as_array()
+        .expect("array output")
+        .iter()
+        .find(|row| row["name"] == "senpi")
+        .expect("Senpi diagnostic");
+    assert_eq!(senpi["status"], "missing");
+    assert_eq!(senpi["files"], 0);
+    assert_eq!(
+        senpi["detail"],
+        "Senpi configuration could not be read or parsed"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn doctor_reports_prime_config_errors_instead_of_detecting_the_sentinel() {
+    let root = unique_temp_dir("doctor-prime-config");
+    write_file(&root.join(".prime/agent/settings.json"), "{broken");
+    let (ok, stdout, stderr) = run_ccstats(
+        &["doctor", "--json"],
+        &[("HOME", &root), ("CCSTATS_TEST_CWD", &root)],
+    );
+
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let rows: Value = serde_json::from_slice(&stdout).expect("doctor json");
+    let prime = rows
+        .as_array()
+        .expect("array output")
+        .iter()
+        .find(|row| row["name"] == "prime")
+        .expect("Prime diagnostic");
+    assert_eq!(prime["status"], "missing");
+    assert_eq!(prime["files"], 0);
+    assert_eq!(
+        prime["detail"],
+        "Prime Agent configuration could not be read or parsed"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn doctor_reports_invalid_omp_profile_instead_of_detecting_the_sentinel() {
+    let root = unique_temp_dir("doctor-omp-profile");
+    let invalid_profile = Path::new("../escape");
+    let (ok, stdout, stderr) = run_ccstats(
+        &["doctor", "--json"],
+        &[("HOME", &root), ("OMP_PROFILE", invalid_profile)],
+    );
+
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let rows: Value = serde_json::from_slice(&stdout).expect("doctor json");
+    let omp = rows
+        .as_array()
+        .expect("array output")
+        .iter()
+        .find(|row| row["name"] == "omp")
+        .expect("Oh My Pi diagnostic");
+    assert_eq!(omp["status"], "missing");
+    assert_eq!(omp["files"], 0);
+    assert_eq!(omp["detail"], "OMP_PROFILE is invalid");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn doctor_table_gives_a_next_step_when_no_sources_are_detected() {
     let root = unique_temp_dir("doctor-empty");
     let (ok, stdout, stderr) = run_ccstats(&["doctor"], &[("HOME", &root)]);

--- a/tests/cli_doctor.rs
+++ b/tests/cli_doctor.rs
@@ -32,7 +32,6 @@ fn doctor_reports_detected_and_configured_sources_without_exposing_credentials()
 
     let rows: Value = serde_json::from_str(&output).expect("doctor json");
     let rows = rows.as_array().expect("array output");
-    assert_eq!(rows.len(), 5);
 
     let claude = rows
         .iter()
@@ -51,6 +50,83 @@ fn doctor_reports_detected_and_configured_sources_without_exposing_credentials()
         cursor["detail"]
             .as_str()
             .is_some_and(|detail| detail.contains("not contacted"))
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn doctor_table_gives_configured_sources_a_runnable_next_step() {
+    let root = unique_temp_dir("doctor-configured");
+    let cursor_key = Path::new("configured-cursor-key");
+    let (ok, stdout, stderr) = run_ccstats(
+        &["doctor"],
+        &[("HOME", &root), ("CURSOR_API_KEY", cursor_key)],
+    );
+
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let output = String::from_utf8(stdout).expect("utf8 output");
+    assert!(output.contains("Next: run `ccstats daily --source all`"));
+    assert!(!output.contains("No source data detected"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn doctor_json_does_not_expose_invalid_cursor_replay_path() {
+    let root = unique_temp_dir("doctor-cursor-path");
+    let replay = root.join("private/account/replay.json");
+    let (ok, stdout, stderr) = run_ccstats(
+        &["doctor", "--json"],
+        &[("HOME", &root), ("CURSOR_USAGE_FILE", &replay)],
+    );
+
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let output = String::from_utf8(stdout).expect("utf8 output");
+    assert!(!output.contains(&root.display().to_string()));
+    let rows: Value = serde_json::from_str(&output).expect("doctor json");
+    let cursor = rows
+        .as_array()
+        .expect("array output")
+        .iter()
+        .find(|row| row["name"] == "cursor")
+        .expect("Cursor diagnostic");
+    assert_eq!(cursor["status"], "missing");
+    assert_eq!(
+        cursor["detail"],
+        "CURSOR_USAGE_FILE is set but does not point to a file"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn doctor_reports_openclaw_config_errors_instead_of_detecting_the_sentinel() {
+    let root = unique_temp_dir("doctor-openclaw-config");
+    let config = root.join("broken-openclaw.json");
+    write_file(&config, "{broken");
+    write_file(&root.join("agents/main/sessions/valid.jsonl"), "{}\n");
+    let (ok, stdout, stderr) = run_ccstats(
+        &["doctor", "--json"],
+        &[
+            ("HOME", &root),
+            ("OPENCLAW_STATE_DIR", &root),
+            ("OPENCLAW_CONFIG_PATH", &config),
+        ],
+    );
+
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let rows: Value = serde_json::from_slice(&stdout).expect("doctor json");
+    let openclaw = rows
+        .as_array()
+        .expect("array output")
+        .iter()
+        .find(|row| row["name"] == "openclaw")
+        .expect("OpenClaw diagnostic");
+    assert_eq!(openclaw["status"], "missing");
+    assert_eq!(
+        openclaw["detail"],
+        "OpenClaw configuration could not be read or parsed"
     );
 
     let _ = fs::remove_dir_all(root);

--- a/tests/cli_doctor.rs
+++ b/tests/cli_doctor.rs
@@ -135,10 +135,13 @@ fn doctor_reports_openclaw_config_errors_instead_of_detecting_the_sentinel() {
 #[test]
 fn doctor_reports_senpi_config_errors_instead_of_detecting_the_sentinel() {
     let root = unique_temp_dir("doctor-senpi-config");
-    write_file(&root.join(".senpi/settings.jsonc"), "{broken");
+    let project = root.join("project");
+    let workspace = project.join("workspace");
+    write_file(&project.join(".senpi/settings.jsonc"), "{broken");
+    fs::create_dir_all(&workspace).expect("create workspace");
     let (ok, stdout, stderr) = run_ccstats(
         &["doctor", "--json"],
-        &[("HOME", &root), ("CCSTATS_TEST_CWD", &root)],
+        &[("HOME", &root), ("CCSTATS_TEST_CWD", &workspace)],
     );
 
     assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));

--- a/tests/public_readiness.rs
+++ b/tests/public_readiness.rs
@@ -49,3 +49,38 @@ fn public_docs_describe_the_full_registry_without_exact_setup_promises() {
     assert!(changelog.contains("all 29 registered sources"));
     assert!(doctor.contains("registered source diagnostics"));
 }
+
+#[test]
+fn changelog_names_every_source_added_across_the_nine_provider_batches() {
+    let changelog = fs::read_to_string("CHANGELOG.md").expect("changelog");
+    let release = changelog
+        .split_once("## [0.5.1]")
+        .expect("0.5.1 release")
+        .1
+        .split_once("## [0.5.0]")
+        .expect("0.5.0 release follows 0.5.1")
+        .0;
+
+    assert!(release.contains("5 to 29 sources across nine provider batches"));
+    for batch in [
+        "Gemini CLI, Amp, Qwen Code, Cline, Roo Code, and Kilo Code",
+        "OpenCode, MiMo Code, and Kilo CLI",
+        "Pi, Senpi, and Kimchi",
+        "Gajae Code, Prime Agent, and Oh My Pi",
+        "GitHub Copilot CLI and Goose",
+        "OpenClaw, Xum, and Hermes Agent",
+        "Reasonix and Vercel Fx",
+        "Unsloth Studio",
+        "DeepSeek Harness",
+    ] {
+        assert!(release.contains(batch), "0.5.1 does not name batch {batch}");
+    }
+}
+
+#[test]
+fn crate_docs_name_the_final_two_registered_sources() {
+    let crate_docs = fs::read_to_string("src/lib.rs").expect("crate docs");
+
+    assert!(crate_docs.contains("Unsloth Studio"));
+    assert!(crate_docs.contains("DeepSeek Harness"));
+}

--- a/tests/public_readiness.rs
+++ b/tests/public_readiness.rs
@@ -1,0 +1,51 @@
+use std::fs;
+
+fn workflow_job<'a>(workflow: &'a str, name: &str, next: &str) -> &'a str {
+    workflow
+        .split_once(&format!("\n  {name}:"))
+        .unwrap_or_else(|| panic!("missing {name} job"))
+        .1
+        .split_once(&format!("\n  {next}:"))
+        .unwrap_or_else(|| panic!("missing {next} job after {name}"))
+        .0
+}
+
+#[test]
+fn crate_publish_waits_for_every_platform_build() {
+    let workflow = fs::read_to_string(".github/workflows/release.yml").expect("release workflow");
+    let publish = workflow_job(&workflow, "publish", "build");
+    let release = workflow_job(&workflow, "release", "homebrew");
+    let homebrew = workflow
+        .split_once("\n  homebrew:")
+        .expect("homebrew job")
+        .1;
+
+    assert!(publish.contains("needs: [preflight, build]"));
+    assert!(release.contains("needs: [build, publish]"));
+    assert!(homebrew.contains("needs: release"));
+}
+
+#[test]
+fn crates_io_auth_action_is_pinned_to_the_reviewed_commit() {
+    let workflow = fs::read_to_string(".github/workflows/release.yml").expect("release workflow");
+    assert!(workflow.contains(
+        "uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18"
+    ));
+}
+
+#[test]
+fn public_docs_describe_the_full_registry_without_exact_setup_promises() {
+    let readme = fs::read_to_string("README.md").expect("README");
+    let privacy = fs::read_to_string("docs/PRIVACY.md").expect("privacy documentation");
+    let changelog = fs::read_to_string("CHANGELOG.md").expect("changelog");
+    let doctor = fs::read_to_string("src/doctor_cmd.rs").expect("doctor implementation");
+
+    assert!(readme.contains("29 AI coding-agent data sources"));
+    assert!(readme.contains("DeepSeek Harness"));
+    assert!(readme.contains("Unsloth Studio"));
+    assert!(!readme.contains("the exact setup step for anything missing"));
+    assert!(privacy.contains("29 registered sources"));
+    assert!(privacy.contains("DeepSeek Harness"));
+    assert!(changelog.contains("all 29 registered sources"));
+    assert!(doctor.contains("registered source diagnostics"));
+}

--- a/tests/sdk_integration.rs
+++ b/tests/sdk_integration.rs
@@ -56,6 +56,7 @@ fn sdk_loads_codex_weekly_quota_from_explicit_home() {
 
 #[test]
 fn sdk_estimates_codex_weekly_api_equivalent_value() {
+    let _guard = ENV_LOCK.lock().expect("env lock");
     let root = tempfile::tempdir().expect("temp dir");
     let codex_home = root.path().join("codex-home");
     let session_file = codex_home.join("sessions").join("quota-and-usage.jsonl");
@@ -115,6 +116,7 @@ fn sdk_estimates_codex_weekly_api_equivalent_value() {
 
 #[test]
 fn sdk_estimates_codex_value_for_an_explicit_exact_window() {
+    let _guard = ENV_LOCK.lock().expect("env lock");
     let root = tempfile::tempdir().expect("temp dir");
     let codex_home = root.path().join("codex-home");
     let session_file = codex_home.join("sessions").join("usage.jsonl");
@@ -175,6 +177,7 @@ fn sdk_estimates_codex_value_for_an_explicit_exact_window() {
 
 #[test]
 fn sdk_explicit_window_rejects_usage_without_a_timestamp() {
+    let _guard = ENV_LOCK.lock().expect("env lock");
     let root = tempfile::tempdir().expect("temp dir");
     let codex_home = root.path().join("codex-home");
     let session_file = codex_home.join("sessions").join("usage.jsonl");


### PR DESCRIPTION
## Outcome

Prepare ccstats for broader public adoption without expanding it into a GUI or a multi-tool platform.

## What changed

- add a read-only `ccstats doctor` command for all five sources, with table, JSON, and CSV output
- make metadata-only commands avoid pricing/network initialization
- document a 30-second onboarding path, differentiation, upgrades, uninstalls, and source support
- add explicit privacy and release documentation
- publish crates.io releases with short-lived OIDC credentials instead of a static token
- make GitHub Releases depend on a successful crate publish and make the Homebrew update wait for the crate artifact
- prepare patch release `0.5.1`

## Competitive research

I compared the current public surfaces and onboarding of the major adjacent projects:

- [ccusage](https://github.com/ryoppippi/ccusage): mature CLI onboarding, docs, and community surface
- [tokscale](https://github.com/junhoyeo/tokscale): terminal, dashboard, and leaderboard distribution
- [codeburn](https://github.com/getagentseal/codeburn): strong cross-tool value narrative and multiple clients
- [TokenTracker](https://github.com/xiufengsun/TokenTracker): diagnostics, privacy messaging, multilingual desktop experience
- [CodexBar](https://github.com/steipete/CodexBar): quota-first menu bar experience and extensive provider documentation
- [claude-usage](https://github.com/phuryn/claude-usage): local dashboard and editor integration
- [agentsview](https://github.com/kenn-io/agentsview): local multi-agent analytics
- [quotio](https://github.com/nguyenphutrong/quotio): account quota and multilingual community surface

Decision: adopt fast onboarding, explicit privacy, and self-diagnostics. Keep ccstats differentiated as a fast single Rust binary with transparent local accounting and consistent CLI/SDK behavior. Deliberately defer GUI/menu-bar clients, gamification/leaderboards, and broad parser expansion.

## Release issue found

GitHub already has a `v0.5.0` release, but crates.io is still at `0.4.0`. The old workflow only ran `cargo publish --dry-run`, while the Homebrew job expected the missing crates.io `0.5.0` artifact. This PR repairs that chain for `0.5.1`.

Before tagging `v0.5.1`, configure the crates.io trusted publisher for crate `ccstats`:

- owner: `majiayu000`
- repository: `ccstats`
- workflow: `release.yml`
- environment: leave blank

No release or tag is created by this PR.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features --quiet` — 580 unit tests plus all integration suites passed
- `cargo publish --dry-run --locked --allow-dirty`
- `cargo deny check`
- `scripts/check-release.sh`
- Ruby YAML parse of `.github/workflows/release.yml`
- `git diff --check`

A TDD red run first confirmed that `doctor` was not recognized; the new doctor integration tests then passed.