### PR TITLE
fix(grok): separate API estimates from provider metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ ccstats daily --source cur
 
 ## Quick Start (Grok)
 
-Grok support reports complete, globally deduplicated token totals from session `turn_completed.usage` records. It separately prices each observed `shell.turn.inference_done` record using xAI's short- or long-context API rate for the whole request. Because Grok trims `unified.jsonl`, the output includes priced-token coverage and marks the API-equivalent cost as a lower bound when inference history is incomplete and no `estimated_proxy` contribution is included.
+Grok support reports complete, globally deduplicated token totals from session `turn_completed.usage` records. It separately prices each observed `shell.turn.inference_done` request using xAI's public short- or long-context API rate. Because Grok trims `unified.jsonl`, ccstats shows the exact observed API equivalent, a coverage-adjusted estimate, and a short/long-context range. It also displays `costUsdTicks` as a separate provider metric. Neither value is labeled as the user's actual subscription charge, which is unavailable in the local logs.
 
 ```bash
 # Install
@@ -491,7 +491,7 @@ By default, ccstats uses:
 
 For Grok 4.5 and 4.6, requests below 200k prompt tokens use the short-context rates. Requests at or above 200k use the long-context input, cached-input, and output rates for the entire inference. `completion_tokens` already includes reasoning, so ccstats does not charge reasoning twice. Rates follow the [xAI pricing reference](https://docs.x.ai/developers/pricing).
 
-Structured period output includes `api_equivalent_cost_coverage` with `total_tokens`, `priced_tokens`, `percent`, `complete`, and `cost_is_lower_bound`. If a session has no `turn_completed.usage`, ccstats retains its explicitly labeled `estimated_proxy` context-snapshot fallback.
+Structured period output includes the backward-compatible `api_equivalent_cost_coverage` object plus `grok_cost_summary`. The latter separates `api_equivalent` observed/estimated/range values, the provider-reported `costUsdTicks` metric and its token coverage, and `actual_billed_usd: null`. If request telemetry and complete turn totals cannot be reconciled, coverage is marked `mismatch` and ccstats does not publish an estimate. If a session has no `turn_completed.usage`, ccstats retains its explicitly labeled `estimated_proxy` context-snapshot fallback.
 
 You can override the Grok home directory with `GROK_HOME`:
 
@@ -501,8 +501,8 @@ GROK_HOME="/path/to/.grok" ccstats grok
 
 Current limitations:
 
-- The durable ledger starts when ccstats first observes an inference. It cannot recover records Grok trimmed before the first run or between ccstats runs, so incomplete API-equivalent cost is reported as a lower bound only when no `estimated_proxy` contribution is included.
-- `turn_completed.usage.costUsdTicks` is not used as an API-equivalent price.
+- The durable ledger starts when ccstats first observes an inference. It cannot recover records Grok trimmed before the first run or between ccstats runs, so incomplete request coverage produces an estimated API equivalent and a short/long-context range.
+- `turn_completed.usage.costUsdTicks` is reported separately as a provider metric. xAI does not document this field as public API list price or as the user's actual subscription charge.
 - Grok models without a published ccstats per-inference tier remain unpriced and reduce priced-token coverage.
 - Grok 5-hour billing blocks are not supported.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -24,7 +24,8 @@ use crate::output::{
 use crate::pricing::{CostDisplayMode, PricingDb};
 use crate::source::{
     Capabilities, CodexScope, CostCoverage, GrokCostReport, Source, all_capabilities, all_sources,
-    grok_cost_reports, load_blocks, load_daily, load_projects, load_sessions, load_tool_calls,
+    load_blocks, load_daily, load_grok_daily_with_cost, load_projects, load_sessions,
+    load_tool_calls,
 };
 use crate::utils::{Timezone, filter_json};
 
@@ -572,13 +573,20 @@ fn handle_period(
         _ => return,
     };
 
-    let result = load_daily(source, ctx.filter, ctx.timezone, false, ctx.cli.debug);
+    let (result, grok_reports) = if source.name() == "grok" {
+        let (result, reports) =
+            load_grok_daily_with_cost(ctx.filter, ctx.timezone, false, ctx.cli.debug);
+        (result, Some(reports))
+    } else {
+        (
+            load_daily(source, ctx.filter, ctx.timezone, false, ctx.cli.debug),
+            None,
+        )
+    };
     if result.day_stats.is_empty() && !should_render_empty_structured_result(&result, ctx) {
         print_no_data_hint(&source_label(source, ctx), "usage");
         return;
     }
-    let grok_reports =
-        (source.name() == "grok").then(|| grok_cost_reports(ctx.filter, ctx.timezone));
     render_period_result(
         &result,
         period,
@@ -586,7 +594,10 @@ fn handle_period(
         codex_scope_for_source(source, ctx),
         grok_reports.as_ref(),
         ctx,
-        CostDisplayMode::Total,
+        grok_reports
+            .as_ref()
+            .filter(|reports| !reports.is_empty())
+            .map_or(CostDisplayMode::Total, |_| CostDisplayMode::RealOnly),
     );
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,6 @@
 mod codex_scope;
 mod cost_coverage;
+mod period_table;
 
 use std::collections::HashMap;
 use std::time::Instant;
@@ -11,15 +12,15 @@ use crate::core::{
 };
 use crate::output::NumberFormat;
 use crate::output::{
-    BlockTableOptions, MonthlyBudgetOptions, OutputFormat, Period, PeriodSummaryFooter,
-    ProjectTableOptions, SessionTableOptions, TokenTableOptions, TopRow, TopTableOptions,
-    add_monthly_budget_to_json, append_data_quality_csv_comment, monthly_budget_reports,
-    output_block_csv, output_block_json, output_monthly_budget_csv, output_period_csv_with_quality,
-    output_period_json_with_quality, output_project_csv, output_project_json, output_session_csv,
-    output_session_json, output_tools_csv, output_tools_json, output_top_csv, output_top_json,
-    print_block_table, print_monthly_budget_table, print_period_table, print_project_table,
-    print_session_table, print_statusline, print_statusline_json_with_quality, print_tools_table,
-    print_top_table, rank_by_model, rank_by_model_with_cost_mode, rank_by_project,
+    BlockTableOptions, MonthlyBudgetOptions, OutputFormat, Period, ProjectTableOptions,
+    SessionTableOptions, TopRow, TopTableOptions, add_monthly_budget_to_json,
+    append_data_quality_csv_comment, monthly_budget_reports, output_block_csv, output_block_json,
+    output_monthly_budget_csv, output_period_csv_with_quality, output_period_json_with_quality,
+    output_project_csv, output_project_json, output_session_csv, output_session_json,
+    output_tools_csv, output_tools_json, output_top_csv, output_top_json, print_block_table,
+    print_project_table, print_session_table, print_statusline, print_statusline_json_with_quality,
+    print_tools_table, print_top_table, rank_by_model, rank_by_model_with_cost_mode,
+    rank_by_project,
 };
 use crate::pricing::{CostDisplayMode, PricingDb};
 use crate::source::{
@@ -69,12 +70,6 @@ fn source_label(source: &dyn Source, ctx: &CommandContext<'_>) -> String {
     match codex_scope_for_source(source, ctx) {
         Some(scope) => format!("{} ({})", source.display_name(), scope.label()),
         None => source.display_name().to_string(),
-    }
-}
-
-fn print_codex_scope_note(scope: Option<CodexScope>) {
-    if let Some(scope) = scope {
-        println!("\n  Codex scope: {}", scope.as_str());
     }
 }
 
@@ -508,55 +503,15 @@ fn render_period_result(
             json = codex_scope::annotate_json(&json, codex_scope);
             print_json(&json, ctx.jq_filter);
         }
-        OutputFormat::Table => {
-            print_codex_scope_note(codex_scope);
-            print_period_table(
-                &result.day_stats,
-                period,
-                ctx.cli.breakdown,
-                PeriodSummaryFooter {
-                    skipped: result.skipped,
-                    valid: result.valid,
-                    elapsed_ms: Some(result.elapsed_ms),
-                },
-                ctx.pricing_db,
-                TokenTableOptions {
-                    order: ctx.cli.sort_order(),
-                    use_color: ctx.cli.use_color(),
-                    compact: ctx.cli.compact,
-                    show_cost: ctx.cli.show_cost(),
-                    number_format: ctx.number_format,
-                    show_reasoning: caps.has_reasoning_tokens,
-                    show_cache_creation: caps.has_cache_creation,
-                    supports_cache_read: caps.has_cache_read,
-                    currency: ctx.currency,
-                    cost_mode,
-                    cost_label: if selected_grok_report.is_some() {
-                        "Observed API Eq."
-                    } else {
-                        "Cost"
-                    },
-                    pricing_note_override: selected_grok_report.map(|_| {
-                        "Pricing source: xAI public API rates applied to observed request telemetry."
-                    }),
-                },
-            );
-            if ctx.cli.show_cost() {
-                cost_coverage::print_note(selected_grok_report, ctx.currency);
-            }
-            if let Some(budget) = monthly_budget {
-                let reports = monthly_budget_reports(
-                    &result.day_stats,
-                    ctx.pricing_db,
-                    ctx.cli.sort_order(),
-                    budget,
-                    ctx.budget_as_of,
-                    ctx.currency,
-                    cost_mode,
-                );
-                print_monthly_budget_table(&reports, ctx.cli.use_color(), ctx.currency);
-            }
-        }
+        OutputFormat::Table => period_table::render(
+            result,
+            period,
+            caps,
+            codex_scope,
+            visible_grok_reports,
+            ctx,
+            cost_mode,
+        ),
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,7 @@
 mod codex_scope;
 mod cost_coverage;
 
+use std::collections::HashMap;
 use std::time::Instant;
 
 use crate::cli::{Cli, SourceCommand, TopDimension};
@@ -22,8 +23,8 @@ use crate::output::{
 };
 use crate::pricing::{CostDisplayMode, PricingDb};
 use crate::source::{
-    Capabilities, CodexScope, CostCoverage, Source, all_capabilities, all_sources, load_blocks,
-    load_daily, load_projects, load_sessions, load_tool_calls,
+    Capabilities, CodexScope, CostCoverage, GrokCostReport, Source, all_capabilities, all_sources,
+    grok_cost_reports, load_blocks, load_daily, load_projects, load_sessions, load_tool_calls,
 };
 use crate::utils::{Timezone, filter_json};
 
@@ -425,10 +426,13 @@ fn render_period_result(
     period: Period,
     caps: &Capabilities,
     codex_scope: Option<CodexScope>,
+    grok_reports: Option<&HashMap<String, GrokCostReport>>,
     ctx: &CommandContext<'_>,
     cost_mode: CostDisplayMode,
 ) {
     let cost_coverage = CostCoverage::from_stats(result.day_stats.values().map(|day| &day.stats));
+    let visible_grok_reports = ctx.cli.show_cost().then_some(grok_reports).flatten();
+    let selected_grok_report = cost_coverage::selected_grok_report(visible_grok_reports);
     let monthly_budget = (period == Period::Month)
         .then_some(ctx.cli.monthly_budget)
         .flatten();
@@ -466,7 +470,7 @@ fn render_period_result(
                     cost_mode,
                 )
             };
-            let csv = cost_coverage::annotate_csv(csv, cost_coverage);
+            let csv = cost_coverage::annotate_csv(csv, cost_coverage, selected_grok_report);
             print!("{}", codex_scope::annotate_csv(csv, codex_scope));
         }
         OutputFormat::Json => {
@@ -494,7 +498,12 @@ fn render_period_result(
                 );
                 json = add_monthly_budget_to_json(&json, &reports);
             }
-            json = cost_coverage::annotate_json(&json, &result.day_stats, period);
+            json = cost_coverage::annotate_json(
+                &json,
+                &result.day_stats,
+                period,
+                visible_grok_reports,
+            );
             json = codex_scope::annotate_json(&json, codex_scope);
             print_json(&json, ctx.jq_filter);
         }
@@ -521,10 +530,18 @@ fn render_period_result(
                     supports_cache_read: caps.has_cache_read,
                     currency: ctx.currency,
                     cost_mode,
+                    cost_label: if selected_grok_report.is_some() {
+                        "Observed API Eq."
+                    } else {
+                        "Cost"
+                    },
+                    pricing_note_override: selected_grok_report.map(|_| {
+                        "Pricing source: xAI public API rates applied to observed request telemetry."
+                    }),
                 },
             );
             if ctx.cli.show_cost() {
-                cost_coverage::print_note(cost_coverage);
+                cost_coverage::print_note(selected_grok_report, ctx.currency);
             }
             if let Some(budget) = monthly_budget {
                 let reports = monthly_budget_reports(
@@ -560,11 +577,14 @@ fn handle_period(
         print_no_data_hint(&source_label(source, ctx), "usage");
         return;
     }
+    let grok_reports =
+        (source.name() == "grok").then(|| grok_cost_reports(ctx.filter, ctx.timezone));
     render_period_result(
         &result,
         period,
         caps,
         codex_scope_for_source(source, ctx),
+        grok_reports.as_ref(),
         ctx,
         CostDisplayMode::Total,
     );
@@ -664,7 +684,15 @@ fn handle_all_period(command: SourceCommand, ctx: &CommandContext<'_>) {
         print_no_data_hint("All Sources", "usage");
         return;
     }
-    render_period_result(&result, period, &caps, None, ctx, CostDisplayMode::RealOnly);
+    render_period_result(
+        &result,
+        period,
+        &caps,
+        None,
+        None,
+        ctx,
+        CostDisplayMode::RealOnly,
+    );
 }
 
 /// Handle aggregate commands across every registered data source.

--- a/src/app/cost_coverage.rs
+++ b/src/app/cost_coverage.rs
@@ -111,6 +111,12 @@ pub(crate) fn annotate_csv(
             report.provider_percent()
         )
         .expect("writing to String cannot fail");
+        writeln!(
+            csv,
+            "# grok_excluded_request_tokens,{}",
+            report.excluded_request_tokens
+        )
+        .expect("writing to String cannot fail");
         csv.push_str("# grok_actual_billed_usd,unavailable\n");
         csv.push_str("# pricing_source,calculated_api_equivalent\n");
     }
@@ -145,12 +151,18 @@ pub(crate) fn print_note(report: Option<GrokCostReport>, currency: Option<&Curre
         _ => println!("  API equivalent range: unavailable"),
     }
     println!(
-        "  Request coverage: {} / {} tokens ({:.2}%, {})",
+        "  Request coverage: {} / {} completed-turn tokens ({:.2}%, {})",
         report.priced_tokens,
         report.total_tokens,
         report.coverage_percent(),
         report.status()
     );
+    if report.excluded_request_tokens > 0 {
+        println!(
+            "  In-flight/unmatched requests excluded: {} tokens",
+            report.excluded_request_tokens
+        );
+    }
     match report.provider_reported_cost_usd {
         Some(cost) => println!(
             "  Provider metric: {} ({:.2}% token coverage)",
@@ -196,6 +208,7 @@ fn grok_summary(report: GrokCostReport) -> serde_json::Value {
             "total_tokens": report.total_tokens,
             "coverage_percent": report.coverage_percent(),
             "coverage_status": report.status(),
+            "excluded_request_tokens": report.excluded_request_tokens,
         },
         "provider_metric": {
             "reported_usd": report.provider_reported_cost_usd,

--- a/src/app/cost_coverage.rs
+++ b/src/app/cost_coverage.rs
@@ -129,27 +129,14 @@ pub(crate) fn print_note(report: Option<GrokCostReport>, currency: Option<&Curre
     };
     println!("\n  Grok cost summary (selected range)");
     println!(
-        "  Observed API equivalent: {}",
-        format_cost(report.observed_api_cost_usd, currency)
+        "  Grok reported cost: {} ({:.2}% token coverage)",
+        provider_cost_display(report, currency),
+        report.provider_percent()
     );
-    match report.estimated_api_cost_usd() {
-        Some(cost) => println!(
-            "  Estimated API equivalent: ~{}",
-            format_cost(cost, currency)
-        ),
-        None => println!("  Estimated API equivalent: unavailable"),
-    }
-    match (
-        report.api_cost_lower_bound_usd,
-        report.api_cost_upper_bound_usd,
-    ) {
-        (Some(minimum), Some(maximum)) => println!(
-            "  API equivalent range: {} - {}",
-            format_cost(minimum, currency),
-            format_cost(maximum, currency)
-        ),
-        _ => println!("  API equivalent range: unavailable"),
-    }
+    println!(
+        "  Public API equivalent: {}",
+        api_cost_summary_display(report, currency)
+    );
     println!(
         "  Request coverage: {} / {} completed-turn tokens ({:.2}%, {})",
         report.priced_tokens,
@@ -163,15 +150,6 @@ pub(crate) fn print_note(report: Option<GrokCostReport>, currency: Option<&Curre
             report.excluded_request_tokens
         );
     }
-    match report.provider_reported_cost_usd {
-        Some(cost) => println!(
-            "  Provider metric: {} ({:.2}% token coverage)",
-            format_cost(cost, currency),
-            report.provider_percent()
-        ),
-        None => println!("  Provider metric: unavailable"),
-    }
-    println!("  Actual billed: unavailable");
 }
 
 pub(crate) fn selected_grok_report(
@@ -180,35 +158,86 @@ pub(crate) fn selected_grok_report(
     reports.and_then(|reports| reports.values().copied().reduce(GrokCostReport::merge))
 }
 
+pub(crate) struct TableCostDisplays {
+    pub(crate) api_rows: HashMap<String, String>,
+    pub(crate) api_total: String,
+    pub(crate) provider_rows: HashMap<String, String>,
+    pub(crate) provider_total: String,
+}
+
 pub(crate) fn table_cost_displays(
     reports: &HashMap<String, GrokCostReport>,
     period: Period,
     currency: Option<&CurrencyConverter>,
-) -> (HashMap<String, String>, String) {
+) -> TableCostDisplays {
     let aggregated = aggregate_grok_reports(reports, period);
-    let rows = aggregated
+    let api_rows = aggregated
         .iter()
-        .map(|(key, report)| (key.clone(), table_cost_display(*report, currency)))
+        .map(|(key, report)| (key.clone(), api_cost_display(*report, currency)))
         .collect();
-    let total = reports
-        .values()
-        .copied()
-        .reduce(GrokCostReport::merge)
-        .map_or_else(
+    let provider_rows = aggregated
+        .iter()
+        .map(|(key, report)| (key.clone(), provider_cost_display(*report, currency)))
+        .collect();
+    let total_report = reports.values().copied().reduce(GrokCostReport::merge);
+    TableCostDisplays {
+        api_rows,
+        api_total: total_report.map_or_else(
             || "N/A".to_string(),
-            |report| table_cost_display(report, currency),
-        );
-    (rows, total)
+            |report| api_cost_display(report, currency),
+        ),
+        provider_rows,
+        provider_total: total_report.map_or_else(
+            || "N/A".to_string(),
+            |report| provider_cost_display(report, currency),
+        ),
+    }
 }
 
-fn table_cost_display(report: GrokCostReport, currency: Option<&CurrencyConverter>) -> String {
+fn api_cost_display(report: GrokCostReport, currency: Option<&CurrencyConverter>) -> String {
     if report.status() == "complete" {
         return format_cost(report.observed_api_cost_usd, currency);
     }
-    report.estimated_api_cost_usd().map_or_else(
-        || "N/A".to_string(),
-        |cost| format!("~{}", format_cost(cost, currency)),
-    )
+    if let Some(cost) = report.estimated_api_cost_usd() {
+        return format!("~{}", format_cost(cost, currency));
+    }
+    api_cost_range_display(report, currency).unwrap_or_else(|| "N/A".to_string())
+}
+
+fn api_cost_summary_display(
+    report: GrokCostReport,
+    currency: Option<&CurrencyConverter>,
+) -> String {
+    let display = api_cost_display(report, currency);
+    if report.estimated_api_cost_usd().is_some()
+        && let Some(range) = api_cost_range_display(report, currency)
+    {
+        return format!("{display} (range {range})");
+    }
+    display
+}
+
+fn api_cost_range_display(
+    report: GrokCostReport,
+    currency: Option<&CurrencyConverter>,
+) -> Option<String> {
+    Some(format!(
+        "{}–{}",
+        format_cost(report.api_cost_lower_bound_usd?, currency),
+        format_cost(report.api_cost_upper_bound_usd?, currency)
+    ))
+}
+
+fn provider_cost_display(report: GrokCostReport, currency: Option<&CurrencyConverter>) -> String {
+    let Some(cost) = report.provider_reported_cost_usd else {
+        return "N/A".to_string();
+    };
+    let display = format_cost(cost, currency);
+    if report.provider_priced_tokens < report.total_tokens {
+        format!("≥{display}")
+    } else {
+        display
+    }
 }
 
 fn aggregate_grok_reports(
@@ -320,5 +349,35 @@ mod tests {
 
         assert!(value[0].get("api_equivalent_cost_coverage").is_some());
         assert!(value[1].get("api_equivalent_cost_coverage").is_none());
+    }
+
+    fn report(priced_tokens: i64, observed_api_cost_usd: f64) -> GrokCostReport {
+        GrokCostReport {
+            total_tokens: 1_000,
+            priced_tokens,
+            observed_api_cost_usd,
+            api_cost_lower_bound_usd: Some(2.0),
+            api_cost_upper_bound_usd: Some(4.0),
+            provider_reported_cost_usd: Some(1.5),
+            provider_priced_tokens: 800,
+            excluded_request_tokens: 0,
+            coverage_mismatch: false,
+        }
+    }
+
+    #[test]
+    fn api_table_cost_uses_range_without_request_coverage() {
+        assert_eq!(api_cost_display(report(0, 0.0), None), "$2.00–$4.00");
+    }
+
+    #[test]
+    fn api_table_cost_marks_partial_estimate_and_complete_value() {
+        assert_eq!(api_cost_display(report(500, 1.5), None), "~$3.00");
+        assert_eq!(api_cost_display(report(1_000, 3.0), None), "$3.00");
+    }
+
+    #[test]
+    fn provider_table_cost_marks_partial_coverage() {
+        assert_eq!(provider_cost_display(report(0, 0.0), None), "≥$1.50");
     }
 }

--- a/src/app/cost_coverage.rs
+++ b/src/app/cost_coverage.rs
@@ -180,6 +180,37 @@ pub(crate) fn selected_grok_report(
     reports.and_then(|reports| reports.values().copied().reduce(GrokCostReport::merge))
 }
 
+pub(crate) fn table_cost_displays(
+    reports: &HashMap<String, GrokCostReport>,
+    period: Period,
+    currency: Option<&CurrencyConverter>,
+) -> (HashMap<String, String>, String) {
+    let aggregated = aggregate_grok_reports(reports, period);
+    let rows = aggregated
+        .iter()
+        .map(|(key, report)| (key.clone(), table_cost_display(*report, currency)))
+        .collect();
+    let total = reports
+        .values()
+        .copied()
+        .reduce(GrokCostReport::merge)
+        .map_or_else(
+            || "N/A".to_string(),
+            |report| table_cost_display(report, currency),
+        );
+    (rows, total)
+}
+
+fn table_cost_display(report: GrokCostReport, currency: Option<&CurrencyConverter>) -> String {
+    if report.status() == "complete" {
+        return format_cost(report.observed_api_cost_usd, currency);
+    }
+    report.estimated_api_cost_usd().map_or_else(
+        || "N/A".to_string(),
+        |cost| format!("~{}", format_cost(cost, currency)),
+    )
+}
+
 fn aggregate_grok_reports(
     reports: &HashMap<String, GrokCostReport>,
     period: Period,

--- a/src/app/cost_coverage.rs
+++ b/src/app/cost_coverage.rs
@@ -2,8 +2,9 @@ use std::collections::HashMap;
 use std::fmt::Write as _;
 
 use crate::core::DayStats;
-use crate::output::{Period, aggregate_day_stats_by_period};
-use crate::source::CostCoverage;
+use crate::output::{Period, aggregate_day_stats_by_period, format_cost, period_key};
+use crate::pricing::CurrencyConverter;
+use crate::source::{CostCoverage, GrokCostReport};
 
 fn metadata(coverage: CostCoverage) -> serde_json::Value {
     serde_json::json!({
@@ -19,6 +20,7 @@ pub(crate) fn annotate_json(
     json: &str,
     day_stats: &HashMap<String, DayStats>,
     period: Period,
+    grok_reports: Option<&HashMap<String, GrokCostReport>>,
 ) -> String {
     let Ok(mut value) = serde_json::from_str::<serde_json::Value>(json) else {
         return json.to_string();
@@ -30,29 +32,55 @@ pub(crate) fn annotate_json(
         aggregated = aggregate_day_stats_by_period(day_stats, period);
         &aggregated
     };
+    let aggregated_grok = grok_reports.map(|reports| aggregate_grok_reports(reports, period));
     if let serde_json::Value::Array(rows) = &mut value {
         for row in rows {
-            let Some(key) = row.get(period.label()).and_then(serde_json::Value::as_str) else {
+            let Some(key) = row
+                .get(period.label())
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+            else {
                 continue;
             };
             let Some(coverage) = rows_by_key
-                .get(key)
+                .get(&key)
                 .and_then(|row| CostCoverage::from_stats(std::iter::once(&row.stats)))
             else {
                 continue;
             };
             row["api_equivalent_cost_coverage"] = metadata(coverage);
+            if let Some(report) = aggregated_grok
+                .as_ref()
+                .and_then(|reports| reports.get(&key))
+            {
+                row["grok_cost_summary"] = grok_summary(*report);
+                row["pricing_source"] = serde_json::json!("calculated_api_equivalent");
+                row["cost_semantics"] = serde_json::json!("observed_api_equivalent");
+                if let Some(breakdown) = row
+                    .get_mut("breakdown")
+                    .and_then(|value| value.as_array_mut())
+                {
+                    for model in breakdown {
+                        model["pricing_source"] = serde_json::json!("calculated_api_equivalent");
+                        model["cost_semantics"] = serde_json::json!("observed_api_equivalent");
+                    }
+                }
+            }
         }
     }
     serde_json::to_string(&value).unwrap_or_else(|_| json.to_string())
 }
 
-pub(crate) fn annotate_csv(mut csv: String, coverage: Option<CostCoverage>) -> String {
+pub(crate) fn annotate_csv(
+    mut csv: String,
+    coverage: Option<CostCoverage>,
+    grok_report: Option<GrokCostReport>,
+) -> String {
     if let Some(coverage) = coverage {
         if !csv.ends_with('\n') {
             csv.push('\n');
         }
-        let _ = writeln!(
+        writeln!(
             csv,
             "# api_equivalent_cost_coverage,{},{},{:.2},{},{}",
             coverage.total_tokens,
@@ -60,23 +88,127 @@ pub(crate) fn annotate_csv(mut csv: String, coverage: Option<CostCoverage>) -> S
             coverage.percent(),
             !coverage.is_partial(),
             coverage.cost_is_lower_bound()
-        );
+        )
+        .expect("writing to String cannot fail");
+    }
+    if let Some(report) = grok_report {
+        writeln!(
+            csv,
+            "# grok_api_equivalent_usd,{:.12},{},{},{},{}",
+            report.observed_api_cost_usd,
+            optional_number(report.estimated_api_cost_usd()),
+            optional_number(report.api_cost_lower_bound_usd),
+            optional_number(report.api_cost_upper_bound_usd),
+            report.status()
+        )
+        .expect("writing to String cannot fail");
+        writeln!(
+            csv,
+            "# grok_provider_metric_usd,{},{},{},{:.2}",
+            optional_number(report.provider_reported_cost_usd),
+            report.provider_priced_tokens,
+            report.total_tokens,
+            report.provider_percent()
+        )
+        .expect("writing to String cannot fail");
+        csv.push_str("# grok_actual_billed_usd,unavailable\n");
+        csv.push_str("# pricing_source,calculated_api_equivalent\n");
     }
     csv
 }
 
-pub(crate) fn print_note(coverage: Option<CostCoverage>) {
-    let Some(coverage) = coverage else {
+pub(crate) fn print_note(report: Option<GrokCostReport>, currency: Option<&CurrencyConverter>) {
+    let Some(report) = report else {
         return;
     };
-    if coverage.cost_is_lower_bound() {
-        println!(
-            "\n  API-equivalent cost coverage: {} / {} tokens ({:.2}%); displayed cost is a lower bound.",
-            coverage.priced_tokens,
-            coverage.total_tokens,
-            coverage.percent()
-        );
+    println!("\n  Grok cost summary (selected range)");
+    println!(
+        "  Observed API equivalent: {}",
+        format_cost(report.observed_api_cost_usd, currency)
+    );
+    match report.estimated_api_cost_usd() {
+        Some(cost) => println!(
+            "  Estimated API equivalent: ~{}",
+            format_cost(cost, currency)
+        ),
+        None => println!("  Estimated API equivalent: unavailable"),
     }
+    match (
+        report.api_cost_lower_bound_usd,
+        report.api_cost_upper_bound_usd,
+    ) {
+        (Some(minimum), Some(maximum)) => println!(
+            "  API equivalent range: {} - {}",
+            format_cost(minimum, currency),
+            format_cost(maximum, currency)
+        ),
+        _ => println!("  API equivalent range: unavailable"),
+    }
+    println!(
+        "  Request coverage: {} / {} tokens ({:.2}%, {})",
+        report.priced_tokens,
+        report.total_tokens,
+        report.coverage_percent(),
+        report.status()
+    );
+    match report.provider_reported_cost_usd {
+        Some(cost) => println!(
+            "  Provider metric: {} ({:.2}% token coverage)",
+            format_cost(cost, currency),
+            report.provider_percent()
+        ),
+        None => println!("  Provider metric: unavailable"),
+    }
+    println!("  Actual billed: unavailable");
+}
+
+pub(crate) fn selected_grok_report(
+    reports: Option<&HashMap<String, GrokCostReport>>,
+) -> Option<GrokCostReport> {
+    reports.and_then(|reports| reports.values().copied().reduce(GrokCostReport::merge))
+}
+
+fn aggregate_grok_reports(
+    reports: &HashMap<String, GrokCostReport>,
+    period: Period,
+) -> HashMap<String, GrokCostReport> {
+    let mut aggregated: HashMap<String, GrokCostReport> = HashMap::new();
+    for (date, report) in reports {
+        let key = period_key(date, period);
+        aggregated
+            .entry(key)
+            .and_modify(|current| *current = current.merge(*report))
+            .or_insert(*report);
+    }
+    aggregated
+}
+
+fn grok_summary(report: GrokCostReport) -> serde_json::Value {
+    serde_json::json!({
+        "api_equivalent": {
+            "observed_usd": report.observed_api_cost_usd,
+            "estimated_usd": report.estimated_api_cost_usd(),
+            "range_usd": {
+                "minimum": report.api_cost_lower_bound_usd,
+                "maximum": report.api_cost_upper_bound_usd,
+            },
+            "priced_tokens": report.priced_tokens,
+            "total_tokens": report.total_tokens,
+            "coverage_percent": report.coverage_percent(),
+            "coverage_status": report.status(),
+        },
+        "provider_metric": {
+            "reported_usd": report.provider_reported_cost_usd,
+            "priced_tokens": report.provider_priced_tokens,
+            "total_tokens": report.total_tokens,
+            "coverage_percent": report.provider_percent(),
+        },
+        "actual_billed_usd": serde_json::Value::Null,
+    })
+}
+
+fn optional_number(value: Option<f64>) -> String {
+    value.map_or_else(|| "unavailable".to_string(), |value| format!("{value:.12}"))
 }
 
 #[cfg(test)]
@@ -104,7 +236,7 @@ mod tests {
     #[test]
     fn json_marks_partial_api_cost_as_lower_bound() {
         let day_stats = HashMap::from([("2026-08-24".to_string(), day(200, 100, 0))]);
-        let output = annotate_json(r#"[{"date":"2026-08-24"}]"#, &day_stats, Period::Day);
+        let output = annotate_json(r#"[{"date":"2026-08-24"}]"#, &day_stats, Period::Day, None);
         let value: serde_json::Value = serde_json::from_str(&output).expect("valid json");
         let coverage = &value[0]["api_equivalent_cost_coverage"];
         assert_eq!(coverage["total_tokens"], 200);
@@ -121,6 +253,7 @@ mod tests {
             r#"[{"date":"2026-08-24","total_tokens":200,"estimated_cost":0.1}]"#,
             &day_stats,
             Period::Day,
+            None,
         );
         let value: serde_json::Value = serde_json::from_str(&output).expect("valid json");
 
@@ -137,6 +270,7 @@ mod tests {
             r#"[{"date":"2026-08-24","total_tokens":200},{"date":"2026-08-25","total_tokens":0}]"#,
             &day_stats,
             Period::Day,
+            None,
         );
         let value: serde_json::Value = serde_json::from_str(&output).expect("valid json");
 

--- a/src/app/period_table.rs
+++ b/src/app/period_table.rs
@@ -48,18 +48,25 @@ pub(super) fn render(
             currency: ctx.currency,
             cost_mode,
             cost_label: if selected_grok_report.is_some() {
-                "API Eq. Price"
+                "Grok Reported"
             } else {
                 "Cost"
             },
             cost_display_overrides: grok_cost_displays
                 .as_ref()
-                .map(|displays| &displays.0),
+                .map(|displays| &displays.provider_rows),
             total_cost_display_override: grok_cost_displays
                 .as_ref()
-                .map(|displays| displays.1.as_str()),
+                .map(|displays| displays.provider_total.as_str()),
+            secondary_cost_label: selected_grok_report.map(|_| "API Eq. Price"),
+            secondary_cost_display_overrides: grok_cost_displays
+                .as_ref()
+                .map(|displays| &displays.api_rows),
+            secondary_total_cost_display_override: grok_cost_displays
+                .as_ref()
+                .map(|displays| displays.api_total.as_str()),
             pricing_note_override: selected_grok_report.map(|_| {
-                "Pricing source: xAI public API rates; ~ is estimated, N/A has no request coverage."
+                "Grok Reported comes from costUsdTicks; API Eq. Price uses xAI public rates. ~ is estimated, ranges mark unknown request boundaries, and ≥ marks partial Grok coverage."
             }),
         },
     );

--- a/src/app/period_table.rs
+++ b/src/app/period_table.rs
@@ -1,0 +1,83 @@
+use std::collections::HashMap;
+
+use crate::core::LoadResult;
+use crate::output::{
+    Period, PeriodSummaryFooter, TokenTableOptions, monthly_budget_reports,
+    print_monthly_budget_table, print_period_table,
+};
+use crate::pricing::CostDisplayMode;
+use crate::source::{Capabilities, CodexScope, GrokCostReport};
+
+use super::{CommandContext, cost_coverage};
+
+pub(super) fn render(
+    result: &LoadResult,
+    period: Period,
+    caps: &Capabilities,
+    codex_scope: Option<CodexScope>,
+    grok_reports: Option<&HashMap<String, GrokCostReport>>,
+    ctx: &CommandContext<'_>,
+    cost_mode: CostDisplayMode,
+) {
+    if let Some(scope) = codex_scope {
+        println!("\n  Codex scope: {}", scope.as_str());
+    }
+
+    let selected_grok_report = cost_coverage::selected_grok_report(grok_reports);
+    let grok_cost_displays = grok_reports
+        .map(|reports| cost_coverage::table_cost_displays(reports, period, ctx.currency));
+    print_period_table(
+        &result.day_stats,
+        period,
+        ctx.cli.breakdown,
+        PeriodSummaryFooter {
+            skipped: result.skipped,
+            valid: result.valid,
+            elapsed_ms: Some(result.elapsed_ms),
+        },
+        ctx.pricing_db,
+        TokenTableOptions {
+            order: ctx.cli.sort_order(),
+            use_color: ctx.cli.use_color(),
+            compact: ctx.cli.compact,
+            show_cost: ctx.cli.show_cost(),
+            number_format: ctx.number_format,
+            show_reasoning: caps.has_reasoning_tokens,
+            show_cache_creation: caps.has_cache_creation,
+            supports_cache_read: caps.has_cache_read,
+            currency: ctx.currency,
+            cost_mode,
+            cost_label: if selected_grok_report.is_some() {
+                "API Eq. Price"
+            } else {
+                "Cost"
+            },
+            cost_display_overrides: grok_cost_displays
+                .as_ref()
+                .map(|displays| &displays.0),
+            total_cost_display_override: grok_cost_displays
+                .as_ref()
+                .map(|displays| displays.1.as_str()),
+            pricing_note_override: selected_grok_report.map(|_| {
+                "Pricing source: xAI public API rates; ~ is estimated, N/A has no request coverage."
+            }),
+        },
+    );
+    if ctx.cli.show_cost() {
+        cost_coverage::print_note(selected_grok_report, ctx.currency);
+    }
+    if period == Period::Month
+        && let Some(budget) = ctx.cli.monthly_budget
+    {
+        let reports = monthly_budget_reports(
+            &result.day_stats,
+            ctx.pricing_db,
+            ctx.cli.sort_order(),
+            budget,
+            ctx.budget_as_of,
+            ctx.currency,
+            cost_mode,
+        );
+        print_monthly_budget_table(&reports, ctx.cli.use_color(), ctx.currency);
+    }
+}

--- a/src/output/format.rs
+++ b/src/output/format.rs
@@ -106,7 +106,7 @@ pub(super) fn compare_cost(a: f64, b: f64) -> std::cmp::Ordering {
     }
 }
 
-pub(super) fn format_cost(cost: f64, currency: Option<&CurrencyConverter>) -> String {
+pub(crate) fn format_cost(cost: f64, currency: Option<&CurrencyConverter>) -> String {
     match currency {
         Some(conv) => conv.format(cost),
         None => {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -37,9 +37,9 @@ pub(crate) use csv::{
     output_period_csv_with_quality, output_project_csv, output_session_csv,
 };
 pub(crate) use endpoints::{EndpointTableOptions, output_endpoint_json, print_endpoint_table};
-pub(crate) use format::{NumberFormat, csv_escape};
+pub(crate) use format::{NumberFormat, csv_escape, format_cost};
 pub(crate) use json::output_period_json_with_quality;
-pub(crate) use period::{Period, aggregate_day_stats_by_period};
+pub(crate) use period::{Period, aggregate_day_stats_by_period, period_key};
 pub(crate) use project::{ProjectTableOptions, output_project_json, print_project_table};
 pub(crate) use quota::{
     QuotaValueEstimate, output_quota_csv, output_quota_json, print_quota_table,

--- a/src/output/period.rs
+++ b/src/output/period.rs
@@ -31,7 +31,7 @@ fn week_start(date_str: &str) -> String {
     }
 }
 
-fn period_key(date: &str, period: Period) -> String {
+pub(crate) fn period_key(date: &str, period: Period) -> String {
     match period {
         Period::Day => date.to_string(),
         Period::Week => week_start(date),

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -27,6 +27,8 @@ pub(crate) struct TokenTableOptions<'a> {
     pub(crate) supports_cache_read: bool,
     pub(crate) currency: Option<&'a CurrencyConverter>,
     pub(crate) cost_mode: CostDisplayMode,
+    pub(crate) cost_label: &'a str,
+    pub(crate) pricing_note_override: Option<&'a str>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -105,7 +107,7 @@ fn build_header(cfg: &PeriodConfig, breakdown: bool, opts: &TokenTableOptions<'_
         h.push(header_cell("Cache Hit", c));
         h.push(header_cell("Total", c));
         if opts.show_cost {
-            h.push(header_cell("Cost", c));
+            h.push(header_cell(opts.cost_label, c));
         }
         h
     } else if breakdown {
@@ -123,7 +125,7 @@ fn build_header(cfg: &PeriodConfig, breakdown: bool, opts: &TokenTableOptions<'_
         h.push(header_cell("Cache Read", c));
         h.push(header_cell("Cache Hit", c));
         if opts.show_cost {
-            h.push(header_cell("Cost", c));
+            h.push(header_cell(opts.cost_label, c));
         }
         h
     } else {
@@ -142,7 +144,7 @@ fn build_header(cfg: &PeriodConfig, breakdown: bool, opts: &TokenTableOptions<'_
         h.push(header_cell("Cache Hit", c));
         h.push(header_cell("Total", c));
         if opts.show_cost {
-            h.push(header_cell("Cost", c));
+            h.push(header_cell(opts.cost_label, c));
         }
         h
     }
@@ -515,11 +517,14 @@ pub(crate) fn print_period_table(
             ),
         }
     }
-    if options.show_cost
-        && let Some(note) =
+    if options.show_cost {
+        if let Some(note) = options.pricing_note_override {
+            println!("\n  {note}");
+        } else if let Some(note) =
             pricing_meta::note_for_maps(stats_ref.values().map(|data| &data.models), pricing_db)
-    {
-        println!("\n  {note}");
+        {
+            println!("\n  {note}");
+        }
     }
     print_summary_line(
         summary.valid,

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -28,6 +28,8 @@ pub(crate) struct TokenTableOptions<'a> {
     pub(crate) currency: Option<&'a CurrencyConverter>,
     pub(crate) cost_mode: CostDisplayMode,
     pub(crate) cost_label: &'a str,
+    pub(crate) cost_display_overrides: Option<&'a HashMap<String, String>>,
+    pub(crate) total_cost_display_override: Option<&'a str>,
     pub(crate) pricing_note_override: Option<&'a str>,
 }
 
@@ -185,7 +187,7 @@ fn add_compact_rows(
     ));
     if opts.show_cost {
         row.push(right_cell(
-            &format_cost(cost, opts.currency),
+            &row_cost_display(key, cost, opts),
             cost_color,
             false,
         ));
@@ -246,11 +248,17 @@ fn add_breakdown_rows(
             false,
         ));
         if opts.show_cost {
-            row.push(right_cell(
-                &format_cost(cost, opts.currency),
-                cost_color,
-                false,
-            ));
+            let display = opts
+                .cost_display_overrides
+                .and_then(|overrides| overrides.get(key));
+            let cost_display = if display.is_some() && i > 0 {
+                String::new()
+            } else {
+                display
+                    .cloned()
+                    .unwrap_or_else(|| format_cost(cost, opts.currency))
+            };
+            row.push(right_cell(&cost_display, cost_color, false));
         }
         table.add_row(row);
     }
@@ -319,7 +327,7 @@ fn add_standard_rows(
     ));
     if opts.show_cost {
         row.push(right_cell(
-            &format_cost(cost, opts.currency),
+            &row_cost_display(key, cost, opts),
             cost_color,
             false,
         ));
@@ -373,7 +381,7 @@ fn add_total_row(
         ));
         if opts.show_cost {
             row.push(right_cell(
-                &format_cost(total_cost, opts.currency),
+                &total_cost_display(total_cost, opts),
                 green,
                 true,
             ));
@@ -425,13 +433,25 @@ fn add_total_row(
         }
         if opts.show_cost {
             row.push(right_cell(
-                &format_cost(total_cost, opts.currency),
+                &total_cost_display(total_cost, opts),
                 green,
                 true,
             ));
         }
         table.add_row(row);
     }
+}
+
+fn row_cost_display(key: &str, cost: f64, opts: &TokenTableOptions<'_>) -> String {
+    opts.cost_display_overrides
+        .and_then(|overrides| overrides.get(key))
+        .cloned()
+        .unwrap_or_else(|| format_cost(cost, opts.currency))
+}
+
+fn total_cost_display(total_cost: f64, opts: &TokenTableOptions<'_>) -> String {
+    opts.total_cost_display_override
+        .map_or_else(|| format_cost(total_cost, opts.currency), str::to_string)
 }
 
 pub(crate) fn print_period_table(

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -30,6 +30,9 @@ pub(crate) struct TokenTableOptions<'a> {
     pub(crate) cost_label: &'a str,
     pub(crate) cost_display_overrides: Option<&'a HashMap<String, String>>,
     pub(crate) total_cost_display_override: Option<&'a str>,
+    pub(crate) secondary_cost_label: Option<&'a str>,
+    pub(crate) secondary_cost_display_overrides: Option<&'a HashMap<String, String>>,
+    pub(crate) secondary_total_cost_display_override: Option<&'a str>,
     pub(crate) pricing_note_override: Option<&'a str>,
 }
 
@@ -110,6 +113,9 @@ fn build_header(cfg: &PeriodConfig, breakdown: bool, opts: &TokenTableOptions<'_
         h.push(header_cell("Total", c));
         if opts.show_cost {
             h.push(header_cell(opts.cost_label, c));
+            if let Some(label) = opts.secondary_cost_label {
+                h.push(header_cell(label, c));
+            }
         }
         h
     } else if breakdown {
@@ -128,6 +134,9 @@ fn build_header(cfg: &PeriodConfig, breakdown: bool, opts: &TokenTableOptions<'_
         h.push(header_cell("Cache Hit", c));
         if opts.show_cost {
             h.push(header_cell(opts.cost_label, c));
+            if let Some(label) = opts.secondary_cost_label {
+                h.push(header_cell(label, c));
+            }
         }
         h
     } else {
@@ -147,6 +156,9 @@ fn build_header(cfg: &PeriodConfig, breakdown: bool, opts: &TokenTableOptions<'_
         h.push(header_cell("Total", c));
         if opts.show_cost {
             h.push(header_cell(opts.cost_label, c));
+            if let Some(label) = opts.secondary_cost_label {
+                h.push(header_cell(label, c));
+            }
         }
         h
     }
@@ -186,11 +198,7 @@ fn add_compact_rows(
         false,
     ));
     if opts.show_cost {
-        row.push(right_cell(
-            &row_cost_display(key, cost, opts),
-            cost_color,
-            false,
-        ));
+        add_cost_cells(&mut row, key, cost, opts, cost_color, false);
     }
     table.add_row(row);
     cost
@@ -248,17 +256,7 @@ fn add_breakdown_rows(
             false,
         ));
         if opts.show_cost {
-            let display = opts
-                .cost_display_overrides
-                .and_then(|overrides| overrides.get(key));
-            let cost_display = if display.is_some() && i > 0 {
-                String::new()
-            } else {
-                display
-                    .cloned()
-                    .unwrap_or_else(|| format_cost(cost, opts.currency))
-            };
-            row.push(right_cell(&cost_display, cost_color, false));
+            add_cost_cells(&mut row, key, cost, opts, cost_color, i > 0);
         }
         table.add_row(row);
     }
@@ -326,11 +324,7 @@ fn add_standard_rows(
         false,
     ));
     if opts.show_cost {
-        row.push(right_cell(
-            &row_cost_display(key, cost, opts),
-            cost_color,
-            false,
-        ));
+        add_cost_cells(&mut row, key, cost, opts, cost_color, false);
     }
     table.add_row(row);
     cost
@@ -380,11 +374,7 @@ fn add_total_row(
             true,
         ));
         if opts.show_cost {
-            row.push(right_cell(
-                &total_cost_display(total_cost, opts),
-                green,
-                true,
-            ));
+            add_total_cost_cells(&mut row, total_cost, opts, green);
         }
         table.add_row(row);
     } else {
@@ -432,26 +422,68 @@ fn add_total_row(
             ));
         }
         if opts.show_cost {
-            row.push(right_cell(
-                &total_cost_display(total_cost, opts),
-                green,
-                true,
-            ));
+            add_total_cost_cells(&mut row, total_cost, opts, green);
         }
         table.add_row(row);
     }
 }
 
-fn row_cost_display(key: &str, cost: f64, opts: &TokenTableOptions<'_>) -> String {
-    opts.cost_display_overrides
-        .and_then(|overrides| overrides.get(key))
-        .cloned()
-        .unwrap_or_else(|| format_cost(cost, opts.currency))
-}
-
 fn total_cost_display(total_cost: f64, opts: &TokenTableOptions<'_>) -> String {
     opts.total_cost_display_override
         .map_or_else(|| format_cost(total_cost, opts.currency), str::to_string)
+}
+
+fn add_cost_cells(
+    row: &mut Vec<Cell>,
+    key: &str,
+    cost: f64,
+    opts: &TokenTableOptions<'_>,
+    color: Option<Color>,
+    continuation: bool,
+) {
+    let primary_override = opts
+        .cost_display_overrides
+        .and_then(|overrides| overrides.get(key));
+    let primary = if continuation && primary_override.is_some() {
+        String::new()
+    } else {
+        primary_override
+            .cloned()
+            .unwrap_or_else(|| format_cost(cost, opts.currency))
+    };
+    row.push(right_cell(&primary, color, false));
+
+    if opts.secondary_cost_label.is_some() {
+        let secondary = if continuation {
+            String::new()
+        } else {
+            opts.secondary_cost_display_overrides
+                .and_then(|overrides| overrides.get(key))
+                .cloned()
+                .unwrap_or_else(|| "N/A".to_string())
+        };
+        row.push(right_cell(&secondary, color, false));
+    }
+}
+
+fn add_total_cost_cells(
+    row: &mut Vec<Cell>,
+    total_cost: f64,
+    opts: &TokenTableOptions<'_>,
+    color: Option<Color>,
+) {
+    row.push(right_cell(
+        &total_cost_display(total_cost, opts),
+        color,
+        true,
+    ));
+    if opts.secondary_cost_label.is_some() {
+        row.push(right_cell(
+            opts.secondary_total_cost_display_override.unwrap_or("N/A"),
+            color,
+            true,
+        ));
+    }
 }
 
 pub(crate) fn print_period_table(

--- a/src/output/table_tests.rs
+++ b/src/output/table_tests.rs
@@ -19,6 +19,9 @@ fn default_opts() -> TokenTableOptions<'static> {
         cost_label: "Cost",
         cost_display_overrides: None,
         total_cost_display_override: None,
+        secondary_cost_label: None,
+        secondary_cost_display_overrides: None,
+        secondary_total_cost_display_override: None,
         pricing_note_override: None,
     }
 }
@@ -32,6 +35,20 @@ fn header_can_label_api_equivalent_price() {
         ..default_opts()
     };
     let h = build_header(&cfg, false, &opts);
+    assert_eq!(h.last().unwrap().content(), "API Eq. Price");
+}
+
+#[test]
+fn header_can_show_reported_and_api_equivalent_prices() {
+    let cfg = period_config(Period::Day);
+    let opts = TokenTableOptions {
+        show_cost: true,
+        cost_label: "Grok Reported",
+        secondary_cost_label: Some("API Eq. Price"),
+        ..default_opts()
+    };
+    let h = build_header(&cfg, false, &opts);
+    assert_eq!(h[h.len() - 2].content(), "Grok Reported");
     assert_eq!(h.last().unwrap().content(), "API Eq. Price");
 }
 

--- a/src/output/table_tests.rs
+++ b/src/output/table_tests.rs
@@ -17,20 +17,22 @@ fn default_opts() -> TokenTableOptions<'static> {
         currency: None,
         cost_mode: CostDisplayMode::Total,
         cost_label: "Cost",
+        cost_display_overrides: None,
+        total_cost_display_override: None,
         pricing_note_override: None,
     }
 }
 
 #[test]
-fn header_can_label_observed_api_equivalent_cost() {
+fn header_can_label_api_equivalent_price() {
     let cfg = period_config(Period::Day);
     let opts = TokenTableOptions {
         show_cost: true,
-        cost_label: "Observed API Eq.",
+        cost_label: "API Eq. Price",
         ..default_opts()
     };
     let h = build_header(&cfg, false, &opts);
-    assert_eq!(h.last().unwrap().content(), "Observed API Eq.");
+    assert_eq!(h.last().unwrap().content(), "API Eq. Price");
 }
 
 #[test]

--- a/src/output/table_tests.rs
+++ b/src/output/table_tests.rs
@@ -16,7 +16,21 @@ fn default_opts() -> TokenTableOptions<'static> {
         supports_cache_read: false,
         currency: None,
         cost_mode: CostDisplayMode::Total,
+        cost_label: "Cost",
+        pricing_note_override: None,
     }
+}
+
+#[test]
+fn header_can_label_observed_api_equivalent_cost() {
+    let cfg = period_config(Period::Day);
+    let opts = TokenTableOptions {
+        show_cost: true,
+        cost_label: "Observed API Eq.",
+        ..default_opts()
+    };
+    let h = build_header(&cfg, false, &opts);
+    assert_eq!(h.last().unwrap().content(), "Observed API Eq.");
 }
 
 #[test]

--- a/src/source/grok/cost_report.rs
+++ b/src/source/grok/cost_report.rs
@@ -1,0 +1,430 @@
+//! Grok cost semantics derived from complete turns and request telemetry.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+
+use crate::consts::DATE_FORMAT;
+use crate::core::{CostKind, CostTokens, DateFilter, DedupAccumulator, RawEntry};
+use crate::utils::Timezone;
+
+use super::canonical_model_name;
+use super::unified::{
+    InferenceRecord, LEDGER_FILE, SYNC_ERROR_FILE, UNIFIED_LOG, api_cost_usd, api_rates,
+    find_grok_files, grok_home, load_ledger, read_inference_records,
+};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub(crate) struct GrokCostReport {
+    pub(crate) total_tokens: i64,
+    pub(crate) priced_tokens: i64,
+    pub(crate) observed_api_cost_usd: f64,
+    pub(crate) api_cost_lower_bound_usd: Option<f64>,
+    pub(crate) api_cost_upper_bound_usd: Option<f64>,
+    pub(crate) provider_reported_cost_usd: Option<f64>,
+    pub(crate) provider_priced_tokens: i64,
+    pub(crate) coverage_mismatch: bool,
+}
+
+impl GrokCostReport {
+    pub(crate) fn estimated_api_cost_usd(self) -> Option<f64> {
+        let (Some(minimum), Some(maximum)) =
+            (self.api_cost_lower_bound_usd, self.api_cost_upper_bound_usd)
+        else {
+            return None;
+        };
+        if self.coverage_mismatch || self.priced_tokens <= 0 {
+            return None;
+        }
+        let scaled =
+            self.observed_api_cost_usd * self.total_tokens as f64 / self.priced_tokens as f64;
+        Some(scaled.clamp(minimum, maximum))
+    }
+
+    pub(crate) fn coverage_percent(self) -> f64 {
+        percent(self.priced_tokens, self.total_tokens)
+    }
+
+    pub(crate) fn provider_percent(self) -> f64 {
+        percent(self.provider_priced_tokens, self.total_tokens)
+    }
+
+    pub(crate) fn status(self) -> &'static str {
+        if self.coverage_mismatch {
+            "mismatch"
+        } else if self.priced_tokens == self.total_tokens {
+            "complete"
+        } else {
+            "partial"
+        }
+    }
+
+    pub(crate) fn merge(self, other: Self) -> Self {
+        Self {
+            total_tokens: self.total_tokens.saturating_add(other.total_tokens),
+            priced_tokens: self.priced_tokens.saturating_add(other.priced_tokens),
+            observed_api_cost_usd: self.observed_api_cost_usd + other.observed_api_cost_usd,
+            api_cost_lower_bound_usd: sum_options(
+                self.api_cost_lower_bound_usd,
+                other.api_cost_lower_bound_usd,
+            ),
+            api_cost_upper_bound_usd: sum_options(
+                self.api_cost_upper_bound_usd,
+                other.api_cost_upper_bound_usd,
+            ),
+            provider_reported_cost_usd: sum_optional_metrics(
+                self.provider_reported_cost_usd,
+                other.provider_reported_cost_usd,
+            ),
+            provider_priced_tokens: self
+                .provider_priced_tokens
+                .saturating_add(other.provider_priced_tokens),
+            coverage_mismatch: self.coverage_mismatch || other.coverage_mismatch,
+        }
+    }
+}
+
+fn percent(part: i64, total: i64) -> f64 {
+    if total <= 0 {
+        0.0
+    } else {
+        part.max(0).min(total) as f64 / total as f64 * 100.0
+    }
+}
+
+fn sum_options(left: Option<f64>, right: Option<f64>) -> Option<f64> {
+    Some(left? + right?)
+}
+
+fn sum_optional_metrics(left: Option<f64>, right: Option<f64>) -> Option<f64> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left + right),
+        (Some(value), None) | (None, Some(value)) => Some(value),
+        (None, None) => None,
+    }
+}
+
+#[derive(Default)]
+struct DailyBuilder {
+    total_by_model: HashMap<String, CostTokens>,
+    priced_by_model: HashMap<String, CostTokens>,
+    observed_api_cost_usd: f64,
+    provider_reported_cost_usd: Option<f64>,
+    provider_priced_tokens: i64,
+    mismatch: bool,
+}
+
+impl DailyBuilder {
+    fn finish(self) -> GrokCostReport {
+        let total_tokens = self.total_by_model.values().fold(0_i64, |sum, tokens| {
+            sum.saturating_add(tokens.total_tokens())
+        });
+        let priced_tokens = self.priced_by_model.values().fold(0_i64, |sum, tokens| {
+            sum.saturating_add(tokens.total_tokens())
+        });
+        let mut mismatch = self.mismatch || priced_tokens > total_tokens;
+        for (model, priced) in &self.priced_by_model {
+            match self.total_by_model.get(model) {
+                Some(total) if !token_components_exceed(*priced, *total) => {}
+                _ if priced.has_entries() => mismatch = true,
+                _ => {}
+            }
+        }
+        let bounds = (!mismatch)
+            .then(|| {
+                api_cost_bounds(
+                    &self.total_by_model,
+                    &self.priced_by_model,
+                    self.observed_api_cost_usd,
+                )
+            })
+            .flatten();
+        GrokCostReport {
+            total_tokens,
+            priced_tokens,
+            observed_api_cost_usd: self.observed_api_cost_usd,
+            api_cost_lower_bound_usd: bounds.map(|(minimum, _)| minimum),
+            api_cost_upper_bound_usd: bounds.map(|(_, maximum)| maximum),
+            provider_reported_cost_usd: self.provider_reported_cost_usd,
+            provider_priced_tokens: self.provider_priced_tokens,
+            coverage_mismatch: mismatch,
+        }
+    }
+}
+
+pub(crate) fn cost_reports(
+    filter: &DateFilter,
+    timezone: Timezone,
+) -> HashMap<String, GrokCostReport> {
+    cost_reports_from_files(&find_grok_files(), filter, timezone)
+}
+
+fn cost_reports_from_files(
+    files: &[PathBuf],
+    filter: &DateFilter,
+    timezone: Timezone,
+) -> HashMap<String, GrokCostReport> {
+    let mut usage = DedupAccumulator::new();
+    let mut provider_usage = DedupAccumulator::new();
+    let mut builders: HashMap<String, DailyBuilder> = HashMap::new();
+    let mut global_mismatch = false;
+
+    for path in files {
+        match path.file_name().and_then(|name| name.to_str()) {
+            Some(LEDGER_FILE) => match load_ledger(path) {
+                Ok(records) => add_inference_records(
+                    records.into_values(),
+                    filter,
+                    timezone,
+                    &mut builders,
+                    &mut global_mismatch,
+                ),
+                Err(_) => global_mismatch = true,
+            },
+            Some(UNIFIED_LOG) => {
+                let sessions_dir = grok_home()
+                    .map(|home| home.join("sessions"))
+                    .unwrap_or_default();
+                match read_inference_records(path, &sessions_dir) {
+                    Ok(records) => add_inference_records(
+                        records,
+                        filter,
+                        timezone,
+                        &mut builders,
+                        &mut global_mismatch,
+                    ),
+                    Err(_) => global_mismatch = true,
+                }
+            }
+            Some(SYNC_ERROR_FILE) => global_mismatch = true,
+            _ => add_turn_records(path, filter, timezone, &mut usage, &mut provider_usage),
+        }
+    }
+
+    let (usage_entries, _) = usage.finalize();
+    for entry in &usage_entries {
+        let builder = builders.entry(entry.date_str.clone()).or_default();
+        let tokens = entry_cost_tokens(entry);
+        builder
+            .total_by_model
+            .entry(canonical_model_name(&entry.model))
+            .or_default()
+            .add(&tokens);
+    }
+
+    let (provider_entries, _) = provider_usage.finalize();
+    for entry in &provider_entries {
+        let Some(cost) = entry.recorded_cost_usd else {
+            continue;
+        };
+        let builder = builders.entry(entry.date_str.clone()).or_default();
+        builder.provider_reported_cost_usd =
+            Some(builder.provider_reported_cost_usd.unwrap_or_default() + cost.max(0.0));
+        builder.provider_priced_tokens = builder
+            .provider_priced_tokens
+            .saturating_add(entry.to_stats().total_tokens());
+    }
+
+    builders
+        .into_iter()
+        .filter_map(|(date, mut builder)| {
+            builder.mismatch |= global_mismatch;
+            let report = builder.finish();
+            (report.total_tokens > 0).then_some((date, report))
+        })
+        .collect()
+}
+
+fn add_turn_records(
+    path: &Path,
+    filter: &DateFilter,
+    timezone: Timezone,
+    usage: &mut DedupAccumulator<RawEntry>,
+    provider_usage: &mut DedupAccumulator<RawEntry>,
+) {
+    let parsed = super::parser::parse_grok_usage_file_with_debug(path, timezone, false);
+    usage.extend(parsed.entries.into_iter().filter(|entry| {
+        entry.cost_kind != CostKind::EstimatedProxy && entry_in_filter(entry, filter)
+    }));
+    let provider = super::parser::parse_grok_session_file_for_provider(path, timezone, false);
+    provider_usage.extend(
+        provider
+            .entries
+            .into_iter()
+            .filter(|entry| entry_in_filter(entry, filter)),
+    );
+}
+
+fn entry_in_filter(entry: &RawEntry, filter: &DateFilter) -> bool {
+    chrono::NaiveDate::parse_from_str(&entry.date_str, DATE_FORMAT)
+        .is_ok_and(|date| filter.contains(date))
+}
+
+fn add_inference_records(
+    records: impl IntoIterator<Item = InferenceRecord>,
+    filter: &DateFilter,
+    timezone: Timezone,
+    builders: &mut HashMap<String, DailyBuilder>,
+    global_mismatch: &mut bool,
+) {
+    for record in records {
+        let Ok(utc_dt) = record.timestamp.parse::<DateTime<Utc>>() else {
+            *global_mismatch = true;
+            continue;
+        };
+        let date = timezone.to_fixed_offset(utc_dt).date_naive();
+        if !filter.contains(date) {
+            continue;
+        }
+        let prompt = record.prompt_tokens.max(0);
+        let cached = record.cached_prompt_tokens.clamp(0, prompt);
+        let completion = record.completion_tokens.max(0);
+        let Some(cost) = api_cost_usd(&record.model, prompt, cached, completion) else {
+            continue;
+        };
+        let tokens = CostTokens {
+            input_tokens: prompt.saturating_sub(cached),
+            output_tokens: completion,
+            cache_read: cached,
+            ..CostTokens::default()
+        };
+        let builder = builders
+            .entry(date.format(DATE_FORMAT).to_string())
+            .or_default();
+        builder
+            .priced_by_model
+            .entry(canonical_model_name(&record.model))
+            .or_default()
+            .add(&tokens);
+        builder.observed_api_cost_usd += cost;
+    }
+}
+
+fn entry_cost_tokens(entry: &RawEntry) -> CostTokens {
+    CostTokens {
+        input_tokens: entry.input_tokens,
+        output_tokens: entry.output_tokens.saturating_add(entry.reasoning_tokens),
+        cache_creation: entry.cache_creation,
+        cache_creation_1h: entry.cache_creation_1h,
+        cache_read: entry.cache_read,
+        reasoning_tokens: 0,
+        count: 0,
+    }
+}
+
+fn token_components_exceed(left: CostTokens, right: CostTokens) -> bool {
+    left.input_tokens > right.input_tokens
+        || left.output_tokens > right.output_tokens
+        || left.cache_creation > right.cache_creation
+        || left.cache_read > right.cache_read
+}
+
+fn api_cost_bounds(
+    total_by_model: &HashMap<String, CostTokens>,
+    priced_by_model: &HashMap<String, CostTokens>,
+    observed_cost: f64,
+) -> Option<(f64, f64)> {
+    let mut minimum = observed_cost;
+    let mut maximum = observed_cost;
+    for (model, total) in total_by_model {
+        let priced = priced_by_model.get(model).copied().unwrap_or_default();
+        let missing = total.saturating_sub(&priced);
+        minimum += cost_tokens_at_tier(model, missing, false)?;
+        maximum += cost_tokens_at_tier(model, missing, true)?;
+    }
+    Some((minimum, maximum))
+}
+
+fn cost_tokens_at_tier(model: &str, tokens: CostTokens, is_long: bool) -> Option<f64> {
+    let rates = api_rates(model, is_long)?;
+    let input = tokens.input_tokens.saturating_add(tokens.cache_creation);
+    let output = tokens.output_tokens.saturating_add(tokens.reasoning_tokens);
+    Some(
+        input as f64 * rates.input
+            + tokens.cache_read as f64 * rates.cache_read
+            + output as f64 * rates.output,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn tz() -> Timezone {
+        Timezone::parse(Some("UTC")).expect("UTC timezone")
+    }
+
+    #[test]
+    fn reports_api_estimate_range_and_provider_metric_separately() {
+        let root = tempdir().expect("temp dir");
+        let session_dir = root.path().join("session-1");
+        fs::create_dir_all(&session_dir).expect("create session dir");
+        fs::write(
+            session_dir.join("summary.json"),
+            r#"{"current_model_id":"grok-4.6","git_root_dir":"/tmp/grok-project"}"#,
+        )
+        .expect("write summary");
+        let updates_path = session_dir.join("updates.jsonl");
+        fs::write(
+            &updates_path,
+            r#"{"timestamp":1786896000,"params":{"sessionId":"session-1","update":{"sessionUpdate":"turn_completed","usage":{"inputTokens":300000,"outputTokens":10000,"cachedReadTokens":200000,"reasoningTokens":2000,"modelCalls":2,"costUsdTicks":10000000000,"modelUsage":{"grok-4.6-build":{"inputTokens":300000,"outputTokens":10000,"cachedReadTokens":200000,"reasoningTokens":2000,"modelCalls":2,"costUsdTicks":10000000000}}}},"_meta":{"eventId":"turn-1"}}}
+"#,
+        )
+        .expect("write updates");
+        let ledger_path = root.path().join(LEDGER_FILE);
+        fs::write(
+            &ledger_path,
+            r#"{"event_key":"inference-1","timestamp":"2026-08-16T00:00:00Z","session_id":"session-1","session_key":"session-1","project_path":"/tmp/grok-project","model":"grok-4.6","prompt_tokens":150000,"cached_prompt_tokens":100000,"completion_tokens":5000,"reasoning_tokens":1000}
+"#,
+        )
+        .expect("write ledger");
+
+        let date = chrono::NaiveDate::from_ymd_opt(2026, 8, 16).unwrap();
+        let reports = cost_reports_from_files(
+            &[updates_path, ledger_path],
+            &DateFilter::new(Some(date), Some(date)),
+            tz(),
+        );
+        let report = reports.get("2026-08-16").expect("daily report");
+
+        assert_eq!(report.total_tokens, 310_000);
+        assert_eq!(report.priced_tokens, 155_000);
+        assert!((report.observed_api_cost_usd - 0.18).abs() < 1e-12);
+        assert!((report.estimated_api_cost_usd().unwrap() - 0.36).abs() < 1e-12);
+        assert!((report.api_cost_lower_bound_usd.unwrap() - 0.36).abs() < 1e-12);
+        assert!((report.api_cost_upper_bound_usd.unwrap() - 0.54).abs() < 1e-12);
+        assert_eq!(report.provider_reported_cost_usd, Some(1.0));
+        assert_eq!(report.provider_priced_tokens, 310_000);
+    }
+
+    #[test]
+    fn mismatch_hides_estimate_and_range() {
+        let mut builder = DailyBuilder::default();
+        builder.total_by_model.insert(
+            "grok-4.6".to_string(),
+            CostTokens {
+                input_tokens: 10,
+                ..CostTokens::default()
+            },
+        );
+        builder.priced_by_model.insert(
+            "grok-4.6".to_string(),
+            CostTokens {
+                input_tokens: 20,
+                ..CostTokens::default()
+            },
+        );
+
+        let report = builder.finish();
+
+        assert_eq!(report.status(), "mismatch");
+        assert_eq!(report.estimated_api_cost_usd(), None);
+        assert_eq!(report.api_cost_lower_bound_usd, None);
+        assert_eq!(report.api_cost_upper_bound_usd, None);
+    }
+}

--- a/src/source/grok/cost_report.rs
+++ b/src/source/grok/cost_report.rs
@@ -1,19 +1,21 @@
 //! Grok cost semantics derived from complete turns and request telemetry.
 
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
-
-use chrono::{DateTime, Utc};
+use std::path::PathBuf;
+use std::time::Instant;
 
 use crate::consts::DATE_FORMAT;
-use crate::core::{CostKind, CostTokens, DateFilter, DedupAccumulator, RawEntry};
+use crate::core::{
+    CostKind, CostTokens, DateFilter, DedupAccumulator, LoadResult, RawEntry, aggregate_daily,
+};
+use crate::source::Source;
 use crate::utils::Timezone;
 
-use super::canonical_model_name;
 use super::unified::{
-    InferenceRecord, LEDGER_FILE, SYNC_ERROR_FILE, UNIFIED_LOG, api_cost_usd, api_rates,
-    find_grok_files, grok_home, load_ledger, read_inference_records,
+    InferenceRecord, LEDGER_FILE, SYNC_ERROR_FILE, UNIFIED_LOG, api_rates, find_grok_files,
+    grok_home, load_ledger, read_inference_records, records_to_parse_output,
 };
+use super::{GrokSource, canonical_model_name};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub(crate) struct GrokCostReport {
@@ -24,6 +26,7 @@ pub(crate) struct GrokCostReport {
     pub(crate) api_cost_upper_bound_usd: Option<f64>,
     pub(crate) provider_reported_cost_usd: Option<f64>,
     pub(crate) provider_priced_tokens: i64,
+    pub(crate) excluded_request_tokens: i64,
     pub(crate) coverage_mismatch: bool,
 }
 
@@ -80,6 +83,9 @@ impl GrokCostReport {
             provider_priced_tokens: self
                 .provider_priced_tokens
                 .saturating_add(other.provider_priced_tokens),
+            excluded_request_tokens: self
+                .excluded_request_tokens
+                .saturating_add(other.excluded_request_tokens),
             coverage_mismatch: self.coverage_mismatch || other.coverage_mismatch,
         }
     }
@@ -112,6 +118,7 @@ struct DailyBuilder {
     observed_api_cost_usd: f64,
     provider_reported_cost_usd: Option<f64>,
     provider_priced_tokens: i64,
+    excluded_request_tokens: i64,
     mismatch: bool,
 }
 
@@ -148,62 +155,73 @@ impl DailyBuilder {
             api_cost_upper_bound_usd: bounds.map(|(_, maximum)| maximum),
             provider_reported_cost_usd: self.provider_reported_cost_usd,
             provider_priced_tokens: self.provider_priced_tokens,
+            excluded_request_tokens: self.excluded_request_tokens,
             coverage_mismatch: mismatch,
         }
     }
 }
 
-pub(crate) fn cost_reports(
-    filter: &DateFilter,
-    timezone: Timezone,
-) -> HashMap<String, GrokCostReport> {
-    cost_reports_from_files(&find_grok_files(), filter, timezone)
+struct InferenceObservation {
+    entry: RawEntry,
+    tokens: CostTokens,
 }
 
-fn cost_reports_from_files(
+struct SnapshotInputs {
+    usage_entries: Vec<RawEntry>,
+    inference_observations: Vec<InferenceObservation>,
+    skipped: i64,
+    parse_errors: usize,
+    mismatch: bool,
+}
+
+pub(crate) fn load_daily_with_cost_reports(
+    filter: &DateFilter,
+    timezone: Timezone,
+    quiet: bool,
+    debug: bool,
+) -> (LoadResult, HashMap<String, GrokCostReport>) {
+    load_daily_with_cost_reports_from_files_and_options(
+        &find_grok_files(),
+        filter,
+        timezone,
+        quiet,
+        debug,
+    )
+}
+
+#[cfg(test)]
+fn load_daily_with_cost_reports_from_files(
     files: &[PathBuf],
     filter: &DateFilter,
     timezone: Timezone,
-) -> HashMap<String, GrokCostReport> {
-    let mut usage = DedupAccumulator::new();
-    let mut provider_usage = DedupAccumulator::new();
-    let mut builders: HashMap<String, DailyBuilder> = HashMap::new();
-    let mut global_mismatch = false;
+) -> (LoadResult, HashMap<String, GrokCostReport>) {
+    load_daily_with_cost_reports_from_files_and_options(files, filter, timezone, true, false)
+}
 
-    for path in files {
-        match path.file_name().and_then(|name| name.to_str()) {
-            Some(LEDGER_FILE) => match load_ledger(path) {
-                Ok(records) => add_inference_records(
-                    records.into_values(),
-                    filter,
-                    timezone,
-                    &mut builders,
-                    &mut global_mismatch,
-                ),
-                Err(_) => global_mismatch = true,
-            },
-            Some(UNIFIED_LOG) => {
-                let sessions_dir = grok_home()
-                    .map(|home| home.join("sessions"))
-                    .unwrap_or_default();
-                match read_inference_records(path, &sessions_dir) {
-                    Ok(records) => add_inference_records(
-                        records,
-                        filter,
-                        timezone,
-                        &mut builders,
-                        &mut global_mismatch,
-                    ),
-                    Err(_) => global_mismatch = true,
-                }
-            }
-            Some(SYNC_ERROR_FILE) => global_mismatch = true,
-            _ => add_turn_records(path, filter, timezone, &mut usage, &mut provider_usage),
-        }
+fn load_daily_with_cost_reports_from_files_and_options(
+    files: &[PathBuf],
+    filter: &DateFilter,
+    timezone: Timezone,
+    quiet: bool,
+    debug: bool,
+) -> (LoadResult, HashMap<String, GrokCostReport>) {
+    let load_start = Instant::now();
+    if !quiet && !files.is_empty() {
+        eprintln!("Scanning {} Grok files...", files.len());
     }
 
-    let (usage_entries, _) = usage.finalize();
+    let SnapshotInputs {
+        mut usage_entries,
+        inference_observations,
+        skipped,
+        parse_errors,
+        mismatch,
+    } = read_snapshot_files(files, filter, timezone, debug);
+    let mut builders: HashMap<String, DailyBuilder> = HashMap::new();
     for entry in &usage_entries {
+        if entry.cost_kind == CostKind::EstimatedProxy {
+            continue;
+        }
         let builder = builders.entry(entry.date_str.clone()).or_default();
         let tokens = entry_cost_tokens(entry);
         builder
@@ -211,49 +229,190 @@ fn cost_reports_from_files(
             .entry(canonical_model_name(&entry.model))
             .or_default()
             .add(&tokens);
+        if let Some(cost) = entry.recorded_cost_usd {
+            builder.provider_reported_cost_usd =
+                Some(builder.provider_reported_cost_usd.unwrap_or_default() + cost.max(0.0));
+            builder.provider_priced_tokens = builder
+                .provider_priced_tokens
+                .saturating_add(entry.to_stats().total_tokens());
+        }
     }
 
-    let (provider_entries, _) = provider_usage.finalize();
-    for entry in &provider_entries {
-        let Some(cost) = entry.recorded_cost_usd else {
-            continue;
-        };
-        let builder = builders.entry(entry.date_str.clone()).or_default();
-        builder.provider_reported_cost_usd =
-            Some(builder.provider_reported_cost_usd.unwrap_or_default() + cost.max(0.0));
-        builder.provider_priced_tokens = builder
-            .provider_priced_tokens
-            .saturating_add(entry.to_stats().total_tokens());
-    }
-
-    builders
+    let inference_entries = reconcile_inference_observations(inference_observations, &mut builders);
+    let reports: HashMap<String, GrokCostReport> = builders
         .into_iter()
         .filter_map(|(date, mut builder)| {
-            builder.mismatch |= global_mismatch;
+            builder.mismatch |= mismatch;
             let report = builder.finish();
             (report.total_tokens > 0).then_some((date, report))
         })
-        .collect()
+        .collect();
+
+    // The same parsed turn entries carry the provider metric into the report.
+    // Clear it before normal aggregation so the table cost remains exclusively
+    // the API-equivalent value from request-boundary inference entries.
+    for entry in &mut usage_entries {
+        if entry.cost_kind != CostKind::EstimatedProxy {
+            entry.recorded_cost_usd = Some(0.0);
+        }
+    }
+    usage_entries.extend(inference_entries);
+    if reports.is_empty() {
+        usage_entries = GrokSource::new().finalize_entries(usage_entries);
+    }
+    let valid = usage_entries.len() as i64;
+    let day_stats = aggregate_daily(usage_entries);
+    let elapsed_ms = load_start.elapsed().as_secs_f64() * 1000.0;
+
+    if !quiet && !files.is_empty() {
+        eprintln!(
+            "Parsed {} files in one Grok snapshot ({elapsed_ms:.2}ms)",
+            files.len()
+        );
+        if skipped > 0 {
+            eprintln!("Deduplicated {skipped} entries");
+        }
+        if parse_errors > 0 {
+            eprintln!("Warning: ignored {parse_errors} malformed records");
+        }
+    }
+
+    (
+        LoadResult {
+            day_stats,
+            skipped,
+            valid,
+            parse_errors,
+            elapsed_ms,
+        },
+        reports,
+    )
 }
 
-fn add_turn_records(
-    path: &Path,
+fn read_snapshot_files(
+    files: &[PathBuf],
     filter: &DateFilter,
     timezone: Timezone,
-    usage: &mut DedupAccumulator<RawEntry>,
-    provider_usage: &mut DedupAccumulator<RawEntry>,
-) {
-    let parsed = super::parser::parse_grok_usage_file_with_debug(path, timezone, false);
-    usage.extend(parsed.entries.into_iter().filter(|entry| {
-        entry.cost_kind != CostKind::EstimatedProxy && entry_in_filter(entry, filter)
-    }));
-    let provider = super::parser::parse_grok_session_file_for_provider(path, timezone, false);
-    provider_usage.extend(
-        provider
-            .entries
-            .into_iter()
-            .filter(|entry| entry_in_filter(entry, filter)),
-    );
+    debug: bool,
+) -> SnapshotInputs {
+    let mut usage = DedupAccumulator::new();
+    let mut inference_observations = Vec::new();
+    let mut mismatch = false;
+    let mut parse_errors = 0;
+
+    for path in files {
+        match path.file_name().and_then(|name| name.to_str()) {
+            Some(LEDGER_FILE) => match load_ledger(path) {
+                Ok(records) => add_inference_snapshot(
+                    records.into_values().collect(),
+                    filter,
+                    timezone,
+                    &mut inference_observations,
+                    &mut mismatch,
+                    &mut parse_errors,
+                ),
+                Err(error) => {
+                    mismatch = true;
+                    parse_errors += 1;
+                    if debug {
+                        eprintln!("{error}");
+                    }
+                }
+            },
+            Some(UNIFIED_LOG) => {
+                let sessions_dir = grok_home()
+                    .map(|home| home.join("sessions"))
+                    .unwrap_or_default();
+                match read_inference_records(path, &sessions_dir) {
+                    Ok(records) => add_inference_snapshot(
+                        records,
+                        filter,
+                        timezone,
+                        &mut inference_observations,
+                        &mut mismatch,
+                        &mut parse_errors,
+                    ),
+                    Err(error) => {
+                        mismatch = true;
+                        parse_errors += 1;
+                        if debug {
+                            eprintln!("{error}");
+                        }
+                    }
+                }
+            }
+            Some(SYNC_ERROR_FILE) => {
+                mismatch = true;
+                parse_errors += 1;
+            }
+            _ => {
+                let parsed =
+                    super::parser::parse_grok_session_file_for_provider(path, timezone, debug);
+                parse_errors += parsed.errors;
+                usage.extend(
+                    parsed
+                        .entries
+                        .into_iter()
+                        .filter(|entry| entry_in_filter(entry, filter)),
+                );
+            }
+        }
+    }
+
+    let (usage_entries, skipped) = usage.finalize();
+    SnapshotInputs {
+        usage_entries,
+        inference_observations,
+        skipped,
+        parse_errors,
+        mismatch,
+    }
+}
+
+fn reconcile_inference_observations(
+    mut inference_observations: Vec<InferenceObservation>,
+    builders: &mut HashMap<String, DailyBuilder>,
+) -> Vec<RawEntry> {
+    let mut inference_entries = Vec::new();
+    inference_observations.sort_by_key(|observation| observation.entry.timestamp_ms);
+    for observation in inference_observations {
+        let builder = builders
+            .entry(observation.entry.date_str.clone())
+            .or_default();
+        if observation.entry.recorded_cost_usd.is_none() {
+            if builder.total_by_model.is_empty() {
+                inference_entries.push(observation.entry);
+            }
+            continue;
+        }
+        let model = canonical_model_name(&observation.entry.model);
+        let mut candidate = builder
+            .priced_by_model
+            .get(&model)
+            .copied()
+            .unwrap_or_default();
+        candidate.add(&observation.tokens);
+        let matches_completed_usage = builder
+            .total_by_model
+            .get(&model)
+            .is_some_and(|total| !token_components_exceed(candidate, *total));
+        if matches_completed_usage {
+            builder.priced_by_model.insert(model, candidate);
+            builder.observed_api_cost_usd +=
+                observation.entry.recorded_cost_usd.unwrap_or_default();
+            inference_entries.push(observation.entry);
+        } else if builder.total_by_model.is_empty() {
+            // Preserve exact inference-only fallback rows for logs that have no
+            // completed turns at all. They remain outside completed-turn cost
+            // coverage, so they cannot poison or inflate a period estimate.
+            inference_entries.push(observation.entry);
+        } else {
+            builder.excluded_request_tokens = builder
+                .excluded_request_tokens
+                .saturating_add(observation.tokens.total_tokens());
+        }
+    }
+    inference_entries
 }
 
 fn entry_in_filter(entry: &RawEntry, filter: &DateFilter) -> bool {
@@ -261,44 +420,41 @@ fn entry_in_filter(entry: &RawEntry, filter: &DateFilter) -> bool {
         .is_ok_and(|date| filter.contains(date))
 }
 
-fn add_inference_records(
-    records: impl IntoIterator<Item = InferenceRecord>,
+fn add_inference_snapshot(
+    records: Vec<InferenceRecord>,
     filter: &DateFilter,
     timezone: Timezone,
-    builders: &mut HashMap<String, DailyBuilder>,
+    observations: &mut Vec<InferenceObservation>,
     global_mismatch: &mut bool,
+    parse_errors: &mut usize,
 ) {
-    for record in records {
-        let Ok(utc_dt) = record.timestamp.parse::<DateTime<Utc>>() else {
-            *global_mismatch = true;
-            continue;
-        };
-        let date = timezone.to_fixed_offset(utc_dt).date_naive();
-        if !filter.contains(date) {
-            continue;
+    let mut tokens_by_event: HashMap<String, CostTokens> = records
+        .iter()
+        .map(|record| {
+            let prompt = record.prompt_tokens.max(0);
+            let cached = record.cached_prompt_tokens.clamp(0, prompt);
+            (
+                record.event_key.clone(),
+                CostTokens {
+                    input_tokens: prompt.saturating_sub(cached),
+                    output_tokens: record.completion_tokens.max(0),
+                    cache_read: cached,
+                    ..CostTokens::default()
+                },
+            )
+        })
+        .collect();
+    let parsed = records_to_parse_output(records, timezone);
+    *parse_errors += parsed.errors;
+    *global_mismatch |= parsed.errors > 0;
+    observations.extend(parsed.entries.into_iter().filter_map(|entry| {
+        if !entry_in_filter(&entry, filter) {
+            return None;
         }
-        let prompt = record.prompt_tokens.max(0);
-        let cached = record.cached_prompt_tokens.clamp(0, prompt);
-        let completion = record.completion_tokens.max(0);
-        let Some(cost) = api_cost_usd(&record.model, prompt, cached, completion) else {
-            continue;
-        };
-        let tokens = CostTokens {
-            input_tokens: prompt.saturating_sub(cached),
-            output_tokens: completion,
-            cache_read: cached,
-            ..CostTokens::default()
-        };
-        let builder = builders
-            .entry(date.format(DATE_FORMAT).to_string())
-            .or_default();
-        builder
-            .priced_by_model
-            .entry(canonical_model_name(&record.model))
-            .or_default()
-            .add(&tokens);
-        builder.observed_api_cost_usd += cost;
-    }
+        let event_key = entry.message_id.as_deref()?;
+        let tokens = tokens_by_event.remove(event_key)?;
+        Some(InferenceObservation { entry, tokens })
+    }));
 }
 
 fn entry_cost_tokens(entry: &RawEntry) -> CostTokens {
@@ -380,18 +536,23 @@ mod tests {
         fs::write(
             &ledger_path,
             r#"{"event_key":"inference-1","timestamp":"2026-08-16T00:00:00Z","session_id":"session-1","session_key":"session-1","project_path":"/tmp/grok-project","model":"grok-4.6","prompt_tokens":150000,"cached_prompt_tokens":100000,"completion_tokens":5000,"reasoning_tokens":1000}
+{"event_key":"inference-2","timestamp":"2026-08-16T00:01:00Z","session_id":"session-1","session_key":"session-1","project_path":"/tmp/grok-project","model":"grok-4.6","prompt_tokens":300000,"cached_prompt_tokens":200000,"completion_tokens":10000,"reasoning_tokens":2000}
 "#,
         )
         .expect("write ledger");
 
         let date = chrono::NaiveDate::from_ymd_opt(2026, 8, 16).unwrap();
-        let reports = cost_reports_from_files(
+        let (result, reports) = load_daily_with_cost_reports_from_files(
             &[updates_path, ledger_path],
             &DateFilter::new(Some(date), Some(date)),
             tz(),
         );
         let report = reports.get("2026-08-16").expect("daily report");
+        let day = result.day_stats.get("2026-08-16").expect("daily table row");
 
+        assert_eq!(day.stats.total_tokens(), report.total_tokens);
+        assert_eq!(day.stats.api_equivalent_priced_tokens, report.priced_tokens);
+        assert!((day.stats.recorded_cost_usd - report.observed_api_cost_usd).abs() < 1e-12);
         assert_eq!(report.total_tokens, 310_000);
         assert_eq!(report.priced_tokens, 155_000);
         assert!((report.observed_api_cost_usd - 0.18).abs() < 1e-12);
@@ -400,6 +561,7 @@ mod tests {
         assert!((report.api_cost_upper_bound_usd.unwrap() - 0.54).abs() < 1e-12);
         assert_eq!(report.provider_reported_cost_usd, Some(1.0));
         assert_eq!(report.provider_priced_tokens, 310_000);
+        assert_eq!(report.excluded_request_tokens, 310_000);
     }
 
     #[test]

--- a/src/source/grok/mod.rs
+++ b/src/source/grok/mod.rs
@@ -12,7 +12,7 @@ mod unified;
 mod usage;
 
 pub(crate) use config::GrokSource;
-pub(crate) use cost_report::{GrokCostReport, cost_reports};
+pub(crate) use cost_report::{GrokCostReport, load_daily_with_cost_reports};
 
 fn canonical_model_name(model: &str) -> String {
     let normalized = model.trim().to_ascii_lowercase();

--- a/src/source/grok/mod.rs
+++ b/src/source/grok/mod.rs
@@ -1,12 +1,26 @@
 //! Grok CLI data source
 //!
-//! Prefers durable `logs/unified.jsonl` inference records. Installations
-//! without unified inference telemetry still use session usage records.
+//! Complete token totals come from session `turn_completed.usage` records.
+//! Durable `logs/unified.jsonl` inference records provide the subset that can
+//! be priced at public API rates.
 
 mod config;
+mod cost_report;
 mod ledger_lock;
 mod parser;
 mod unified;
 mod usage;
 
 pub(crate) use config::GrokSource;
+pub(crate) use cost_report::{GrokCostReport, cost_reports};
+
+fn canonical_model_name(model: &str) -> String {
+    let normalized = model.trim().to_ascii_lowercase();
+    if normalized.contains("grok-4.6") {
+        "grok-4.6".to_string()
+    } else if normalized.contains("grok-4.5") {
+        "grok-4.5".to_string()
+    } else {
+        model.trim().to_string()
+    }
+}

--- a/src/source/grok/parser.rs
+++ b/src/source/grok/parser.rs
@@ -319,6 +319,14 @@ pub(super) fn parse_grok_usage_file_with_debug(
     parse_grok_session_file(path, timezone, debug, false)
 }
 
+pub(super) fn parse_grok_session_file_for_provider(
+    path: &Path,
+    timezone: Timezone,
+    debug: bool,
+) -> ParseOutput {
+    parse_grok_session_file(path, timezone, debug, true)
+}
+
 fn parse_grok_session_file(
     path: &Path,
     timezone: Timezone,
@@ -580,7 +588,7 @@ mod tests {
         assert_eq!(entry.reasoning_tokens, 5);
         assert_eq!(entry.call_count, 3);
         assert_eq!(entry.date_str, "2026-08-16");
-        assert_eq!(entry.model, "grok-4.5-build");
+        assert_eq!(entry.model, "grok-4.5");
         assert_eq!(entry.cost_kind, CostKind::Real);
         assert_eq!(entry.recorded_cost_usd, Some(2.0));
     }

--- a/src/source/grok/unified.rs
+++ b/src/source/grok/unified.rs
@@ -509,7 +509,7 @@ fn parse_ledger_file(path: &Path, timezone: Timezone, debug: bool) -> ParseOutpu
     }
 }
 
-fn records_to_parse_output(
+pub(super) fn records_to_parse_output(
     records: impl IntoIterator<Item = InferenceRecord>,
     timezone: Timezone,
 ) -> ParseOutput {

--- a/src/source/grok/unified.rs
+++ b/src/source/grok/unified.rs
@@ -24,9 +24,9 @@ const APP_DATA_DIR: &str = "ccstats";
 const GROK_CACHE_DIR: &str = "grok";
 const GROK_HOME_ENV: &str = "GROK_HOME";
 const DEFAULT_GROK_DIR: &str = ".grok";
-const UNIFIED_LOG: &str = "unified.jsonl";
-const LEDGER_FILE: &str = "inference-v1.jsonl";
-const SYNC_ERROR_FILE: &str = "inference-v1.sync-error";
+pub(super) const UNIFIED_LOG: &str = "unified.jsonl";
+pub(super) const LEDGER_FILE: &str = "inference-v1.jsonl";
+pub(super) const SYNC_ERROR_FILE: &str = "inference-v1.sync-error";
 const INFERENCE_DONE: &str = "shell.turn.inference_done";
 const MODEL_CHANGED: &str = "model changed";
 const LONG_CONTEXT_THRESHOLD: i64 = 200_000;
@@ -66,36 +66,30 @@ struct SessionMetadata {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-struct InferenceRecord {
-    event_key: String,
-    timestamp: String,
-    session_id: String,
-    session_key: String,
-    project_path: String,
-    model: String,
-    prompt_tokens: i64,
-    cached_prompt_tokens: i64,
-    completion_tokens: i64,
-    reasoning_tokens: i64,
+pub(super) struct InferenceRecord {
+    pub(super) event_key: String,
+    pub(super) timestamp: String,
+    pub(super) session_id: String,
+    pub(super) session_key: String,
+    pub(super) project_path: String,
+    pub(super) model: String,
+    pub(super) prompt_tokens: i64,
+    pub(super) cached_prompt_tokens: i64,
+    pub(super) completion_tokens: i64,
+    pub(super) reasoning_tokens: i64,
 }
 
 #[derive(Clone, Copy)]
-struct TokenRates {
-    input: f64,
-    cache_read: f64,
-    output: f64,
+pub(super) struct TokenRates {
+    pub(super) input: f64,
+    pub(super) cache_read: f64,
+    pub(super) output: f64,
 }
 
-fn api_cost_usd(
-    model: &str,
-    prompt_tokens: i64,
-    cached_prompt_tokens: i64,
-    completion_tokens: i64,
-) -> Option<f64> {
+pub(super) fn api_rates(model: &str, is_long: bool) -> Option<TokenRates> {
     let model = model.to_ascii_lowercase();
-    let is_long = prompt_tokens.max(0) >= LONG_CONTEXT_THRESHOLD;
-    let rates = if model.contains("grok-4.6") {
-        if is_long {
+    if model.contains("grok-4.6") {
+        Some(if is_long {
             TokenRates {
                 input: 4e-6,
                 cache_read: 1e-6,
@@ -107,9 +101,9 @@ fn api_cost_usd(
                 cache_read: 0.5e-6,
                 output: 6e-6,
             }
-        }
+        })
     } else if model.contains("grok-4.5") {
-        if is_long {
+        Some(if is_long {
             TokenRates {
                 input: 4e-6,
                 cache_read: 0.6e-6,
@@ -121,10 +115,20 @@ fn api_cost_usd(
                 cache_read: 0.3e-6,
                 output: 6e-6,
             }
-        }
+        })
     } else {
-        return None;
-    };
+        None
+    }
+}
+
+pub(super) fn api_cost_usd(
+    model: &str,
+    prompt_tokens: i64,
+    cached_prompt_tokens: i64,
+    completion_tokens: i64,
+) -> Option<f64> {
+    let is_long = prompt_tokens.max(0) >= LONG_CONTEXT_THRESHOLD;
+    let rates = api_rates(model, is_long)?;
 
     let prompt_tokens = prompt_tokens.max(0);
     let cached_prompt_tokens = cached_prompt_tokens.clamp(0, prompt_tokens);
@@ -232,7 +236,7 @@ fn sync_ledger_at(
     Ok(records.len())
 }
 
-fn load_ledger(path: &Path) -> Result<BTreeMap<String, InferenceRecord>, String> {
+pub(super) fn load_ledger(path: &Path) -> Result<BTreeMap<String, InferenceRecord>, String> {
     let file = match File::open(path) {
         Ok(file) => file,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(BTreeMap::new()),
@@ -262,7 +266,7 @@ fn load_ledger(path: &Path) -> Result<BTreeMap<String, InferenceRecord>, String>
     Ok(records)
 }
 
-fn read_inference_records(
+pub(super) fn read_inference_records(
     path: &Path,
     sessions_dir: &Path,
 ) -> Result<Vec<InferenceRecord>, String> {
@@ -353,7 +357,7 @@ fn load_session_metadata(sessions_root: &Path) -> HashMap<String, SessionMetadat
                 SessionMetadata {
                     session_key: session_path.display().to_string(),
                     project_path,
-                    model,
+                    model: super::canonical_model_name(&model),
                 },
             ))
         })
@@ -539,7 +543,7 @@ fn records_to_parse_output(
                     record.session_id
                 },
                 project_path: record.project_path,
-                model: record.model,
+                model: super::canonical_model_name(&record.model),
                 // Complete usage comes from turn_completed records. These
                 // inference entries contribute only their exact request-boundary
                 // API-equivalent cost, otherwise captured tokens are counted twice.

--- a/src/source/grok/usage.rs
+++ b/src/source/grok/usage.rs
@@ -2,8 +2,8 @@
 //!
 //! `turn_completed.usage` is the provider-reported request total for that turn
 //! (including every model call in the tool loop). `inputTokens` includes cache
-//! reads and `outputTokens` includes reasoning, so those nested counts are
-//! subtracted before they are stored on `RawEntry`.
+//! reads and cache creation, while `outputTokens` includes reasoning, so those
+//! nested counts are subtracted before they are stored on `RawEntry`.
 
 use std::collections::{HashMap, hash_map::DefaultHasher};
 use std::fs::File;
@@ -276,6 +276,7 @@ fn parse_turn_line(
             continue;
         }
         let message_id = Some(format!("{base_message_id}:{model}"));
+        let model = super::canonical_model_name(&model);
         entries.push(RawEntry {
             timestamp: utc_dt.to_rfc3339(),
             timestamp_ms: utc_dt.timestamp_millis(),
@@ -331,7 +332,7 @@ fn normalize_usage(tokens: &UsageTokens) -> NormalizedUsage {
     let raw_output = tokens.output_tokens.unwrap_or(0).max(0);
     let model_calls = tokens.model_calls.unwrap_or(0).max(0);
     NormalizedUsage {
-        input_tokens: (raw_input - cache_read).max(0),
+        input_tokens: (raw_input - cache_read - cache_creation).max(0),
         output_tokens: (raw_output - reasoning_tokens).max(0),
         cache_creation,
         cache_read,
@@ -434,7 +435,7 @@ mod tests {
         assert_eq!(parsed.errors, 0);
         assert_eq!(parsed.entries.len(), 1);
         let entry = &parsed.entries[0];
-        assert_eq!(entry.model, "grok-4.5-build");
+        assert_eq!(entry.model, "grok-4.5");
         assert_eq!(entry.input_tokens, 37666);
         assert_eq!(entry.cache_read, 127_360);
         assert_eq!(entry.output_tokens, 2125);
@@ -509,6 +510,24 @@ mod tests {
         assert_eq!(usage.reasoning_tokens, 0);
         assert_eq!(usage.call_count, 1);
         assert_eq!(usage.recorded_cost_usd, None);
+    }
+
+    #[test]
+    fn cache_creation_is_not_counted_twice_as_uncached_input() {
+        let usage = normalize_usage(&UsageTokens {
+            input_tokens: Some(100),
+            output_tokens: Some(10),
+            cached_read_tokens: Some(20),
+            cache_creation_tokens: Some(30),
+            reasoning_tokens: Some(4),
+            model_calls: Some(1),
+            cost_usd_ticks: None,
+        });
+        assert_eq!(usage.input_tokens, 50);
+        assert_eq!(usage.cache_read, 20);
+        assert_eq!(usage.cache_creation, 30);
+        assert_eq!(usage.output_tokens, 6);
+        assert_eq!(usage.reasoning_tokens, 4);
     }
 
     #[test]

--- a/src/source/grok/usage.rs
+++ b/src/source/grok/usage.rs
@@ -95,6 +95,22 @@ pub(super) struct TurnUsageParseOutput {
     pub(super) saw_usage_record: bool,
 }
 
+enum TurnLineOutcome {
+    MissingUsage,
+    InvalidUsage,
+    Entries(Vec<RawEntry>),
+}
+
+impl TurnLineOutcome {
+    fn from_entries(entries: Vec<RawEntry>) -> Self {
+        if entries.is_empty() {
+            Self::InvalidUsage
+        } else {
+            Self::Entries(entries)
+        }
+    }
+}
+
 pub(super) fn parse_turn_completed_usage(
     path: &Path,
     timezone: Timezone,
@@ -144,15 +160,15 @@ pub(super) fn parse_turn_completed_usage(
         if !looks_like_turn_completed_record(&line) {
             continue;
         }
-        // A turn-completed record is authoritative even when it is truncated
-        // before the usage object. Never replace it with a cumulative snapshot.
+        // A turn-completed record is authoritative even when it has no usage
+        // object. Never replace it with a cumulative snapshot.
         saw_usage_record = true;
         match parse_turn_line(&line, timezone, ctx) {
-            Ok(Some(turn_entries)) => {
-                saw_usage_record = true;
+            Ok(TurnLineOutcome::Entries(turn_entries)) => {
                 entries.extend(turn_entries);
             }
-            Ok(None) => {
+            Ok(TurnLineOutcome::MissingUsage) => {}
+            Ok(TurnLineOutcome::InvalidUsage) => {
                 errors += 1;
             }
             Err(err) => {
@@ -200,19 +216,19 @@ fn parse_turn_line(
     line: &str,
     timezone: Timezone,
     ctx: &GrokSessionContext,
-) -> Result<Option<Vec<RawEntry>>, serde_json::Error> {
+) -> Result<TurnLineOutcome, serde_json::Error> {
     let envelope: UpdateEnvelope = serde_json::from_str(line)?;
     let params = envelope.params.as_ref();
     let update = params.and_then(|params| params.update.as_ref());
     if update.and_then(|update| update.kind.as_deref()) != Some(TURN_COMPLETED) {
-        return Ok(None);
+        return Ok(TurnLineOutcome::InvalidUsage);
     }
     let Some(usage) = update.and_then(|update| update.usage.as_ref()) else {
-        return Ok(None);
+        return Ok(TurnLineOutcome::MissingUsage);
     };
 
     let Some(utc_dt) = event_time(&envelope) else {
-        return Ok(None);
+        return Ok(TurnLineOutcome::InvalidUsage);
     };
     let local_dt = timezone.to_fixed_offset(utc_dt);
     let date_str = local_dt.date_naive().format(DATE_FORMAT).to_string();
@@ -302,7 +318,7 @@ fn parse_turn_line(
             api_equivalent_coverage_tokens: coverage_tokens(&normalized),
         });
     }
-    Ok(Some(entries).filter(|entries| !entries.is_empty()))
+    Ok(TurnLineOutcome::from_entries(entries))
 }
 
 fn event_time(envelope: &UpdateEnvelope) -> Option<DateTime<Utc>> {
@@ -419,6 +435,15 @@ mod tests {
         }
     }
 
+    fn parse_entries(line: &str) -> Vec<RawEntry> {
+        match parse_turn_line(line, tz(), &ctx()).expect("valid turn") {
+            TurnLineOutcome::Entries(entries) => entries,
+            TurnLineOutcome::MissingUsage | TurnLineOutcome::InvalidUsage => {
+                panic!("expected usage entries")
+            }
+        }
+    }
+
     #[test]
     fn parses_turn_completed_usage_and_server_cost() {
         let root = tempdir().expect("temp dir");
@@ -453,6 +478,23 @@ mod tests {
         assert_eq!(stats.count, 5);
         assert_eq!(stats.recorded_cost_entries, 1);
         assert!((stats.recorded_cost_usd - 0.13816).abs() < 1e-12);
+    }
+
+    #[test]
+    fn skips_turn_completed_without_usage_without_parse_error() {
+        let root = tempdir().expect("temp dir");
+        let path = root.path().join("updates.jsonl");
+        fs::write(
+            &path,
+            r#"{"timestamp":1776374400,"params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"p1","stop_reason":"end_turn"}}}
+"#,
+        )
+        .expect("write updates");
+
+        let parsed = parse_turn_completed_usage(&path, tz(), true, &ctx());
+        assert_eq!(parsed.errors, 0);
+        assert!(parsed.entries.is_empty());
+        assert!(parsed.saw_usage_record);
     }
 
     #[test]
@@ -604,9 +646,7 @@ mod tests {
     #[test]
     fn residual_tokens_do_not_invent_a_model_call() {
         let line = r#"{"timestamp":1786896000,"params":{"update":{"sessionUpdate":"turn_completed","usage":{"inputTokens":30,"modelCalls":2,"modelUsage":{"grok-a":{"inputTokens":10,"modelCalls":1},"grok-b":{"inputTokens":10,"modelCalls":1}}}}}}"#;
-        let entries = parse_turn_line(line, tz(), &ctx())
-            .expect("valid turn")
-            .expect("usage entries");
+        let entries = parse_entries(line);
 
         assert_eq!(
             entries
@@ -624,9 +664,7 @@ mod tests {
     #[test]
     fn accepts_snake_case_turn_discriminator() {
         let line = r#"{"timestamp":1786896000,"params":{"update":{"session_update":"turn_completed","usage":{"inputTokens":10}}}}"#;
-        let entries = parse_turn_line(line, tz(), &ctx())
-            .expect("valid turn")
-            .expect("usage entries");
+        let entries = parse_entries(line);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].input_tokens, 10);
     }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -612,7 +612,7 @@ pub(crate) type BoxedSource = Box<dyn Source>;
 pub(crate) use codex::load_weekly_window_usage_from_home;
 pub use codex::{CodexQuotaError, CodexQuotaStatus, CodexWeeklyQuota};
 pub(crate) use codex::{CodexScope, CodexSource, load_weekly_quota, load_weekly_quota_from_home};
-pub(crate) use grok::{GrokCostReport, cost_reports as grok_cost_reports};
+pub(crate) use grok::{GrokCostReport, load_daily_with_cost_reports as load_grok_daily_with_cost};
 
 // Re-export registry functions
 pub(crate) use registry::{ALL_SOURCES, all_sources, get_source, source_choices, suggest_source};

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -612,6 +612,7 @@ pub(crate) type BoxedSource = Box<dyn Source>;
 pub(crate) use codex::load_weekly_window_usage_from_home;
 pub use codex::{CodexQuotaError, CodexQuotaStatus, CodexWeeklyQuota};
 pub(crate) use codex::{CodexScope, CodexSource, load_weekly_quota, load_weekly_quota_from_home};
+pub(crate) use grok::{GrokCostReport, cost_reports as grok_cost_reports};
 
 // Re-export registry functions
 pub(crate) use registry::{ALL_SOURCES, all_sources, get_source, source_choices, suggest_source};

--- a/tests/cli_grok_cursor.rs
+++ b/tests/cli_grok_cursor.rs
@@ -232,7 +232,7 @@ fn grok_keeps_complete_turn_tokens_and_marks_partial_api_cost() {
     assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
     let table = String::from_utf8(stdout).expect("utf8 table");
     assert!(
-        table.contains("120 / 180 tokens (66.67%, partial)"),
+        table.contains("120 / 180 completed-turn tokens (66.67%, partial)"),
         "table: {table}"
     );
     assert!(

--- a/tests/cli_grok_cursor.rs
+++ b/tests/cli_grok_cursor.rs
@@ -236,11 +236,15 @@ fn grok_keeps_complete_turn_tokens_and_marks_partial_api_cost() {
         "table: {table}"
     );
     assert!(
-        table.contains("API Eq. Price") && table.contains("~$0.00"),
+        table.contains("Grok Reported")
+            && table.contains("API Eq. Price")
+            && table.contains("$2.50")
+            && table.contains("~$0.00"),
         "table: {table}"
     );
     assert!(
-        table.contains("Provider metric: $2.50") && table.contains("Actual billed: unavailable"),
+        table.contains("Grok reported cost: $2.50")
+            && table.contains("Public API equivalent: ~$0.00"),
         "table: {table}"
     );
 
@@ -262,7 +266,7 @@ fn grok_keeps_complete_turn_tokens_and_marks_partial_api_cost() {
         .lines()
         .find(|line| line.contains("2026-08-17"))
         .expect("zero-coverage daily row");
-    assert!(row.contains("N/A"), "row: {row}");
+    assert!(row.contains("$0.50") && row.contains("–"), "row: {row}");
 
     let _ = fs::remove_dir_all(root);
 }

--- a/tests/cli_grok_cursor.rs
+++ b/tests/cli_grok_cursor.rs
@@ -190,6 +190,32 @@ fn grok_keeps_complete_turn_tokens_and_marks_partial_api_cost() {
     assert_close(coverage["percent"].as_f64().unwrap(), 66.666_666_666_666_66);
     assert_eq!(coverage["complete"].as_bool(), Some(false));
     assert_eq!(coverage["cost_is_lower_bound"].as_bool(), Some(true));
+    let summary = &row["grok_cost_summary"];
+    assert_close(
+        summary["api_equivalent"]["observed_usd"].as_f64().unwrap(),
+        0.000_252,
+    );
+    assert_close(
+        summary["api_equivalent"]["estimated_usd"].as_f64().unwrap(),
+        0.000_395,
+    );
+    assert_close(
+        summary["api_equivalent"]["range_usd"]["minimum"]
+            .as_f64()
+            .unwrap(),
+        0.000_395,
+    );
+    assert_close(
+        summary["api_equivalent"]["range_usd"]["maximum"]
+            .as_f64()
+            .unwrap(),
+        0.000_538,
+    );
+    assert_close(
+        summary["provider_metric"]["reported_usd"].as_f64().unwrap(),
+        2.5,
+    );
+    assert!(summary["actual_billed_usd"].is_null());
 
     let table_args = [
         "grok",
@@ -206,11 +232,11 @@ fn grok_keeps_complete_turn_tokens_and_marks_partial_api_cost() {
     assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
     let table = String::from_utf8(stdout).expect("utf8 table");
     assert!(
-        table.contains("120 / 180 tokens (66.67%)"),
+        table.contains("120 / 180 tokens (66.67%, partial)"),
         "table: {table}"
     );
     assert!(
-        table.contains("displayed cost is a lower bound"),
+        table.contains("Provider metric: $2.50") && table.contains("Actual billed: unavailable"),
         "table: {table}"
     );
 
@@ -809,16 +835,26 @@ fn grok_daily_json_uses_turn_tokens_without_treating_cost_ticks_as_api_price() {
     assert_eq!(arr[0]["total_tokens"].as_i64(), Some(120));
     assert_close(arr[0]["cache_hit_rate"].as_f64().unwrap(), 40.0);
     assert_close(arr[0]["cost"].as_f64().unwrap(), 0.0);
-    assert_eq!(arr[0]["pricing_source"].as_str(), Some("recorded"));
+    assert_eq!(
+        arr[0]["pricing_source"].as_str(),
+        Some("calculated_api_equivalent")
+    );
     assert!(arr[0].get("cost_kind").is_none() || arr[0]["cost_kind"].is_null());
     assert_eq!(
         arr[0]["models"].as_array().unwrap()[0].as_str(),
-        Some("grok-4.5-build")
+        Some("grok-4.5")
     );
     let coverage = &arr[0]["api_equivalent_cost_coverage"];
     assert_eq!(coverage["total_tokens"].as_i64(), Some(120));
     assert_eq!(coverage["priced_tokens"].as_i64(), Some(0));
     assert_eq!(coverage["cost_is_lower_bound"].as_bool(), Some(true));
+    let summary = &arr[0]["grok_cost_summary"];
+    assert!(summary["api_equivalent"]["estimated_usd"].is_null());
+    assert_close(
+        summary["provider_metric"]["reported_usd"].as_f64().unwrap(),
+        2.0,
+    );
+    assert!(summary["actual_billed_usd"].is_null());
 
     let _ = fs::remove_dir_all(root);
 }

--- a/tests/cli_grok_cursor.rs
+++ b/tests/cli_grok_cursor.rs
@@ -236,9 +236,33 @@ fn grok_keeps_complete_turn_tokens_and_marks_partial_api_cost() {
         "table: {table}"
     );
     assert!(
+        table.contains("API Eq. Price") && table.contains("~$0.00"),
+        "table: {table}"
+    );
+    assert!(
         table.contains("Provider metric: $2.50") && table.contains("Actual billed: unavailable"),
         "table: {table}"
     );
+
+    let daily_args = [
+        "grok",
+        "daily",
+        "-O",
+        "--timezone",
+        "UTC",
+        "--since",
+        "2026-08-17",
+        "--until",
+        "2026-08-17",
+    ];
+    let (ok, stdout, stderr) = run_ccstats(&daily_args, &env);
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let table = String::from_utf8(stdout).expect("utf8 daily table");
+    let row = table
+        .lines()
+        .find(|line| line.contains("2026-08-17"))
+        .expect("zero-coverage daily row");
+    assert!(row.contains("N/A"), "row: {row}");
 
     let _ = fs::remove_dir_all(root);
 }


### PR DESCRIPTION
## What

- keep complete, globally deduplicated `turn_completed.usage` token totals authoritative
- label exact request telemetry cost as `Observed API Eq.`
- add per-period API-equivalent observed value, coverage-adjusted estimate, and short/long-context range
- expose `costUsdTicks` separately as a provider metric with independent token coverage
- mark actual billed cost unavailable instead of inferring a subscription charge
- merge Grok 4.5/4.6 display aliases without changing dedup identity
- subtract cache creation from overlapping Grok input totals

## Why

The observed API-equivalent subset depends on durable request-boundary ledger coverage, while complete token totals come from turn records. The provider-reported tick value is a third measurement. Presenting any of these as one generic Cost value makes correct but different numbers look like a calculation bug.

Closes #127

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo test` (642 unit tests plus all CLI, SDK, and doc tests)
- [x] `cargo deny check`
- [x] `cargo clippy --all-targets -- -D warnings -A clippy::collapsible-match`
- [x] live Grok weekly JSON/table check for 2026-08-24 through 2026-08-30
- [x] live complete-day check: 39,468,074 tokens, $37.11707 observed API equivalent, $6.4749019 provider metric, both at 100% coverage
- [x] `--no-cost` retains token coverage and omits all monetary summary fields

Strict clippy without the one explicit allowance is currently blocked by the pre-existing `clippy::collapsible_match` finding in `src/source/dsh.rs:423` on Rust 1.95; this PR does not modify DSH.