### PR TITLE
docs: record 2026-09-02 audit and decoupling design

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,10 @@
 # ccstats 架构文档
 
+> 2026-09-02：本文仍描述加载/解析/聚合的运行时轮廓，但源数量、`Capabilities` 字段和 SDK 合同已超过文中示例。以代码中的 `src/source/registry.rs` 与 `UsageSource` 为准。审计与解耦设计见：
+>
+> - [Codebase audit (2026-09-02)](audits/2026-09-02-codebase-audit.md)
+> - [Provenance, pricing families, and source inventory](architecture/2026-09-02-provenance-and-source-decoupling.md)
+
 ## 概述
 
 ccstats 是一个快速的 CLI 工具，用于分析多种 AI CLI 工具的 token 使用统计。采用插件架构，便于添加新的数据源。

--- a/docs/architecture/2026-09-02-provenance-and-source-decoupling.md
+++ b/docs/architecture/2026-09-02-provenance-and-source-decoupling.md
@@ -1,0 +1,191 @@
+# Provenance, Pricing Families, and Source Inventory
+
+**Status:** Proposed
+**Created:** 2026-09-02
+**Baseline:** `origin/main` `6bec20d`
+**Audit:** [`docs/audits/2026-09-02-codebase-audit.md`](../audits/2026-09-02-codebase-audit.md)
+
+This is the design that later issues/PRs must follow. Bugfix PRs implement one slice. They do not invent a second accounting model.
+
+## Problem
+
+**Current state:** Every source normalizes into one `RawEntry`. That is correct for the five non-overlapping token buckets. It is not sufficient for:
+
+1. **Provenance** — Grok context snapshots, estimated proxy rows, and API-reported usage share the same `input_tokens` field. `--source all` then sums them and prices only `CostKind::Real`.
+2. **Pricing families** — LiteLLM ingest is a boolean soup (`contains("claude")`, `starts_with("gpt-")`, …) that currently drops Gemini even though Gemini is a registered source.
+3. **Inventory** — 29 sources are wired by hand in `registry.rs` and again in `UsageSource`. CLI nested commands, doctor hints, and README are more copies.
+
+**Impact:** Wrong combined numbers, N/A costs for first-class sources, and a growing shotgun-surgery tax.
+
+**Constraint:** No backward-compat shims (`AGENTS.md`). Public SDK JSON may add fields; it must not silently change the meaning of existing fields without a changelog note.
+
+**Goal:** Make mixed-source output honest, make pricing family membership explicit, and make “add a source” a single inventory edit — without a rewrite of parsers.
+
+## Success metrics
+
+| Metric | Current | Target | Measurement |
+|--------|---------|--------|-------------|
+| All-source token total vs sum of real sources | Mixed (includes estimated-proxy) | All-source default token totals equal the sum of `CostKind::Real` rows | Fixture with Claude real + Grok estimated-proxy |
+| Gemini list-price lookup | `google/gemini` dropped | Known Gemini ids resolve from LiteLLM or fallback | Unit test on `parse_litellm_data` + `fallback_pricing` |
+| 1h cache observability | Billed, not serialized | JSON/CSV/SDK expose `cache_creation_1h_tokens` | Snapshot tests on JSON + `TokenBreakdown` |
+| Source add touchpoints | ≥4 files (`registry`, `sdk` enum/as_str/from_name, docs) | 1 inventory module + parser crate path | Checklist in this doc |
+| Docs vs runtime source count | ARCHITECTURE lists a subset | Architecture doc names the inventory as source of truth | `ccstats sources --json` length matches inventory |
+
+## Current data flow
+
+```mermaid
+flowchart TD
+    CLI["CLI / SDK"] --> Reg["registry.rs SOURCES + UsageSource"]
+    Reg --> Loader["DataLoader"]
+    Loader --> Parser["per-source parse_file"]
+    Parser --> Raw["RawEntry five buckets + CostKind"]
+    Raw --> Agg["aggregate_daily / sessions / blocks"]
+    Agg --> Price["PricingDb family allowlist"]
+    Price --> Out["table / JSON / CSV / SDK"]
+```
+
+The breakages sit at three seams: `CostKind` is ignored when summing tokens for `--source all`; `parse_litellm_data` is a second, narrower product surface than the registry; `UsageSource` is a third copy of the registry.
+
+## Proposed solution
+
+Keep parsers. Change the **contracts between** parsers, aggregation, pricing, and output.
+
+### 1. Provenance is a first-class aggregation key
+
+`CostKind` already exists (`real`, `estimated_proxy`, `mixed`). Aggregation today folds it into `Stats.estimated_proxy` for **cost**, then `--source all` still displays combined token columns.
+
+**Rule:** Output layers must never present a single token total that mixes `CostKind::Real` and `CostKind::EstimatedProxy` without naming both.
+
+Default all-source view:
+
+| Column | Meaning |
+|---|---|
+| token columns | `CostKind::Real` only |
+| `estimated_proxy_tokens` (structured) | Sum of estimated-proxy buckets, optional |
+| `cost` | Real-only (already `CostDisplayMode::RealOnly`) |
+
+Single-source Grok keeps the existing `GrokCostReport` path. Do not bypass that path.
+
+Parser invariant unchanged:
+
+```
+total_tokens = input + output + reasoning + cache_creation + cache_read
+```
+
+`cache_creation_1h` remains a **subset** of `cache_creation`, not a sixth additive bucket.
+
+### 2. Pricing families are an allowlist type, not scattered booleans
+
+```text
+PricingFamily: Anthropic | OpenAI | Xai | Google | DeepSeek | Qwen | Glm | Moonshot
+```
+
+`parse_litellm_data` asks `PricingFamily::from_litellm_name(name)`. Unknown families are skipped on purpose. Google is included. Tests that currently require `google/gemini` to vanish must reverse.
+
+Fallback pricing is per family + model series, still returning `None` for unknown ids (N/A, never a silent Sonnet guess).
+
+### 3. One inventory, generated wiring
+
+Rust cannot derive enum variants from a runtime `Vec` without a macro or build script.
+
+**Chosen approach:** a `define_sources!` inventory in `src/source/inventory.rs` that expands:
+
+- `SOURCES` constructors
+- `UsageSource` variants
+- `as_str` / `from_name`
+- `VARIANTS` for tests
+
+Parsers stay in `src/source/<name>/`. The inventory only names them.
+
+CLI nested subcommands (`ccstats grok`, `ccstats kimi`, …) stay as optional sugar. New sources are `--source <name>` only unless a later PR adds a nested command. That removes the “must add clap enums” tax.
+
+### 4. Source root policy (already mostly true for Grok)
+
+Explicit env override never falls back to the default home directory. Missing override directory ⇒ no files, not “read ~/.tool instead”. Shared helper in `src/source/roots.rs` so new parsers do not reintroduce fallback.
+
+## Alternatives considered
+
+### Provenance
+
+| Option | Pros | Cons | Decision |
+|---|---|---|---|
+| **A. Split all-source token columns (recommended)** | Honest; small diff; keeps `RawEntry` | JSON grows a field | Chosen |
+| B. Drop estimated-proxy sources from `--source all` | Simplest | Hides Grok presence entirely | Rejected |
+| C. New `ProxyEntry` type beside `RawEntry` | Clean types | Touches every parser and aggregator | Deferred; too large for the bug |
+
+### Pricing families
+
+| Option | Pros | Cons | Decision |
+|---|---|---|---|
+| **A. Explicit family enum + Google (recommended)** | Matches product; testable | Must maintain family list | Chosen |
+| B. Ingest entire LiteLLM dump | Zero allowlist bugs | Huge cache, ambiguous aliases, $0 metadata risk | Rejected |
+| C. Per-source price tables | Precise | Diverges from LiteLLM; 29 tables | Rejected |
+
+### Inventory
+
+| Option | Pros | Cons | Decision |
+|---|---|---|---|
+| A. `inventory`/`linkme` crate | Auto-register | Extra dep, harder review | Rejected for now |
+| **B. `define_sources!` macro in-repo (recommended)** | One file, no new dep | Macro complexity | Chosen for a **later** PR |
+| C. Stringly-typed SDK source | No enum drift | Weaker typed API | Rejected |
+| D. Keep dual lists + a drift test only | Already partly true | Does not reduce add-source cost | Keep as interim until B ships |
+
+## Target module boundaries
+
+```mermaid
+flowchart LR
+    Inv["source/inventory.rs"] --> Reg["Source trait objects"]
+    Inv --> SdkEnum["sdk UsageSource"]
+    Parsers["source/<name>/parser.rs"] --> RawEntry
+    RawEntry --> Loader
+    Loader --> Stats["Stats + CostKind rollup"]
+    Stats --> Pricing["pricing/families.rs"]
+    Stats --> Output
+    Pricing --> Output
+```
+
+**Do not** put parser field semantics in `pricing/` or `output/`. Those layers consume already-normalized buckets.
+
+**Do not** use `Capabilities::combine` AND on `has_cache_read` as the way to hide mixed-source cache hit rate once all sources claim `true`. Cache hit rate follows **whether the underlying stats have trustworthy cache-read data**, not a folded bool. That follow-up is parked until C1 ships; current `main` sets `has_cache_read: true` on every source, so the AND is a no-op.
+
+## Implementation slices (one issue, one PR)
+
+Order is dependency, not “all at once”. Parallel is allowed for slices that do not share files.
+
+| Slice | Issue title | Files (expected) | Depends | Merge rule |
+|---|---|---|---|---|
+| 0 | Document audit + this design | `docs/audits/*`, `docs/architecture/*` | — | Docs only; no runtime change |
+| 1 | Load Gemini/Google prices from LiteLLM | `pricing/resolver/parse.rs`, `fallback.rs`, tests | 0 optional | Tests prove Gemini ids price; no $0 metadata |
+| 2 | Expose 1h cache creation tokens | `sdk.rs` `TokenBreakdown`, `output/json.rs`, `output/csv.rs`, tests | independent of 1 | Additive JSON field; `cache_creation` still inclusive |
+| 3 | All-source token totals use real provenance only | `app.rs` all-source path, aggregator/output helpers, tests | 0 | Fixture: real + estimated-proxy; default tokens exclude proxy |
+| 4 | `define_sources!` inventory | `source/inventory.rs`, `sdk.rs`, `registry.rs` | 1–3 merged | Park until 1–3 are green; high blast radius |
+| Park | Rolling 5h billing blocks | `core/aggregator.rs` | Product call | Do not merge without an explicit “match ccusage” decision |
+| Park | CLI `this-week` vs `weekly` rename | CLI + SDK | Breaking UX | Docs-only clarification until then |
+
+## Risks and mitigations
+
+| Risk | Severity | Likelihood | Mitigation |
+|------|----------|------------|------------|
+| All-source JSON consumers treated mixed tokens as billable | High | High today | Slice 3 changes default totals; changelog must say so |
+| Gemini fallback rates go stale | Medium | High | Prefer LiteLLM; fallback is last resort; `--strict-pricing` still yields N/A |
+| Inventory macro becomes unreadable | Medium | Medium | Park slice 4; keep drift test until then |
+| Open desktop PR `#129` collides | Medium | Medium | Branch every slice from current `origin/main`; do not stack on `codex/provider-algorithm-audit` |
+| Dirty local Codex-scope worktree | High | Certain | Remains at `refs/backup/pre-audit-remediation-20260902`; never reset that tree |
+
+## Open questions (parked)
+
+1. Should `ccstats weekly` grow a `--current` flag, or should SDK `ThisWeek` be renamed `this_week` in docs only?
+2. Should `blocks` match Anthropic rolling windows or be renamed `clock-blocks`?
+3. Should `--source all` list per-source subtotals by default, not only a combined table?
+
+Until those are answered, implementations must not guess.
+
+## Traceability
+
+| Requirement | Design element | First PR |
+|-------------|---------------|----------|
+| Honest mixed-source tokens | Provenance rule | Slice 3 |
+| Gemini cost not N/A for known models | Pricing families | Slice 1 |
+| Explain 1h cache surcharge | Additive token field | Slice 2 |
+| Add-source without enum drift | Inventory macro | Slice 4 (later) |
+| Docs match runtime | This pair of docs | Slice 0 |

--- a/docs/architecture/2026-09-02-provenance-and-source-decoupling.md
+++ b/docs/architecture/2026-09-02-provenance-and-source-decoupling.md
@@ -29,7 +29,7 @@ This is the design that later issues/PRs must follow. Bugfix PRs implement one s
 | Gemini list-price lookup | `google/gemini` dropped | Known Gemini ids resolve from LiteLLM or fallback | Unit test on `parse_litellm_data` + `fallback_pricing` |
 | 1h cache observability | Billed, not serialized | JSON/CSV/SDK expose `cache_creation_1h_tokens` | Snapshot tests on JSON + `TokenBreakdown` |
 | Source add touchpoints | ≥4 files (`registry`, `sdk` enum/as_str/from_name, docs) | 1 inventory module + parser crate path | Checklist in this doc |
-| Docs vs runtime source count | ARCHITECTURE lists a subset | Architecture doc names the inventory as source of truth | `ccstats sources --json` length matches inventory |
+| Docs vs runtime source count | ARCHITECTURE lists a subset | Architecture doc names the inventory as source of truth | Registered source count matches inventory (`ccstats sources --json` includes an extra `all` sentinel; compare length minus that sentinel) |
 
 ## Current data flow
 
@@ -155,7 +155,7 @@ Order is dependency, not “all at once”. Parallel is allowed for slices that 
 | Slice | Issue title | Files (expected) | Depends | Merge rule |
 |---|---|---|---|---|
 | 0 | Document audit + this design | `docs/audits/*`, `docs/architecture/*` | — | Docs only; no runtime change |
-| 1 | Load Gemini/Google prices from LiteLLM | `pricing/resolver/parse.rs`, `fallback.rs`, tests | 0 optional | Tests prove Gemini ids price; no $0 metadata |
+| 1 | Load Gemini/Google prices from LiteLLM | `src/pricing/resolver/parse.rs`, `src/pricing/resolver/fallback.rs`, tests | 0 optional | Tests prove Gemini ids price; no $0 metadata |
 | 2 | Expose 1h cache creation tokens | `sdk.rs` `TokenBreakdown`, `output/json.rs`, `output/csv.rs`, tests | independent of 1 | Additive JSON field; `cache_creation` still inclusive |
 | 3 | All-source token totals use real provenance only | `app.rs` all-source path, aggregator/output helpers, tests | 0 | Fixture: real + estimated-proxy; default tokens exclude proxy |
 | 4 | `define_sources!` inventory | `source/inventory.rs`, `sdk.rs`, `registry.rs` | 1–3 merged | Park until 1–3 are green; high blast radius |

--- a/docs/audits/2026-09-02-codebase-audit.md
+++ b/docs/audits/2026-09-02-codebase-audit.md
@@ -1,0 +1,122 @@
+# Codebase Audit Report
+
+> Audit date: 2026-09-02
+> Target: `origin/main` at `6bec20d` (`majiayu000/ccstats`)
+> Tech stack: Rust 2024 CLI + library SDK
+> Method: Static evidence pass against current `main`. An earlier pass on `codex/provider-algorithm-audit` is **not** the implementation baseline; that branch is behind `main` and its dirty worktree is snapshotted at `refs/backup/pre-audit-remediation-20260902`.
+
+## How to read this report
+
+- **Fact** is observed in current `main`.
+- **Inference** is labeled.
+- **Parked** means do not implement until a later design decision is confirmed.
+- Companion design: [`docs/architecture/2026-09-02-provenance-and-source-decoupling.md`](../architecture/2026-09-02-provenance-and-source-decoupling.md).
+
+## Summary
+
+| Severity | Count on `main` | Status vs older branch |
+|---|---:|---|
+| Critical | 1 | Still open: `--source all` mixes token provenance |
+| High | 4 | Gemini pricing, 1h cache opacity, clock-aligned blocks, registry duplication |
+| Medium | 4 | Docs/SDK contract drift, Gemini JSON last-write, Cline dual logs, weekly full-history scan |
+| Already fixed on `main` | 2 | Grok env fallback; Grok-only cost reports |
+
+`main` now registers **29** sources. Token parsers for Claude / Codex / Qwen ledger remain the strongest path. The product risk is no longer “missing sources”; it is **one uniform `RawEntry` plus a hand-maintained registry** that cannot describe provenance, pricing families, or CLI/SDK contracts in one place.
+
+## Already fixed on `main` (do not re-implement)
+
+| Older finding | Evidence on `main` | Status |
+|---|---|---|
+| Grok `GROK_HOME` fell back to `~/.grok` when the override was not a directory | `src/source/grok/parser.rs:75-83` returns `None` when the override exists but is not a directory | Fixed |
+| Grok-only views treated context snapshots as billable cost without a dedicated report | Grok daily path uses `load_grok_daily_with_cost` and `GrokCostReport` (`src/app.rs:531-555`, `src/source/grok/cost_report.rs`) | Fixed for `--source grok` only |
+| OpenCode / Copilot / Pi missing as product gaps | Registry includes OpenCode, Copilot, Pi and forks (`src/source/registry.rs:35-66`) | Coverage added; quality still source-specific |
+
+## Critical
+
+### C1: `--source all` still mixes estimated-proxy tokens into token totals while pricing real-only
+
+- Evidence: `src/app.rs:623-661` merges every source with `merge_day_stats`, then renders with `CostDisplayMode::RealOnly`. Grok snapshot rows still use `CostKind::EstimatedProxy` (`src/source/grok/parser.rs`).
+- Fact: All-source tables/JSON can show Grok (and any other estimated-proxy) tokens in `input_tokens` / `total_tokens` while omitting those rows from cost.
+- Impact: Users read one number as “usage” and another as “cost” and they are not the same accounting.
+- Confidence: High.
+- Suggested fix: Follow the provenance design. Split all-source token totals into `real` vs `estimated_proxy`, or exclude estimated-proxy tokens from the default all-source token columns. Do not invent a third mixed total without a label.
+
+## High
+
+### H1: LiteLLM ingest still drops Gemini / Google models
+
+- Evidence: `src/pricing/resolver/parse.rs:11-25` only keeps Claude, OpenAI, xAI, and selected CN names. The unit test `test_parse_filters_non_claude_non_openai` asserts `google/gemini` is discarded.
+- Fact: Gemini is a first-class source (`UsageSource::Gemini`) whose list prices never enter `PricingDb`. `fallback_pricing` has no Gemini family.
+- Impact: `ccstats daily --source gemini` reports tokens and N/A (or fallback-none) cost. Cursor/Cline/OpenCode rows that name Gemini models have the same hole.
+- Confidence: High.
+- Suggested fix: Vendor allowlist becomes an explicit family set that includes Google/Gemini. Add fallback rates for current Gemini Flash/Pro ids. Keep the “metadata-only must not load as $0” rule.
+
+### H2: `blocks` is clock-aligned, not Anthropic’s rolling 5-hour billing window
+
+- Evidence: `src/core/aggregator.rs:237-249` uses `hour() / 5 * 5`. CLI copy still says “5-hour billing blocks”.
+- Fact: Windows start at local 00:00 / 05:00 / 10:00 / 15:00 / 20:00.
+- Impact: Numbers will not match Claude Code `/cost` or ccusage rolling windows.
+- Confidence: High that the algorithm is not Anthropic billing; **parked** as a product decision (rename vs reimplement).
+- Suggested fix: Either rename the command to clock windows, or implement gap-based rolling 5h windows with fixtures. Do not ship a silent algorithm swap.
+
+### H3: 1-hour cache creation is billed but never shown
+
+- Evidence: Pricing uses `cache_creation_1h` (`src/pricing/cost.rs:20-27`). Claude parser writes it (`src/source/claude/parser.rs:311-332`). JSON/CSV/SDK only expose `cache_creation_tokens` (`src/output/json.rs:68`, `src/sdk.rs` `TokenBreakdown`).
+- Fact: Cost can exceed `cache_creation × 5-minute cache-create price` with no column explaining why.
+- Impact: Claude 1h-cache users think pricing is wrong.
+- Confidence: High.
+- Suggested fix: Add `cache_creation_1h_tokens` to JSON, CSV, SDK `TokenBreakdown`, and optional table breakdown. Keep `cache_creation` as the inclusive total.
+
+### H4: Source registry and SDK enum are parallel sources of truth
+
+- Evidence: Adding a source requires `src/source/registry.rs` `SOURCES`, `UsageSource` plus `as_str` / `from_name` / `VARIANTS` in `src/sdk.rs` (869 lines), optional CLI routing, README, and doctor hints. `src/source/mod.rs` inlines an entire Reasonix parser module.
+- Fact: 29 constructors are listed by hand. Tests can catch name drift after the fact; they cannot generate the wiring.
+- Impact: CLI and SDK silently diverge; every new source is shotgun surgery across god files (`sdk.rs` 869, `types.rs` 882, `aggregator.rs` 799, `pricing/db.rs` 798, `loader.rs` 786, `app.rs` 754).
+- Confidence: High.
+- Suggested fix: One inventory macro/module that expands registry + SDK enum + name tables. Do not start that refactor in the same PR as a parser or pricing bug.
+
+## Medium
+
+### M1: Gemini chat JSON does not last-write-win on message id
+
+- Evidence: JSONL `type=gemini` uses `direct_indices` (`src/source/gemini.rs`). `parse_session_json` does not. `needs_dedup` is false.
+- Impact: Rewritten chat JSON messages can double-count.
+- Confidence: Medium (depends on whether Gemini CLI rewrites in place).
+
+### M2: Cline source reads CLI and VS Code extension logs together
+
+- Evidence: `src/source/cline.rs` concatenates CLI `*.messages.json` and extension task files. CLI subtracts cache from `inputTokens`; extension `tokensIn` is stored as-is (`src/source/cline_extension.rs`).
+- Impact: Dual-install users can double-count. Field inclusion may still differ across formats.
+- Confidence: Medium.
+
+### M3: CLI `weekly` / `monthly` load all history; SDK `ThisWeek` / `ThisMonth` filter to the current period
+
+- Evidence: `SourceCommand::needs_today_filter` is only today/statusline (`src/cli/commands.rs`). SDK `UsageRange::ThisWeek` resolves Monday–today (`src/sdk.rs`).
+- Impact: Same English word, different dates. Large histories make `weekly` a full scan.
+- Confidence: High. Rename, do not silently change CLI defaults.
+
+### M4: Architecture docs list a subset of sources and an outdated `Capabilities` shape
+
+- Evidence: `docs/ARCHITECTURE.md` still describes a small source set and a 4-bool capability struct. Runtime has 8 capability flags, doctor, quota, Grok cost reports, and 29 sources.
+- Impact: New parsers get implemented against the wrong contract.
+- Confidence: High. Update as part of the design PR, not as a silent rewrite of runtime behavior.
+
+## Out of scope / parked
+
+| Item | Why parked |
+|---|---|
+| Rolling Anthropic billing blocks (H2 implementation) | Needs an explicit product choice vs ccusage |
+| Full 200-line file split of `sdk.rs` / `app.rs` | Unrelated churn; decouple via inventory first |
+| Cursor cross-database dedup | Cursor on `main` now has a usage-API client; re-audit after that path is stable |
+| Codex `--codex-scope` session_meta ordering | Lives on the uncommitted `codex/provider-algorithm-audit` worktree, not `main` |
+| Further inferred sources | Coverage is already wide; correctness of existing sources first |
+
+## Repair order
+
+See the companion design for contracts. Implementation slices:
+
+1. This document pair (audit + architecture).
+2. Gemini/Google pricing allowlist (H1).
+3. Expose `cache_creation_1h` (H3).
+4. All-source provenance split (C1).
+5. Later, inventory macro (H4) and parked items only after review of 2–4.


### PR DESCRIPTION
## What

Record the 2026-09-02 codebase audit against current `main` and the architecture contract for later bugfix PRs: provenance in mixed-source views, LiteLLM pricing families, and a single source inventory.

Fixes #130

## Why

`main` already moved past the older `codex/provider-algorithm-audit` branch (Grok cost reports, 29 sources). Implementation PRs need a written contract so they do not re-fix solved items or silently change CLI `weekly` / billing-block semantics.

## Test Plan

- [x] Docs-only; no runtime change
- [ ] `cargo check` not required
- [ ] Tested manually: rendered markdown locally


Made with [Cursor](https://cursor.com)