### PR TITLE
fix: load Gemini prices from LiteLLM and fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - `--source all` default token totals no longer include estimated-proxy rows (for example Grok context snapshots). Cost remains real-only. Estimated-proxy token counts are omitted from those default totals; they are still priced separately as `estimated_cost` when present.
 
+### Fixed
+- Gemini/Google models now load from LiteLLM / fallback instead of N/A.
+
 ## [0.5.1] - 2026-08-31
 
 ### Added

--- a/src/pricing/resolver/fallback.rs
+++ b/src/pricing/resolver/fallback.rs
@@ -33,6 +33,17 @@ fn moonshot_pricing(input: f64, output: f64, cache_read: f64) -> ModelPricing {
     }
 }
 
+fn google_pricing(input: f64, output: f64, cache_read: f64) -> ModelPricing {
+    ModelPricing {
+        input,
+        output,
+        reasoning_output: output,
+        cache_create: 0.0,
+        cache_create_1h: 0.0,
+        cache_read,
+    }
+}
+
 pub(crate) fn fallback_pricing(model: &str) -> Option<ModelPricing> {
     let model_lower = model.to_lowercase();
     Some(
@@ -99,6 +110,12 @@ pub(crate) fn fallback_pricing(model: &str) -> Option<ModelPricing> {
             openai_pricing(1.25e-6, 10e-6, 0.125e-6)
         } else if model_lower.contains("gpt-4") {
             openai_pricing(2.5e-6, 10e-6, 0.0)
+        } else if model_lower.contains("gemini-2.5-flash-lite") {
+            google_pricing(1e-7, 4e-7, 1e-8)
+        } else if model_lower.contains("gemini-2.5-pro") {
+            google_pricing(1.25e-6, 1e-5, 1.25e-7)
+        } else if model_lower.contains("gemini-2.5-flash") {
+            google_pricing(3e-7, 2.5e-6, 3e-8)
         } else {
             // Unknown model: no fallback estimate. The caller surfaces N/A instead
             // of silently applying a sonnet-shaped guess.
@@ -238,5 +255,47 @@ mod tests {
         let p = fallback_pricing("gpt-4o-mini").unwrap();
         assert_eq!(p.input, 2.5e-6);
         assert_eq!(p.output, 10e-6);
+    }
+
+    #[test]
+    fn test_fallback_gemini_2_5_flash_lite() {
+        let p = fallback_pricing("gemini-2.5-flash-lite").unwrap();
+        assert_eq!(p.input, 1e-7);
+        assert_eq!(p.output, 4e-7);
+        assert_eq!(p.cache_read, 1e-8);
+        assert_eq!(p.reasoning_output, 4e-7);
+        assert_eq!(p.cache_create, 0.0);
+        assert_eq!(p.cache_create_1h, 0.0);
+    }
+
+    #[test]
+    fn test_fallback_gemini_2_5_flash() {
+        let p = fallback_pricing("google/gemini-2.5-flash").unwrap();
+        assert_eq!(p.input, 3e-7);
+        assert_eq!(p.output, 2.5e-6);
+        assert_eq!(p.cache_read, 3e-8);
+        assert_eq!(p.reasoning_output, 2.5e-6);
+    }
+
+    #[test]
+    fn test_fallback_gemini_2_5_pro() {
+        let p = fallback_pricing("gemini-2.5-pro").unwrap();
+        assert_eq!(p.input, 1.25e-6);
+        assert_eq!(p.output, 1e-5);
+        assert_eq!(p.cache_read, 1.25e-7);
+        assert_eq!(p.reasoning_output, 1e-5);
+    }
+
+    #[test]
+    fn test_fallback_gemini_flash_lite_not_flash() {
+        let lite = fallback_pricing("gemini-2.5-flash-lite").unwrap();
+        let flash = fallback_pricing("gemini-2.5-flash").unwrap();
+        assert_ne!(lite.input, flash.input);
+        assert_eq!(lite.input, 1e-7);
+    }
+
+    #[test]
+    fn test_fallback_unknown_gemini_returns_none() {
+        assert!(fallback_pricing("gemini-1.5-pro").is_none());
     }
 }

--- a/src/pricing/resolver/family.rs
+++ b/src/pricing/resolver/family.rs
@@ -1,4 +1,4 @@
-/// Allowlisted LiteLLM pricing families. Unknown families are skipped on ingest.
+/// Allowlisted `LiteLLM` pricing families. Unknown families are skipped on ingest.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum PricingFamily {
     Anthropic,

--- a/src/pricing/resolver/family.rs
+++ b/src/pricing/resolver/family.rs
@@ -1,0 +1,94 @@
+/// Allowlisted LiteLLM pricing families. Unknown families are skipped on ingest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PricingFamily {
+    Anthropic,
+    OpenAI,
+    Xai,
+    Google,
+    DeepSeek,
+    Qwen,
+    Glm,
+    Moonshot,
+}
+
+impl PricingFamily {
+    pub(super) fn from_litellm_name(name: &str) -> Option<Self> {
+        if name.contains("claude") {
+            Some(Self::Anthropic)
+        } else if name.starts_with("openai/")
+            || name.starts_with("gpt-")
+            || name.starts_with("codex")
+        {
+            Some(Self::OpenAI)
+        } else if name.starts_with("xai/") || name.starts_with("grok-") {
+            Some(Self::Xai)
+        } else if name.starts_with("google/") || name.contains("gemini") {
+            Some(Self::Google)
+        } else if name.contains("deepseek") {
+            Some(Self::DeepSeek)
+        } else if name.contains("qwen") {
+            Some(Self::Qwen)
+        } else if name.contains("glm") {
+            Some(Self::Glm)
+        } else if name.starts_with("moonshot/") || name.contains("kimi") {
+            Some(Self::Moonshot)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PricingFamily;
+
+    #[test]
+    fn google_matches_prefix_and_bare_gemini() {
+        assert_eq!(
+            PricingFamily::from_litellm_name("google/gemini-2.5-pro"),
+            Some(PricingFamily::Google)
+        );
+        assert_eq!(
+            PricingFamily::from_litellm_name("gemini-2.5-flash"),
+            Some(PricingFamily::Google)
+        );
+    }
+
+    #[test]
+    fn unknown_families_are_skipped() {
+        assert_eq!(PricingFamily::from_litellm_name("mistral/large"), None);
+        assert_eq!(PricingFamily::from_litellm_name("meta-llama/llama-3"), None);
+    }
+
+    #[test]
+    fn existing_families_still_match() {
+        assert_eq!(
+            PricingFamily::from_litellm_name("claude-sonnet-4"),
+            Some(PricingFamily::Anthropic)
+        );
+        assert_eq!(
+            PricingFamily::from_litellm_name("openai/gpt-4o"),
+            Some(PricingFamily::OpenAI)
+        );
+        assert_eq!(
+            PricingFamily::from_litellm_name("xai/grok-4.3"),
+            Some(PricingFamily::Xai)
+        );
+        assert_eq!(
+            PricingFamily::from_litellm_name("deepseek/deepseek-chat"),
+            Some(PricingFamily::DeepSeek)
+        );
+        assert_eq!(
+            PricingFamily::from_litellm_name("dashscope/qwen-max"),
+            Some(PricingFamily::Qwen)
+        );
+        assert_eq!(
+            PricingFamily::from_litellm_name("zai/glm-5"),
+            Some(PricingFamily::Glm)
+        );
+        assert_eq!(
+            PricingFamily::from_litellm_name("moonshot/moonshot-v1"),
+            Some(PricingFamily::Moonshot)
+        );
+    }
+}

--- a/src/pricing/resolver/mod.rs
+++ b/src/pricing/resolver/mod.rs
@@ -1,4 +1,5 @@
 mod fallback;
+mod family;
 mod parse;
 mod resolve;
 

--- a/src/pricing/resolver/parse.rs
+++ b/src/pricing/resolver/parse.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use super::super::types::{ModelPricing, dot_version_variant};
+use super::family::PricingFamily;
 
 pub(crate) fn parse_litellm_data(
     data: HashMap<String, serde_json::Value>,
@@ -8,21 +9,9 @@ pub(crate) fn parse_litellm_data(
     let mut models = HashMap::new();
 
     for (name, value) in data {
-        // Load Claude, OpenAI GPT/Codex, xAI Grok, and CN vendor model names.
-        let is_claude = name.contains("claude");
-        let is_openai =
-            name.starts_with("openai/") || name.starts_with("gpt-") || name.starts_with("codex");
-        let is_xai = name.starts_with("xai/") || name.starts_with("grok-");
-        // Chinese vendors: DeepSeek, Qwen (Alibaba), GLM (Zhipu/zai), Moonshot/Kimi.
-        let is_cn = name.contains("deepseek")
-            || name.contains("qwen")
-            || name.contains("glm")
-            || name.starts_with("moonshot/")
-            || name.contains("kimi");
-
-        if !is_claude && !is_openai && !is_xai && !is_cn {
+        let Some(family) = PricingFamily::from_litellm_name(&name) else {
             continue;
-        }
+        };
 
         let input = value
             .get("input_cost_per_token")
@@ -65,38 +54,47 @@ pub(crate) fn parse_litellm_data(
         // Store with multiple key variations for matching
         models.insert(name.clone(), pricing.clone());
 
-        // Also store normalized versions
-        if is_claude {
-            let normalized = name.replace("claude-", "").replace("anthropic.", "");
-            models.insert(normalized, pricing);
-        } else if is_openai {
-            // Store without openai/ prefix
-            if let Some(stripped) = name.strip_prefix("openai/") {
-                models.insert(stripped.to_string(), pricing);
+        match family {
+            PricingFamily::Anthropic => {
+                let normalized = name.replace("claude-", "").replace("anthropic.", "");
+                models.insert(normalized, pricing);
             }
-        } else if is_xai && let Some(stripped) = name.strip_prefix("xai/") {
-            models.insert(stripped.to_string(), pricing.clone());
-            if stripped == "grok-build-0.1" {
-                models.insert("grok-build".to_string(), pricing);
+            PricingFamily::OpenAI => {
+                if let Some(stripped) = name.strip_prefix("openai/") {
+                    models.insert(stripped.to_string(), pricing);
+                }
             }
-        } else if is_cn {
-            // Store the bare name (last path segment) plus a dot-version variant
-            // so hoster spellings like `glm-5p2` (p == point) match a dot-spelled
-            // `glm-5.2` alias. Official vendor prefixes win over hosters on
-            // name collisions.
-            let bare = name.rsplit('/').next().unwrap_or(&name).to_lowercase();
-            let name_lower = name.to_lowercase();
-            let official = name.starts_with("zai/")
-                || name.starts_with("deepseek/")
-                || name.starts_with("dashscope/")
-                || name.starts_with("moonshot/")
-                || !name.contains('/');
-            for variant in [bare.clone(), dot_version_variant(&bare)] {
-                if variant != name_lower && !variant.is_empty() {
-                    if official {
-                        models.insert(variant, pricing.clone());
-                    } else {
-                        models.entry(variant).or_insert(pricing.clone());
+            PricingFamily::Xai => {
+                if let Some(stripped) = name.strip_prefix("xai/") {
+                    models.insert(stripped.to_string(), pricing.clone());
+                    if stripped == "grok-build-0.1" {
+                        models.insert("grok-build".to_string(), pricing);
+                    }
+                }
+            }
+            PricingFamily::Google => insert_google_aliases(&mut models, &name, &pricing),
+            PricingFamily::DeepSeek
+            | PricingFamily::Qwen
+            | PricingFamily::Glm
+            | PricingFamily::Moonshot => {
+                // Store the bare name (last path segment) plus a dot-version variant
+                // so hoster spellings like `glm-5p2` (p == point) match a dot-spelled
+                // `glm-5.2` alias. Official vendor prefixes win over hosters on
+                // name collisions.
+                let bare = name.rsplit('/').next().unwrap_or(&name).to_lowercase();
+                let name_lower = name.to_lowercase();
+                let official = name.starts_with("zai/")
+                    || name.starts_with("deepseek/")
+                    || name.starts_with("dashscope/")
+                    || name.starts_with("moonshot/")
+                    || !name.contains('/');
+                for variant in [bare.clone(), dot_version_variant(&bare)] {
+                    if variant != name_lower && !variant.is_empty() {
+                        if official {
+                            models.insert(variant, pricing.clone());
+                        } else {
+                            models.entry(variant).or_insert(pricing.clone());
+                        }
                     }
                 }
             }
@@ -104,6 +102,27 @@ pub(crate) fn parse_litellm_data(
     }
 
     models
+}
+
+fn insert_google_aliases(
+    models: &mut HashMap<String, ModelPricing>,
+    name: &str,
+    pricing: &ModelPricing,
+) {
+    if let Some(stripped) = name.strip_prefix("google/") {
+        models.insert(stripped.to_string(), pricing.clone());
+    }
+    let bare = name.rsplit('/').next().unwrap_or(name);
+    if bare == name || bare.is_empty() {
+        return;
+    }
+    // Official `google/` keys win over hoster collisions (same spirit as CN).
+    let official = name.starts_with("google/") || !name.contains('/');
+    if official {
+        models.insert(bare.to_string(), pricing.clone());
+    } else {
+        models.entry(bare.to_string()).or_insert(pricing.clone());
+    }
 }
 
 #[cfg(test)]
@@ -120,10 +139,65 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_filters_non_claude_non_openai() {
+    fn test_parse_keeps_google_and_filters_unknown_families() {
         let mut data = HashMap::new();
         data.insert("mistral/large".to_string(), make_litellm_entry(1e-6, 2e-6));
         data.insert("google/gemini".to_string(), make_litellm_entry(1e-6, 2e-6));
+
+        let result = parse_litellm_data(data);
+        assert!(!result.contains_key("mistral/large"));
+        assert!(result.contains_key("google/gemini"));
+        assert_eq!(result["google/gemini"].input, 1e-6);
+        assert_eq!(result["gemini"].input, 1e-6);
+    }
+
+    #[test]
+    fn test_parse_gemini_flash_and_pro_aliases() {
+        let mut data = HashMap::new();
+        data.insert(
+            "gemini-2.5-flash".to_string(),
+            make_litellm_entry(3e-7, 2.5e-6),
+        );
+        data.insert(
+            "google/gemini-2.5-pro".to_string(),
+            json!({
+                "input_cost_per_token": 1.25e-6,
+                "output_cost_per_token": 1e-5,
+                "cache_read_input_token_cost": 1.25e-7,
+            }),
+        );
+
+        let result = parse_litellm_data(data);
+        assert!(result.contains_key("gemini-2.5-flash"));
+        assert!(result.contains_key("google/gemini-2.5-pro"));
+        assert!(result.contains_key("gemini-2.5-pro"));
+        let pro = &result["gemini-2.5-pro"];
+        assert_eq!(pro.input, 1.25e-6);
+        assert_eq!(pro.output, 1e-5);
+        assert_eq!(pro.cache_read, 1.25e-7);
+        assert_eq!(result["gemini-2.5-flash"].input, 3e-7);
+    }
+
+    #[test]
+    fn test_parse_google_official_wins_over_hoster() {
+        let mut data = HashMap::new();
+        data.insert(
+            "google/gemini-2.5-flash".to_string(),
+            make_litellm_entry(3e-7, 2.5e-6),
+        );
+        data.insert(
+            "openrouter/google/gemini-2.5-flash".to_string(),
+            make_litellm_entry(99e-6, 99e-6),
+        );
+
+        let result = parse_litellm_data(data);
+        assert_eq!(result["gemini-2.5-flash"].input, 3e-7);
+    }
+
+    #[test]
+    fn test_parse_google_metadata_only_skipped() {
+        let mut data = HashMap::new();
+        data.insert("google/gemini-meta".to_string(), json!({"mode": "chat"}));
 
         let result = parse_litellm_data(data);
         assert!(result.is_empty());


### PR DESCRIPTION
## What
Load Google/Gemini list prices through an explicit `PricingFamily` allowlist and add Gemini 2.5 Flash/Pro/Flash-Lite fallback rates so registered Gemini usage is no longer N/A.

Fixes #132

## Why
LiteLLM ingest only kept Claude, OpenAI, xAI, and CN vendors, and tests required `google/gemini` to be discarded. Gemini is a first-class source, so `ccstats daily --source gemini` (and other sources naming Gemini) showed tokens with no cost.

## Test Plan
- [x] `cargo check` passes
- [x] `cargo test` passes
- [ ] Tested manually: `ccstats daily --source gemini` against live Gemini logs (not run in this worktree)


Made with [Cursor](https://cursor.com)