### PR TITLE
fix(output): expose cache_creation_1h_tokens in JSON, CSV, and SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Expose `cache_creation_1h_tokens` in JSON, CSV, and SDK `TokenBreakdown`. `cache_creation_tokens` remains the inclusive cache-creation total; the 1-hour figure is a billed subset, not a sixth token bucket.
+
 ### Changed
 - `--source all` default token totals no longer include estimated-proxy rows (for example Grok context snapshots). Cost remains real-only. Estimated-proxy token counts are omitted from those default totals; they are still priced separately as `estimated_cost` when present.
 

--- a/src/output/blocks.rs
+++ b/src/output/blocks.rs
@@ -271,6 +271,7 @@ pub(crate) fn output_block_json(
                 "input_tokens": block.stats.input_tokens,
                 "output_tokens": block.stats.output_tokens,
                 "cache_creation_tokens": block.stats.cache_creation,
+                "cache_creation_1h_tokens": block.stats.cache_creation_1h,
                 "cache_read_tokens": block.stats.cache_read,
                 "cache_hit_rate": cache_hit_rate_json_value(
                     block.stats.cache_hit_rate(supports_cache_read)
@@ -423,6 +424,7 @@ mod tests {
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&json_str).unwrap();
 
         assert_eq!(parsed[0]["cache_creation_tokens"], 200);
+        assert_eq!(parsed[0]["cache_creation_1h_tokens"], 0);
         assert_eq!(parsed[0]["cache_read_tokens"], 300);
         assert_eq!(parsed[0]["cache_hit_rate"], 20.0);
         assert_eq!(parsed[0]["total_tokens"], 2000); // 1000+500+200+300

--- a/src/output/csv.rs
+++ b/src/output/csv.rs
@@ -136,7 +136,7 @@ fn write_period_csv_breakdown(
 ) {
     let _ = write!(
         out,
-        "{},model,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens",
+        "{},model,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_creation_1h_tokens,cache_read_tokens,cache_hit_rate,total_tokens",
         ctx.label
     );
     write_period_cost_header(out, ctx);
@@ -147,13 +147,14 @@ fn write_period_csv_breakdown(
         for (model, model_stats) in &models {
             let _ = write!(
                 out,
-                "{},{},{},{},{},{},{},{},{}",
+                "{},{},{},{},{},{},{},{},{},{}",
                 csv_escape(key),
                 csv_escape(model),
                 model_stats.input_tokens,
                 model_stats.output_tokens,
                 model_stats.reasoning_tokens,
                 model_stats.cache_creation,
+                model_stats.cache_creation_1h,
                 model_stats.cache_read,
                 cache_hit_rate_csv_value(model_stats.cache_hit_rate(ctx.supports_cache_read)),
                 model_stats.total_tokens(),
@@ -192,7 +193,7 @@ fn write_period_csv_standard(
 ) {
     let _ = write!(
         out,
-        "{},input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens",
+        "{},input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_creation_1h_tokens,cache_read_tokens,cache_hit_rate,total_tokens",
         ctx.label
     );
     write_period_cost_header(out, ctx);
@@ -200,12 +201,13 @@ fn write_period_csv_standard(
     for &(key, stats) in rows {
         let _ = write!(
             out,
-            "{},{},{},{},{},{},{},{}",
+            "{},{},{},{},{},{},{},{},{}",
             csv_escape(key),
             stats.stats.input_tokens,
             stats.stats.output_tokens,
             stats.stats.reasoning_tokens,
             stats.stats.cache_creation,
+            stats.stats.cache_creation_1h,
             stats.stats.cache_read,
             cache_hit_rate_csv_value(stats.stats.cache_hit_rate(ctx.supports_cache_read)),
             stats.stats.total_tokens(),
@@ -323,7 +325,7 @@ pub(crate) fn output_monthly_budget_csv(
     if options.breakdown {
         let _ = write!(
             out,
-            "month,model,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
+            "month,model,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_creation_1h_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
         );
         if options.show_cost {
             let _ = write!(out, ",cost");
@@ -341,13 +343,14 @@ pub(crate) fn output_monthly_budget_csv(
             for (model, model_stats) in &models {
                 let _ = write!(
                     out,
-                    "{},{},{},{},{},{},{},{},{}",
+                    "{},{},{},{},{},{},{},{},{},{}",
                     csv_escape(&report.month),
                     csv_escape(model),
                     model_stats.input_tokens,
                     model_stats.output_tokens,
                     model_stats.reasoning_tokens,
                     model_stats.cache_creation,
+                    model_stats.cache_creation_1h,
                     model_stats.cache_read,
                     cache_hit_rate_csv_value(
                         model_stats.cache_hit_rate(options.supports_cache_read)
@@ -373,7 +376,7 @@ pub(crate) fn output_monthly_budget_csv(
     } else {
         let _ = write!(
             out,
-            "month,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
+            "month,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_creation_1h_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
         );
         if options.show_cost {
             let _ = write!(out, ",cost");
@@ -388,12 +391,13 @@ pub(crate) fn output_monthly_budget_csv(
             };
             let _ = write!(
                 out,
-                "{},{},{},{},{},{},{},{}",
+                "{},{},{},{},{},{},{},{},{}",
                 csv_escape(&report.month),
                 stats.stats.input_tokens,
                 stats.stats.output_tokens,
                 stats.stats.reasoning_tokens,
                 stats.stats.cache_creation,
+                stats.stats.cache_creation_1h,
                 stats.stats.cache_read,
                 cache_hit_rate_csv_value(stats.stats.cache_hit_rate(options.supports_cache_read)),
                 stats.stats.total_tokens(),
@@ -441,7 +445,7 @@ pub(crate) fn output_session_csv(
         pricing_meta::csv_has_cache_fields(pricing_source, pricing_db);
     let _ = write!(
         out,
-        "session_id,project_path,first_timestamp,last_timestamp,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
+        "session_id,project_path,first_timestamp,last_timestamp,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_creation_1h_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
     );
     if show_cost {
         let _ = write!(out, ",cost");
@@ -455,7 +459,7 @@ pub(crate) fn output_session_csv(
     for s in &sorted {
         let _ = write!(
             out,
-            "{},{},{},{},{},{},{},{},{},{},{}",
+            "{},{},{},{},{},{},{},{},{},{},{},{}",
             csv_escape(&s.session_id),
             csv_escape(&s.project_path),
             csv_escape(&s.first_timestamp),
@@ -464,6 +468,7 @@ pub(crate) fn output_session_csv(
             s.stats.output_tokens,
             s.stats.reasoning_tokens,
             s.stats.cache_creation,
+            s.stats.cache_creation_1h,
             s.stats.cache_read,
             cache_hit_rate_csv_value(s.stats.cache_hit_rate(supports_cache_read)),
             s.stats.total_tokens(),
@@ -600,7 +605,7 @@ pub(crate) fn output_block_csv(
         pricing_meta::csv_has_cache_fields(pricing_source, pricing_db);
     let _ = write!(
         out,
-        "block_start,block_end,input_tokens,output_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
+        "block_start,block_end,input_tokens,output_tokens,cache_creation_tokens,cache_creation_1h_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
     );
     if show_cost {
         let _ = write!(out, ",cost");
@@ -614,12 +619,13 @@ pub(crate) fn output_block_csv(
     for b in &sorted {
         let _ = write!(
             out,
-            "{},{},{},{},{},{},{},{}",
+            "{},{},{},{},{},{},{},{},{}",
             csv_escape(&b.block_start),
             csv_escape(&b.block_end),
             b.stats.input_tokens,
             b.stats.output_tokens,
             b.stats.cache_creation,
+            b.stats.cache_creation_1h,
             b.stats.cache_read,
             cache_hit_rate_csv_value(b.stats.cache_hit_rate(supports_cache_read)),
             b.stats.total_tokens(),

--- a/src/output/csv_tests.rs
+++ b/src/output/csv_tests.rs
@@ -54,7 +54,7 @@ fn period_csv_daily_no_cost() {
     let lines: Vec<&str> = csv.lines().collect();
     assert_eq!(
         lines[0],
-        "date,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
+        "date,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_creation_1h_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
     );
     assert!(lines[1].starts_with("2025-01-01,1000,500,"));
     assert!(!lines[0].contains("cost"));
@@ -108,7 +108,7 @@ fn period_csv_converts_cost_when_currency_is_set() {
     let lines: Vec<&str> = csv.lines().collect();
     assert_eq!(
         lines[1],
-        "2025-01-01,1000000,500000,0,0,0,0.00,1500000,73.500000,fallback"
+        "2025-01-01,1000000,500000,0,0,0,0,0.00,1500000,73.500000,fallback"
     );
 }
 
@@ -157,7 +157,7 @@ fn session_csv_structure() {
     let lines: Vec<&str> = csv.lines().collect();
     assert_eq!(
         lines[0],
-        "session_id,project_path,first_timestamp,last_timestamp,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
+        "session_id,project_path,first_timestamp,last_timestamp,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_creation_1h_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
     );
     assert!(lines[1].starts_with("abc-123,/home/user/project,"));
 }
@@ -188,7 +188,7 @@ fn session_csv_includes_reasoning_and_cache_tokens() {
 
     assert_eq!(
         lines[1],
-        "reasoning,,2025-01-01T00:00:00Z,2025-01-01T01:00:00Z,1000,300,200,50,100,8.70,1650"
+        "reasoning,,2025-01-01T00:00:00Z,2025-01-01T01:00:00Z,1000,300,200,50,0,100,8.70,1650"
     );
 }
 
@@ -237,7 +237,7 @@ fn block_csv_structure() {
     let lines: Vec<&str> = csv.lines().collect();
     assert_eq!(
         lines[0],
-        "block_start,block_end,input_tokens,output_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
+        "block_start,block_end,input_tokens,output_tokens,cache_creation_tokens,cache_creation_1h_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
     );
     assert_eq!(lines.len(), 2);
 }
@@ -280,7 +280,7 @@ fn breakdown_csv_header_includes_model() {
     let lines: Vec<&str> = csv.lines().collect();
     assert_eq!(
         lines[0],
-        "date,model,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
+        "date,model,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_creation_1h_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
     );
 }
 
@@ -331,8 +331,8 @@ fn breakdown_csv_with_cost() {
     let lines: Vec<&str> = csv.lines().collect();
     assert!(lines[0].ends_with(",cost,pricing_source"));
     let fields: Vec<&str> = lines[1].split(',').collect();
-    assert_eq!(fields.len(), 11);
-    assert_eq!(fields[10], "fallback");
+    assert_eq!(fields.len(), 12);
+    assert_eq!(fields[11], "fallback");
 }
 
 #[test]
@@ -381,4 +381,41 @@ fn csv_float_and_cost_handle_nan() {
     assert_eq!(csv_float(f64::NAN), "N/A");
     assert_eq!(csv_float(1.5), "1.500000");
     assert_eq!(csv_cost(f64::NAN, None), "N/A");
+}
+
+#[test]
+fn period_csv_exposes_cache_creation_1h_as_subset() {
+    let mut day_stats = HashMap::new();
+    let mut ds = DayStats::default();
+    ds.add_stats(
+        "sonnet".to_string(),
+        &Stats {
+            input_tokens: 10,
+            output_tokens: 5,
+            cache_creation: 30,
+            cache_creation_1h: 25,
+            cache_read: 2,
+            count: 1,
+            ..Default::default()
+        },
+    );
+    day_stats.insert("2025-01-01".to_string(), ds);
+
+    let db = PricingDb::default();
+    let csv = output_period_csv(
+        &day_stats,
+        Period::Day,
+        &db,
+        SortOrder::Asc,
+        false,
+        false,
+        None,
+    );
+    let lines: Vec<&str> = csv.lines().collect();
+    assert_eq!(
+        lines[0],
+        "date,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_creation_1h_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
+    );
+    // 1h tokens are a subset of cache_creation, so total is 10+5+30+2 = 47, not 72.
+    assert_eq!(lines[1], "2025-01-01,10,5,0,30,25,2,4.76,47");
 }

--- a/src/output/endpoints.rs
+++ b/src/output/endpoints.rs
@@ -183,6 +183,7 @@ pub(crate) fn output_endpoint_json(
                 "input_tokens": ep.stats.input_tokens,
                 "output_tokens": ep.stats.output_tokens,
                 "cache_creation_tokens": ep.stats.cache_creation,
+                "cache_creation_1h_tokens": ep.stats.cache_creation_1h,
                 "cache_read_tokens": ep.stats.cache_read,
                 "total_tokens": ep.stats.total_tokens(),
                 "avg_input_per_call": avg_input_per_call(&ep.stats),

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 
 use crate::cli::SortOrder;
-use crate::core::{DataQuality, DayStats};
+use crate::core::{DataQuality, DayStats, Stats};
 use crate::output::format::{cache_hit_rate_json_value, cost_json_value};
 use crate::output::period::{Period, aggregate_day_stats_by_period};
 use crate::output::pricing_meta;
@@ -49,6 +49,34 @@ fn sort_models_breakdown(breakdown: &mut [serde_json::Value], show_cost: bool) {
     }
 }
 
+fn token_usage_json(stats: &Stats, supports_cache_read: bool) -> serde_json::Value {
+    serde_json::json!({
+        "input_tokens": stats.input_tokens,
+        "output_tokens": stats.output_tokens,
+        "reasoning_tokens": stats.reasoning_tokens,
+        "cache_creation_tokens": stats.cache_creation,
+        "cache_creation_1h_tokens": stats.cache_creation_1h,
+        "cache_read_tokens": stats.cache_read,
+        "cache_hit_rate": cache_hit_rate_json_value(stats.cache_hit_rate(supports_cache_read)),
+        "total_tokens": stats.total_tokens(),
+    })
+}
+
+fn attach_period_cost(
+    obj: &mut serde_json::Value,
+    models: &HashMap<String, Stats>,
+    options: &PeriodJsonOptions<'_>,
+    period_cost: f64,
+) {
+    obj["cost"] = cost_json_value(period_cost, options.currency);
+    pricing_meta::add_json(obj, models, options.pricing_db);
+    let estimated_cost = sum_estimated_proxy_model_costs(models, options.pricing_db);
+    if estimated_cost > 0.0 {
+        obj["cost_kind"] = serde_json::json!(model_cost_kind(models).as_str());
+        obj["estimated_cost"] = cost_json_value(estimated_cost, options.currency);
+    }
+}
+
 fn build_period_entry(
     label: &str,
     key: &str,
@@ -60,19 +88,8 @@ fn build_period_entry(
         let mut period_cost = 0.0;
 
         for (model, model_stats) in &stats.models {
-            let mut model_obj = serde_json::json!({
-                "model": model,
-                "input_tokens": model_stats.input_tokens,
-                "output_tokens": model_stats.output_tokens,
-                "reasoning_tokens": model_stats.reasoning_tokens,
-                "cache_creation_tokens": model_stats.cache_creation,
-                "cache_creation_1h_tokens": model_stats.cache_creation_1h,
-                "cache_read_tokens": model_stats.cache_read,
-                "cache_hit_rate": cache_hit_rate_json_value(
-                    model_stats.cache_hit_rate(options.supports_cache_read)
-                ),
-                "total_tokens": model_stats.total_tokens(),
-            });
+            let mut model_obj = token_usage_json(model_stats, options.supports_cache_read);
+            model_obj["model"] = serde_json::json!(model);
             if options.show_cost {
                 let cost = calculate_display_cost(
                     model_stats,
@@ -100,28 +117,11 @@ fn build_period_entry(
 
         sort_models_breakdown(&mut models_breakdown, options.show_cost);
 
-        let mut obj = serde_json::json!({
-            (label): key,
-            "input_tokens": stats.stats.input_tokens,
-            "output_tokens": stats.stats.output_tokens,
-            "reasoning_tokens": stats.stats.reasoning_tokens,
-            "cache_creation_tokens": stats.stats.cache_creation,
-            "cache_creation_1h_tokens": stats.stats.cache_creation_1h,
-            "cache_read_tokens": stats.stats.cache_read,
-            "cache_hit_rate": cache_hit_rate_json_value(
-                stats.stats.cache_hit_rate(options.supports_cache_read)
-            ),
-            "total_tokens": stats.stats.total_tokens(),
-            "breakdown": models_breakdown,
-        });
+        let mut obj = token_usage_json(&stats.stats, options.supports_cache_read);
+        obj[label] = serde_json::json!(key);
+        obj["breakdown"] = serde_json::json!(models_breakdown);
         if options.show_cost {
-            obj["cost"] = cost_json_value(period_cost, options.currency);
-            pricing_meta::add_json(&mut obj, &stats.models, options.pricing_db);
-            let estimated_cost = sum_estimated_proxy_model_costs(&stats.models, options.pricing_db);
-            if estimated_cost > 0.0 {
-                obj["cost_kind"] = serde_json::json!(model_cost_kind(&stats.models).as_str());
-                obj["estimated_cost"] = cost_json_value(estimated_cost, options.currency);
-            }
+            attach_period_cost(&mut obj, &stats.models, options, period_cost);
         }
         obj
     } else {
@@ -136,28 +136,11 @@ fn build_period_entry(
         };
         let mut models: Vec<_> = stats.models.keys().cloned().collect();
         models.sort();
-        let mut obj = serde_json::json!({
-            (label): key,
-            "input_tokens": stats.stats.input_tokens,
-            "output_tokens": stats.stats.output_tokens,
-            "reasoning_tokens": stats.stats.reasoning_tokens,
-            "cache_creation_tokens": stats.stats.cache_creation,
-            "cache_creation_1h_tokens": stats.stats.cache_creation_1h,
-            "cache_read_tokens": stats.stats.cache_read,
-            "cache_hit_rate": cache_hit_rate_json_value(
-                stats.stats.cache_hit_rate(options.supports_cache_read)
-            ),
-            "total_tokens": stats.stats.total_tokens(),
-            "models": models,
-        });
+        let mut obj = token_usage_json(&stats.stats, options.supports_cache_read);
+        obj[label] = serde_json::json!(key);
+        obj["models"] = serde_json::json!(models);
         if options.show_cost {
-            obj["cost"] = cost_json_value(period_cost.unwrap_or(0.0), options.currency);
-            pricing_meta::add_json(&mut obj, &stats.models, options.pricing_db);
-            let estimated_cost = sum_estimated_proxy_model_costs(&stats.models, options.pricing_db);
-            if estimated_cost > 0.0 {
-                obj["cost_kind"] = serde_json::json!(model_cost_kind(&stats.models).as_str());
-                obj["estimated_cost"] = cost_json_value(estimated_cost, options.currency);
-            }
+            attach_period_cost(&mut obj, &stats.models, options, period_cost.unwrap_or(0.0));
         }
         obj
     }
@@ -262,7 +245,6 @@ pub(crate) fn output_period_json_with_quality(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::Stats;
 
     fn make_day_stats(models: &[(&str, i64)]) -> DayStats {
         let mut ds = DayStats::default();

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -66,6 +66,7 @@ fn build_period_entry(
                 "output_tokens": model_stats.output_tokens,
                 "reasoning_tokens": model_stats.reasoning_tokens,
                 "cache_creation_tokens": model_stats.cache_creation,
+                "cache_creation_1h_tokens": model_stats.cache_creation_1h,
                 "cache_read_tokens": model_stats.cache_read,
                 "cache_hit_rate": cache_hit_rate_json_value(
                     model_stats.cache_hit_rate(options.supports_cache_read)
@@ -105,6 +106,7 @@ fn build_period_entry(
             "output_tokens": stats.stats.output_tokens,
             "reasoning_tokens": stats.stats.reasoning_tokens,
             "cache_creation_tokens": stats.stats.cache_creation,
+            "cache_creation_1h_tokens": stats.stats.cache_creation_1h,
             "cache_read_tokens": stats.stats.cache_read,
             "cache_hit_rate": cache_hit_rate_json_value(
                 stats.stats.cache_hit_rate(options.supports_cache_read)
@@ -140,6 +142,7 @@ fn build_period_entry(
             "output_tokens": stats.stats.output_tokens,
             "reasoning_tokens": stats.stats.reasoning_tokens,
             "cache_creation_tokens": stats.stats.cache_creation,
+            "cache_creation_1h_tokens": stats.stats.cache_creation_1h,
             "cache_read_tokens": stats.stats.cache_read,
             "cache_hit_rate": cache_hit_rate_json_value(
                 stats.stats.cache_hit_rate(options.supports_cache_read)
@@ -450,5 +453,44 @@ mod tests {
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&json_str).unwrap();
 
         assert_eq!(parsed[0]["month"], "2025-03");
+    }
+
+    #[test]
+    fn period_json_exposes_cache_creation_1h_as_subset() {
+        let mut day_stats = HashMap::new();
+        let mut ds = DayStats::default();
+        ds.add_stats(
+            "sonnet".to_string(),
+            &Stats {
+                input_tokens: 10,
+                output_tokens: 5,
+                cache_creation: 30,
+                cache_creation_1h: 25,
+                cache_read: 2,
+                count: 1,
+                ..Default::default()
+            },
+        );
+        day_stats.insert("2025-01-01".to_string(), ds);
+
+        let db = PricingDb::default();
+        let json_str = output_period_json(
+            &day_stats,
+            Period::Day,
+            &db,
+            SortOrder::Asc,
+            true,
+            false,
+            None,
+        );
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&json_str).unwrap();
+        let breakdown = parsed[0]["breakdown"].as_array().unwrap();
+
+        assert_eq!(parsed[0]["cache_creation_tokens"], 30);
+        assert_eq!(parsed[0]["cache_creation_1h_tokens"], 25);
+        assert_eq!(parsed[0]["total_tokens"], 47);
+        assert_eq!(breakdown[0]["cache_creation_tokens"], 30);
+        assert_eq!(breakdown[0]["cache_creation_1h_tokens"], 25);
+        assert_eq!(breakdown[0]["total_tokens"], 47);
     }
 }

--- a/src/output/project.rs
+++ b/src/output/project.rs
@@ -284,6 +284,7 @@ pub(crate) fn output_project_json(
                 "input_tokens": project.stats.input_tokens,
                 "output_tokens": project.stats.output_tokens,
                 "cache_creation_tokens": project.stats.cache_creation,
+                "cache_creation_1h_tokens": project.stats.cache_creation_1h,
                 "cache_read_tokens": project.stats.cache_read,
                 "cache_hit_rate": cache_hit_rate_json_value(
                     project.stats.cache_hit_rate(supports_cache_read)

--- a/src/output/session.rs
+++ b/src/output/session.rs
@@ -332,6 +332,7 @@ pub(crate) fn output_session_json(
                 "output_tokens": session.stats.output_tokens,
                 "reasoning_tokens": session.stats.reasoning_tokens,
                 "cache_creation_tokens": session.stats.cache_creation,
+                "cache_creation_1h_tokens": session.stats.cache_creation_1h,
                 "cache_read_tokens": session.stats.cache_read,
                 "cache_hit_rate": cache_hit_rate_json_value(
                     session.stats.cache_hit_rate(supports_cache_read)

--- a/src/output/statusline.rs
+++ b/src/output/statusline.rs
@@ -111,6 +111,7 @@ pub(crate) fn print_statusline_json_with_quality(
         "output_tokens": t.stats.output_tokens,
         "reasoning_tokens": t.stats.reasoning_tokens,
         "cache_creation_tokens": t.stats.cache_creation,
+        "cache_creation_1h_tokens": t.stats.cache_creation_1h,
         "cache_read_tokens": t.stats.cache_read,
         "cache_hit_rate": cache_hit_rate_json_value(
             t.stats.cache_hit_rate(supports_cache_read)
@@ -253,6 +254,7 @@ mod tests {
         assert_eq!(v["output_tokens"].as_i64(), Some(6000));
         assert_eq!(v["reasoning_tokens"].as_i64(), Some(100));
         assert_eq!(v["cache_creation_tokens"].as_i64(), Some(50));
+        assert_eq!(v["cache_creation_1h_tokens"].as_i64(), Some(0));
         assert_eq!(v["cache_read_tokens"].as_i64(), Some(700));
         assert_eq!(v["cache_hit_rate"].as_f64(), Some(14.74));
         assert_eq!(v["total_tokens"].as_i64(), Some(10850));

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -329,6 +329,11 @@ pub struct TokenBreakdown {
     pub output_tokens: i64,
     pub reasoning_tokens: i64,
     pub cache_creation_tokens: i64,
+    /// Portion of `cache_creation_tokens` written with a 1-hour TTL.
+    /// This is a subset of `cache_creation_tokens`, not an extra additive bucket.
+    // Default keeps summaries serialized before this field existed loadable.
+    #[serde(default)]
+    pub cache_creation_1h_tokens: i64,
     pub cache_read_tokens: i64,
     /// Reported prompt-cache hit rate as a percentage from 0 to 100.
     /// `None` means the source does not expose trustworthy cache-read data or
@@ -503,6 +508,7 @@ impl TokenBreakdown {
             output_tokens: stats.output_tokens,
             reasoning_tokens: stats.reasoning_tokens,
             cache_creation_tokens: stats.cache_creation,
+            cache_creation_1h_tokens: stats.cache_creation_1h,
             cache_read_tokens: stats.cache_read,
             cache_hit_rate: stats.cache_hit_rate(supports_cache_read),
             total_tokens: stats.total_tokens(),
@@ -784,7 +790,30 @@ mod tests {
         let tokens: TokenBreakdown =
             serde_json::from_str(legacy).expect("legacy breakdown without cache_hit_rate");
         assert_eq!(tokens.cache_hit_rate, None);
+        assert_eq!(tokens.cache_creation_1h_tokens, 0);
         assert_eq!(tokens.total_tokens, 20);
+    }
+
+    #[test]
+    fn token_breakdown_treats_cache_creation_1h_as_subset() {
+        let stats = Stats {
+            input_tokens: 10,
+            output_tokens: 5,
+            cache_creation: 30,
+            cache_creation_1h: 25,
+            cache_read: 2,
+            ..Stats::default()
+        };
+        let tokens = TokenBreakdown::from_stats(&stats, true);
+        let serialized = serde_json::to_value(&tokens).expect("serialize breakdown");
+
+        assert_eq!(tokens.cache_creation_tokens, 30);
+        assert_eq!(tokens.cache_creation_1h_tokens, 25);
+        assert_eq!(serialized["cache_creation_tokens"], 30);
+        assert_eq!(serialized["cache_creation_1h_tokens"], 25);
+        // 1h tokens are already inside cache_creation; total must not add them again.
+        assert_eq!(tokens.total_tokens, 47);
+        assert_eq!(serialized["total_tokens"], 47);
     }
 
     #[test]

--- a/tests/cli_budget_currency_statusline.rs
+++ b/tests/cli_budget_currency_statusline.rs
@@ -343,7 +343,7 @@ fn daily_csv_uses_requested_currency() {
     let lines: Vec<&str> = output.lines().collect();
     assert_eq!(
         lines[0],
-        "date,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens,cost,pricing_source"
+        "date,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_creation_1h_tokens,cache_read_tokens,cache_hit_rate,total_tokens,cost,pricing_source"
     );
     assert!(
         lines[1].ends_with(",0.007350,fallback"),
@@ -416,9 +416,9 @@ fn daily_outputs_fresh_cache_pricing_source() {
         ",cost,pricing_source,pricing_cache_age_seconds,pricing_cache_mtime_epoch_seconds"
     ));
     let fields: Vec<&str> = lines[1].split(',').collect();
-    assert_eq!(fields[9], "cache");
-    assert!(fields[10].parse::<u64>().is_ok());
+    assert_eq!(fields[10], "cache");
     assert!(fields[11].parse::<u64>().is_ok());
+    assert!(fields[12].parse::<u64>().is_ok());
 
     let _ = fs::remove_dir_all(root);
 }
@@ -528,7 +528,7 @@ fn daily_outputs_mixed_pricing_source() {
     assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
     let output = String::from_utf8(stdout).expect("utf8 stdout");
     let fields: Vec<&str> = output.lines().nth(1).expect("row").split(',').collect();
-    assert_eq!(fields[9], "mixed");
+    assert_eq!(fields[10], "mixed");
 
     let _ = fs::remove_dir_all(root);
 }

--- a/tests/cli_claude.rs
+++ b/tests/cli_claude.rs
@@ -522,10 +522,10 @@ fn claude_daily_csv_outputs_correct_format() {
     assert_eq!(lines.len(), 2, "header + 1 data row");
     assert_eq!(
         lines[0],
-        "date,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
+        "date,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_creation_1h_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
     );
     // input=100, output=50, reasoning=0, cache_creation=10, cache_read=20, total=180
-    assert_eq!(lines[1], "2026-02-06,100,50,0,10,20,15.38,180");
+    assert_eq!(lines[1], "2026-02-06,100,50,0,10,0,20,15.38,180");
 
     let (ok, stdout, stderr) = run_ccstats(
         &[
@@ -588,13 +588,13 @@ fn claude_session_csv_outputs_correct_format() {
     assert_eq!(lines.len(), 3, "header + 2 sessions");
     assert_eq!(
         lines[0],
-        "session_id,project_path,first_timestamp,last_timestamp,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
+        "session_id,project_path,first_timestamp,last_timestamp,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_creation_1h_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
     );
     // Sessions sorted by last_timestamp asc: session-a (10:00) then session-b (11:00)
     assert!(lines[1].starts_with("session-a,"));
-    assert!(lines[1].ends_with(",100,50,0,0,0,0.00,150"));
+    assert!(lines[1].ends_with(",100,50,0,0,0,0,0.00,150"));
     assert!(lines[2].starts_with("session-b,"));
-    assert!(lines[2].ends_with(",200,80,0,0,0,0.00,280"));
+    assert!(lines[2].ends_with(",200,80,0,0,0,0,0.00,280"));
 
     let _ = fs::remove_dir_all(root);
 }
@@ -691,14 +691,14 @@ fn claude_blocks_csv_outputs_correct_format() {
     assert_eq!(lines.len(), 3, "header + 2 blocks");
     assert_eq!(
         lines[0],
-        "block_start,block_end,input_tokens,output_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
+        "block_start,block_end,input_tokens,output_tokens,cache_creation_tokens,cache_creation_1h_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
     );
     // Block 1: 10:00-15:00, input=100, output=50, cache_creation=10, cache_read=20, total=180
     assert!(lines[1].contains("10:00"));
-    assert!(lines[1].ends_with(",100,50,10,20,15.38,180"));
+    assert!(lines[1].ends_with(",100,50,10,0,20,15.38,180"));
     // Block 2: 15:00-20:00, input=300, output=150, cache_creation=0, cache_read=0, total=450
     assert!(lines[2].contains("15:00"));
-    assert!(lines[2].ends_with(",300,150,0,0,0.00,450"));
+    assert!(lines[2].ends_with(",300,150,0,0,0,0.00,450"));
 
     let _ = fs::remove_dir_all(root);
 }

--- a/tests/cli_codex_source_routing.rs
+++ b/tests/cli_codex_source_routing.rs
@@ -845,11 +845,11 @@ fn codex_session_csv_includes_reasoning_and_cache_tokens() {
     let row = lines.next().expect("row");
     assert_eq!(
         header,
-        "session_id,project_path,first_timestamp,last_timestamp,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
+        "session_id,project_path,first_timestamp,last_timestamp,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_creation_1h_tokens,cache_read_tokens,cache_hit_rate,total_tokens"
     );
     assert_eq!(
         row,
-        "reasoning-session,,2026-02-06T10:00:00Z,2026-02-06T10:00:00Z,900,300,200,0,100,10.00,1500"
+        "reasoning-session,,2026-02-06T10:00:00Z,2026-02-06T10:00:00Z,900,300,200,0,0,100,10.00,1500"
     );
 
     let _ = fs::remove_dir_all(root);


### PR DESCRIPTION
## What
- Add additive `cache_creation_1h_tokens` to SDK `TokenBreakdown`, CLI JSON (period/session/project/blocks/statusline/endpoints), and CSV immediately after `cache_creation_tokens`.
- Keep `cache_creation_tokens` as the inclusive total. `cache_creation_1h` remains a billed subset, not a sixth token bucket, so `total_tokens` does not add 1h on top of cache creation.
- Skip the default table column to avoid widening the layout.

Fixes #133

## Why
Pricing already bills `cache_creation_1h` (`src/pricing/cost.rs`), and the Claude parser stores it, but JSON/CSV/SDK only exposed inclusive `cache_creation_tokens`. Cost can exceed the 5-minute cache-create list price with no column explaining why.

## Test Plan
- [x] `cargo test` passes (lib + integration)
- [x] SDK: legacy JSON without the new field deserializes to `0`; `cache_creation=30` / `cache_creation_1h=25` serializes both and `total_tokens` stays 47
- [x] JSON/CSV unit tests assert the new field/column and subset totals
- [x] CLI CSV header/row assertions updated for daily, session, blocks, and pricing-source column indexes
- [ ] Tested manually


Made with [Cursor](https://cursor.com)