### PR TITLE
fix: exclude estimated-proxy tokens from --source all totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- `--source all` default token totals no longer include estimated-proxy rows (for example Grok context snapshots). Cost remains real-only. Estimated-proxy token counts are omitted from those default totals; they are still priced separately as `estimated_cost` when present.
+
 ## [0.5.1] - 2026-08-31
 
 ### Added

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,7 +8,7 @@ use std::time::Instant;
 use crate::cli::{Cli, SourceCommand, TopDimension};
 use crate::core::{
     BlockStats, DateFilter, LoadResult, ProjectStats, SessionStats, ToolSummary, aggregate_tools,
-    merge_day_stats,
+    apply_real_token_totals_for_all_source, merge_day_stats,
 };
 use crate::output::NumberFormat;
 use crate::output::{
@@ -633,6 +633,13 @@ fn load_all_daily(ctx: &CommandContext<'_>, quiet: bool) -> (LoadResult, Capabil
         merge_day_stats(&mut combined.day_stats, result.day_stats);
     }
 
+    // Default all-source token columns are CostKind::Real only. Keep
+    // estimated_proxy populated so estimated_cost still reports proxy rows
+    // (e.g. Grok context snapshots). Display buckets are already real, so
+    // callers must use CostDisplayMode::Total — RealOnly would subtract
+    // estimated_proxy a second time.
+    apply_real_token_totals_for_all_source(&mut combined.day_stats);
+
     combined.elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
     (combined, caps)
 }
@@ -657,7 +664,7 @@ fn handle_all_period(command: SourceCommand, ctx: &CommandContext<'_>) {
         None,
         None,
         ctx,
-        CostDisplayMode::RealOnly,
+        CostDisplayMode::Total,
     );
 }
 
@@ -681,7 +688,7 @@ pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandCo
                     ctx.currency,
                     caps.has_cache_read,
                     Some(result.data_quality()),
-                    CostDisplayMode::RealOnly,
+                    CostDisplayMode::Total,
                 );
                 print_json(&json, ctx.jq_filter);
             } else {
@@ -692,7 +699,7 @@ pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandCo
                     ctx.number_format,
                     ctx.currency,
                     caps.has_cache_read,
-                    CostDisplayMode::RealOnly,
+                    CostDisplayMode::Total,
                 );
             }
             return;
@@ -718,7 +725,7 @@ pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandCo
             let rows = rank_by_model_with_cost_mode(
                 &result.day_stats,
                 ctx.pricing_db,
-                CostDisplayMode::RealOnly,
+                CostDisplayMode::Total,
             );
             handle_top(
                 &rows,
@@ -728,7 +735,7 @@ pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandCo
                     source_label: "All Sources",
                     supports_cache_read: caps.has_cache_read,
                     codex_scope: None,
-                    cost_mode: CostDisplayMode::RealOnly,
+                    cost_mode: CostDisplayMode::Total,
                 },
                 ctx,
             );

--- a/src/core/all_source_provenance_tests.rs
+++ b/src/core/all_source_provenance_tests.rs
@@ -1,0 +1,93 @@
+//! Fixture tests for `--source all` real-only token totals.
+//!
+//! Kept out of `types.rs` / `aggregator.rs` because those modules are at the
+//! size limit.
+
+use std::collections::HashMap;
+
+use crate::core::{
+    CostKind, Endpoint, RawEntry, aggregate_daily, apply_real_token_totals_for_all_source,
+    merge_day_stats,
+};
+
+fn entry(date: &str, model: &str, input: i64, cost_kind: CostKind) -> RawEntry {
+    RawEntry {
+        timestamp: "2025-01-15T12:00:00Z".to_string(),
+        timestamp_ms: 1_737_000_000_000,
+        date_str: date.to_string(),
+        message_id: None,
+        session_key: model.to_string(),
+        session_id: model.to_string(),
+        project_path: String::new(),
+        model: model.to_string(),
+        input_tokens: input,
+        output_tokens: 0,
+        cache_creation: 0,
+        cache_creation_1h: 0,
+        cache_read: 0,
+        reasoning_tokens: 0,
+        stop_reason: Some("end_turn".to_string()),
+        cost_kind,
+        endpoint: Endpoint::Unknown,
+        call_count: 1,
+        reported_total_tokens: None,
+        recorded_cost_usd: None,
+        api_equivalent_priced_tokens: 0,
+        api_equivalent_coverage_tokens: 0,
+    }
+}
+
+#[test]
+fn all_source_helper_keeps_real_tokens_and_proxy_sidecar() {
+    let date = "2025-01-15";
+    let claude = aggregate_daily(vec![entry(date, "claude-sonnet", 100, CostKind::Real)]);
+    let grok = aggregate_daily(vec![entry(date, "grok", 1000, CostKind::EstimatedProxy)]);
+
+    let mut combined = claude;
+    merge_day_stats(&mut combined, grok);
+    assert_eq!(combined[date].stats.input_tokens, 1100);
+    assert_eq!(combined[date].stats.total_tokens(), 1100);
+
+    apply_real_token_totals_for_all_source(&mut combined);
+
+    let day = &combined[date];
+    assert_eq!(day.stats.input_tokens, 100);
+    assert_eq!(day.stats.total_tokens(), 100);
+    assert_eq!(day.stats.estimated_proxy.input_tokens, 1000);
+    assert_eq!(day.models["claude-sonnet"].input_tokens, 100);
+    assert_eq!(day.models["grok"].input_tokens, 0);
+    assert_eq!(day.models["grok"].estimated_proxy.input_tokens, 1000);
+    assert_eq!(day.models["claude-sonnet"].cost_kind(), CostKind::Real);
+    assert_eq!(day.models["grok"].cost_kind(), CostKind::EstimatedProxy);
+}
+
+#[test]
+fn grok_only_aggregation_keeps_proxy_tokens_without_helper() {
+    let date = "2025-01-15";
+    let grok = aggregate_daily(vec![entry(date, "grok", 1000, CostKind::EstimatedProxy)]);
+    let mixed = {
+        let claude = aggregate_daily(vec![entry(date, "claude-sonnet", 100, CostKind::Real)]);
+        let mut days = claude;
+        merge_day_stats(
+            &mut days,
+            aggregate_daily(vec![entry(date, "grok", 1000, CostKind::EstimatedProxy)]),
+        );
+        days
+    };
+
+    assert_eq!(grok[date].stats.input_tokens, 1000);
+    assert_eq!(grok[date].stats.total_tokens(), 1000);
+    assert_eq!(grok[date].stats.estimated_proxy.input_tokens, 1000);
+    assert_eq!(grok[date].stats.cost_kind(), CostKind::EstimatedProxy);
+    assert_eq!(mixed[date].stats.input_tokens, 1100);
+    assert_eq!(mixed[date].stats.total_tokens(), 1100);
+    assert_eq!(mixed[date].stats.estimated_proxy.input_tokens, 1000);
+    assert_eq!(mixed[date].stats.cost_kind(), CostKind::Mixed);
+}
+
+#[test]
+fn helper_is_a_no_op_on_empty_days() {
+    let mut empty = HashMap::new();
+    apply_real_token_totals_for_all_source(&mut empty);
+    assert!(empty.is_empty());
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,6 +3,8 @@
 mod aggregator;
 #[cfg(test)]
 mod aggregator_endpoint_tests;
+#[cfg(test)]
+mod all_source_provenance_tests;
 mod dedup;
 mod tool_aggregator;
 mod tool_types;
@@ -20,4 +22,5 @@ pub(crate) use tool_types::{ToolCall, ToolCallIdentity, ToolSummary};
 pub(crate) use types::{
     BlockStats, CostKind, CostTokens, DataQuality, DateFilter, DayStats, Endpoint, EndpointStats,
     LoadResult, ProjectStats, RawEntry, SessionStats, Stats,
+    apply_real_token_totals_for_all_source,
 };

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -121,6 +121,38 @@ impl Stats {
         self.cost_tokens().saturating_sub(&self.estimated_proxy)
     }
 
+    /// Copy `CostKind::Real` buckets into the default display totals.
+    ///
+    /// Leaves `estimated_proxy` populated so estimated proxy cost can still be
+    /// reported. After this transform, `CostDisplayMode::Total` prices the
+    /// remaining buckets (already real); `RealOnly` would subtract
+    /// `estimated_proxy` a second time.
+    pub(crate) fn retain_real_token_totals(&mut self) {
+        let real = self.real_cost_tokens();
+        self.input_tokens = real.input_tokens;
+        self.output_tokens = real.output_tokens;
+        self.cache_creation = real.cache_creation;
+        self.cache_creation_1h = real.cache_creation_1h;
+        self.cache_read = real.cache_read;
+        self.reasoning_tokens = real.reasoning_tokens;
+        self.count = real.count;
+        // Keep Total-mode recorded+priced cost real-only: priced_tokens still
+        // includes estimated-proxy rows until they are dropped here.
+        self.priced_tokens = self.priced_tokens.saturating_sub(&self.estimated_proxy);
+    }
+
+    /// True when default token buckets still contain estimated-proxy tokens.
+    pub(crate) fn display_includes_estimated_proxy(&self) -> bool {
+        let proxy = self.estimated_proxy;
+        proxy.has_entries()
+            && self.input_tokens >= proxy.input_tokens
+            && self.output_tokens >= proxy.output_tokens
+            && self.cache_creation >= proxy.cache_creation
+            && self.cache_creation_1h >= proxy.cache_creation_1h
+            && self.cache_read >= proxy.cache_read
+            && self.reasoning_tokens >= proxy.reasoning_tokens
+    }
+
     pub(crate) fn cost_kind(&self) -> CostKind {
         let estimated_count = self.estimated_proxy.count.max(0);
         if estimated_count == 0 {
@@ -264,6 +296,19 @@ impl DayStats {
     pub(crate) fn add_stats(&mut self, model: String, stats: &Stats) {
         self.stats.add(stats);
         self.models.entry(model).or_default().add(stats);
+    }
+}
+
+/// Restrict `--source all` display totals to `CostKind::Real` tokens.
+///
+/// Does not clear `estimated_proxy`, so estimated proxy cost can still be
+/// reported separately. Do not apply this to the Grok-only load path.
+pub(crate) fn apply_real_token_totals_for_all_source(day_stats: &mut HashMap<String, DayStats>) {
+    for day in day_stats.values_mut() {
+        day.stats.retain_real_token_totals();
+        for model_stats in day.models.values_mut() {
+            model_stats.retain_real_token_totals();
+        }
     }
 }
 

--- a/src/output/statusline.rs
+++ b/src/output/statusline.rs
@@ -7,7 +7,7 @@ use crate::output::format::{
 };
 use crate::output::pricing_meta;
 use crate::pricing::{
-    CostDisplayMode, CurrencyConverter, PricingDb, sum_display_model_costs,
+    CostDisplayMode, CurrencyConverter, PricingDb, model_cost_kind, sum_display_model_costs,
     sum_estimated_proxy_model_costs,
 };
 
@@ -137,7 +137,13 @@ pub(crate) fn print_statusline_json_with_quality(
         pricing_db,
     );
     if t.estimated_proxy_cost > 0.0 {
-        output["cost_kind"] = serde_json::json!(t.stats.cost_kind().as_str());
+        let mut models: HashMap<String, Stats> = HashMap::new();
+        for day in day_stats.values() {
+            for (model, stats) in &day.models {
+                models.entry(model.clone()).or_default().add(stats);
+            }
+        }
+        output["cost_kind"] = serde_json::json!(model_cost_kind(&models).as_str());
         output["estimated_cost"] = cost_json_value(t.estimated_proxy_cost, currency);
     }
 

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -558,15 +558,22 @@ pub(crate) fn print_period_table(
     println!("\n  {}\n", cfg.title);
     println!("{table}");
     if options.show_cost && has_estimated_proxy {
-        match options.cost_mode {
-            CostDisplayMode::RealOnly => println!(
-                "\n  Estimated proxy cost excluded from Cost total: {}",
-                format_cost(estimated_proxy_cost, options.currency)
-            ),
-            CostDisplayMode::Total => println!(
+        let included_in_cost = matches!(options.cost_mode, CostDisplayMode::Total)
+            && stats_ref.values().any(|data| {
+                data.models
+                    .values()
+                    .any(Stats::display_includes_estimated_proxy)
+            });
+        if included_in_cost {
+            println!(
                 "\n  Cost includes estimated proxy values: {}",
                 format_cost(estimated_proxy_cost, options.currency)
-            ),
+            );
+        } else {
+            println!(
+                "\n  Estimated proxy cost excluded from Cost total: {}",
+                format_cost(estimated_proxy_cost, options.currency)
+            );
         }
     }
     if options.show_cost {

--- a/src/output/top.rs
+++ b/src/output/top.rs
@@ -16,9 +16,9 @@ use crate::output::format::{
     format_number, header_cell, right_cell, styled_cell,
 };
 use crate::pricing::{
-    CostDisplayMode, CurrencyConverter, PricingDb, calculate_display_cost, model_cost_kind,
-    pricing_source_for_model_stats, pricing_source_for_models, sum_display_model_costs,
-    sum_estimated_proxy_model_costs,
+    CostDisplayMode, CurrencyConverter, PricingDb, calculate_display_cost,
+    calculate_estimated_proxy_cost, model_cost_kind, pricing_source_for_model_stats,
+    pricing_source_for_models, sum_display_model_costs, sum_estimated_proxy_model_costs,
 };
 
 /// One row in the leaderboard.
@@ -74,9 +74,7 @@ pub(crate) fn rank_by_model_with_cost_mode(
         .into_iter()
         .map(|(model, stats)| {
             let cost = calculate_display_cost(&stats, &model, pricing_db, cost_mode);
-            let estimated_cost =
-                calculate_display_cost(&stats, &model, pricing_db, CostDisplayMode::Total)
-                    - calculate_display_cost(&stats, &model, pricing_db, CostDisplayMode::RealOnly);
+            let estimated_cost = calculate_estimated_proxy_cost(&stats, &model, pricing_db);
             let cost_kind = stats.cost_kind();
             let pricing_source = pricing_source_for_model_stats(&model, &stats, pricing_db);
             let (pricing_cache_age_seconds, pricing_cache_mtime_epoch_seconds) =
@@ -400,15 +398,20 @@ pub(crate) fn print_top_table(rows: &[TopRow], options: TopTableOptions<'_>) {
     }
     println!("{table}");
     if options.show_cost && estimated_proxy_cost > 0.0 {
-        match options.cost_mode {
-            CostDisplayMode::RealOnly => println!(
-                "\nEstimated proxy cost excluded from Cost ranking: {}",
-                format_cost(estimated_proxy_cost, options.currency)
-            ),
-            CostDisplayMode::Total => println!(
+        let included_in_cost = matches!(options.cost_mode, CostDisplayMode::Total)
+            && limited
+                .iter()
+                .any(|row| row.stats.display_includes_estimated_proxy());
+        if included_in_cost {
+            println!(
                 "\nCost includes estimated proxy values: {}",
                 format_cost(estimated_proxy_cost, options.currency)
-            ),
+            );
+        } else {
+            println!(
+                "\nEstimated proxy cost excluded from Cost ranking: {}",
+                format_cost(estimated_proxy_cost, options.currency)
+            );
         }
     }
     if options.show_cost


### PR DESCRIPTION
## What
`--source all` default token columns now count `CostKind::Real` rows only. Estimated-proxy usage (Grok context snapshots and similar) stays on `estimated_proxy` so `estimated_cost` can still be reported, but it is no longer mixed into unlabeled `input_tokens` / `total_tokens`.

This is an accounting change: all-source default token totals will no longer match the previous mixed real+proxy sum. Cost remains real-only. Grok is still included in `--source all`; it is not dropped. `--source grok` still uses `load_grok_daily_with_cost` / `GrokCostReport` and is not stripped.

## Why
C1 / slice 3 of the provenance design: output must not present a single unlabeled token total that mixes `CostKind::Real` and `CostKind::EstimatedProxy`. Cost already used `CostDisplayMode::RealOnly`; token columns did not, so usage and cost described different sets of rows.

After the load-path strip, remaining display buckets are already real, so all-source cost_mode is **option B**: `CostDisplayMode::Total` (RealOnly would subtract `estimated_proxy` a second time). `json.rs` is untouched.

## Test plan
- [x] Fixture unit test: Claude-like Real (100 input) + Grok-like EstimatedProxy (1000 input), `aggregate_daily` + `merge_day_stats` + helper → default `input_tokens` / `total_tokens()` are 100, `estimated_proxy.input_tokens` stays 1000
- [x] Grok-only aggregation without the helper still shows proxy tokens
- [x] `cargo test` (lib + integration, including `cli_grok_cursor` all-source cases)
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] Manual: `ccstats daily --source all` vs `ccstats daily --source grok` on a machine with both Claude logs and Grok snapshots

Fixes #134


Made with [Cursor](https://cursor.com)