### PR TITLE
docs: rewrite ARCHITECTURE.md against inventory and current runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Expose `cache_creation_1h_tokens` in JSON, CSV, and SDK `TokenBreakdown`. `cache_creation_tokens` remains the inclusive cache-creation total; the 1-hour figure is a billed subset, not a sixth token bucket.
 
 ### Changed
+- Rewrite `ARCHITECTURE.md` against the source inventory and current runtime.
 - Register sources and `UsageSource` from one inventory so adding a source is a single table edit.
 - `--source all` default token totals no longer include estimated-proxy rows (for example Grok context snapshots). Cost remains real-only. Estimated-proxy token counts are omitted from those default totals; they are still priced separately as `estimated_cost` when present.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,192 +1,290 @@
-# ccstats 架构文档
+# ccstats architecture
 
-> 2026-09-02：本文仍描述加载/解析/聚合的运行时轮廓，但源数量、`Capabilities` 字段和 SDK 合同已超过文中示例。以代码中的 `src/source/registry.rs` 与 `UsageSource` 为准。审计与解耦设计见：
+> **Source of truth for registered sources is** [`src/source/inventory.rs`](../src/source/inventory.rs) (`define_sources!`). That table expands `UsageSource`, canonical names, and boxed constructors. `registry.rs` only looks up those constructors by name/alias. The SDK re-exports the generated `UsageSource` enum — do not keep a second list in `sdk.rs`.
+>
+> Audit and design (read these; this file does not repeat them):
 >
 > - [Codebase audit (2026-09-02)](audits/2026-09-02-codebase-audit.md)
 > - [Provenance, pricing families, and source inventory](architecture/2026-09-02-provenance-and-source-decoupling.md)
 
-## 概述
+ccstats is a local-first CLI and Rust SDK for token and cost analytics from coding-agent logs. Each product implements `Source`, parses into one `RawEntry` shape, then shares loader, aggregation, pricing, and output.
 
-ccstats 是一个快速的 CLI 工具，用于分析多种 AI CLI 工具的 token 使用统计。采用插件架构，便于添加新的数据源。
+Default CLI source when neither a nested command nor `--source` is set: `claude`. `--source all` is a registry sentinel (not an inventory row) that merges every registered source.
 
-## 目录结构
+## Directory layout
 
 ```
 src/
-├── lib.rs                  # library crate, SDK exports, CLI runtime dispatch
-├── cli/                    # 命令行接口
-│   ├── args.rs            # CLI 参数定义
-│   ├── commands.rs        # 子命令定义
-│   └── mod.rs
-├── core/                   # 核心共享逻辑
-│   ├── types.rs           # 统一数据类型
-│   ├── dedup.rs           # 去重算法
-│   ├── aggregator.rs      # 聚合函数
-│   └── mod.rs
-├── source/                 # 数据源插件
-│   ├── claude/            # Claude Code 数据源
-│   │   ├── config.rs      # Source trait 实现
-│   │   ├── parser.rs      # JSONL 解析逻辑
-│   │   └── mod.rs
-│   ├── codex/             # OpenAI Codex 数据源
-│   │   ├── config.rs      # Source trait 实现
-│   │   ├── parser.rs      # JSONL 解析逻辑
-│   │   └── mod.rs
-│   ├── cursor/            # Cursor 数据源
-│   │   ├── config.rs      # Source trait 实现
-│   │   ├── client.rs      # Usage API 客户端
-│   │   ├── parser.rs      # Usage event 解析逻辑
-│   │   └── mod.rs
-│   ├── grok/              # Grok 数据源
-│   │   ├── config.rs      # Source trait 实现
-│   │   ├── unified.rs     # inference 解析、分档计价和原子持久化
-│   │   ├── parser.rs      # 旧版 session fallback
-│   │   └── mod.rs
-│   ├── loader.rs          # 统一数据加载器
-│   ├── registry.rs        # 数据源注册表
-│   └── mod.rs             # Source trait 定义
-├── output/                 # 输出格式化
-├── pricing/                # 价格计算
-├── sdk.rs                  # public Rust SDK: summarize_cost and DTO types
-├── utils/                  # 工具函数
-└── main.rs                 # CLI binary thin entry point
+├── lib.rs                 # library crate, SDK exports, CLI dispatch
+├── main.rs                # thin binary entry
+├── cli/                   # clap: args, commands
+├── config.rs              # optional TOML config
+├── core/                  # RawEntry, CostKind, aggregator, dedup
+├── source/
+│   ├── inventory.rs       # define_sources! — registered source table
+│   ├── registry.rs        # lookup by name/alias; ALL_SOURCES = "all"
+│   ├── loader.rs          # discover → parse → filter → aggregate
+│   ├── mod.rs             # Source, Capabilities, ParseOutput
+│   └── <name>/            # per-source parsers (see table below)
+├── pricing/               # LiteLLM ingest, families (Google included), cache
+├── output/                # table / JSON / CSV / statusline
+├── sdk.rs                 # public summarize_cost* + re-export UsageSource
+└── utils/                 # timezone, date parsing, jq
 ```
 
-## 核心概念
+Parsers live under `src/source/<name>/` (some older sources are still a single `src/source/<name>.rs` file). Do not treat a hand-written file list as the product surface — the inventory table is the list.
 
-### Source Trait
+## Registered sources
 
-所有数据源必须实现 `Source` trait：
+Canonical `--source` names from `define_sources!` (29 sources). Aliases stay on `Source::aliases()` (examples: `cc`, `cx`, `cur`, `gx`, `km`, `gm`, `qw`).
+
+| `--source` | Inventory variant | Typical data |
+|------------|-------------------|--------------|
+| `claude` | `Claude` | `~/.claude/projects` JSONL |
+| `codex` | `Codex` | `~/.codex` sessions + archived sessions |
+| `cursor` | `Cursor` | Cursor usage API / `CURSOR_USAGE_FILE` |
+| `grok` | `Grok` | `~/.grok/logs/unified.jsonl` |
+| `kimi` | `Kimi` | `~/.kimi-code/sessions` wire logs |
+| `gemini` | `Gemini` | `~/.gemini/tmp` chats |
+| `amp` | `Amp` | XDG Amp thread logs |
+| `qwen` | `Qwen` | `~/.qwen/usage` ledger |
+| `cline` | `Cline` | Cline CLI + VS Code task logs |
+| `roocode` | `RooCode` | Roo Code VS Code task logs |
+| `kilocode` | `KiloCode` | Kilo Code VS Code task logs |
+| `opencode` | `OpenCode` | local OpenCode SQLite |
+| `mimocode` | `MiMoCode` | local MiMo Code SQLite |
+| `kilo` | `Kilo` | local Kilo CLI SQLite |
+| `pi` | `Pi` | Pi JSONL sessions |
+| `senpi` | `Senpi` | Senpi JSONL sessions |
+| `kimchi` | `Kimchi` | Kimchi harness JSONL |
+| `gjc` | `Gjc` | Gajae Code v5 JSONL |
+| `prime` | `Prime` | Prime Agent JSONL |
+| `omp` | `Omp` | Oh My Pi JSONL |
+| `copilot` | `Copilot` | Copilot CLI OTel JSONL |
+| `goose` | `Goose` | Goose SQLite usage ledger |
+| `openclaw` | `OpenClaw` | OpenClaw v3 transcripts |
+| `xum` | `Xum` | Xum per-workspace snapshots |
+| `hermes` | `Hermes` | Hermes Agent usage ledger |
+| `reasonix` | `Reasonix` | Reasonix provider ledger |
+| `fx` | `Fx` | Vercel Fx generation ledger |
+| `unsloth` | `Unsloth` | Unsloth Studio receipts |
+| `dsh` | `Dsh` | DeepSeek Harness sessions |
+
+`ccstats sources` / `ccstats sources --json` lists the same names plus the `all` sentinel.
+
+## `Source` trait
+
+Implemented by each product. Methods with default bodies are optional.
 
 ```rust
 pub trait Source: Send + Sync {
-    /// 数据源名称 (用于 CLI 和注册表)
     fn name(&self) -> &'static str;
-
-    /// 显示名称 (用于用户输出)
-    fn display_name(&self) -> &'static str;
-
-    /// 别名列表 (例如 "cc" 是 "claude" 的别名)
-    fn aliases(&self) -> &'static [&'static str];
-
-    /// 数据源能力声明
+    fn display_name(&self) -> &'static str { self.name() }
+    fn aliases(&self) -> &'static [&'static str] { &[] }
     fn capabilities(&self) -> Capabilities;
 
-    /// 发现所有数据文件
-    fn find_files(&self) -> Vec<PathBuf>;
+    fn setup_hint(&self) -> &'static str { /* doctor copy */ }
+    fn diagnose(&self) -> SourceDiagnostic { /* default: find_files().len() */ }
 
-    /// 解析单个文件，返回统一记录和解析错误统计
+    fn find_files(&self) -> Vec<PathBuf>;
+    fn find_files_for_filter(
+        &self,
+        filter: &DateFilter,
+        timezone: Timezone,
+    ) -> Vec<PathBuf> {
+        self.find_files()
+    }
     fn parse_file(&self, path: &Path, timezone: Timezone, debug: bool) -> ParseOutput;
+    fn finalize_entries(&self, entries: Vec<RawEntry>) -> Vec<RawEntry> { entries }
+
+    fn find_tool_call_files(&self) -> Vec<PathBuf> { Vec::new() }
+    fn parse_tool_call_file(&self, path: &Path, timezone: Timezone) -> Vec<ToolCall> {
+        Vec::new()
+    }
 }
 ```
 
-### Capabilities (能力声明)
+Required for a new source: `name`, `capabilities`, `find_files`, `parse_file`. Put CLI aliases on `aliases()`. `finalize_entries` is used after parse (Grok uses it to suppress overlapping snapshot rows). Tool-call hooks are Claude-only today. Cursor overrides `find_files_for_filter` so API requests can follow the date range.
+
+## `Capabilities`
+
+All eight flags that exist today:
 
 ```rust
 pub struct Capabilities {
-    /// 是否支持项目聚合
     pub has_projects: bool,
-
-    /// 是否支持 5 小时计费块
     pub has_billing_blocks: bool,
-
-    /// 是否有推理 token (如 o1 模型)
     pub has_reasoning_tokens: bool,
-
-    /// 是否需要去重 (流式响应)
+    pub has_cache_creation: bool,
+    pub has_cache_read: bool,       // trustworthy prompt-cache reads
     pub needs_dedup: bool,
+    pub has_tool_calls: bool,
+    pub has_endpoints: bool,        // native vs proxy (Claude)
 }
 ```
 
-### RawEntry (统一数据结构)
+`Capabilities::combine` ORs most flags across `--source all`. `has_cache_read` is AND (a mixed-source cache hit rate is hidden unless every selected source reports trustworthy cache reads).
 
-所有数据源将其原生格式转换为统一的 `RawEntry`：
+## `RawEntry`
+
+Every parser maps native logs into this shape.
 
 ```rust
 pub struct RawEntry {
-    pub timestamp: String,      // UTC 时间戳
-    pub timestamp_ms: i64,      // 毫秒时间戳 (用于排序)
-    pub date_str: String,       // 本地日期 (YYYY-MM-DD)
-    pub message_id: Option<String>,  // 消息 ID (用于去重)
-    pub session_id: String,     // 会话 ID
-    pub project_path: String,   // 项目路径 (可为空)
-    pub model: String,          // 模型名称
-    pub input_tokens: i64,      // 输入 token
-    pub output_tokens: i64,     // 输出 token
-    pub cache_creation: i64,    // 缓存创建 token
-    pub cache_read: i64,        // 缓存读取 token
-    pub reasoning_tokens: i64,  // 推理 token
-    pub stop_reason: Option<String>,  // 停止原因 (用于去重)
+    pub timestamp: String,           // UTC
+    pub timestamp_ms: i64,
+    pub date_str: String,            // local YYYY-MM-DD
+    pub message_id: Option<String>,  // dedup key
+    pub session_key: String,         // stable internal session identity
+    pub session_id: String,
+    pub project_path: String,
+    pub model: String,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_creation: i64,
+    pub cache_creation_1h: i64,      // subset of cache_creation, not additive
+    pub cache_read: i64,
+    pub reasoning_tokens: i64,
+    pub stop_reason: Option<String>,
+    pub cost_kind: CostKind,         // Real | EstimatedProxy | Mixed
 }
 ```
 
-## 数据流
+Five **non-overlapping** token buckets:
 
 ```
-┌─────────────────────────────────────────────────────────────────────┐
-│                     CLI (main.rs) / SDK (lib.rs)                    │
-└─────────────────────────────────────────────────────────────────────┘
-                                    │
-                                    ▼
-┌─────────────────────────────────────────────────────────────────────┐
-│                      Source Registry                                 │
-│                   (选择数据源: claude/codex)                          │
-└─────────────────────────────────────────────────────────────────────┘
-                                    │
-                                    ▼
-┌─────────────────────────────────────────────────────────────────────┐
-│                        DataLoader                                    │
-│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐              │
-│  │ File Discovery│  │   Parsing    │  │ Date Filter  │              │
-│  │  find_files() │  │ parse_file() │  │  + timezone  │              │
-│  └──────────────┘  └──────────────┘  └──────────────┘              │
-└─────────────────────────────────────────────────────────────────────┘
-                                    │
-                                    ▼
-┌─────────────────────────────────────────────────────────────────────┐
-│                    Deduplication (if needed)                         │
-│              (保留有 stop_reason 的完整消息)                           │
-└─────────────────────────────────────────────────────────────────────┘
-                                    │
-                                    ▼
-┌─────────────────────────────────────────────────────────────────────┐
-│                         Aggregation                                  │
-│  ┌───────────┐ ┌───────────┐ ┌───────────┐ ┌───────────┐           │
-│  │   Daily   │ │  Session  │ │  Project  │ │   Blocks  │           │
-│  └───────────┘ └───────────┘ └───────────┘ └───────────┘           │
-└─────────────────────────────────────────────────────────────────────┘
-                                    │
-                                    ▼
-┌─────────────────────────────────────────────────────────────────────┐
-│                    Pricing + Output Formatting                       │
-└─────────────────────────────────────────────────────────────────────┘
+total_tokens = input + output + reasoning + cache_creation + cache_read
 ```
 
-SDK 调用通过 `summarize_cost(SummaryOptions)` 复用同一套 source registry、loader、聚合和 pricing 逻辑，但返回结构化 `CostSummary`，不经过 table/JSON 输出层。需要和 CLI 持久化配置同口径时，SDK 使用 `summarize_cost_with_cli_config` 复用 timezone、offline pricing、strict pricing 和 currency 默认值。
+`cache_creation_1h` is the portion of `cache_creation` written with a 1-hour TTL (higher list price). It is **not** a sixth additive bucket. Entries also carry `endpoint`, `call_count`, and optional recorded/API-equivalent cost fields used by aggregation — see `src/core/types.rs`.
 
-### CLI 配置加载
+## Data flow
 
-CLI 启动时先读取可选的 TOML 配置，再合并命令行参数。命令行参数优先级高于配置文件。
+```
+CLI (main.rs / lib.rs)  or  SDK (summarize_cost*)
+        │
+        ▼
+inventory.rs  →  registry lookup (name / alias / "all")
+        │
+        ▼
+DataLoader
+  find_files[_for_filter] → parse_file (rayon) → date filter
+  → finalize_entries → dedup (if needs_dedup)
+        │
+        ▼
+RawEntry  (five buckets + CostKind + session_key)
+        │
+        ▼
+aggregate  daily / session / project / blocks / endpoints
+        │
+        ▼
+PricingDb  families: Anthropic | OpenAI | Xai | Google | DeepSeek | Qwen | Glm | Moonshot
+        │
+        ▼
+table / JSON / CSV / statusline    or    CostSummary (SDK skips the output layer)
+```
 
-配置搜索顺序：
+- **`--source all`:** default token columns are `CostKind::Real` only (`apply_real_token_totals_for_all_source`). Estimated-proxy tokens (for example Grok context snapshots) stay out of those totals; estimated proxy cost can still be reported separately. Do not apply that transform to the Grok-only path.
+- **Grok-only:** daily/weekly/monthly/today use `load_grok_daily_with_cost` and `GrokCostReport`. Do not bypass that path.
+- SDK `summarize_cost` / `summarize_cost_with_cli_config` reuse inventory, loader, aggregation, and pricing.
+
+## Add a source
+
+This is the checklist that compiles. Nested clap is optional.
+
+1. Parser module under `src/source/<name>/` (for example `src/source/newcli/mod.rs`).
+2. `mod newcli;` in `src/source/mod.rs`.
+3. **One row** in `define_sources!` in `src/source/inventory.rs`.
+4. Aliases on `Source::aliases()`.
+5. `--source newcli` is enough. Nested `ccstats newcli` in `cli/commands.rs` is optional sugar (only Codex, Grok, and Kimi have nested commands today).
+
+Do **not** edit a `registry.rs` `vec!` of constructors. Do **not** add a parallel `UsageSource` variant in `sdk.rs`. Both are generated from the inventory row.
+
+```rust
+// src/source/newcli/mod.rs
+use std::path::{Path, PathBuf};
+
+use crate::source::{Capabilities, ParseOutput, Source};
+use crate::utils::Timezone;
+
+pub(crate) struct NewcliSource;
+
+impl NewcliSource {
+    pub(crate) const fn new() -> Self {
+        Self
+    }
+}
+
+impl Source for NewcliSource {
+    fn name(&self) -> &'static str {
+        "newcli"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "NewCLI"
+    }
+
+    fn aliases(&self) -> &'static [&'static str] {
+        &["nc"]
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            has_projects: false,
+            has_billing_blocks: false,
+            has_reasoning_tokens: false,
+            has_cache_creation: false,
+            has_cache_read: false,
+            needs_dedup: false,
+            has_tool_calls: false,
+            has_endpoints: false,
+        }
+    }
+
+    fn find_files(&self) -> Vec<PathBuf> {
+        Vec::new()
+    }
+
+    fn parse_file(&self, _path: &Path, _timezone: Timezone, _debug: bool) -> ParseOutput {
+        ParseOutput::default()
+    }
+}
+```
+
+```rust
+// src/source/mod.rs — next to the other `mod` lines
+mod newcli;
+```
+
+```rust
+// src/source/inventory.rs — inside define_sources! { ... }
+/// NewCLI local usage.
+Newcli => "newcli", super::newcli::NewcliSource::new(),
+```
+
+Map native records into `RawEntry` (five buckets, `cache_creation_1h` ⊆ `cache_creation`, `cost_kind`, `session_key`). Explicit root env vars that are set but not a directory must not fall back to the default home.
+
+## CLI config
+
+CLI reads optional TOML, then merges command-line flags. Flags win.
+
+Search order (first file that exists is authoritative):
 
 1. `~/.config/ccstats/config.toml`
-2. 平台配置目录，例如 macOS 的 `~/Library/Application Support/ccstats/config.toml`
+2. Platform config dir, for example macOS `~/Library/Application Support/ccstats/config.toml`
 3. `~/.ccstats.toml`
 
-第一个存在的配置文件是权威配置。如果它无法读取、TOML 语法错误或字段类型错误，CLI 直接返回错误；normal、quiet/statusline 路径都不能回落默认值继续输出。只有所有路径都不存在时才使用 `Config::default()`。
+If that file cannot be read, or TOML/types are invalid, CLI errors. Quiet/statusline paths do not fall back to defaults. Only when **no** file exists is `Config::default()` used.
 
-配置键保持简单，且不定义 source 根目录路径：
+Config keys do not set source roots:
 
-| 键 | 类型 | 取值 |
-|----|------|------|
+| Key | Type | Values |
+|-----|------|--------|
 | `offline`, `compact`, `no_cost`, `no_color`, `breakdown`, `debug`, `strict_pricing` | boolean | `true` / `false` |
 | `order` | string | `asc` / `desc` |
 | `color` | string | `auto` / `always` / `never` |
 | `cost` | string | `show` / `hide` |
-| `timezone`, `locale`, `currency`, `source` | string | 对应 CLI 参数的字符串值 |
-
-示例：
+| `timezone`, `locale`, `currency`, `source` | string | same strings as the CLI flags |
 
 ```toml
 source = "codex"
@@ -200,140 +298,25 @@ color = "auto"
 cost = "show"
 ```
 
-Source 根目录仍由环境变量覆盖：
+## Env overrides
 
-| Source | Env var | Value | Default |
-|--------|---------|-------|---------|
-| Claude Code | `CLAUDE_CONFIG_DIR` | Claude config root containing `projects/` | `~/.claude` |
-| OpenAI Codex | `CODEX_HOME` | Codex root containing `sessions/` | `~/.codex` |
+Source roots are env vars, not config keys. If an override **is set** but is not a usable directory, discovery must return no files — it must **not** fall back to the default home. Grok already does this (`GROK_HOME`).
+
+| Source | Env var | Value | Default when unset |
+|--------|---------|-------|--------------------|
+| Claude Code | `CLAUDE_CONFIG_DIR` | Config root containing `projects/` | `~/.claude` |
+| OpenAI Codex | `CODEX_HOME` | Root containing `sessions/` and `archived_sessions/` | `~/.codex` |
 | Cursor | `CURSOR_API_KEY` / `CURSOR_SESSION_TOKEN` | Admin API key or dashboard session cookie | Optional `CURSOR_USAGE_FILE` replay |
-| Grok | `GROK_HOME` | Grok root containing `logs/unified.jsonl` and `sessions/` metadata | `~/.grok` |
-| Kimi Code | `KIMI_CODE_HOME` | Kimi Code root containing `sessions/` | `~/.kimi-code` |
+| Grok | `GROK_HOME` | Root containing `logs/unified.jsonl` and `sessions/` | `~/.grok` |
+| Kimi Code | `KIMI_CODE_HOME` | Root containing `sessions/` | `~/.kimi-code` |
 
-## 添加新数据源
+Other registered sources have their own env vars (see README / `ccstats doctor`).
 
-### 1. 创建目录结构
+## Claude Code parse sketch
 
-```bash
-mkdir -p src/source/newcli
-touch src/source/newcli/{mod.rs,config.rs,parser.rs}
-```
-
-### 2. 实现 parser.rs
-
-```rust
-//! NewCLI JSONL parser
-
-use crate::core::RawEntry;
-use crate::utils::Timezone;
-use std::path::PathBuf;
-
-/// 发现数据文件
-pub fn find_files() -> Vec<PathBuf> {
-    let Some(home) = dirs::home_dir() else {
-        return Vec::new();
-    };
-
-    let data_path = home.join(".newcli").join("sessions");
-    let mut files = Vec::new();
-
-    if let Ok(entries) = glob::glob(&format!("{}/**/*.jsonl", data_path.display())) {
-        for entry in entries.flatten() {
-            files.push(entry);
-        }
-    }
-    files
-}
-
-/// 解析单个文件
-pub fn parse_file(
-    path: &PathBuf,
-    timezone: &Timezone,
-) -> Vec<RawEntry> {
-    // 实现解析逻辑
-    // 返回 Vec<RawEntry>
-    Vec::new()
-}
-```
-
-### 3. 实现 config.rs
-
-```rust
-//! NewCLI data source configuration
-
-use std::path::PathBuf;
-use crate::core::RawEntry;
-use crate::source::{Capabilities, Source};
-use crate::utils::Timezone;
-use super::parser::{find_files, parse_file};
-
-pub struct NewCliSource;
-
-impl NewCliSource {
-    pub fn new() -> Self { Self }
-}
-
-impl Default for NewCliSource {
-    fn default() -> Self { Self::new() }
-}
-
-impl Source for NewCliSource {
-    fn name(&self) -> &'static str { "newcli" }
-    fn display_name(&self) -> &'static str { "NewCLI" }
-    fn aliases(&self) -> &'static [&'static str] { &["nc"] }
-
-    fn capabilities(&self) -> Capabilities {
-        Capabilities {
-            has_projects: false,
-            has_billing_blocks: false,
-            has_reasoning_tokens: false,
-            needs_dedup: false,
-        }
-    }
-
-    fn find_files(&self) -> Vec<PathBuf> { find_files() }
-
-    fn parse_file(&self, path: &Path, timezone: Timezone, debug: bool) -> ParseOutput {
-        parse_file_with_debug(path, timezone, debug)
-    }
-}
-```
-
-### 4. 更新 mod.rs
-
-```rust
-mod config;
-mod parser;
-
-pub use config::NewCliSource;
-```
-
-### 5. 注册数据源
-
-在 `src/source/registry.rs` 中添加：
-
-```rust
-use super::newcli::NewCliSource;
-
-static SOURCES: LazyLock<Vec<BoxedSource>> = LazyLock::new(|| {
-    vec![
-        Box::new(ClaudeSource::new()),
-        Box::new(CodexSource::new()),
-        Box::new(NewCliSource::new()),  // 添加这行
-    ]
-});
-```
-
-### 6. 添加 CLI 命令 (可选)
-
-在 `src/cli/commands.rs` 中添加新的子命令。
-
-## Claude Code 解析算法
+Input: `$CLAUDE_CONFIG_DIR/projects/**/*.jsonl` (default `~/.claude/projects`).
 
 ```
-输入: ~/.claude/projects/**/*.jsonl
-
-每行格式:
 {
   "timestamp": "2026-02-05T10:30:00Z",
   "message": {
@@ -343,27 +326,27 @@ static SOURCES: LazyLock<Vec<BoxedSource>> = LazyLock::new(|| {
     "usage": {
       "input_tokens": 1000,
       "output_tokens": 500,
-      "cache_creation_input_tokens": 0,
-      "cache_read_input_tokens": 200
+      "cache_creation_input_tokens": 80,
+      "cache_read_input_tokens": 200,
+      "cache_creation": { "ephemeral_1h_input_tokens": 20 }
     }
   }
 }
-
-处理步骤:
-1. 文件发现: glob("~/.claude/projects/**/*.jsonl")
-2. 并行解析每个文件
-3. 提取 session_id (文件名), project_path (父目录名)
-4. 规范化模型名称 (去除前缀和日期后缀)
-5. 去重: 相同 message_id 保留有 stop_reason 的条目
-6. 聚合: daily/session/project/blocks
 ```
 
-## Codex CLI 解析算法
+1. Glob JSONL under `projects/`.
+2. Parse files in parallel (`DataLoader` + rayon).
+3. `session_id` = file stem; `session_key` = file path; `project_path` = directory under `projects/`.
+4. Strip `anthropic.` / `claude-` prefixes and `-YYYYMMDD` suffixes from the model name.
+5. Five buckets from `usage`; `cache_creation_1h` from `ephemeral_1h_input_tokens`, clamped to `cache_creation`.
+6. Dedup by `message_id` (source-wide prefix); keep the completed (`stop_reason`) entry.
+7. Aggregate daily / session / project / clock-aligned blocks.
+
+## Codex CLI parse sketch
+
+Input: `$CODEX_HOME/sessions/**/*.jsonl` and `$CODEX_HOME/archived_sessions/**/*.jsonl` (default `~/.codex`).
 
 ```
-输入: ~/.codex/sessions/**/*.jsonl
-
-每行格式 (token_count 事件):
 {
   "timestamp": "2026-02-05T10:30:00Z",
   "type": "event_msg",
@@ -377,41 +360,38 @@ static SOURCES: LazyLock<Vec<BoxedSource>> = LazyLock::new(|| {
         "reasoning_output_tokens": 500,
         "total_tokens": 7000
       },
-      "last_token_usage": { ... },  // 可选
+      "last_token_usage": { ... },
       "model": "gpt-5.2"
     }
   }
 }
-
-处理步骤:
-1. 文件发现: glob("~/.codex/sessions/**/*.jsonl")
-2. 并行解析每个文件
-3. 处理 turn_context 事件获取模型信息
-4. 处理 event_msg + token_count 事件
-5. Delta 计算:
-   - 如果有 last_token_usage, 直接使用
-   - 否则: delta = total - previous_total
-6. 跳过 total 未变化的重复事件
-7. input_tokens 包含 cached_input_tokens, 需要减去
-8. 无需去重 (Codex 内部已处理)
 ```
 
-## 定价缓存机制
+1. Glob active and archived session JSONL.
+2. `turn_context` (and similar) events update the current model.
+3. `event_msg` + `token_count` events carry **cumulative** totals.
+4. Delta: use `last_token_usage` when present; otherwise `total - previous_total`.
+5. Skip when the full cumulative vector is unchanged, or the delta is empty.
+6. Split buckets: `input = input_tokens - cached_input_tokens`; `output = output_tokens - reasoning_output_tokens`; `cache_read = cached_input_tokens`; `reasoning = reasoning_output_tokens`. Codex `input_tokens` includes cache; OpenAI `output_tokens` includes reasoning.
+7. `needs_dedup` is true; message ids are synthesized from totals/deltas.
 
-```
-缓存位置: ~/.cache/ccstats/pricing.json
+## Pricing cache (24h TTL)
 
-策略:
-1. 默认优先使用 24 小时内的本地定价缓存
-2. 缓存过期后尝试从 LiteLLM 拉取最新定价并回写缓存
-3. 拉取失败时回退到旧缓存
-4. 无缓存时使用内置兜底价格
-```
+Preferred file: platform cache dir / `ccstats/pricing.json` (for example `~/Library/Caches/ccstats/pricing.json` on macOS). Legacy read path: `~/.cache/ccstats/pricing.json`.
 
-## 性能优化
+1. If a cache file is younger than 24 hours, use it.
+2. After TTL, fetch LiteLLM, parse allowlisted families (including Google/Gemini), and rewrite the cache.
+3. Fetch failure falls back to the existing cache (even if stale).
+4. No cache: built-in per-family fallback prices. Unknown models stay N/A under `--strict-pricing` (never a silent Sonnet guess).
 
-- 并行文件解析 (rayon)
-- 统一解析后过滤 (按日期与时区过滤入口)
-- 延迟加载定价数据
-- 定价缓存 (24h TTL)
-- 流式 JSONL 解析
+## Performance
+
+- Parallel file parse (rayon)
+- Filter after parse (local date + timezone, optional timestamp bounds)
+- Lazy pricing load and 24h cache
+- Streaming JSONL reads
+
+## Parked (do not invent a fix)
+
+- **`blocks`** are clock-aligned 5-hour windows (`hour() / 5 * 5` → local 00:00 / 05:00 / 10:00 / 15:00 / 20:00), not Anthropic’s rolling billing window. See issue [#135](https://github.com/majiayu000/ccstats/issues/135).
+- **CLI `weekly` vs SDK `ThisWeek`:** `ccstats weekly` loads history (only `today` / `statusline` apply a today filter). SDK `UsageRange::ThisWeek` is Monday–today in the selected timezone. Same English word, different dates. See issue [#136](https://github.com/majiayu000/ccstats/issues/136).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,14 +2,14 @@
 
 > **Source of truth for registered sources is** [`src/source/inventory.rs`](../src/source/inventory.rs) (`define_sources!`). That table expands `UsageSource`, canonical names, and boxed constructors. `registry.rs` only looks up those constructors by name/alias. The SDK re-exports the generated `UsageSource` enum — do not keep a second list in `sdk.rs`.
 >
-> Audit and design (read these; this file does not repeat them):
+> The 2026-09-02 audit is a snapshot. This file wins for inventory, `--source all` token provenance, and Google pricing families after the follow-up PRs landed. Still-open product questions stay in GitHub issues, not here as invented behavior.
 >
 > - [Codebase audit (2026-09-02)](audits/2026-09-02-codebase-audit.md)
 > - [Provenance, pricing families, and source inventory](architecture/2026-09-02-provenance-and-source-decoupling.md)
 
 ccstats is a local-first CLI and Rust SDK for token and cost analytics from coding-agent logs. Each product implements `Source`, parses into one `RawEntry` shape, then shares loader, aggregation, pricing, and output.
 
-Default CLI source when neither a nested command nor `--source` is set: `claude`. `--source all` is a registry sentinel (not an inventory row) that merges every registered source.
+Default CLI source is `claude` when neither a nested command, `--source`, nor `config.toml` `source` is set. Nested command and `--source` beat the config file. `--source all` is a registry sentinel (not an inventory row) that merges every registered source.
 
 ## Directory layout
 
@@ -32,7 +32,7 @@ src/
 └── utils/                 # timezone, date parsing, jq
 ```
 
-Parsers live under `src/source/<name>/` (some older sources are still a single `src/source/<name>.rs` file). Do not treat a hand-written file list as the product surface — the inventory table is the list.
+Most sources are a single `src/source/<name>.rs` file. Claude, Codex, Cursor, Grok, and Kimi use a directory. `reasonix` is inlined in `source/mod.rs`. Do not treat a hand-written file list as the product surface — the inventory table is the list.
 
 ## Registered sources
 
@@ -104,7 +104,7 @@ pub trait Source: Send + Sync {
 }
 ```
 
-Required for a new source: `name`, `capabilities`, `find_files`, `parse_file`. Put CLI aliases on `aliases()`. `finalize_entries` is used after parse (Grok uses it to suppress overlapping snapshot rows). Tool-call hooks are Claude-only today. Cursor overrides `find_files_for_filter` so API requests can follow the date range.
+Required for a new source: `name`, `capabilities`, `find_files`, `parse_file`. Put CLI aliases on `aliases()`. `finalize_entries` runs only on the **dedup path** (after `DedupAccumulator`), not on incremental daily/session aggregation. Grok uses it to **reclassify** overlapping `EstimatedProxy` snapshot rows to `CostKind::Real` with `recorded_cost_usd = Some(0.0)` when the same session already has API-equivalent priced rows — it does not drop those rows. Snapshot-only sessions stay `EstimatedProxy`. Tool-call hooks are Claude-only today. Cursor overrides `find_files_for_filter` so API requests can follow the date range.
 
 ## `Capabilities`
 
@@ -169,7 +169,9 @@ inventory.rs  →  registry lookup (name / alias / "all")
         ▼
 DataLoader
   find_files[_for_filter] → parse_file (rayon) → date filter
-  → finalize_entries → dedup (if needs_dedup)
+  then either:
+    needs_dedup: DedupAccumulator → finalize_entries → aggregate
+    else: aggregate incrementally (no finalize_entries)
         │
         ▼
 RawEntry  (five buckets + CostKind + session_key)


### PR DESCRIPTION
## What

Rewrite `docs/ARCHITECTURE.md` so it matches current `main` after the source inventory landed. Registered sources come from `src/source/inventory.rs` (`define_sources!`), not a hand-maintained `registry.rs` vec or a parallel `UsageSource` list in `sdk.rs`.

## Why

Issue #145 (M4 leftover). The old architecture doc still pointed at `registry.rs` + `UsageSource`, listed a 4-flag `Capabilities` stub, and an add-source recipe that would not compile. Copy-paste from that file would miss `inventory.rs`, the eight capability flags, and the five-bucket `RawEntry` contract.

Fixes #145

## Test Plan

Docs-only; no `src/` runtime change.

- [x] Spot-checked `src/source/inventory.rs`, `Source` / `Capabilities`, `RawEntry` / `CostKind`, Claude and Codex parsers, CLI config search order, pricing 24h TTL, Grok env no-fallback, `--source all` real-only totals, and Grok `GrokCostReport` path
- [ ] `cargo check` passes (unchanged runtime)
- [ ] `cargo test` passes (unchanged runtime)
- [ ] Skim `docs/ARCHITECTURE.md`: inventory banner, 29-name table (no 29 parser files), add-source recipe is one inventory row, parked #135 / #136 with no invented fix


Made with [Cursor](https://cursor.com)