### PR TITLE
fix: use activity-driven 5-hour session windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Expose `cache_creation_1h_tokens` in JSON, CSV, and SDK `TokenBreakdown`. `cache_creation_tokens` remains the inclusive cache-creation total; the 1-hour figure is a billed subset, not a sixth token bucket.
 
 ### Changed
+- `blocks` uses activity-driven 5-hour estimated session windows (ccusage-style), not clock-aligned 00/05/10/15/20 buckets. Not an official billing reset.
 - Rewrite `ARCHITECTURE.md` against the source inventory and current runtime.
 - Register sources and `UsageSource` from one inventory so adding a source is a single table edit.
 - `--source all` default token totals no longer include estimated-proxy rows (for example Grok context snapshots). Cost remains real-only. Estimated-proxy token counts are omitted from those default totals; they are still priced separately as `estimated_cost` when present.

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ ccstats project
 # By session
 ccstats session
 
-# 5-hour billing blocks
+# Estimated 5-hour session windows (not an official Anthropic billing reset)
 ccstats blocks
 
 # Top-N leaderboard (ranks by cost, falls back to tokens when costs unknown)

--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ CURSOR_SESSION_TOKEN="..." ccstats daily --source cursor
 Current limitations:
 
 - ccstats does not read local Cursor SQLite auth tokens. Set `CURSOR_API_KEY` or `CURSOR_SESSION_TOKEN` explicitly.
-- Project aggregation and 5-hour billing blocks are not supported for Cursor.
+- Project aggregation and estimated session windows (`blocks`) are not supported for Cursor.
 - Dashboard session cookies expire; refresh `CURSOR_SESSION_TOKEN` when requests start failing.
 - Self-serve plans may return token counts with `$0` event costs. ccstats records that billed amount instead of estimating Cursor subscription cost from LiteLLM prices.
 
@@ -504,7 +504,7 @@ Current limitations:
 - The durable ledger starts when ccstats first observes an inference. It cannot recover records Grok trimmed before the first run or between ccstats runs, so incomplete request coverage produces an estimated API equivalent and a short/long-context range.
 - `turn_completed.usage.costUsdTicks` is reported separately as a provider metric. xAI does not document this field as public API list price or as the user's actual subscription charge.
 - Grok models without a published ccstats per-inference tier remain unpriced and reduce priced-token coverage.
-- Grok 5-hour billing blocks are not supported.
+- Grok estimated session windows (`blocks`) are not supported.
 
 ### Kimi Code
 
@@ -543,7 +543,7 @@ Current limitations:
 
 - Kimi Code subscription models (e.g. `kimi-code/k3`) have no public per-token pricing; costs use fallback estimates based on Moonshot's official `kimi-k2.6` API rates and are marked as `fallback` in structured output. Use `--strict-pricing` to show N/A instead.
 - Cache creation tokens are reported but priced at $0 by the Kimi fallback estimate (Moonshot does not publish a separate cache-creation rate).
-- Kimi 5-hour billing blocks and tool-call statistics are not supported.
+- Kimi estimated session windows (`blocks`) and tool-call statistics are not supported.
 
 ### Common Options
 

--- a/README.md
+++ b/README.md
@@ -732,7 +732,7 @@ Warning: ignored <N> malformed records
 
 | Source | Directory | Override | Features |
 |--------|-----------|----------|----------|
-| Claude Code | `~/.claude/projects/` | `CLAUDE_CONFIG_DIR` | Projects, Billing Blocks, Deduplication |
+| Claude Code | `~/.claude/projects/` | `CLAUDE_CONFIG_DIR` | Projects, Estimated session windows, Deduplication |
 | OpenAI Codex | `~/.codex/sessions/` and `~/.codex/archived_sessions/` | `CODEX_HOME` | Reasoning Tokens, cumulative-event deduplication |
 | All Sources | Multiple | Source-specific env vars | Combined daily/weekly/monthly/today/statusline summaries |
 | Cursor | Cursor usage API | `CURSOR_API_KEY` / `CURSOR_SESSION_TOKEN` | Per-event tokens, cache tokens, recorded `chargedCents` |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -342,7 +342,7 @@ Input: `$CLAUDE_CONFIG_DIR/projects/**/*.jsonl` (default `~/.claude/projects`).
 4. Strip `anthropic.` / `claude-` prefixes and `-YYYYMMDD` suffixes from the model name.
 5. Five buckets from `usage`; `cache_creation_1h` from `ephemeral_1h_input_tokens`, clamped to `cache_creation`.
 6. Dedup by `message_id` (source-wide prefix); keep the completed (`stop_reason`) entry.
-7. Aggregate daily / session / project / clock-aligned blocks.
+7. Aggregate daily / session / project / activity-driven 5-hour estimated session windows.
 
 ## Codex CLI parse sketch
 
@@ -393,7 +393,16 @@ Preferred file: platform cache dir / `ccstats/pricing.json` (for example `~/Libr
 - Lazy pricing load and 24h cache
 - Streaming JSONL reads
 
+## Session windows (`blocks`)
+
+`ccstats blocks` groups Claude usage into activity-driven 5-hour estimated session windows (ccusage `identifySessionBlocks` / `floorToHour`):
+
+1. Sort entries by timestamp.
+2. Floor the first activity to the UTC hour; the window lasts 5 hours from that start.
+3. Close the window and start a new one (again floor-to-UTC-hour) when an entry is more than 5 hours after the window start **or** more than 5 hours after the previous entry.
+
+`block_start` / `block_end` labels use the selected local timezone. This is inferred from local logs, **not** an official Anthropic billing reset. Gap placeholder rows, `--active`, and burn-rate projection are not emitted.
+
 ## Parked (do not invent a fix)
 
-- **`blocks`** are clock-aligned 5-hour windows (`hour() / 5 * 5` → local 00:00 / 05:00 / 10:00 / 15:00 / 20:00), not Anthropic’s rolling billing window. See issue [#135](https://github.com/majiayu000/ccstats/issues/135).
 - **CLI `weekly` vs SDK `ThisWeek`:** `ccstats weekly` loads history (only `today` / `statusline` apply a today filter). SDK `UsageRange::ThisWeek` is Monday–today in the selected timezone. Same English word, different dates. See issue [#136](https://github.com/majiayu000/ccstats/issues/136).

--- a/docs/algorithm/authoritative-token-accounting.md
+++ b/docs/algorithm/authoritative-token-accounting.md
@@ -661,7 +661,7 @@ session_id         ← conversationId
 
 ### 限制
 
-- 不支持项目聚合和 5 小时 billing block。
+- 不支持项目聚合和估算 session 窗口（`blocks`）。
 - 个人 dashboard API 不是公开稳定接口，session cookie 会过期。
 - Self-serve 计划可能只返回 token、事件成本为 0；ccstats 记录该 billed 金额，不用 LiteLLM 估算 Cursor 订阅费用。
 - 默认抓取当前计费周期（dashboard）或最近 90 天（Admin API）。

--- a/src/app.rs
+++ b/src/app.rs
@@ -193,7 +193,7 @@ fn render_project(projects: &[ProjectStats], source: &dyn Source, ctx: &CommandC
 fn handle_blocks(source: &dyn Source, ctx: &CommandContext<'_>) {
     let blocks = load_blocks(source, ctx.filter, ctx.timezone, false);
     if blocks.is_empty() {
-        print_no_data_hint(source.display_name(), "billing block");
+        print_no_data_hint(source.display_name(), "session window");
         return;
     }
 
@@ -582,7 +582,7 @@ pub(crate) fn handle_source_command(
         SourceCommand::Blocks => {
             if !caps.has_billing_blocks {
                 println!(
-                    "{} does not support billing block aggregation.\nHint: try `daily`/`session`, or run `ccstats sources` to inspect capabilities.",
+                    "{} does not support estimated session window aggregation.\nHint: try `daily`/`session`, or run `ccstats sources` to inspect capabilities.",
                     source.display_name()
                 );
                 return;

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -35,7 +35,10 @@ pub(crate) enum Commands {
     Session,
     /// Show usage by project
     Project,
-    /// Show usage by 5-hour billing blocks
+    /// Show usage by estimated 5-hour session windows
+    ///
+    /// Windows are inferred from local logs (ccusage-style activity-driven).
+    /// This is not an official Anthropic billing reset.
     Blocks,
     /// Show usage split by serving endpoint (native Anthropic vs proxy)
     Endpoints,

--- a/src/core/aggregator.rs
+++ b/src/core/aggregator.rs
@@ -2,7 +2,7 @@
 //!
 //! Converts raw entries into various aggregated views (daily, session, etc.)
 
-use chrono::{DateTime, Duration, FixedOffset, TimeZone, Timelike};
+use chrono::{DateTime, FixedOffset, Utc};
 use std::collections::HashMap;
 
 use crate::core::types::{
@@ -200,57 +200,106 @@ pub(crate) fn format_project_name(path: &str) -> String {
     path.trim_start_matches('-').to_string()
 }
 
-/// Aggregate entries by 5-hour billing blocks (consumes entries to avoid cloning)
-pub(crate) fn aggregate_blocks(
-    entries: Vec<RawEntry>,
-    local_times: &HashMap<i64, DateTime<FixedOffset>>,
-) -> Vec<BlockStats> {
-    let mut block_map: HashMap<DateTime<FixedOffset>, BlockStats> =
-        HashMap::with_capacity(entries.len() / 2 + 1);
+/// Activity-driven 5-hour estimated session window (ccusage `identifySessionBlocks`).
+///
+/// Inferred from local logs. Not an official Anthropic billing reset.
+const SESSION_WINDOW_MS: i64 = 5 * 60 * 60 * 1000;
+const UTC_HOUR_MS: i64 = 60 * 60 * 1000;
 
-    for entry in entries {
-        let local_dt = match local_times.get(&entry.timestamp_ms) {
-            Some(dt) => *dt,
-            None => continue,
-        };
-
-        let stats = entry.to_stats();
-        let block_start = get_block_start(local_dt);
-        let block_end = block_start + Duration::hours(5);
-
-        let block = block_map.entry(block_start).or_insert_with(|| BlockStats {
-            block_start: block_start.format("%Y-%m-%d %H:%M").to_string(),
-            block_end: block_end.format("%H:%M").to_string(),
-            stats: Stats::default(),
-            models: HashMap::new(),
-        });
-
-        block.stats.add(&stats);
-        block.models.entry(entry.model).or_default().add(&stats);
-    }
-
-    let mut blocks: Vec<BlockStats> = block_map.into_values().collect();
-    blocks.sort_by(|a, b| a.block_start.cmp(&b.block_start));
-    blocks
+/// Floor a Unix-ms timestamp to the start of its UTC hour (`setUTCMinutes(0,0,0)`).
+fn floor_to_utc_hour_ms(timestamp_ms: i64) -> i64 {
+    timestamp_ms.div_euclid(UTC_HOUR_MS) * UTC_HOUR_MS
 }
 
-/// Calculate the 5-hour block start time for a given timestamp
-fn get_block_start(dt: DateTime<FixedOffset>) -> DateTime<FixedOffset> {
-    let block_hour = dt.hour() / 5 * 5;
-    let offset = *dt.offset();
-    let naive = dt
-        .date_naive()
-        .and_hms_opt(block_hour, 0, 0)
-        .unwrap_or_else(|| dt.naive_utc());
-    offset
-        .from_local_datetime(&naive)
-        .single()
-        .unwrap_or_else(|| offset.from_utc_datetime(&naive))
+fn local_from_utc_ms(utc_ms: i64, offset: FixedOffset) -> DateTime<FixedOffset> {
+    DateTime::<Utc>::from_timestamp_millis(utc_ms)
+        .unwrap_or(DateTime::<Utc>::UNIX_EPOCH)
+        .with_timezone(&offset)
+}
+
+fn into_block_stats(
+    start_ms: i64,
+    offset: FixedOffset,
+    stats: Stats,
+    models: HashMap<String, Stats>,
+) -> BlockStats {
+    let local_start = local_from_utc_ms(start_ms, offset);
+    let local_end = local_from_utc_ms(start_ms + SESSION_WINDOW_MS, offset);
+    BlockStats {
+        block_start: local_start.format("%Y-%m-%d %H:%M").to_string(),
+        block_end: local_end.format("%H:%M").to_string(),
+        stats,
+        models,
+    }
+}
+
+/// Aggregate entries into activity-driven 5-hour estimated session windows.
+///
+/// Matches ccusage `identifySessionBlocks` / `floorToHour`: sort by timestamp,
+/// floor the first activity to the UTC hour, lasts 5 hours from that start, and
+/// open a new window when an entry is more than 5 hours after the start **or**
+/// more than 5 hours after the previous entry. Does not emit gap placeholders.
+///
+/// Labels use the same local timezone as `local_times`. Not an official
+/// Anthropic billing reset.
+pub(crate) fn aggregate_blocks(
+    mut entries: Vec<RawEntry>,
+    local_times: &HashMap<i64, DateTime<FixedOffset>>,
+) -> Vec<BlockStats> {
+    entries.sort_by_key(|entry| entry.timestamp_ms);
+
+    let mut blocks = Vec::new();
+    let mut current: Option<(i64, i64, FixedOffset)> = None; // start_ms, last_ms, offset
+    let mut stats = Stats::default();
+    let mut models: HashMap<String, Stats> = HashMap::new();
+
+    for entry in entries {
+        let Some(local_dt) = local_times.get(&entry.timestamp_ms) else {
+            continue;
+        };
+        let offset = *local_dt.offset();
+        let entry_stats = entry.to_stats();
+
+        let start_new = match current {
+            None => true,
+            Some((start_ms, last_ms, _)) => {
+                entry.timestamp_ms - start_ms > SESSION_WINDOW_MS
+                    || entry.timestamp_ms - last_ms > SESSION_WINDOW_MS
+            }
+        };
+
+        if start_new {
+            if let Some((start_ms, _, prev_offset)) = current {
+                blocks.push(into_block_stats(
+                    start_ms,
+                    prev_offset,
+                    std::mem::take(&mut stats),
+                    std::mem::take(&mut models),
+                ));
+            }
+            current = Some((
+                floor_to_utc_hour_ms(entry.timestamp_ms),
+                entry.timestamp_ms,
+                offset,
+            ));
+        } else if let Some((_, last_ms, _)) = current.as_mut() {
+            *last_ms = entry.timestamp_ms;
+        }
+
+        stats.add(&entry_stats);
+        models.entry(entry.model).or_default().add(&entry_stats);
+    }
+
+    if let Some((start_ms, _, offset)) = current {
+        blocks.push(into_block_stats(start_ms, offset, stats, models));
+    }
+    blocks
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::TimeZone;
 
     fn make_entry(
         date: &str,
@@ -709,7 +758,31 @@ mod tests {
         assert_eq!(result[1].project_name, "small");
     }
 
-    // --- aggregate_blocks ---
+    // --- aggregate_blocks (activity-driven session windows) ---
+
+    fn utc(hour: u32, min: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2025, 1, 1, hour, min, 0).unwrap()
+    }
+
+    fn utc_local_map(times: &[DateTime<Utc>]) -> HashMap<i64, DateTime<FixedOffset>> {
+        let offset = FixedOffset::east_opt(0).unwrap();
+        times
+            .iter()
+            .map(|dt| (dt.timestamp_millis(), dt.with_timezone(&offset)))
+            .collect()
+    }
+
+    fn entry_at(dt: DateTime<Utc>, input: i64) -> RawEntry {
+        make_entry(
+            "2025-01-01",
+            "s1",
+            "p1",
+            "claude",
+            input,
+            50,
+            dt.timestamp_millis(),
+        )
+    }
 
     #[test]
     fn aggregate_blocks_empty() {
@@ -720,80 +793,90 @@ mod tests {
     #[test]
     fn aggregate_blocks_skips_missing_timestamps() {
         let entries = vec![make_entry("2025-01-01", "s1", "p1", "claude", 100, 50, 999)];
-        // local_times map doesn't contain ts_ms=999
         let result = aggregate_blocks(entries, &HashMap::new());
         assert!(result.is_empty());
     }
 
     #[test]
     fn aggregate_blocks_groups_by_5h_window() {
-        let offset = FixedOffset::east_opt(0).unwrap();
-        let dt1 = offset.with_ymd_and_hms(2025, 1, 1, 2, 30, 0).unwrap(); // block 0:00-5:00
-        let dt2 = offset.with_ymd_and_hms(2025, 1, 1, 3, 0, 0).unwrap(); // same block
-        let dt3 = offset.with_ymd_and_hms(2025, 1, 1, 7, 0, 0).unwrap(); // block 5:00-10:00
-
-        let local_times: HashMap<i64, DateTime<FixedOffset>> =
-            HashMap::from([(1000, dt1), (2000, dt2), (3000, dt3)]);
-
-        let entries = vec![
-            make_entry("2025-01-01", "s1", "p1", "claude", 100, 50, 1000),
-            make_entry("2025-01-01", "s1", "p1", "claude", 200, 100, 2000),
-            make_entry("2025-01-01", "s1", "p1", "claude", 300, 150, 3000),
-        ];
+        // 02:30 floors to 02:00 (not clock-aligned 00:00). 06:00 stays in that
+        // window even though it would have been a 05:00 clock bucket. 08:00
+        // exceeds the 5h window and starts a new one at 08:00.
+        let t1 = utc(2, 30);
+        let t2 = utc(6, 0);
+        let t3 = utc(8, 0);
+        let local_times = utc_local_map(&[t1, t2, t3]);
+        let entries = vec![entry_at(t1, 100), entry_at(t2, 200), entry_at(t3, 300)];
 
         let result = aggregate_blocks(entries, &local_times);
         assert_eq!(result.len(), 2);
-        // sorted by block_start
-        assert!(result[0].block_start.contains("00:00"));
-        assert_eq!(result[0].stats.input_tokens, 300); // 100+200
-        assert!(result[1].block_start.contains("05:00"));
+        assert_eq!(result[0].block_start, "2025-01-01 02:00");
+        assert_eq!(result[0].block_end, "07:00");
+        assert_eq!(result[0].stats.input_tokens, 300);
+        assert_eq!(result[1].block_start, "2025-01-01 08:00");
+        assert_eq!(result[1].block_end, "13:00");
         assert_eq!(result[1].stats.input_tokens, 300);
     }
 
     #[test]
     fn aggregate_blocks_sorted_chronologically() {
-        let offset = FixedOffset::east_opt(0).unwrap();
-        let dt_late = offset.with_ymd_and_hms(2025, 1, 1, 22, 0, 0).unwrap();
-        let dt_early = offset.with_ymd_and_hms(2025, 1, 1, 1, 0, 0).unwrap();
-
-        let local_times: HashMap<i64, DateTime<FixedOffset>> =
-            HashMap::from([(2000, dt_late), (1000, dt_early)]);
-
-        let entries = vec![
-            make_entry("2025-01-01", "s1", "p1", "claude", 100, 50, 2000),
-            make_entry("2025-01-01", "s1", "p1", "claude", 100, 50, 1000),
-        ];
+        let early = utc(1, 0);
+        let late = utc(22, 0);
+        let local_times = utc_local_map(&[early, late]);
+        let entries = vec![entry_at(late, 100), entry_at(early, 100)];
 
         let result = aggregate_blocks(entries, &local_times);
-        assert!(result[0].block_start < result[1].block_start);
-    }
-
-    // --- get_block_start ---
-
-    #[test]
-    fn get_block_start_boundaries() {
-        let offset = FixedOffset::east_opt(0).unwrap();
-        // Hour 0 → block 0
-        let dt = offset.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
-        assert_eq!(get_block_start(dt).hour(), 0);
-        // Hour 4 → block 0
-        let dt = offset.with_ymd_and_hms(2025, 1, 1, 4, 59, 59).unwrap();
-        assert_eq!(get_block_start(dt).hour(), 0);
-        // Hour 5 → block 5
-        let dt = offset.with_ymd_and_hms(2025, 1, 1, 5, 0, 0).unwrap();
-        assert_eq!(get_block_start(dt).hour(), 5);
-        // Hour 23 → block 20
-        let dt = offset.with_ymd_and_hms(2025, 1, 1, 23, 30, 0).unwrap();
-        assert_eq!(get_block_start(dt).hour(), 20);
+        assert_eq!(result[0].block_start, "2025-01-01 01:00");
+        assert_eq!(result[1].block_start, "2025-01-01 22:00");
     }
 
     #[test]
-    fn get_block_start_preserves_date_and_offset() {
-        let offset = FixedOffset::east_opt(9 * 3600).unwrap(); // +09:00
-        let dt = offset.with_ymd_and_hms(2025, 6, 15, 14, 30, 0).unwrap();
-        let block = get_block_start(dt);
-        assert_eq!(block.hour(), 10);
-        assert_eq!(block.minute(), 0);
-        assert_eq!(*block.offset(), offset);
+    fn session_windows_same_utc_hour_floor() {
+        // 10:55 UTC and 11:10 UTC same day → one window starting 10:00 UTC.
+        let t1 = utc(10, 55);
+        let t2 = utc(11, 10);
+        let local_times = utc_local_map(&[t1, t2]);
+        let result = aggregate_blocks(vec![entry_at(t1, 100), entry_at(t2, 200)], &local_times);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].block_start, "2025-01-01 10:00");
+        assert_eq!(result[0].block_end, "15:00");
+        assert_eq!(result[0].stats.input_tokens, 300);
+    }
+
+    #[test]
+    fn session_windows_split_after_five_hours_from_start() {
+        // 10:55 UTC then 16:10 UTC (>5h after the 10:00 start) → two windows.
+        let t1 = utc(10, 55);
+        let t2 = utc(16, 10);
+        let local_times = utc_local_map(&[t1, t2]);
+        let result = aggregate_blocks(vec![entry_at(t1, 100), entry_at(t2, 200)], &local_times);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].block_start, "2025-01-01 10:00");
+        assert_eq!(result[0].stats.input_tokens, 100);
+        assert_eq!(result[1].block_start, "2025-01-01 16:00");
+        assert_eq!(result[1].stats.input_tokens, 200);
+    }
+
+    #[test]
+    fn session_windows_split_on_gap_since_last_activity() {
+        // 10:00 UTC then 16:30 UTC (6.5h gap since last activity) → two windows.
+        let t1 = utc(10, 0);
+        let t2 = utc(16, 30);
+        let local_times = utc_local_map(&[t1, t2]);
+        let result = aggregate_blocks(vec![entry_at(t1, 100), entry_at(t2, 200)], &local_times);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].block_start, "2025-01-01 10:00");
+        assert_eq!(result[1].block_start, "2025-01-01 16:00");
+    }
+
+    #[test]
+    fn session_window_labels_convert_floored_utc_to_local() {
+        let offset = FixedOffset::east_opt(9 * 3600).unwrap();
+        let t1 = Utc.with_ymd_and_hms(2025, 6, 15, 10, 55, 0).unwrap();
+        let local_times = HashMap::from([(t1.timestamp_millis(), t1.with_timezone(&offset))]);
+        let result = aggregate_blocks(vec![entry_at(t1, 100)], &local_times);
+        // 10:00 UTC → 19:00 +09:00; window end 15:00 UTC → 00:00 local.
+        assert_eq!(result[0].block_start, "2025-06-15 19:00");
+        assert_eq!(result[0].block_end, "00:00");
     }
 }

--- a/src/core/aggregator.rs
+++ b/src/core/aggregator.rs
@@ -2,12 +2,13 @@
 //!
 //! Converts raw entries into various aggregated views (daily, session, etc.)
 
-use chrono::{DateTime, FixedOffset, Utc};
+use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 
 use crate::core::types::{
     BlockStats, DayStats, Endpoint, EndpointStats, ProjectStats, RawEntry, SessionStats, Stats,
 };
+use crate::utils::Timezone;
 
 /// Aggregate entries by day (consumes entries to avoid cloning)
 pub(crate) fn aggregate_daily(entries: Vec<RawEntry>) -> HashMap<String, DayStats> {
@@ -211,20 +212,19 @@ fn floor_to_utc_hour_ms(timestamp_ms: i64) -> i64 {
     timestamp_ms.div_euclid(UTC_HOUR_MS) * UTC_HOUR_MS
 }
 
-fn local_from_utc_ms(utc_ms: i64, offset: FixedOffset) -> DateTime<FixedOffset> {
-    DateTime::<Utc>::from_timestamp_millis(utc_ms)
-        .unwrap_or(DateTime::<Utc>::UNIX_EPOCH)
-        .with_timezone(&offset)
+fn local_from_utc_ms(utc_ms: i64, timezone: Timezone) -> DateTime<chrono::FixedOffset> {
+    let utc = DateTime::<Utc>::from_timestamp_millis(utc_ms).unwrap_or(DateTime::<Utc>::UNIX_EPOCH);
+    timezone.to_fixed_offset(utc)
 }
 
 fn into_block_stats(
     start_ms: i64,
-    offset: FixedOffset,
+    timezone: Timezone,
     stats: Stats,
     models: HashMap<String, Stats>,
 ) -> BlockStats {
-    let local_start = local_from_utc_ms(start_ms, offset);
-    let local_end = local_from_utc_ms(start_ms + SESSION_WINDOW_MS, offset);
+    let local_start = local_from_utc_ms(start_ms, timezone);
+    let local_end = local_from_utc_ms(start_ms + SESSION_WINDOW_MS, timezone);
     BlockStats {
         block_start: local_start.format("%Y-%m-%d %H:%M").to_string(),
         block_end: local_end.format("%H:%M").to_string(),
@@ -240,49 +240,41 @@ fn into_block_stats(
 /// open a new window when an entry is more than 5 hours after the start **or**
 /// more than 5 hours after the previous entry. Does not emit gap placeholders.
 ///
-/// Labels use the same local timezone as `local_times`. Not an official
-/// Anthropic billing reset.
-pub(crate) fn aggregate_blocks(
-    mut entries: Vec<RawEntry>,
-    local_times: &HashMap<i64, DateTime<FixedOffset>>,
-) -> Vec<BlockStats> {
+/// Labels convert the floored UTC start/end independently in `timezone`.
+/// Not an official Anthropic billing reset.
+pub(crate) fn aggregate_blocks(mut entries: Vec<RawEntry>, timezone: Timezone) -> Vec<BlockStats> {
     entries.sort_by_key(|entry| entry.timestamp_ms);
 
     let mut blocks = Vec::new();
-    let mut current: Option<(i64, i64, FixedOffset)> = None; // start_ms, last_ms, offset
+    let mut current: Option<(i64, i64)> = None; // start_ms, last_ms
     let mut stats = Stats::default();
     let mut models: HashMap<String, Stats> = HashMap::new();
 
     for entry in entries {
-        let Some(local_dt) = local_times.get(&entry.timestamp_ms) else {
+        if DateTime::<Utc>::from_timestamp_millis(entry.timestamp_ms).is_none() {
             continue;
-        };
-        let offset = *local_dt.offset();
+        }
         let entry_stats = entry.to_stats();
 
         let start_new = match current {
             None => true,
-            Some((start_ms, last_ms, _)) => {
+            Some((start_ms, last_ms)) => {
                 entry.timestamp_ms - start_ms > SESSION_WINDOW_MS
                     || entry.timestamp_ms - last_ms > SESSION_WINDOW_MS
             }
         };
 
         if start_new {
-            if let Some((start_ms, _, prev_offset)) = current {
+            if let Some((start_ms, _)) = current {
                 blocks.push(into_block_stats(
                     start_ms,
-                    prev_offset,
+                    timezone,
                     std::mem::take(&mut stats),
                     std::mem::take(&mut models),
                 ));
             }
-            current = Some((
-                floor_to_utc_hour_ms(entry.timestamp_ms),
-                entry.timestamp_ms,
-                offset,
-            ));
-        } else if let Some((_, last_ms, _)) = current.as_mut() {
+            current = Some((floor_to_utc_hour_ms(entry.timestamp_ms), entry.timestamp_ms));
+        } else if let Some((_, last_ms)) = current.as_mut() {
             *last_ms = entry.timestamp_ms;
         }
 
@@ -290,8 +282,8 @@ pub(crate) fn aggregate_blocks(
         models.entry(entry.model).or_default().add(&entry_stats);
     }
 
-    if let Some((start_ms, _, offset)) = current {
-        blocks.push(into_block_stats(start_ms, offset, stats, models));
+    if let Some((start_ms, _)) = current {
+        blocks.push(into_block_stats(start_ms, timezone, stats, models));
     }
     blocks
 }
@@ -764,12 +756,8 @@ mod tests {
         Utc.with_ymd_and_hms(2025, 1, 1, hour, min, 0).unwrap()
     }
 
-    fn utc_local_map(times: &[DateTime<Utc>]) -> HashMap<i64, DateTime<FixedOffset>> {
-        let offset = FixedOffset::east_opt(0).unwrap();
-        times
-            .iter()
-            .map(|dt| (dt.timestamp_millis(), dt.with_timezone(&offset)))
-            .collect()
+    fn utc_tz() -> Timezone {
+        Timezone::parse(Some("UTC")).unwrap()
     }
 
     fn entry_at(dt: DateTime<Utc>, input: i64) -> RawEntry {
@@ -786,14 +774,22 @@ mod tests {
 
     #[test]
     fn aggregate_blocks_empty() {
-        let result = aggregate_blocks(vec![], &HashMap::new());
+        let result = aggregate_blocks(vec![], utc_tz());
         assert!(result.is_empty());
     }
 
     #[test]
     fn aggregate_blocks_skips_missing_timestamps() {
-        let entries = vec![make_entry("2025-01-01", "s1", "p1", "claude", 100, 50, 999)];
-        let result = aggregate_blocks(entries, &HashMap::new());
+        let entries = vec![make_entry(
+            "2025-01-01",
+            "s1",
+            "p1",
+            "claude",
+            100,
+            50,
+            i64::MAX,
+        )];
+        let result = aggregate_blocks(entries, utc_tz());
         assert!(result.is_empty());
     }
 
@@ -805,10 +801,9 @@ mod tests {
         let t1 = utc(2, 30);
         let t2 = utc(6, 0);
         let t3 = utc(8, 0);
-        let local_times = utc_local_map(&[t1, t2, t3]);
         let entries = vec![entry_at(t1, 100), entry_at(t2, 200), entry_at(t3, 300)];
 
-        let result = aggregate_blocks(entries, &local_times);
+        let result = aggregate_blocks(entries, utc_tz());
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].block_start, "2025-01-01 02:00");
         assert_eq!(result[0].block_end, "07:00");
@@ -822,10 +817,9 @@ mod tests {
     fn aggregate_blocks_sorted_chronologically() {
         let early = utc(1, 0);
         let late = utc(22, 0);
-        let local_times = utc_local_map(&[early, late]);
         let entries = vec![entry_at(late, 100), entry_at(early, 100)];
 
-        let result = aggregate_blocks(entries, &local_times);
+        let result = aggregate_blocks(entries, utc_tz());
         assert_eq!(result[0].block_start, "2025-01-01 01:00");
         assert_eq!(result[1].block_start, "2025-01-01 22:00");
     }
@@ -835,8 +829,7 @@ mod tests {
         // 10:55 UTC and 11:10 UTC same day → one window starting 10:00 UTC.
         let t1 = utc(10, 55);
         let t2 = utc(11, 10);
-        let local_times = utc_local_map(&[t1, t2]);
-        let result = aggregate_blocks(vec![entry_at(t1, 100), entry_at(t2, 200)], &local_times);
+        let result = aggregate_blocks(vec![entry_at(t1, 100), entry_at(t2, 200)], utc_tz());
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].block_start, "2025-01-01 10:00");
         assert_eq!(result[0].block_end, "15:00");
@@ -848,8 +841,7 @@ mod tests {
         // 10:55 UTC then 16:10 UTC (>5h after the 10:00 start) → two windows.
         let t1 = utc(10, 55);
         let t2 = utc(16, 10);
-        let local_times = utc_local_map(&[t1, t2]);
-        let result = aggregate_blocks(vec![entry_at(t1, 100), entry_at(t2, 200)], &local_times);
+        let result = aggregate_blocks(vec![entry_at(t1, 100), entry_at(t2, 200)], utc_tz());
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].block_start, "2025-01-01 10:00");
         assert_eq!(result[0].stats.input_tokens, 100);
@@ -862,8 +854,7 @@ mod tests {
         // 10:00 UTC then 16:30 UTC (6.5h gap since last activity) → two windows.
         let t1 = utc(10, 0);
         let t2 = utc(16, 30);
-        let local_times = utc_local_map(&[t1, t2]);
-        let result = aggregate_blocks(vec![entry_at(t1, 100), entry_at(t2, 200)], &local_times);
+        let result = aggregate_blocks(vec![entry_at(t1, 100), entry_at(t2, 200)], utc_tz());
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].block_start, "2025-01-01 10:00");
         assert_eq!(result[1].block_start, "2025-01-01 16:00");
@@ -871,12 +862,22 @@ mod tests {
 
     #[test]
     fn session_window_labels_convert_floored_utc_to_local() {
-        let offset = FixedOffset::east_opt(9 * 3600).unwrap();
+        let timezone = Timezone::parse(Some("Asia/Tokyo")).unwrap();
         let t1 = Utc.with_ymd_and_hms(2025, 6, 15, 10, 55, 0).unwrap();
-        let local_times = HashMap::from([(t1.timestamp_millis(), t1.with_timezone(&offset))]);
-        let result = aggregate_blocks(vec![entry_at(t1, 100)], &local_times);
+        let result = aggregate_blocks(vec![entry_at(t1, 100)], timezone);
         // 10:00 UTC → 19:00 +09:00; window end 15:00 UTC → 00:00 local.
         assert_eq!(result[0].block_start, "2025-06-15 19:00");
         assert_eq!(result[0].block_end, "00:00");
+    }
+
+    #[test]
+    fn session_window_labels_convert_start_and_end_independently_across_dst() {
+        // DST ends 2025-11-02 02:00 America/New_York (07:00 UTC).
+        // 04:30Z floors to 04:00Z = 00:00 EDT; window end 09:00Z = 04:00 EST.
+        let timezone = Timezone::parse(Some("America/New_York")).unwrap();
+        let t1 = Utc.with_ymd_and_hms(2025, 11, 2, 4, 30, 0).unwrap();
+        let result = aggregate_blocks(vec![entry_at(t1, 100)], timezone);
+        assert_eq!(result[0].block_start, "2025-11-02 00:00");
+        assert_eq!(result[0].block_end, "04:00");
     }
 }

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -334,7 +334,7 @@ pub(crate) struct ProjectStats {
     pub(crate) models: HashMap<String, Stats>,
 }
 
-/// 5-hour billing block statistics
+/// Estimated 5-hour session window statistics (inferred from local logs; not an official billing reset)
 #[derive(Debug, Default, Clone)]
 pub(crate) struct BlockStats {
     pub(crate) block_start: String,

--- a/src/output/blocks.rs
+++ b/src/output/blocks.rs
@@ -223,7 +223,7 @@ pub(crate) fn print_block_table(
         table.add_row(row);
     }
 
-    println!("\n  {source_label} 5-Hour Billing Blocks\n");
+    println!("\n  {source_label} Estimated 5-Hour Session Windows\n");
     println!("{table}");
     if show_cost && has_estimated_cost {
         println!(

--- a/src/source/loader.rs
+++ b/src/source/loader.rs
@@ -483,12 +483,12 @@ impl<'a> DataLoader<'a> {
         if !self.quiet {
             if skipped > 0 {
                 eprintln!(
-                    "Found {} billing blocks after deduplicating {} entries",
+                    "Found {} estimated session windows after deduplicating {} entries",
                     blocks.len(),
                     skipped
                 );
             } else {
-                eprintln!("Found {} billing blocks", blocks.len());
+                eprintln!("Found {} estimated session windows", blocks.len());
             }
         }
 

--- a/src/source/loader.rs
+++ b/src/source/loader.rs
@@ -14,7 +14,7 @@ use crate::source::Source;
 use crate::utils::Timezone;
 #[cfg(test)]
 use chrono::NaiveDate;
-use chrono::{DateTime, FixedOffset, Utc};
+use chrono::{DateTime, Utc};
 
 /// Load data from a source
 pub(super) struct DataLoader<'a> {
@@ -469,16 +469,7 @@ impl<'a> DataLoader<'a> {
             return Vec::new();
         }
 
-        // Build local time map for block calculation
-        let mut local_times: HashMap<i64, DateTime<FixedOffset>> = HashMap::new();
-        for entry in &final_entries {
-            if let Some(utc_dt) = DateTime::<Utc>::from_timestamp_millis(entry.timestamp_ms) {
-                let local_dt = timezone.to_fixed_offset(utc_dt);
-                local_times.insert(entry.timestamp_ms, local_dt);
-            }
-        }
-
-        let blocks = aggregate_blocks(final_entries, &local_times);
+        let blocks = aggregate_blocks(final_entries, timezone);
 
         if !self.quiet {
             if skipped > 0 {

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -506,7 +506,7 @@ impl SourceDiagnostic {
 pub(crate) struct Capabilities {
     /// Supports project-level aggregation
     pub(crate) has_projects: bool,
-    /// Supports 5-hour billing block aggregation
+    /// Supports 5-hour estimated session window aggregation
     pub(crate) has_billing_blocks: bool,
     /// Has reasoning tokens (e.g., o1 models)
     pub(crate) has_reasoning_tokens: bool,

--- a/tests/cli_claude.rs
+++ b/tests/cli_claude.rs
@@ -181,14 +181,13 @@ fn claude_blocks_json_groups_by_5h_window() {
     let root = unique_temp_dir("claude-blocks");
     let session = root.join(".claude/projects/myapp/session-blocks.jsonl");
 
-    // Entry at 10:00 UTC → block 10:00-15:00
-    // Entry at 14:30 UTC → same block 10:00-15:00
-    // Entry at 15:00 UTC → block 15:00-20:00
+    // Activity-driven windows: 10:00 floors to 10:00, lasts until 15:00.
+    // 14:30 stays in that window. 15:00:01 exceeds it and floors to 15:00.
     write_file(
         &session,
         r#"{"timestamp":"2026-02-06T10:00:00Z","message":{"id":"msg_a","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
 {"timestamp":"2026-02-06T14:30:00Z","message":{"id":"msg_b","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":200,"output_tokens":100,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
-{"timestamp":"2026-02-06T15:00:00Z","message":{"id":"msg_c","model":"claude-4-opus-20250514","stop_reason":"end_turn","usage":{"input_tokens":300,"output_tokens":150,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+{"timestamp":"2026-02-06T15:00:01Z","message":{"id":"msg_c","model":"claude-4-opus-20250514","stop_reason":"end_turn","usage":{"input_tokens":300,"output_tokens":150,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
 "#,
     );
 
@@ -660,12 +659,11 @@ fn claude_blocks_csv_outputs_correct_format() {
     let root = unique_temp_dir("claude-csv-blocks");
     let session = root.join(".claude/projects/myapp/session-blocks.jsonl");
 
-    // Entry at 10:00 UTC → block 10:00-15:00
-    // Entry at 15:00 UTC → block 15:00-20:00
+    // 10:00 starts a window until 15:00. 15:00:01 exceeds it (15:00 exact would stay).
     write_file(
         &session,
         r#"{"timestamp":"2026-02-06T10:00:00Z","message":{"id":"msg_a","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":10,"cache_read_input_tokens":20}}}
-{"timestamp":"2026-02-06T15:00:00Z","message":{"id":"msg_b","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":300,"output_tokens":150,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+{"timestamp":"2026-02-06T15:00:01Z","message":{"id":"msg_b","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":300,"output_tokens":150,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
 "#,
     );
 


### PR DESCRIPTION
## Summary
- Replace clock-aligned `hour() / 5 * 5` (00/05/10/15/20) buckets with ccusage-style activity-driven 5-hour estimated session windows: floor first activity to the UTC hour, the window lasts 5 hours from that start, and a new window opens when activity is more than 5 hours after the start or after the previous entry.
- Display `block_start` / `block_end` in the existing local timezone. Copy now says these are estimated session windows inferred from local logs, not an official Anthropic billing reset. Gap placeholders, `--active`, and burn-rate projection are not added. `has_billing_blocks` is unchanged.

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes
- [x] Unit fixtures: 10:55+11:10 UTC → one window at 10:00; 10:55 then 16:10 → two windows; 10:00 then 16:30 (6h+ gap) → two windows
- [x] CLI Claude `blocks` JSON/CSV tests updated for exclusive 5-hour window close (`>` not `>=`)

Fixes #135