### PR TITLE
feat: add --source-breakdown for --source all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- `--source-breakdown` for `--source all` (per-source subtotals + combined total). Default combined output unchanged.
+- `--source-breakdown` for `--source all` (per-source subtotals + combined total). Default combined output unchanged. Monthly `--monthly-budget --csv` keeps budget columns.
 - Expose `cache_creation_1h_tokens` in JSON, CSV, and SDK `TokenBreakdown`. `cache_creation_tokens` remains the inclusive cache-creation total; the 1-hour figure is a billed subset, not a sixth token bucket.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `--source-breakdown` for `--source all` (per-source subtotals + combined total). Default combined output unchanged.
 - Expose `cache_creation_1h_tokens` in JSON, CSV, and SDK `TokenBreakdown`. `cache_creation_tokens` remains the inclusive cache-creation total; the 1-hour figure is a billed subset, not a sixth token bucket.
 
 ### Changed

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,14 +1,13 @@
 mod codex_scope;
 mod cost_coverage;
 mod period_table;
+mod source_breakdown;
 
 use std::collections::HashMap;
-use std::time::Instant;
 
 use crate::cli::{Cli, SourceCommand, TopDimension};
 use crate::core::{
     BlockStats, DateFilter, LoadResult, ProjectStats, SessionStats, ToolSummary, aggregate_tools,
-    apply_real_token_totals_for_all_source, merge_day_stats,
 };
 use crate::output::NumberFormat;
 use crate::output::{
@@ -24,9 +23,8 @@ use crate::output::{
 };
 use crate::pricing::{CostDisplayMode, PricingDb};
 use crate::source::{
-    Capabilities, CodexScope, CostCoverage, GrokCostReport, Source, all_capabilities, all_sources,
-    load_blocks, load_daily, load_grok_daily_with_cost, load_projects, load_sessions,
-    load_tool_calls,
+    Capabilities, CodexScope, CostCoverage, GrokCostReport, Source, load_blocks, load_daily,
+    load_grok_daily_with_cost, load_projects, load_sessions, load_tool_calls,
 };
 use crate::utils::{Timezone, filter_json};
 
@@ -73,7 +71,10 @@ fn source_label(source: &dyn Source, ctx: &CommandContext<'_>) -> String {
     }
 }
 
-fn should_render_empty_structured_result(result: &LoadResult, ctx: &CommandContext<'_>) -> bool {
+pub(super) fn should_render_empty_structured_result(
+    result: &LoadResult,
+    ctx: &CommandContext<'_>,
+) -> bool {
     result.day_stats.is_empty()
         && result.data_quality().has_warnings()
         && matches!(
@@ -621,27 +622,8 @@ pub(crate) fn handle_source_command(
 }
 
 fn load_all_daily(ctx: &CommandContext<'_>, quiet: bool) -> (LoadResult, Capabilities) {
-    let start = Instant::now();
-    let mut combined = LoadResult::default();
-    let caps = all_capabilities();
-
-    for source in all_sources() {
-        let result = load_daily(source, ctx.filter, ctx.timezone, quiet, ctx.cli.debug);
-        combined.skipped += result.skipped;
-        combined.valid += result.valid;
-        combined.parse_errors += result.parse_errors;
-        merge_day_stats(&mut combined.day_stats, result.day_stats);
-    }
-
-    // Default all-source token columns are CostKind::Real only. Keep
-    // estimated_proxy populated so estimated_cost still reports proxy rows
-    // (e.g. Grok context snapshots). Display buckets are already real, so
-    // callers must use CostDisplayMode::Total — RealOnly would subtract
-    // estimated_proxy a second time.
-    apply_real_token_totals_for_all_source(&mut combined.day_stats);
-
-    combined.elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
-    (combined, caps)
+    let loaded = source_breakdown::load_all_sources(ctx, quiet, false);
+    (loaded.combined, loaded.caps)
 }
 
 fn handle_all_period(command: SourceCommand, ctx: &CommandContext<'_>) {
@@ -651,6 +633,11 @@ fn handle_all_period(command: SourceCommand, ctx: &CommandContext<'_>) {
         SourceCommand::Monthly => Period::Month,
         _ => return,
     };
+
+    if ctx.cli.source_breakdown {
+        source_breakdown::render(period, ctx);
+        return;
+    }
 
     let (result, caps) = load_all_daily(ctx, false);
     if result.day_stats.is_empty() && !should_render_empty_structured_result(&result, ctx) {

--- a/src/app/source_breakdown.rs
+++ b/src/app/source_breakdown.rs
@@ -1,0 +1,296 @@
+//! Per-source subtotals for `--source all --source-breakdown`.
+
+use std::time::Instant;
+
+use serde_json::{Value, json};
+
+use super::{
+    CommandContext, cost_coverage, period_table, print_json, print_no_data_hint,
+    should_render_empty_structured_result,
+};
+use crate::core::{LoadResult, apply_real_token_totals_for_all_source, merge_day_stats};
+use crate::output::{
+    OutputFormat, Period, PeriodSummaryFooter, TokenTableOptions, add_monthly_budget_to_json,
+    append_data_quality_csv_comment, csv_escape, monthly_budget_reports,
+    output_period_csv_with_quality, output_period_json_with_quality, print_period_table,
+};
+use crate::pricing::CostDisplayMode;
+use crate::source::{Capabilities, CostCoverage, all_capabilities, all_sources, load_daily};
+
+pub(super) struct SourceSection {
+    name: &'static str,
+    display_name: &'static str,
+    result: LoadResult,
+}
+
+pub(super) struct AllSourceLoad {
+    pub(super) combined: LoadResult,
+    pub(super) caps: Capabilities,
+    sections: Vec<SourceSection>,
+}
+
+pub(super) fn load_all_sources(
+    ctx: &CommandContext<'_>,
+    quiet: bool,
+    keep_sections: bool,
+) -> AllSourceLoad {
+    let start = Instant::now();
+    let mut combined = LoadResult::default();
+    let caps = all_capabilities();
+    let mut sections = Vec::new();
+
+    for source in all_sources() {
+        let mut result = load_daily(source, ctx.filter, ctx.timezone, quiet, ctx.cli.debug);
+        if keep_sections {
+            apply_real_token_totals_for_all_source(&mut result.day_stats);
+        }
+        combined.skipped += result.skipped;
+        combined.valid += result.valid;
+        combined.parse_errors += result.parse_errors;
+        if keep_sections && !result.day_stats.is_empty() {
+            merge_day_stats(&mut combined.day_stats, result.day_stats.clone());
+            sections.push(SourceSection {
+                name: source.name(),
+                display_name: source.display_name(),
+                result,
+            });
+        } else {
+            merge_day_stats(&mut combined.day_stats, result.day_stats);
+        }
+    }
+
+    if !keep_sections {
+        // Default all-source token columns are CostKind::Real only. Keep
+        // estimated_proxy populated so estimated_cost still reports proxy rows
+        // (e.g. Grok context snapshots). Display buckets are already real, so
+        // callers must use CostDisplayMode::Total — RealOnly would subtract
+        // estimated_proxy a second time.
+        apply_real_token_totals_for_all_source(&mut combined.day_stats);
+    }
+
+    combined.elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+    AllSourceLoad {
+        combined,
+        caps,
+        sections,
+    }
+}
+
+pub(super) fn render(period: Period, ctx: &CommandContext<'_>) {
+    let loaded = load_all_sources(ctx, false, true);
+    if loaded.combined.day_stats.is_empty()
+        && !should_render_empty_structured_result(&loaded.combined, ctx)
+    {
+        print_no_data_hint("All Sources", "usage");
+        return;
+    }
+
+    match ctx.cli.output_format() {
+        OutputFormat::Csv => render_csv(&loaded, period, ctx),
+        OutputFormat::Json => render_json(&loaded, period, ctx),
+        OutputFormat::Table => render_table(&loaded, period, ctx),
+    }
+}
+
+fn period_json(
+    result: &LoadResult,
+    period: Period,
+    caps: &Capabilities,
+    ctx: &CommandContext<'_>,
+) -> String {
+    output_period_json_with_quality(
+        &result.day_stats,
+        period,
+        ctx.pricing_db,
+        ctx.cli.sort_order(),
+        ctx.cli.breakdown,
+        ctx.cli.show_cost(),
+        caps.has_cache_read,
+        ctx.currency,
+        Some(result.data_quality()),
+        CostDisplayMode::Total,
+    )
+}
+
+fn period_csv(
+    result: &LoadResult,
+    period: Period,
+    caps: &Capabilities,
+    ctx: &CommandContext<'_>,
+) -> String {
+    output_period_csv_with_quality(
+        &result.day_stats,
+        period,
+        ctx.pricing_db,
+        ctx.cli.sort_order(),
+        ctx.cli.breakdown,
+        ctx.cli.show_cost(),
+        caps.has_cache_read,
+        ctx.currency,
+        None,
+        CostDisplayMode::Total,
+    )
+}
+
+fn parse_json_value(json: &str) -> Value {
+    serde_json::from_str(json).unwrap_or_else(|_| json!([]))
+}
+
+fn render_json(loaded: &AllSourceLoad, period: Period, ctx: &CommandContext<'_>) {
+    let monthly_budget = (period == Period::Month)
+        .then_some(ctx.cli.monthly_budget)
+        .flatten();
+
+    let sources: Vec<Value> = loaded
+        .sections
+        .iter()
+        .map(|section| {
+            let json = period_json(&section.result, period, &loaded.caps, ctx);
+            let json = cost_coverage::annotate_json(&json, &section.result.day_stats, period, None);
+            json!({
+                "source": section.name,
+                "rows": parse_json_value(&json),
+            })
+        })
+        .collect();
+
+    let mut total = period_json(&loaded.combined, period, &loaded.caps, ctx);
+    if let Some(budget) = monthly_budget {
+        let reports = monthly_budget_reports(
+            &loaded.combined.day_stats,
+            ctx.pricing_db,
+            ctx.cli.sort_order(),
+            budget,
+            ctx.budget_as_of,
+            ctx.currency,
+            CostDisplayMode::Total,
+        );
+        total = add_monthly_budget_to_json(&total, &reports);
+    }
+    total = cost_coverage::annotate_json(&total, &loaded.combined.day_stats, period, None);
+
+    let wrapped = json!({
+        "sources": sources,
+        "total": parse_json_value(&total),
+    });
+    let json = serde_json::to_string(&wrapped).unwrap_or_else(|e| {
+        eprintln!("Failed to serialize JSON output: {e}");
+        "{}".to_string()
+    });
+    print_json(&json, ctx.jq_filter);
+}
+
+fn with_source_column(csv: &str, source: &str) -> String {
+    let mut out = String::new();
+    let mut header_written = false;
+    for line in csv.lines() {
+        if line.starts_with('#') || line.is_empty() {
+            out.push_str(line);
+            out.push('\n');
+            continue;
+        }
+        if header_written {
+            out.push_str(&csv_escape(source));
+            out.push(',');
+            out.push_str(line);
+            out.push('\n');
+        } else {
+            out.push_str("source,");
+            out.push_str(line);
+            out.push('\n');
+            header_written = true;
+        }
+    }
+    out
+}
+
+fn render_csv(loaded: &AllSourceLoad, period: Period, ctx: &CommandContext<'_>) {
+    let mut csv = String::new();
+    for (index, section) in loaded.sections.iter().enumerate() {
+        if index > 0 {
+            csv.push('\n');
+        }
+        csv.push_str(&with_source_column(
+            &period_csv(&section.result, period, &loaded.caps, ctx),
+            section.name,
+        ));
+    }
+    if !loaded.sections.is_empty() {
+        csv.push('\n');
+    }
+    csv.push_str(&with_source_column(
+        &period_csv(&loaded.combined, period, &loaded.caps, ctx),
+        "total",
+    ));
+    append_data_quality_csv_comment(&mut csv, Some(loaded.combined.data_quality()));
+    let coverage =
+        CostCoverage::from_stats(loaded.combined.day_stats.values().map(|day| &day.stats));
+    let csv = cost_coverage::annotate_csv(csv, coverage, None);
+    print!("{csv}");
+}
+
+fn table_options<'a>(caps: &Capabilities, ctx: &'a CommandContext<'a>) -> TokenTableOptions<'a> {
+    TokenTableOptions {
+        order: ctx.cli.sort_order(),
+        use_color: ctx.cli.use_color(),
+        compact: ctx.cli.compact,
+        show_cost: ctx.cli.show_cost(),
+        number_format: ctx.number_format,
+        show_reasoning: caps.has_reasoning_tokens,
+        show_cache_creation: caps.has_cache_creation,
+        supports_cache_read: caps.has_cache_read,
+        currency: ctx.currency,
+        cost_mode: CostDisplayMode::Total,
+        cost_label: "Cost",
+        cost_display_overrides: None,
+        total_cost_display_override: None,
+        secondary_cost_label: None,
+        secondary_cost_display_overrides: None,
+        secondary_total_cost_display_override: None,
+        pricing_note_override: None,
+    }
+}
+
+fn print_section_table(
+    result: &LoadResult,
+    period: Period,
+    caps: &Capabilities,
+    ctx: &CommandContext<'_>,
+    heading: &str,
+) {
+    println!("\n  {heading}");
+    print_period_table(
+        &result.day_stats,
+        period,
+        ctx.cli.breakdown,
+        PeriodSummaryFooter {
+            skipped: result.skipped,
+            valid: result.valid,
+            elapsed_ms: Some(result.elapsed_ms),
+        },
+        ctx.pricing_db,
+        table_options(caps, ctx),
+    );
+}
+
+fn render_table(loaded: &AllSourceLoad, period: Period, ctx: &CommandContext<'_>) {
+    for section in &loaded.sections {
+        print_section_table(
+            &section.result,
+            period,
+            &loaded.caps,
+            ctx,
+            section.display_name,
+        );
+    }
+    println!("\n  All Sources");
+    period_table::render(
+        &loaded.combined,
+        period,
+        &loaded.caps,
+        None,
+        None,
+        ctx,
+        CostDisplayMode::Total,
+    );
+}

--- a/src/app/source_breakdown.rs
+++ b/src/app/source_breakdown.rs
@@ -10,9 +10,10 @@ use super::{
 };
 use crate::core::{LoadResult, apply_real_token_totals_for_all_source, merge_day_stats};
 use crate::output::{
-    OutputFormat, Period, PeriodSummaryFooter, TokenTableOptions, add_monthly_budget_to_json,
-    append_data_quality_csv_comment, csv_escape, monthly_budget_reports,
-    output_period_csv_with_quality, output_period_json_with_quality, print_period_table,
+    MonthlyBudgetOptions, OutputFormat, Period, PeriodSummaryFooter, TokenTableOptions,
+    add_monthly_budget_to_json, append_data_quality_csv_comment, csv_escape,
+    monthly_budget_reports, output_monthly_budget_csv, output_period_csv_with_quality,
+    output_period_json_with_quality, print_period_table,
 };
 use crate::pricing::CostDisplayMode;
 use crate::source::{Capabilities, CostCoverage, all_capabilities, all_sources, load_daily};
@@ -118,6 +119,24 @@ fn period_csv(
     caps: &Capabilities,
     ctx: &CommandContext<'_>,
 ) -> String {
+    if period == Period::Month
+        && let Some(budget) = ctx.cli.monthly_budget
+    {
+        return output_monthly_budget_csv(
+            &result.day_stats,
+            ctx.pricing_db,
+            MonthlyBudgetOptions {
+                order: ctx.cli.sort_order(),
+                breakdown: ctx.cli.breakdown,
+                show_cost: ctx.cli.show_cost(),
+                supports_cache_read: caps.has_cache_read,
+                limit: budget,
+                as_of: ctx.budget_as_of,
+                currency: ctx.currency,
+                cost_mode: CostDisplayMode::Total,
+            },
+        );
+    }
     output_period_csv_with_quality(
         &result.day_stats,
         period,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -64,6 +64,10 @@ pub(crate) struct Cli {
     #[arg(short, long, global = true)]
     pub(crate) breakdown: bool,
 
+    /// Show per-source subtotals with `--source all` (plus the combined total)
+    #[arg(long, global = true)]
+    pub(crate) source_breakdown: bool,
+
     /// Output as JSON
     #[arg(short, long, global = true)]
     pub(crate) json: bool,
@@ -535,6 +539,14 @@ mod tests {
     fn output_format_csv_wins_over_json_flag() {
         let cli = Cli::parse_from(["ccstats", "daily", "--json", "--csv"]);
         assert_eq!(cli.output_format(), OutputFormat::Csv);
+    }
+
+    #[test]
+    fn source_breakdown_flag_parses() {
+        let cli = Cli::parse_from(["ccstats", "daily", "--source", "all", "--source-breakdown"]);
+        assert!(cli.source_breakdown);
+        let cli = Cli::parse_from(["ccstats", "daily", "--source", "all"]);
+        assert!(!cli.source_breakdown);
     }
 
     #[test]

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -155,6 +155,33 @@ impl SourceCommand {
     pub(crate) fn needs_today_filter(self) -> bool {
         matches!(self, SourceCommand::Today | SourceCommand::Statusline)
     }
+
+    /// CLI subcommand token used in user-facing errors.
+    pub(crate) fn cli_name(self) -> &'static str {
+        match self {
+            Self::Doctor => "doctor",
+            Self::Sources => "sources",
+            Self::Daily => "daily",
+            Self::Weekly => "weekly",
+            Self::Quota => "quota",
+            Self::Monthly => "monthly",
+            Self::Today => "today",
+            Self::Session => "session",
+            Self::Project => "project",
+            Self::Blocks => "blocks",
+            Self::Endpoints => "endpoints",
+            Self::Statusline => "statusline",
+            Self::Tools => "tools",
+            Self::Top { .. } => "top",
+        }
+    }
+
+    pub(crate) fn supports_source_breakdown(self) -> bool {
+        matches!(
+            self,
+            Self::Daily | Self::Weekly | Self::Monthly | Self::Today
+        )
+    }
 }
 
 impl From<&Commands> for SourceCommand {
@@ -334,5 +361,32 @@ mod tests {
         let parsed = parse_command(Some(&Commands::Doctor));
         assert_eq!(parsed.command, SourceCommand::Doctor);
         assert_eq!(parsed.source_hint, None);
+    }
+
+    #[test]
+    fn source_breakdown_supported_only_for_period_views() {
+        assert!(SourceCommand::Daily.supports_source_breakdown());
+        assert!(SourceCommand::Weekly.supports_source_breakdown());
+        assert!(SourceCommand::Monthly.supports_source_breakdown());
+        assert!(SourceCommand::Today.supports_source_breakdown());
+        assert!(!SourceCommand::Session.supports_source_breakdown());
+        assert!(!SourceCommand::Statusline.supports_source_breakdown());
+        assert!(
+            !SourceCommand::Top {
+                dim: TopDimension::Model,
+                limit: 10
+            }
+            .supports_source_breakdown()
+        );
+        assert_eq!(SourceCommand::Session.cli_name(), "session");
+        assert_eq!(SourceCommand::Statusline.cli_name(), "statusline");
+        assert_eq!(
+            SourceCommand::Top {
+                dim: TopDimension::Model,
+                limit: 3
+            }
+            .cli_name(),
+            "top"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,6 +249,23 @@ fn load_currency_converter(
     })
 }
 
+fn validate_source_breakdown(cli: &Cli, source_name: &str, source_cmd: SourceCommand) {
+    if !cli.source_breakdown {
+        return;
+    }
+    if !source_cmd.supports_source_breakdown() {
+        eprintln!(
+            "Error: {} does not support --source-breakdown",
+            source_cmd.cli_name()
+        );
+        std::process::exit(1);
+    }
+    if !source_name.eq_ignore_ascii_case(ALL_SOURCES) {
+        eprintln!("Error: --source-breakdown requires --source all");
+        std::process::exit(1);
+    }
+}
+
 fn validate_codex_scope(scope: CodexScope, source_name: &str) {
     if scope == CodexScope::All {
         return;
@@ -339,6 +356,7 @@ pub fn run_cli() {
         cli.source.as_deref(),
         source_cmd,
     );
+    validate_source_breakdown(&cli, source_name, source_cmd);
     validate_codex_scope(cli.codex_scope, source_name);
     let needs_currency = source_cmd != SourceCommand::Quota && needs_pricing;
     let currency_converter = load_currency_converter(&cli, needs_currency, is_statusline);

--- a/tests/cli_codex_source_routing.rs
+++ b/tests/cli_codex_source_routing.rs
@@ -386,19 +386,7 @@ fn source_flag_can_select_codex_without_subcommand() {
 fn source_all_daily_json_merges_registered_sources() {
     let root = unique_temp_dir("source-all-daily");
     let codex_home = root.join("codex-home");
-    let claude_session = root.join(".claude/projects/myapp/claude-session.jsonl");
-    let codex_session = codex_home.join("sessions").join("codex-session.jsonl");
-
-    write_file(
-        &claude_session,
-        r#"{"timestamp":"2026-02-06T10:00:00Z","message":{"id":"msg_1","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
-"#,
-    );
-    write_file(
-        &codex_session,
-        r#"{"timestamp":"2026-02-06T11:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":0,"total_tokens":15},"last_token_usage":{"input_tokens":10,"cached_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":0,"total_tokens":15},"model":"gpt-5"}}}
-"#,
-    );
+    write_claude_and_codex_daily_fixture(&root, &codex_home);
 
     let (ok, stdout, stderr) = run_ccstats(
         &[
@@ -438,6 +426,127 @@ fn source_all_daily_json_merges_registered_sources() {
     assert!(models.iter().any(|model| model.as_str() == Some("gpt-5")));
 
     let _ = fs::remove_dir_all(root);
+}
+
+fn write_claude_and_codex_daily_fixture(root: &Path, codex_home: &Path) {
+    write_file(
+        &root.join(".claude/projects/myapp/claude-session.jsonl"),
+        r#"{"timestamp":"2026-02-06T10:00:00Z","message":{"id":"msg_1","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+"#,
+    );
+    write_file(
+        &codex_home.join("sessions").join("codex-session.jsonl"),
+        r#"{"timestamp":"2026-02-06T11:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":0,"total_tokens":15},"last_token_usage":{"input_tokens":10,"cached_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":0,"total_tokens":15},"model":"gpt-5"}}}
+"#,
+    );
+}
+
+#[test]
+fn source_all_daily_json_source_breakdown_wraps_per_source_and_total() {
+    let root = unique_temp_dir("source-all-daily-breakdown");
+    let codex_home = root.join("codex-home");
+    write_claude_and_codex_daily_fixture(&root, &codex_home);
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "--source",
+            "all",
+            "--source-breakdown",
+            "-j",
+            "-O",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("HOME", &root), ("CODEX_HOME", &codex_home)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let json: Value = serde_json::from_slice(&stdout).expect("json");
+    assert!(
+        json.is_object(),
+        "flag wraps JSON; default remains an array"
+    );
+    let sources = json["sources"].as_array().expect("sources");
+    assert!(
+        sources.len() >= 2,
+        "expected per-source sections, got {sources:?}"
+    );
+    let names: Vec<&str> = sources
+        .iter()
+        .filter_map(|entry| entry["source"].as_str())
+        .collect();
+    assert!(names.contains(&"claude"), "sources: {names:?}");
+    assert!(names.contains(&"codex"), "sources: {names:?}");
+
+    let claude = sources
+        .iter()
+        .find(|entry| entry["source"] == "claude")
+        .expect("claude section");
+    assert_eq!(claude["rows"][0]["total_tokens"].as_i64(), Some(150));
+    let codex = sources
+        .iter()
+        .find(|entry| entry["source"] == "codex")
+        .expect("codex section");
+    assert_eq!(codex["rows"][0]["total_tokens"].as_i64(), Some(15));
+
+    let total = json["total"].as_array().expect("total");
+    assert_eq!(total[0]["date"].as_str(), Some("2026-02-06"));
+    assert_eq!(total[0]["total_tokens"].as_i64(), Some(165));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn source_breakdown_with_source_claude_errors() {
+    let (ok, _stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "--source",
+            "claude",
+            "--source-breakdown",
+            "-O",
+            "--no-cost",
+        ],
+        &[],
+    );
+    assert!(
+        !ok,
+        "expected --source-breakdown without --source all to fail"
+    );
+    let stderr = String::from_utf8_lossy(&stderr);
+    assert!(
+        stderr.contains("--source-breakdown requires --source all"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn source_breakdown_rejected_for_session_statusline_and_top() {
+    for command in ["session", "statusline", "top"] {
+        let (ok, _stdout, stderr) = run_ccstats(
+            &[
+                command,
+                "--source",
+                "all",
+                "--source-breakdown",
+                "-O",
+                "--no-cost",
+            ],
+            &[],
+        );
+        assert!(!ok, "expected {command} to reject --source-breakdown");
+        let stderr = String::from_utf8_lossy(&stderr);
+        assert!(
+            stderr.contains(&format!("{command} does not support --source-breakdown")),
+            "stderr for {command}: {stderr}"
+        );
+    }
 }
 
 #[test]

--- a/tests/cli_codex_source_routing.rs
+++ b/tests/cli_codex_source_routing.rs
@@ -473,16 +473,23 @@ fn source_all_daily_json_source_breakdown_wraps_per_source_and_total() {
         "flag wraps JSON; default remains an array"
     );
     let sources = json["sources"].as_array().expect("sources");
-    assert!(
-        sources.len() >= 2,
-        "expected per-source sections, got {sources:?}"
-    );
     let names: Vec<&str> = sources
         .iter()
         .filter_map(|entry| entry["source"].as_str())
         .collect();
-    assert!(names.contains(&"claude"), "sources: {names:?}");
-    assert!(names.contains(&"codex"), "sources: {names:?}");
+    assert_eq!(
+        names,
+        vec!["claude", "codex"],
+        "empty sources must be omitted"
+    );
+    for entry in sources {
+        let rows = entry["rows"].as_array().expect("rows");
+        assert!(
+            !rows.is_empty(),
+            "empty source leaked into breakdown: {}",
+            entry["source"]
+        );
+    }
 
     let claude = sources
         .iter()
@@ -498,6 +505,57 @@ fn source_all_daily_json_source_breakdown_wraps_per_source_and_total() {
     let total = json["total"].as_array().expect("total");
     assert_eq!(total[0]["date"].as_str(), Some("2026-02-06"));
     assert_eq!(total[0]["total_tokens"].as_i64(), Some(165));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn source_all_monthly_csv_source_breakdown_keeps_budget_columns() {
+    let root = unique_temp_dir("source-all-monthly-breakdown-budget");
+    write_file(
+        &root.join(".claude/projects/myapp/claude-session.jsonl"),
+        r#"{"timestamp":"2025-02-10T10:00:00Z","message":{"id":"msg_1","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":1000000,"output_tokens":100000,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+"#,
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "monthly",
+            "--source",
+            "all",
+            "--source-breakdown",
+            "--csv",
+            "-O",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2025-02-01",
+            "--until",
+            "2025-02-10",
+            "--monthly-budget",
+            "10",
+        ],
+        &[("HOME", &root)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let output = String::from_utf8_lossy(&stdout);
+    assert!(
+        output.contains("budget_projected"),
+        "budget columns missing: {output}"
+    );
+    assert!(
+        output.contains("budget_status"),
+        "budget status missing: {output}"
+    );
+    assert!(
+        output.contains("source,month"),
+        "source column missing: {output}"
+    );
+    assert!(
+        output.contains("over_budget"),
+        "budget status row missing: {output}"
+    );
 
     let _ = fs::remove_dir_all(root);
 }


### PR DESCRIPTION
## Summary
- Add opt-in global `--source-breakdown` for `--source all` on daily / weekly / monthly / today. Default combined table/JSON/CSV is unchanged.
- Each source subtotal uses the same `load_daily` + real-only token transform as `--source all` (Grok stays on that path, not `GrokCostReport`). Empty sources are skipped; the existing combined total is still printed.
- `--source-breakdown` without `--source all` exits 1. `statusline` / `top` / `session` (and other non-period views) exit 1 with a one-line unsupported-view error.

## JSON / CSV shape (flag only)

Without the flag, JSON remains an array of period rows.

With `--source-breakdown`:

```json
{
  "sources": [
    { "source": "claude", "rows": [ /* same period-row objects as today */ ] },
    { "source": "codex", "rows": [ /* ... */ ] }
  ],
  "total": [ /* same combined array as default --source all */ ]
}
```

CSV emits sequential tables with a leading `source` column (`claude`, `codex`, …, then `total`). Default CSV is unchanged.

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] Flag absent: `daily --source all -j` stays an array of period rows (`source_all_daily_json_merges_registered_sources`)
- [x] Flag present: JSON has per-source sections plus `total` (`source_all_daily_json_source_breakdown_wraps_per_source_and_total`)
- [x] Flag with `--source claude` errors (`source_breakdown_with_source_claude_errors`)
- [x] `session` / `statusline` / `top` reject the flag

Fixes #144

Made with [Cursor](https://cursor.com)