### PR TITLE
docs: distinguish CLI weekly grouping from SDK ThisWeek

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to this project will be documented in this file.
 - Gemini session JSON last-writes on message id like the JSONL path.
 - Gemini/Google models now load from LiteLLM / fallback instead of N/A.
 
+### Documentation
+- Distinguish CLI `weekly`/`monthly` grouping of filtered history from SDK `UsageRange::ThisWeek`/`ThisMonth` current-period date ranges.
+
 ## [0.5.1] - 2026-08-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -302,6 +302,11 @@ for summary in overview.summaries {
 }
 ```
 
+`UsageRange::ThisWeek` and `ThisMonth` are current-period date filters
+(Monday–today / month-start–today in the selected timezone). They are not the
+CLI `weekly` / `monthly` commands, which group already-filtered history by
+period instead of loading only the current week or month.
+
 ## Usage
 
 ### Claude Code
@@ -313,10 +318,11 @@ ccstats today
 # Daily breakdown
 ccstats daily
 
-# Weekly summary
+# Weekly grouping of history (not "this week")
 ccstats weekly
+ccstats weekly --since 20260901 --until 20260915
 
-# Monthly summary
+# Monthly grouping of history (not "this month")
 ccstats monthly
 
 # By project
@@ -346,6 +352,13 @@ ccstats today --debug
 # Unknown models are reported as: Pricing: <model> -> no match (unknown)
 ccstats today --breakdown --strict-pricing --debug
 ```
+
+`weekly` and `monthly` are aggregation grains: they group already-filtered
+history by week (Monday start) or calendar month. They do not default to the
+current period. Bound dates with `--since` / `--until`. There is no `--current`
+flag. SDK `UsageRange::ThisWeek` / `ThisMonth` are a different concept: those
+filter to the current period in the selected timezone (Monday–today /
+month-start–today).
 
 By default, ccstats checks Claude Code logs under `~/.claude/projects/`.
 If Claude Code uses a moved config directory, set `CLAUDE_CONFIG_DIR` to the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -393,7 +393,13 @@ Preferred file: platform cache dir / `ccstats/pricing.json` (for example `~/Libr
 - Lazy pricing load and 24h cache
 - Streaming JSONL reads
 
+## CLI period grain vs SDK current period
+
+These share English words but are different concepts. Decided in issue [#136](https://github.com/majiayu000/ccstats/issues/136): keep current behavior; no `--current` flag.
+
+- **CLI `weekly` / `monthly`** are aggregation grains. They group already-filtered history by ISO week (Monday start) or calendar month. Only `today` / `statusline` apply a today date filter. Bound dates with `--since` / `--until`.
+- **SDK `UsageRange::ThisWeek` / `ThisMonth`** are current-period date ranges in the selected timezone: Monday–today and month-start–today.
+
 ## Parked (do not invent a fix)
 
 - **`blocks`** are clock-aligned 5-hour windows (`hour() / 5 * 5` → local 00:00 / 05:00 / 10:00 / 15:00 / 20:00), not Anthropic’s rolling billing window. See issue [#135](https://github.com/majiayu000/ccstats/issues/135).
-- **CLI `weekly` vs SDK `ThisWeek`:** `ccstats weekly` loads history (only `today` / `statusline` apply a today filter). SDK `UsageRange::ThisWeek` is Monday–today in the selected timezone. Same English word, different dates. See issue [#136](https://github.com/majiayu000/ccstats/issues/136).

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -49,15 +49,28 @@ impl FromStr for UsageSource {
 }
 
 /// Date or exact UTC timestamp range to summarize.
+///
+/// [`Self::ThisWeek`] and [`Self::ThisMonth`] are **current-period date
+/// filters** in the selected timezone. They are not the CLI `weekly` /
+/// `monthly` commands, which only change aggregation grain over already-filtered
+/// history (bound those with `--since` / `--until`).
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum UsageRange {
     /// Current local day in the selected timezone.
     #[default]
     Today,
-    /// Monday through today in the selected timezone.
+    /// Current week in the selected timezone: Monday through today.
+    ///
+    /// This is a date filter, not the CLI `weekly` command. `ccstats weekly`
+    /// groups already-filtered history by week; bound dates there with
+    /// `--since` / `--until`.
     ThisWeek,
-    /// First day of the current month through today in the selected timezone.
+    /// Current month in the selected timezone: the 1st through today.
+    ///
+    /// This is a date filter, not the CLI `monthly` command. `ccstats monthly`
+    /// groups already-filtered history by month; bound dates there with
+    /// `--since` / `--until`.
     ThisMonth,
     /// Explicit inclusive date range. `None` means unbounded on that side.
     DateRange {


### PR DESCRIPTION
## Summary
- Record the #136 decision: CLI `weekly`/`monthly` are aggregation grains over already-filtered history; bound dates with `--since`/`--until`. No `--current` flag.
- SDK `UsageRange::ThisWeek` / `ThisMonth` remain current-period date filters (Monday–today / month-start–today) in the selected timezone.
- Un-park this in `ARCHITECTURE.md`, clarify README examples and SDK rustdoc, and add a CHANGELOG Documentation note.

## Test plan
- [ ] README `ccstats weekly` / `monthly` examples state grouping vs current-period and show `--since`/`--until`
- [ ] `docs/ARCHITECTURE.md` no longer lists CLI weekly vs SDK ThisWeek as parked/undecided
- [ ] `UsageRange::ThisWeek` / `ThisMonth` rustdoc contrast with CLI commands
- [ ] CHANGELOG `[Unreleased]` Documentation mentions CLI weekly grouping vs SDK ThisWeek
- [ ] No CLI flag or behavior change

Fixes #136

Made with [Cursor](https://cursor.com)