### PR TITLE
feat(sdk): expose Grok API-equivalent estimates

### DIFF
--- a/desktop/src-tauri/src/machines/tests.rs
+++ b/desktop/src-tauri/src/machines/tests.rs
@@ -29,6 +29,7 @@ fn sample_source(today: i64, week: i64, month: i64) -> MultiCostSummary {
         cost_kind: "real".to_string(),
         pricing_source: "recorded".to_string(),
         api_equivalent_cost_coverage: None,
+        grok_api_equivalent_cost: None,
         tokens: TokenBreakdown {
             input_tokens: tokens,
             total_tokens: tokens,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,12 +55,12 @@ pub use catalog::{
 pub use sdk::{
     ApiEquivalentCostCoverage, CodexQuotaError, CodexQuotaStatus, CodexWeeklyQuota,
     CodexWeeklyValueError, CodexWeeklyValueEstimate, CodexWeeklyValueWindow,
-    CodexWeeklyValueWindowError, CostSummary, CurrentUsageWindow, ModelCostSummary,
-    MultiCostSummary, MultiSummaryOptions, SdkError, SummaryOptions, TokenBreakdown, UsageRange,
-    UsageSource, current_usage_date_with_cli_config, current_usage_windows_with_cli_config,
-    estimate_codex_weekly_value, estimate_codex_weekly_value_for_window, load_codex_weekly_quota,
-    summarize_cost, summarize_cost_ranges, summarize_cost_ranges_with_cli_config,
-    summarize_cost_with_cli_config,
+    CodexWeeklyValueWindowError, CostSummary, CurrentUsageWindow, GrokApiEquivalentCostSummary,
+    ModelCostSummary, MultiCostSummary, MultiSummaryOptions, SdkError, SummaryOptions,
+    TokenBreakdown, UsageRange, UsageSource, current_usage_date_with_cli_config,
+    current_usage_windows_with_cli_config, estimate_codex_weekly_value,
+    estimate_codex_weekly_value_for_window, load_codex_weekly_quota, summarize_cost,
+    summarize_cost_ranges, summarize_cost_ranges_with_cli_config, summarize_cost_with_cli_config,
 };
 
 use chrono::{NaiveDate, Utc};

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -18,7 +18,9 @@ use crate::pricing::{
     pricing_source_for_model_stats, pricing_source_for_models, sum_estimated_proxy_model_costs,
     sum_model_costs,
 };
-use crate::source::{CostCoverage, Source, get_source, load_daily};
+use crate::source::{
+    CostCoverage, GrokCostReport, Source, get_source, load_daily, load_grok_daily_with_cost,
+};
 use crate::utils::Timezone;
 
 pub use crate::source::{CodexQuotaError, CodexQuotaStatus, CodexWeeklyQuota, UsageSource};
@@ -233,6 +235,36 @@ impl From<CostCoverage> for ApiEquivalentCostCoverage {
     }
 }
 
+/// Grok API-equivalent cost derived from complete turns and request telemetry.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GrokApiEquivalentCostSummary {
+    pub observed_usd: f64,
+    pub estimated_usd: Option<f64>,
+    pub minimum_usd: Option<f64>,
+    pub maximum_usd: Option<f64>,
+    pub priced_tokens: i64,
+    pub total_tokens: i64,
+    pub coverage_percent: f64,
+    pub coverage_status: String,
+    pub excluded_request_tokens: i64,
+}
+
+impl From<GrokCostReport> for GrokApiEquivalentCostSummary {
+    fn from(report: GrokCostReport) -> Self {
+        Self {
+            observed_usd: report.observed_api_cost_usd,
+            estimated_usd: report.estimated_api_cost_usd(),
+            minimum_usd: report.api_cost_lower_bound_usd,
+            maximum_usd: report.api_cost_upper_bound_usd,
+            priced_tokens: report.priced_tokens,
+            total_tokens: report.total_tokens,
+            coverage_percent: report.coverage_percent(),
+            coverage_status: report.status().to_string(),
+            excluded_request_tokens: report.excluded_request_tokens,
+        }
+    }
+}
+
 /// Structured usage and cost summary for SDK consumers.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CostSummary {
@@ -250,6 +282,7 @@ pub struct CostSummary {
     pub cost_kind: String,
     pub pricing_source: String,
     pub api_equivalent_cost_coverage: Option<ApiEquivalentCostCoverage>,
+    pub grok_api_equivalent_cost: Option<GrokApiEquivalentCostSummary>,
     pub tokens: TokenBreakdown,
     pub models: Vec<ModelCostSummary>,
     pub valid_entries: i64,
@@ -304,9 +337,15 @@ pub fn summarize_cost(options: SummaryOptions) -> Result<CostSummary, SdkError> 
         |conv| conv.currency_code().to_string(),
     );
 
-    let result = load_daily(source, &filter, timezone, true, false);
+    let (result, grok_api_equivalent_cost) = if options.source == UsageSource::Grok {
+        let (result, reports) = load_grok_daily_with_cost(&filter, timezone, true, false);
+        let report = reports.values().copied().reduce(GrokCostReport::merge);
+        (result, report.map(Into::into))
+    } else {
+        (load_daily(source, &filter, timezone, true, false), None)
+    };
     let cost_coverage = CostCoverage::from_stats(result.day_stats.values().map(|day| &day.stats));
-    Ok(build_cost_summary(
+    let mut summary = build_cost_summary(
         options.source,
         source,
         options.range,
@@ -317,7 +356,9 @@ pub fn summarize_cost(options: SummaryOptions) -> Result<CostSummary, SdkError> 
         currency.as_ref(),
         &currency_code,
         cost_coverage,
-    ))
+    );
+    summary.grok_api_equivalent_cost = grok_api_equivalent_cost;
+    Ok(summary)
 }
 
 /// Summarize local token usage using the same reusable config defaults as the CLI.
@@ -475,6 +516,7 @@ pub(in crate::sdk) fn build_cost_summary(
             .as_str()
             .to_string(),
         api_equivalent_cost_coverage: cost_coverage.map(Into::into),
+        grok_api_equivalent_cost: None,
         tokens: TokenBreakdown::from_stats(&stats, supports_cache_read),
         models: summarize_models(&models, pricing_db, currency, supports_cache_read),
         valid_entries: result.valid,

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -317,9 +317,16 @@ pub enum SdkError {
 /// Returns an error when the source or timezone is invalid, or when an explicit
 /// date or timestamp range has `since` after `until`.
 pub fn summarize_cost(options: SummaryOptions) -> Result<CostSummary, SdkError> {
+    summarize_cost_at(options, Utc::now())
+}
+
+pub(super) fn summarize_cost_at(
+    options: SummaryOptions,
+    observed_at: DateTime<Utc>,
+) -> Result<CostSummary, SdkError> {
     let timezone = Timezone::parse(options.timezone.as_deref())
         .map_err(|err| SdkError::Configuration(err.to_string()))?;
-    let today = timezone.to_fixed_offset(Utc::now()).date_naive();
+    let today = timezone.to_fixed_offset(observed_at).date_naive();
     let (since, until) = options.range.resolve(today)?;
     let mut filter = DateFilter::new(since, until);
     if let Some((since_timestamp, until_timestamp)) = options.range.timestamp_bounds() {

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -317,16 +317,9 @@ pub enum SdkError {
 /// Returns an error when the source or timezone is invalid, or when an explicit
 /// date or timestamp range has `since` after `until`.
 pub fn summarize_cost(options: SummaryOptions) -> Result<CostSummary, SdkError> {
-    summarize_cost_at(options, Utc::now())
-}
-
-pub(super) fn summarize_cost_at(
-    options: SummaryOptions,
-    observed_at: DateTime<Utc>,
-) -> Result<CostSummary, SdkError> {
     let timezone = Timezone::parse(options.timezone.as_deref())
         .map_err(|err| SdkError::Configuration(err.to_string()))?;
-    let today = timezone.to_fixed_offset(observed_at).date_naive();
+    let today = timezone.to_fixed_offset(Utc::now()).date_naive();
     let (since, until) = options.range.resolve(today)?;
     let mut filter = DateFilter::new(since, until);
     if let Some((since_timestamp, until_timestamp)) = options.range.timestamp_bounds() {

--- a/src/sdk/batch.rs
+++ b/src/sdk/batch.rs
@@ -5,8 +5,8 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    CostSummary, SdkError, UsageRange, UsageSource, build_cost_summary, load_cli_config,
-    load_requested_currency,
+    CostSummary, SdkError, SummaryOptions, UsageRange, UsageSource, build_cost_summary,
+    load_cli_config, load_requested_currency, summarize_cost,
 };
 use crate::config::Config;
 use crate::consts::DATE_FORMAT;
@@ -70,16 +70,19 @@ struct ResolvedRange {
 
 /// Summarize multiple local token usage ranges while reusing source and pricing work.
 ///
-/// This preserves the ordering of `options.ranges` in `summaries`, resolves
-/// timezone/source/pricing/currency once, scans source files once, and then
-/// applies each range's filtering, deduplication, and aggregation semantics to
-/// the shared parsed entries.
+/// This preserves the ordering of `options.ranges` in `summaries`. Most sources
+/// scan their files once; Grok evaluates each range through the single-range
+/// SDK path so request reconciliation and API-equivalent estimates stay exact.
 ///
 /// # Errors
 ///
 /// Returns an error when no ranges are requested, when the source or timezone is
 /// invalid, or when any explicit date or timestamp range is reversed.
 pub fn summarize_cost_ranges(options: MultiSummaryOptions) -> Result<MultiCostSummary, SdkError> {
+    if options.source == UsageSource::Grok {
+        return summarize_grok_cost_ranges(options);
+    }
+
     let start = Instant::now();
     let MultiSummaryOptions {
         source: usage_source,
@@ -133,6 +136,41 @@ pub fn summarize_cost_ranges(options: MultiSummaryOptions) -> Result<MultiCostSu
         source_name: source.name().to_string(),
         display_name: source.display_name().to_string(),
         currency: currency_code,
+        generated_at: Utc::now().to_rfc3339(),
+        summaries,
+        elapsed_ms: start.elapsed().as_secs_f64() * 1000.0,
+    })
+}
+
+fn summarize_grok_cost_ranges(options: MultiSummaryOptions) -> Result<MultiCostSummary, SdkError> {
+    if options.ranges.is_empty() {
+        return Err(SdkError::Configuration(
+            "at least one usage range is required".to_string(),
+        ));
+    }
+
+    let start = Instant::now();
+    let summaries = options
+        .ranges
+        .into_iter()
+        .map(|range| {
+            summarize_cost(SummaryOptions {
+                source: UsageSource::Grok,
+                range,
+                timezone: options.timezone.clone(),
+                offline: options.offline,
+                strict_pricing: options.strict_pricing,
+                currency: options.currency.clone(),
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let first = &summaries[0];
+
+    Ok(MultiCostSummary {
+        source: UsageSource::Grok,
+        source_name: first.source_name.clone(),
+        display_name: first.display_name.clone(),
+        currency: first.currency.clone(),
         generated_at: Utc::now().to_rfc3339(),
         summaries,
         elapsed_ms: start.elapsed().as_secs_f64() * 1000.0,

--- a/src/sdk/batch.rs
+++ b/src/sdk/batch.rs
@@ -321,6 +321,14 @@ fn aggregate_entries_for_filter(
 }
 
 fn discovery_filter(ranges: &[ResolvedRange]) -> DateFilter {
+    let timestamp_range_count = ranges
+        .iter()
+        .filter(|range| range.filter.has_timestamp_range())
+        .count();
+    if timestamp_range_count > 0 && timestamp_range_count < ranges.len() {
+        return DateFilter::default();
+    }
+
     let since = ranges
         .iter()
         .all(|range| range.since.is_some())
@@ -679,6 +687,31 @@ mod tests {
                 .expect("valid until")
                 .timestamp_millis()
         );
+    }
+
+    #[test]
+    fn mixed_timestamp_and_date_ranges_leave_shared_discovery_unbounded() {
+        let ranges = resolve_ranges(
+            &[
+                UsageRange::TimestampRange {
+                    since: "2026-02-06T01:00:00Z".parse().expect("valid since"),
+                    until: "2026-02-06T02:00:00Z".parse().expect("valid until"),
+                },
+                UsageRange::DateRange {
+                    since: Some(d(2026, 2, 6)),
+                    until: Some(d(2026, 2, 6)),
+                },
+            ],
+            d(2026, 2, 6),
+        )
+        .expect("resolve ranges");
+
+        let filter = discovery_filter(&ranges);
+
+        assert_eq!(filter.since, None);
+        assert_eq!(filter.until, None);
+        assert!(!filter.has_timestamp_range());
+        assert!(ranges[0].filter.has_timestamp_range());
     }
 
     #[test]

--- a/src/sdk/batch.rs
+++ b/src/sdk/batch.rs
@@ -5,8 +5,8 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    CostSummary, SdkError, SummaryOptions, UsageRange, UsageSource, build_cost_summary,
-    load_cli_config, load_requested_currency, summarize_cost_at,
+    CostSummary, SdkError, UsageRange, UsageSource, build_cost_summary, load_cli_config,
+    load_requested_currency,
 };
 use crate::config::Config;
 use crate::consts::DATE_FORMAT;
@@ -14,6 +14,10 @@ use crate::core::{DateFilter, DedupAccumulator, LoadResult, RawEntry, aggregate_
 use crate::pricing::PricingDb;
 use crate::source::{CostCoverage, Source, get_source};
 use crate::utils::Timezone;
+
+mod grok;
+
+use grok::summarize_grok_cost_ranges;
 
 /// Options for [`summarize_cost_ranges`].
 ///
@@ -80,7 +84,7 @@ struct ResolvedRange {
 /// invalid, or when any explicit date or timestamp range is reversed.
 pub fn summarize_cost_ranges(options: MultiSummaryOptions) -> Result<MultiCostSummary, SdkError> {
     if options.source == UsageSource::Grok {
-        return summarize_grok_cost_ranges(options);
+        return summarize_grok_cost_ranges(&options);
     }
 
     let start = Instant::now();
@@ -136,51 +140,6 @@ pub fn summarize_cost_ranges(options: MultiSummaryOptions) -> Result<MultiCostSu
         source_name: source.name().to_string(),
         display_name: source.display_name().to_string(),
         currency: currency_code,
-        generated_at: Utc::now().to_rfc3339(),
-        summaries,
-        elapsed_ms: start.elapsed().as_secs_f64() * 1000.0,
-    })
-}
-
-fn summarize_grok_cost_ranges(options: MultiSummaryOptions) -> Result<MultiCostSummary, SdkError> {
-    summarize_grok_cost_ranges_at(options, Utc::now())
-}
-
-fn summarize_grok_cost_ranges_at(
-    options: MultiSummaryOptions,
-    observed_at: DateTime<Utc>,
-) -> Result<MultiCostSummary, SdkError> {
-    if options.ranges.is_empty() {
-        return Err(SdkError::Configuration(
-            "at least one usage range is required".to_string(),
-        ));
-    }
-
-    let start = Instant::now();
-    let summaries = options
-        .ranges
-        .into_iter()
-        .map(|range| {
-            summarize_cost_at(
-                SummaryOptions {
-                    source: UsageSource::Grok,
-                    range,
-                    timezone: options.timezone.clone(),
-                    offline: options.offline,
-                    strict_pricing: options.strict_pricing,
-                    currency: options.currency.clone(),
-                },
-                observed_at,
-            )
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    let first = &summaries[0];
-
-    Ok(MultiCostSummary {
-        source: UsageSource::Grok,
-        source_name: first.source_name.clone(),
-        display_name: first.display_name.clone(),
-        currency: first.currency.clone(),
         generated_at: Utc::now().to_rfc3339(),
         summaries,
         elapsed_ms: start.elapsed().as_secs_f64() * 1000.0,
@@ -564,42 +523,6 @@ mod tests {
         let err = resolve_ranges(&[], d(2026, 5, 9)).expect_err("empty ranges should fail");
 
         assert!(err.to_string().contains("at least one usage range"));
-    }
-
-    #[test]
-    fn grok_batch_resolves_relative_ranges_from_one_observation_time() {
-        let root = tempfile::tempdir().expect("temp dir");
-        let previous_grok_home = std::env::var_os("GROK_HOME");
-        unsafe {
-            std::env::set_var("GROK_HOME", root.path());
-        }
-
-        let summary = summarize_grok_cost_ranges_at(
-            MultiSummaryOptions {
-                source: UsageSource::Grok,
-                ranges: vec![UsageRange::Today, UsageRange::Today, UsageRange::ThisWeek],
-                timezone: Some("Asia/Shanghai".to_string()),
-                offline: true,
-                strict_pricing: false,
-                currency: None,
-            },
-            "2026-09-06T15:59:59Z"
-                .parse()
-                .expect("valid observation time"),
-        )
-        .expect("summarize Grok ranges");
-
-        match previous_grok_home {
-            Some(value) => unsafe { std::env::set_var("GROK_HOME", value) },
-            None => unsafe { std::env::remove_var("GROK_HOME") },
-        }
-
-        assert_eq!(summary.summaries[0].since, Some(d(2026, 9, 6)));
-        assert_eq!(summary.summaries[0].until, Some(d(2026, 9, 6)));
-        assert_eq!(summary.summaries[1].since, summary.summaries[0].since);
-        assert_eq!(summary.summaries[1].until, summary.summaries[0].until);
-        assert_eq!(summary.summaries[2].since, Some(d(2026, 8, 31)));
-        assert_eq!(summary.summaries[2].until, Some(d(2026, 9, 6)));
     }
 
     #[test]

--- a/src/sdk/batch.rs
+++ b/src/sdk/batch.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     CostSummary, SdkError, SummaryOptions, UsageRange, UsageSource, build_cost_summary,
-    load_cli_config, load_requested_currency, summarize_cost,
+    load_cli_config, load_requested_currency, summarize_cost_at,
 };
 use crate::config::Config;
 use crate::consts::DATE_FORMAT;
@@ -143,6 +143,13 @@ pub fn summarize_cost_ranges(options: MultiSummaryOptions) -> Result<MultiCostSu
 }
 
 fn summarize_grok_cost_ranges(options: MultiSummaryOptions) -> Result<MultiCostSummary, SdkError> {
+    summarize_grok_cost_ranges_at(options, Utc::now())
+}
+
+fn summarize_grok_cost_ranges_at(
+    options: MultiSummaryOptions,
+    observed_at: DateTime<Utc>,
+) -> Result<MultiCostSummary, SdkError> {
     if options.ranges.is_empty() {
         return Err(SdkError::Configuration(
             "at least one usage range is required".to_string(),
@@ -154,14 +161,17 @@ fn summarize_grok_cost_ranges(options: MultiSummaryOptions) -> Result<MultiCostS
         .ranges
         .into_iter()
         .map(|range| {
-            summarize_cost(SummaryOptions {
-                source: UsageSource::Grok,
-                range,
-                timezone: options.timezone.clone(),
-                offline: options.offline,
-                strict_pricing: options.strict_pricing,
-                currency: options.currency.clone(),
-            })
+            summarize_cost_at(
+                SummaryOptions {
+                    source: UsageSource::Grok,
+                    range,
+                    timezone: options.timezone.clone(),
+                    offline: options.offline,
+                    strict_pricing: options.strict_pricing,
+                    currency: options.currency.clone(),
+                },
+                observed_at,
+            )
         })
         .collect::<Result<Vec<_>, _>>()?;
     let first = &summaries[0];
@@ -554,6 +564,42 @@ mod tests {
         let err = resolve_ranges(&[], d(2026, 5, 9)).expect_err("empty ranges should fail");
 
         assert!(err.to_string().contains("at least one usage range"));
+    }
+
+    #[test]
+    fn grok_batch_resolves_relative_ranges_from_one_observation_time() {
+        let root = tempfile::tempdir().expect("temp dir");
+        let previous_grok_home = std::env::var_os("GROK_HOME");
+        unsafe {
+            std::env::set_var("GROK_HOME", root.path());
+        }
+
+        let summary = summarize_grok_cost_ranges_at(
+            MultiSummaryOptions {
+                source: UsageSource::Grok,
+                ranges: vec![UsageRange::Today, UsageRange::Today, UsageRange::ThisWeek],
+                timezone: Some("Asia/Shanghai".to_string()),
+                offline: true,
+                strict_pricing: false,
+                currency: None,
+            },
+            "2026-09-06T15:59:59Z"
+                .parse()
+                .expect("valid observation time"),
+        )
+        .expect("summarize Grok ranges");
+
+        match previous_grok_home {
+            Some(value) => unsafe { std::env::set_var("GROK_HOME", value) },
+            None => unsafe { std::env::remove_var("GROK_HOME") },
+        }
+
+        assert_eq!(summary.summaries[0].since, Some(d(2026, 9, 6)));
+        assert_eq!(summary.summaries[0].until, Some(d(2026, 9, 6)));
+        assert_eq!(summary.summaries[1].since, summary.summaries[0].since);
+        assert_eq!(summary.summaries[1].until, summary.summaries[0].until);
+        assert_eq!(summary.summaries[2].since, Some(d(2026, 8, 31)));
+        assert_eq!(summary.summaries[2].until, Some(d(2026, 9, 6)));
     }
 
     #[test]

--- a/src/sdk/batch/grok.rs
+++ b/src/sdk/batch/grok.rs
@@ -1,0 +1,131 @@
+use std::time::Instant;
+
+use chrono::{DateTime, Utc};
+
+use super::{MultiCostSummary, MultiSummaryOptions, discovery_filter, resolve_ranges};
+use crate::pricing::PricingDb;
+use crate::sdk::{SdkError, UsageSource, build_cost_summary, load_requested_currency};
+use crate::source::{CostCoverage, GrokCostReport, get_source, load_grok_daily_ranges_with_cost};
+use crate::utils::Timezone;
+
+pub(super) fn summarize_grok_cost_ranges(
+    options: &MultiSummaryOptions,
+) -> Result<MultiCostSummary, SdkError> {
+    summarize_grok_cost_ranges_at(options, Utc::now())
+}
+
+pub(super) fn summarize_grok_cost_ranges_at(
+    options: &MultiSummaryOptions,
+    observed_at: DateTime<Utc>,
+) -> Result<MultiCostSummary, SdkError> {
+    let start = Instant::now();
+    let timezone = Timezone::parse(options.timezone.as_deref())
+        .map_err(|err| SdkError::Configuration(err.to_string()))?;
+    let today = timezone.to_fixed_offset(observed_at).date_naive();
+    let resolved_ranges = resolve_ranges(&options.ranges, today)?;
+    let source = get_source(UsageSource::Grok.as_str()).ok_or_else(|| SdkError::InvalidSource {
+        name: UsageSource::Grok.as_str().to_string(),
+    })?;
+    let pricing_db = PricingDb::try_load_quiet(options.offline, options.strict_pricing)
+        .map_err(|err| SdkError::Configuration(err.to_string()))?;
+    let currency = load_requested_currency(options.currency.as_deref(), options.offline)?;
+    let currency_code = currency.as_ref().map_or_else(
+        || "USD".to_string(),
+        |converter| converter.currency_code().to_string(),
+    );
+
+    let filters: Vec<_> = resolved_ranges
+        .iter()
+        .map(|range| range.filter.clone())
+        .collect();
+    let results = load_grok_daily_ranges_with_cost(
+        &discovery_filter(&resolved_ranges),
+        &filters,
+        timezone,
+        true,
+        false,
+    );
+    let summaries = resolved_ranges
+        .into_iter()
+        .zip(results)
+        .map(|(range, (result, reports))| {
+            let cost_coverage =
+                CostCoverage::from_stats(result.day_stats.values().map(|day| &day.stats));
+            let mut summary = build_cost_summary(
+                UsageSource::Grok,
+                source,
+                range.range,
+                range.since,
+                range.until,
+                &result,
+                &pricing_db,
+                currency.as_ref(),
+                &currency_code,
+                cost_coverage,
+            );
+            summary.grok_api_equivalent_cost = reports
+                .values()
+                .copied()
+                .reduce(GrokCostReport::merge)
+                .map(Into::into);
+            summary
+        })
+        .collect();
+
+    Ok(MultiCostSummary {
+        source: UsageSource::Grok,
+        source_name: source.name().to_string(),
+        display_name: source.display_name().to_string(),
+        currency: currency_code,
+        generated_at: Utc::now().to_rfc3339(),
+        summaries,
+        elapsed_ms: start.elapsed().as_secs_f64() * 1000.0,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::NaiveDate;
+
+    use super::*;
+    use crate::sdk::UsageRange;
+
+    fn date(value: &str) -> NaiveDate {
+        value.parse().expect("valid date")
+    }
+
+    #[test]
+    fn relative_ranges_reuse_one_observation_and_snapshot() {
+        let root = tempfile::tempdir().expect("temp dir");
+        let previous_grok_home = std::env::var_os("GROK_HOME");
+        unsafe {
+            std::env::set_var("GROK_HOME", root.path());
+        }
+
+        let summary = summarize_grok_cost_ranges_at(
+            &MultiSummaryOptions {
+                source: UsageSource::Grok,
+                ranges: vec![UsageRange::Today, UsageRange::Today, UsageRange::ThisWeek],
+                timezone: Some("Asia/Shanghai".to_string()),
+                offline: true,
+                strict_pricing: false,
+                currency: None,
+            },
+            "2026-09-06T15:59:59Z"
+                .parse()
+                .expect("valid observation time"),
+        )
+        .expect("summarize Grok ranges");
+
+        match previous_grok_home {
+            Some(value) => unsafe { std::env::set_var("GROK_HOME", value) },
+            None => unsafe { std::env::remove_var("GROK_HOME") },
+        }
+
+        assert_eq!(summary.summaries[0].since, Some(date("2026-09-06")));
+        assert_eq!(summary.summaries[0].until, Some(date("2026-09-06")));
+        assert_eq!(summary.summaries[1], summary.summaries[0]);
+        assert_eq!(summary.summaries[2].since, Some(date("2026-08-31")));
+        assert_eq!(summary.summaries[2].until, Some(date("2026-09-06")));
+    }
+}

--- a/src/source/grok/cost_report.rs
+++ b/src/source/grok/cost_report.rs
@@ -416,6 +416,9 @@ fn reconcile_inference_observations(
 }
 
 fn entry_in_filter(entry: &RawEntry, filter: &DateFilter) -> bool {
+    if filter.has_timestamp_range() {
+        return filter.contains_entry_timestamp(&entry.timestamp, entry.timestamp_ms);
+    }
     chrono::NaiveDate::parse_from_str(&entry.date_str, DATE_FORMAT)
         .is_ok_and(|date| filter.contains(date))
 }

--- a/src/source/grok/cost_report.rs
+++ b/src/source/grok/cost_report.rs
@@ -161,6 +161,7 @@ impl DailyBuilder {
     }
 }
 
+#[derive(Clone)]
 struct InferenceObservation {
     entry: RawEntry,
     tokens: CostTokens,
@@ -169,7 +170,6 @@ struct InferenceObservation {
 struct SnapshotInputs {
     usage_entries: Vec<RawEntry>,
     inference_observations: Vec<InferenceObservation>,
-    skipped: i64,
     parse_errors: usize,
     mismatch: bool,
 }
@@ -180,9 +180,28 @@ pub(crate) fn load_daily_with_cost_reports(
     quiet: bool,
     debug: bool,
 ) -> (LoadResult, HashMap<String, GrokCostReport>) {
-    load_daily_with_cost_reports_from_files_and_options(
-        &find_grok_files(),
+    load_daily_ranges_with_cost_reports(
         filter,
+        std::slice::from_ref(filter),
+        timezone,
+        quiet,
+        debug,
+    )
+    .pop()
+    .unwrap_or_else(|| (LoadResult::default(), HashMap::new()))
+}
+
+pub(crate) fn load_daily_ranges_with_cost_reports(
+    discovery_filter: &DateFilter,
+    filters: &[DateFilter],
+    timezone: Timezone,
+    quiet: bool,
+    debug: bool,
+) -> Vec<(LoadResult, HashMap<String, GrokCostReport>)> {
+    load_daily_ranges_with_cost_reports_from_files_and_options(
+        &find_grok_files(),
+        discovery_filter,
+        filters,
         timezone,
         quiet,
         debug,
@@ -195,28 +214,81 @@ fn load_daily_with_cost_reports_from_files(
     filter: &DateFilter,
     timezone: Timezone,
 ) -> (LoadResult, HashMap<String, GrokCostReport>) {
-    load_daily_with_cost_reports_from_files_and_options(files, filter, timezone, true, false)
+    load_daily_ranges_with_cost_reports_from_files_and_options(
+        files,
+        filter,
+        std::slice::from_ref(filter),
+        timezone,
+        true,
+        false,
+    )
+    .pop()
+    .unwrap_or_else(|| (LoadResult::default(), HashMap::new()))
 }
 
-fn load_daily_with_cost_reports_from_files_and_options(
+fn load_daily_ranges_with_cost_reports_from_files_and_options(
     files: &[PathBuf],
-    filter: &DateFilter,
+    discovery_filter: &DateFilter,
+    filters: &[DateFilter],
     timezone: Timezone,
     quiet: bool,
     debug: bool,
-) -> (LoadResult, HashMap<String, GrokCostReport>) {
+) -> Vec<(LoadResult, HashMap<String, GrokCostReport>)> {
     let load_start = Instant::now();
     if !quiet && !files.is_empty() {
         eprintln!("Scanning {} Grok files...", files.len());
     }
 
-    let SnapshotInputs {
-        mut usage_entries,
-        inference_observations,
-        skipped,
-        parse_errors,
-        mismatch,
-    } = read_snapshot_files(files, filter, timezone, debug);
+    let snapshot = read_snapshot_files(files, discovery_filter, timezone, debug);
+    let mut results: Vec<_> = filters
+        .iter()
+        .map(|filter| cost_report_for_filter(&snapshot, filter))
+        .collect();
+    let elapsed_ms = load_start.elapsed().as_secs_f64() * 1000.0;
+    for (result, _) in &mut results {
+        result.elapsed_ms = elapsed_ms;
+    }
+
+    if !quiet && !files.is_empty() {
+        eprintln!(
+            "Parsed {} files in one Grok snapshot ({elapsed_ms:.2}ms)",
+            files.len()
+        );
+        if let Some(skipped) = results.iter().map(|(result, _)| result.skipped).max()
+            && skipped > 0
+        {
+            eprintln!("Deduplicated {skipped} entries");
+        }
+        if snapshot.parse_errors > 0 {
+            eprintln!(
+                "Warning: ignored {} malformed records",
+                snapshot.parse_errors
+            );
+        }
+    }
+
+    results
+}
+
+fn cost_report_for_filter(
+    snapshot: &SnapshotInputs,
+    filter: &DateFilter,
+) -> (LoadResult, HashMap<String, GrokCostReport>) {
+    let mut usage = DedupAccumulator::new();
+    usage.extend(
+        snapshot
+            .usage_entries
+            .iter()
+            .filter(|entry| entry_in_filter(entry, filter))
+            .cloned(),
+    );
+    let (mut usage_entries, skipped) = usage.finalize();
+    let inference_observations = snapshot
+        .inference_observations
+        .iter()
+        .filter(|observation| entry_in_filter(&observation.entry, filter))
+        .cloned()
+        .collect();
     let mut builders: HashMap<String, DailyBuilder> = HashMap::new();
     for entry in &usage_entries {
         if entry.cost_kind == CostKind::EstimatedProxy {
@@ -242,7 +314,7 @@ fn load_daily_with_cost_reports_from_files_and_options(
     let reports: HashMap<String, GrokCostReport> = builders
         .into_iter()
         .filter_map(|(date, mut builder)| {
-            builder.mismatch |= mismatch;
+            builder.mismatch |= snapshot.mismatch;
             let report = builder.finish();
             (report.total_tokens > 0).then_some((date, report))
         })
@@ -262,28 +334,13 @@ fn load_daily_with_cost_reports_from_files_and_options(
     }
     let valid = usage_entries.len() as i64;
     let day_stats = aggregate_daily(usage_entries);
-    let elapsed_ms = load_start.elapsed().as_secs_f64() * 1000.0;
-
-    if !quiet && !files.is_empty() {
-        eprintln!(
-            "Parsed {} files in one Grok snapshot ({elapsed_ms:.2}ms)",
-            files.len()
-        );
-        if skipped > 0 {
-            eprintln!("Deduplicated {skipped} entries");
-        }
-        if parse_errors > 0 {
-            eprintln!("Warning: ignored {parse_errors} malformed records");
-        }
-    }
-
     (
         LoadResult {
             day_stats,
             skipped,
             valid,
-            parse_errors,
-            elapsed_ms,
+            parse_errors: snapshot.parse_errors,
+            elapsed_ms: 0.0,
         },
         reports,
     )
@@ -295,7 +352,7 @@ fn read_snapshot_files(
     timezone: Timezone,
     debug: bool,
 ) -> SnapshotInputs {
-    let mut usage = DedupAccumulator::new();
+    let mut usage_entries = Vec::new();
     let mut inference_observations = Vec::new();
     let mut mismatch = false;
     let mut parse_errors = 0;
@@ -349,7 +406,7 @@ fn read_snapshot_files(
                 let parsed =
                     super::parser::parse_grok_session_file_for_provider(path, timezone, debug);
                 parse_errors += parsed.errors;
-                usage.extend(
+                usage_entries.extend(
                     parsed
                         .entries
                         .into_iter()
@@ -359,11 +416,9 @@ fn read_snapshot_files(
         }
     }
 
-    let (usage_entries, skipped) = usage.finalize();
     SnapshotInputs {
         usage_entries,
         inference_observations,
-        skipped,
         parse_errors,
         mismatch,
     }

--- a/src/source/grok/mod.rs
+++ b/src/source/grok/mod.rs
@@ -12,7 +12,9 @@ mod unified;
 mod usage;
 
 pub(crate) use config::GrokSource;
-pub(crate) use cost_report::{GrokCostReport, load_daily_with_cost_reports};
+pub(crate) use cost_report::{
+    GrokCostReport, load_daily_ranges_with_cost_reports, load_daily_with_cost_reports,
+};
 
 fn canonical_model_name(model: &str) -> String {
     let normalized = model.trim().to_ascii_lowercase();

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -613,7 +613,10 @@ pub(crate) type BoxedSource = Box<dyn Source>;
 pub(crate) use codex::load_weekly_window_usage_from_home;
 pub use codex::{CodexQuotaError, CodexQuotaStatus, CodexWeeklyQuota};
 pub(crate) use codex::{CodexScope, CodexSource, load_weekly_quota, load_weekly_quota_from_home};
-pub(crate) use grok::{GrokCostReport, load_daily_with_cost_reports as load_grok_daily_with_cost};
+pub(crate) use grok::{
+    GrokCostReport, load_daily_ranges_with_cost_reports as load_grok_daily_ranges_with_cost,
+    load_daily_with_cost_reports as load_grok_daily_with_cost,
+};
 
 pub use inventory::UsageSource;
 

--- a/tests/sdk_integration.rs
+++ b/tests/sdk_integration.rs
@@ -321,6 +321,14 @@ fn assert_stable_summary_eq(actual: &CostSummary, expected: &CostSummary) {
     assert_eq!(actual.estimated_cost, expected.estimated_cost);
     assert_eq!(actual.estimated_cost_usd, expected.estimated_cost_usd);
     assert_eq!(actual.cost_kind, expected.cost_kind);
+    assert_eq!(
+        actual.api_equivalent_cost_coverage,
+        expected.api_equivalent_cost_coverage
+    );
+    assert_eq!(
+        actual.grok_api_equivalent_cost,
+        expected.grok_api_equivalent_cost
+    );
     assert_eq!(actual.tokens, expected.tokens);
     assert_eq!(actual.models, expected.models);
     assert_eq!(actual.valid_entries, expected.valid_entries);
@@ -786,5 +794,103 @@ fn sdk_summarizes_grok_context_tokens_without_running_cli() {
     assert_eq!(
         batch_json["summaries"][0]["api_equivalent_cost_coverage"]["total_tokens"],
         1500
+    );
+}
+
+#[test]
+fn sdk_exposes_grok_partial_cost_estimate_for_exact_window() {
+    let _guard = ENV_LOCK.lock().expect("env lock");
+    let root = tempfile::tempdir().expect("temp dir");
+    let grok_home = root.path().join("grok-home");
+    let session_dir = grok_home
+        .join("sessions")
+        .join("%2Ftmp%2Fgrok-project")
+        .join("sdk-grok-cost-session");
+    write_file(
+        &session_dir.join("summary.json"),
+        r#"{"updated_at":"2026-08-16T01:00:00Z","current_model_id":"grok-4.5-build","git_root_dir":"/tmp/grok-project/"}"#,
+    );
+    write_file(
+        &session_dir.join("updates.jsonl"),
+        r#"{"timestamp":1786838400,"params":{"sessionId":"sdk-grok-cost-session","update":{"sessionUpdate":"turn_completed","prompt_id":"p1","usage":{"inputTokens":100,"outputTokens":20,"cachedReadTokens":40,"reasoningTokens":5,"modelCalls":1,"costUsdTicks":20000000000,"modelUsage":{"grok-4.5-build":{"inputTokens":100,"outputTokens":20,"cachedReadTokens":40,"reasoningTokens":5,"modelCalls":1,"costUsdTicks":20000000000}}}}}}
+{"timestamp":1786839000,"params":{"sessionId":"sdk-grok-cost-session","update":{"sessionUpdate":"turn_completed","prompt_id":"p2","usage":{"inputTokens":50,"outputTokens":10,"cachedReadTokens":10,"reasoningTokens":2,"modelCalls":1,"costUsdTicks":5000000000,"modelUsage":{"grok-4.5-build":{"inputTokens":50,"outputTokens":10,"cachedReadTokens":10,"reasoningTokens":2,"modelCalls":1,"costUsdTicks":5000000000}}}}}}
+{"timestamp":1786842000,"params":{"sessionId":"sdk-grok-cost-session","update":{"sessionUpdate":"turn_completed","prompt_id":"outside","usage":{"inputTokens":1000,"outputTokens":100,"cachedReadTokens":0,"reasoningTokens":0,"modelCalls":1,"costUsdTicks":5000000000,"modelUsage":{"grok-4.5-build":{"inputTokens":1000,"outputTokens":100,"cachedReadTokens":0,"reasoningTokens":0,"modelCalls":1,"costUsdTicks":5000000000}}}}}}
+"#,
+    );
+    write_file(
+        &grok_home.join("logs/unified.jsonl"),
+        r#"{"ts":"2026-08-16T00:00:00Z","sid":"sdk-grok-cost-session","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":100,"cached_prompt_tokens":40,"completion_tokens":20,"reasoning_tokens":5}}
+{"ts":"2026-08-16T01:00:00Z","sid":"sdk-grok-cost-session","msg":"shell.turn.inference_done","ctx":{"loop_index":2,"prompt_tokens":1000,"cached_prompt_tokens":0,"completion_tokens":100,"reasoning_tokens":0}}
+"#,
+    );
+
+    let range = UsageRange::TimestampRange {
+        since: "2026-08-16T00:00:00Z".parse().expect("valid since"),
+        until: "2026-08-16T00:30:00Z".parse().expect("valid until"),
+    };
+    let previous_home = std::env::var_os("HOME");
+    let previous_xdg_data = std::env::var_os("XDG_DATA_HOME");
+    let previous_grok_home = std::env::var_os("GROK_HOME");
+    unsafe {
+        std::env::set_var("HOME", root.path());
+        std::env::set_var("XDG_DATA_HOME", root.path().join("xdg-data"));
+        std::env::set_var("GROK_HOME", &grok_home);
+    }
+
+    let summary = summarize_cost(SummaryOptions {
+        source: UsageSource::Grok,
+        range: range.clone(),
+        timezone: Some("UTC".to_string()),
+        offline: true,
+        ..SummaryOptions::default()
+    })
+    .expect("summarize exact Grok cost window");
+    let batch = summarize_cost_ranges(MultiSummaryOptions {
+        source: UsageSource::Grok,
+        ranges: vec![range],
+        timezone: Some("UTC".to_string()),
+        offline: true,
+        strict_pricing: false,
+        currency: None,
+    })
+    .expect("summarize exact Grok cost window in batch");
+
+    match previous_home {
+        Some(value) => unsafe { std::env::set_var("HOME", value) },
+        None => unsafe { std::env::remove_var("HOME") },
+    }
+    match previous_xdg_data {
+        Some(value) => unsafe { std::env::set_var("XDG_DATA_HOME", value) },
+        None => unsafe { std::env::remove_var("XDG_DATA_HOME") },
+    }
+    match previous_grok_home {
+        Some(value) => unsafe { std::env::set_var("GROK_HOME", value) },
+        None => unsafe { std::env::remove_var("GROK_HOME") },
+    }
+
+    assert_eq!(summary.tokens.total_tokens, 180);
+    let coverage = summary
+        .api_equivalent_cost_coverage
+        .as_ref()
+        .expect("Grok cost coverage");
+    assert_eq!(coverage.total_tokens, 180);
+    assert_eq!(coverage.priced_tokens, 120);
+    assert!((coverage.percent - 66.666_666_666_666_66).abs() < 1e-12);
+
+    let estimate = summary
+        .grok_api_equivalent_cost
+        .as_ref()
+        .expect("Grok API-equivalent estimate");
+    assert!((estimate.observed_usd - 0.000_252).abs() < 1e-12);
+    assert!((estimate.estimated_usd.expect("point estimate") - 0.000_395).abs() < 1e-12);
+    assert!((estimate.minimum_usd.expect("minimum") - 0.000_395).abs() < 1e-12);
+    assert!((estimate.maximum_usd.expect("maximum") - 0.000_538).abs() < 1e-12);
+    assert_eq!(estimate.priced_tokens, 120);
+    assert_eq!(estimate.total_tokens, 180);
+    assert_eq!(estimate.coverage_status, "partial");
+    assert_eq!(estimate.excluded_request_tokens, 0);
+    assert_eq!(
+        batch.summaries[0].grok_api_equivalent_cost,
+        summary.grok_api_equivalent_cost
     );
 }


### PR DESCRIPTION
Expose ccstats' existing Grok point estimate, bounds, coverage status, and excluded-token metadata through the public SDK. Exact timestamp ranges now flow through Grok request reconciliation, and multi-range SDK summaries use the same cost semantics.

Tests:
- `cargo test --all-targets`
- `cargo test --doc`
- `cargo clippy --all-targets -- -A clippy::collapsible_match -D warnings`
- post-rebase focused SDK integration test