### PR TITLE
feat(desktop): complete local usage workbench

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 
 ![ccstats token and cost analytics card](docs/branding/readme-card.png)
 
-`ccstats` is a fast, local-first CLI and Rust SDK for token and cost analytics
-across 29 AI coding-agent data sources.
+`ccstats` is a fast, local-first CLI, Rust SDK, and desktop workbench for token
+and cost analytics across 29 AI coding-agent data sources.
 
 One binary turns the usage metadata your coding agents already produce into
 terminal reports and structured JSON/CSV. No ccstats account or telemetry is
@@ -41,11 +41,11 @@ missing sources.
 - **Local-first** — local session data stays on the machine; network access is
   bounded by feature and pricing refreshes can be disabled with `--offline`.
 
-ccstats keeps its CLI and Rust SDK as the accounting engine. The desktop MVP
-adds a local audit surface over the same source registry and summary APIs; it
-does not upload transcripts or substitute mock data when a source fails.
+ccstats keeps its CLI and Rust SDK as the accounting engine. The desktop app is
+a local investigation surface over the same source registry and summary APIs;
+it does not upload transcripts or substitute mock data when a source fails.
 
-## Desktop MVP development
+## Desktop application development
 
 The desktop app requires Node.js 20.19+ (or 22.12+), Rust 1.88+, and the
 platform prerequisites for [Tauri 2](https://v2.tauri.app/start/prerequisites/).
@@ -57,9 +57,24 @@ npm install
 npm run tauri -- dev
 ```
 
-The Overview reads one of the 29 registered usage sources and loads Today, This
-Week, and This Month in a single scan. It displays token buckets, model
-attribution, record and parse quality, and leaves unknown costs visibly unknown.
+The app discovers detected or configured sources at startup and opens the first
+ready ledger. If none are ready, it opens Diagnostics instead of presenting an
+empty default source. “All Sources” scans ready ledgers only; all 29 registered
+sources remain available for explicit inspection and setup.
+
+The workspace is organized by the questions a usage investigation asks:
+
+- **Observe** — totals, live 15-second monitoring, top consumers, and spikes.
+- **Explain** — model turns, tool calls, projects, sessions, and daily history.
+- **Trust** — pricing provenance, API-equivalent coverage, Codex quota, budget,
+  and source readiness.
+- **Devices** — explicit JSON snapshot exchange and a local SQLite rollup.
+
+Unknown, partial, fallback-priced, malformed, and provider-adjusted values stay
+visible as evidence states. Live, History, Limits, and Machines treat only real
+usage backed by recorded, live, or fresh cached pricing with complete coverage
+as exact cost. Machine totals use canonical USD and evaluate Today, This week,
+and This month freshness independently using the configured CLI timezone.
 
 Focused desktop checks:
 
@@ -76,6 +91,10 @@ before the page loads. Rust tests cover the command boundary, and the native tes
 launches a debug app through an embedded WebDriver before crossing Tauri IPC into
 the real ccstats SDK. Production builds call those commands directly and have no
 sample-data fallback.
+
+The desktop target is currently a development target in this repository; the
+CLI remains the installable release artifact until signed desktop packages are
+added to the release workflow.
 
 Usage files and transcripts remain local; pricing refreshes and sources configured
 with remote APIs may still make their documented network requests.

--- a/desktop/design.md
+++ b/desktop/design.md
@@ -1,0 +1,60 @@
+# ccstats Polar Workbench
+
+## Product idea
+
+ccstats is a local analytical instrument, not a report, landing page, terminal, or collection of dashboard cards. The interface should feel like a precise native desktop workspace for tracing AI usage back to sources, projects, sessions, models, and dates.
+
+## Reader job
+
+A developer opens the app to answer five questions quickly:
+
+1. How much usage was recorded in this period?
+2. Which token components, sources, or models explain the total?
+3. Can the cost and records be trusted?
+4. Which project, session, or day should be inspected next?
+5. Is a remote-machine snapshot current enough to contribute to this window?
+
+Missing prices, unsupported project identity, malformed records, and dates without activity remain explicit. Never fabricate continuity or certainty.
+
+## Composition
+
+- Use a permanent left rail for product identity, four task groups, source selection, and the local-only privacy state.
+- Observe contains Overview, Live, and Top consumers. Explain contains Turns & tools, Projects, and History. Trust contains Cost evidence, Limits, and Diagnostics. Devices contains Machines.
+- Use the remaining window as a task-specific workspace. The top toolbar owns the period and refresh action.
+- Overview is organized around a Token Map. The total and token composition share one focal surface, while cost, records, and cache status form a narrow diagnostic column.
+- Projects is a master-detail workspace. Selecting a project reveals its sessions in an adjacent inspector; do not expand rows inside a ledger.
+- History is a chart workspace with export actions in its header and the exact daily ledger below it.
+- Tables live inside their owning work pane. Long evidence scrolls locally instead of widening the whole window.
+- On narrow screens, the left rail becomes a compact header and master-detail layouts stack.
+
+## Visual language
+
+- Use an ice-white workspace with a pale blue-gray navigation rail, ink-blue text, cobalt selection, amber unknown states, and red errors.
+- Surfaces are functional panes with quiet elevation and 8px to 12px radii. Do not recreate the previous border-only report composition.
+- Manrope is used for interface language. IBM Plex Mono is reserved for values, timestamps, paths, model names, and session IDs.
+- Navigation labels and controls use sentence case. No fake terminal copy, tracked uppercase labels, neon color, grid texture, black report canvas, oversized editorial hero, or decorative effects.
+- Density is controlled and desktop-native: 44px controls, 13px body text, 12px metadata, and tabular numeric alignment.
+- Motion is limited to hover, selection, and loading state continuity.
+
+## Evidence rules
+
+- Token components share one total and one scale. Use a proportional map, not independent progress bars.
+- Unknown cost is amber and always includes an explanation.
+- Healthy quality is compact. Warnings become a dedicated diagnostic state.
+- Text columns align left; quantities and monetary values align right.
+- Project selection must be visible through shape, background, and text weight, not color alone.
+- History bars share a zero baseline and reserve equal time slots. Exact values remain available in the table.
+- Source and model attribution preserve every returned row and never hide zero or unknown values.
+- All Sources aggregates only ledgers that discovery marks detected or configured. Empty registered sources do not change aggregate pricing provenance.
+- A provider-reported total adjustment is first-class reconciliation evidence. Positive differences use an unallocated segment; negative differences remain an explicit note instead of distorting named buckets.
+- Partial API-equivalent cost is always labeled as a lower bound with priced-token coverage. Fallback, stale-cache, proxy, and mixed evidence is marked for review rather than presented as exact spend.
+- Machine Today, This week, and This month windows are checked independently against the CLI-configured timezone. A stale range stays visible but contributes to neither that range's token total nor its canonical USD cost total.
+- Exact-range pages may attribute parse errors to their range. Combined multi-range scans must label parse errors as unattributed.
+
+## Mechanical checks
+
+- At 1440 by 1000, navigation, source, period, total usage, cost status, records, and quality are visible without scrolling.
+- At 390px wide, the document has no horizontal page overflow; tables may scroll within their pane.
+- All controls retain visible keyboard focus and expose native labels or accessible names.
+- Every top-level request has an identity guard so a slower prior source, range, or page cannot overwrite the current selection.
+- Overview, Projects, History, Live, Cost evidence, Limits, Diagnostics, Activity, and Machines use the real bridge data and preserve loading, empty, error, malformed, stale, partial-cost, and unsupported states.

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -436,6 +436,10 @@ name = "ccstats-desktop"
 version = "0.1.0"
 dependencies = [
  "ccstats",
+ "chrono",
+ "rusqlite",
+ "serde",
+ "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-wdio-webdriver",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -18,5 +18,9 @@ tauri-build = { version = "2.6.3", features = [] }
 
 [dependencies]
 ccstats = { path = "../..", version = "0.5.1" }
+chrono = "0.4.43"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
+rusqlite = { version = "0.40.2", features = ["bundled"] }
 tauri = { version = "=2.11.5", features = [] }
 tauri-plugin-wdio-webdriver = { version = "=1.3.0", optional = true }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1,9 +1,30 @@
+use std::path::Path;
 use std::str::FromStr;
 
 use ccstats::{
-    MultiCostSummary, MultiSummaryOptions, SourceDescriptor, UsageRange, UsageSource,
-    list_usage_sources, summarize_cost_ranges_with_cli_config,
+    CodexWeeklyQuota, CodexWeeklyValueEstimate, CodexWeeklyValueWindow, MultiCostSummary,
+    MultiSummaryOptions, ProjectDrilldownSummary, SourceDescriptor, SourceDiagnosticDescriptor,
+    SummaryOptions, TurnToolBreakdown, UsageHistory, UsageRange, UsageSource,
+    diagnose_usage_sources, estimate_codex_weekly_value_for_window, list_usage_sources,
+    load_codex_weekly_quota, summarize_cost_ranges_with_cli_config,
+    summarize_project_drilldown_with_cli_config, turn_tool_breakdown_with_cli_config,
+    usage_history_with_cli_config,
 };
+use serde::Serialize;
+use tauri::Manager;
+
+mod machines;
+
+use machines::{
+    MachineRollup, export_bundle_at, import_bundle_at, machine_rollup_at, save_local_snapshot_at,
+};
+
+#[derive(Debug, Serialize)]
+struct CodexQuotaOverview {
+    quota: CodexWeeklyQuota,
+    value_estimate: Option<CodexWeeklyValueEstimate>,
+    value_estimate_error: Option<String>,
+}
 
 #[tauri::command]
 fn list_sources() -> Result<Vec<SourceDescriptor>, String> {
@@ -11,22 +32,188 @@ fn list_sources() -> Result<Vec<SourceDescriptor>, String> {
 }
 
 #[tauri::command]
+async fn source_diagnostics() -> Result<Vec<SourceDiagnosticDescriptor>, String> {
+    tauri::async_runtime::spawn_blocking(|| {
+        diagnose_usage_sources().map_err(|error| error.to_string())
+    })
+    .await
+    .map_err(|error| format!("source diagnostics task failed: {error}"))?
+}
+
+fn load_codex_quota_overview(codex_home: Option<&Path>) -> Result<CodexQuotaOverview, String> {
+    let quota = load_codex_weekly_quota(codex_home).map_err(|error| error.to_string())?;
+    let window = CodexWeeklyValueWindow {
+        observed_at: quota.observed_at,
+        resets_at: quota.resets_at,
+        window_minutes: quota.window_minutes,
+        used_pct: quota.used_pct,
+    };
+    let (value_estimate, value_estimate_error) =
+        match estimate_codex_weekly_value_for_window(&window, codex_home, true, false) {
+            Ok(estimate) => (Some(estimate), None),
+            Err(error) => (None, Some(error.to_string())),
+        };
+    Ok(CodexQuotaOverview {
+        quota,
+        value_estimate,
+        value_estimate_error,
+    })
+}
+
+#[tauri::command]
+async fn codex_quota_overview() -> Result<CodexQuotaOverview, String> {
+    tauri::async_runtime::spawn_blocking(|| load_codex_quota_overview(None))
+        .await
+        .map_err(|error| format!("quota scan task failed: {error}"))?
+}
+
+fn summarize_source(source: &str) -> Result<MultiCostSummary, String> {
+    let source = UsageSource::from_str(source).map_err(|error| error.to_string())?;
+    summarize_cost_ranges_with_cli_config(MultiSummaryOptions {
+        source,
+        ranges: vec![
+            UsageRange::Today,
+            UsageRange::ThisWeek,
+            UsageRange::ThisMonth,
+        ],
+        ..MultiSummaryOptions::default()
+    })
+    .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
 async fn usage_overview(source: String) -> Result<MultiCostSummary, String> {
-    let source = UsageSource::from_str(&source).map_err(|error| error.to_string())?;
+    tauri::async_runtime::spawn_blocking(move || summarize_source(&source))
+        .await
+        .map_err(|error| format!("usage scan task failed: {error}"))?
+}
+
+#[tauri::command]
+async fn usage_overviews(sources: Vec<String>) -> Result<Vec<MultiCostSummary>, String> {
+    if sources.is_empty() {
+        return Err("at least one usage source is required".to_string());
+    }
     tauri::async_runtime::spawn_blocking(move || {
-        summarize_cost_ranges_with_cli_config(MultiSummaryOptions {
-            source,
-            ranges: vec![
-                UsageRange::Today,
-                UsageRange::ThisWeek,
-                UsageRange::ThisMonth,
-            ],
-            ..MultiSummaryOptions::default()
-        })
-        .map_err(|error| error.to_string())
+        sources
+            .iter()
+            .map(|source| summarize_source(source))
+            .collect()
     })
     .await
     .map_err(|error| format!("usage scan task failed: {error}"))?
+}
+
+fn parse_range(range: &str) -> Result<UsageRange, String> {
+    match range {
+        "today" => Ok(UsageRange::Today),
+        "this_week" => Ok(UsageRange::ThisWeek),
+        "this_month" => Ok(UsageRange::ThisMonth),
+        _ => Err(format!("invalid usage range '{range}'")),
+    }
+}
+
+fn summary_options(source: &str, range: &str) -> Result<SummaryOptions, String> {
+    Ok(SummaryOptions {
+        source: UsageSource::from_str(source).map_err(|error| error.to_string())?,
+        range: parse_range(range)?,
+        ..SummaryOptions::default()
+    })
+}
+
+#[tauri::command]
+async fn project_drilldown(
+    source: String,
+    range: String,
+) -> Result<ProjectDrilldownSummary, String> {
+    let options = summary_options(&source, &range)?;
+    tauri::async_runtime::spawn_blocking(move || {
+        summarize_project_drilldown_with_cli_config(options).map_err(|error| error.to_string())
+    })
+    .await
+    .map_err(|error| format!("project scan task failed: {error}"))?
+}
+
+#[tauri::command]
+async fn usage_history(source: String, range: String) -> Result<UsageHistory, String> {
+    let options = summary_options(&source, &range)?;
+    tauri::async_runtime::spawn_blocking(move || {
+        usage_history_with_cli_config(options).map_err(|error| error.to_string())
+    })
+    .await
+    .map_err(|error| format!("history scan task failed: {error}"))?
+}
+
+#[tauri::command]
+async fn turn_tool_breakdown(source: String, range: String) -> Result<TurnToolBreakdown, String> {
+    let options = summary_options(&source, &range)?;
+    tauri::async_runtime::spawn_blocking(move || {
+        turn_tool_breakdown_with_cli_config(options).map_err(|error| error.to_string())
+    })
+    .await
+    .map_err(|error| format!("turn and tool scan task failed: {error}"))?
+}
+
+#[tauri::command]
+async fn export_history(source: String, range: String, format: String) -> Result<String, String> {
+    let options = summary_options(&source, &range)?;
+    tauri::async_runtime::spawn_blocking(move || {
+        let history = usage_history_with_cli_config(options).map_err(|error| error.to_string())?;
+        match format.as_str() {
+            "csv" => history.to_csv().map_err(|error| error.to_string()),
+            "json" => history.to_json().map_err(|error| error.to_string()),
+            _ => Err(format!("unsupported history export format '{format}'")),
+        }
+    })
+    .await
+    .map_err(|error| format!("history export task failed: {error}"))?
+}
+
+fn machine_database_path(app: &tauri::AppHandle) -> Result<std::path::PathBuf, String> {
+    app.path()
+        .app_data_dir()
+        .map(|directory| directory.join("machine-snapshots.sqlite3"))
+        .map_err(|error| format!("failed to resolve app data directory: {error}"))
+}
+
+#[tauri::command]
+async fn machine_rollup(app: tauri::AppHandle) -> Result<MachineRollup, String> {
+    let path = machine_database_path(&app)?;
+    tauri::async_runtime::spawn_blocking(move || machine_rollup_at(&path))
+        .await
+        .map_err(|error| format!("machine rollup task failed: {error}"))?
+}
+
+#[tauri::command]
+async fn save_machine_snapshot(
+    app: tauri::AppHandle,
+    machine_name: String,
+    sources: Vec<MultiCostSummary>,
+) -> Result<MachineRollup, String> {
+    let path = machine_database_path(&app)?;
+    tauri::async_runtime::spawn_blocking(move || {
+        save_local_snapshot_at(&path, &machine_name, sources)
+    })
+    .await
+    .map_err(|error| format!("machine snapshot task failed: {error}"))?
+}
+
+#[tauri::command]
+async fn export_machine_bundle(app: tauri::AppHandle) -> Result<String, String> {
+    let path = machine_database_path(&app)?;
+    tauri::async_runtime::spawn_blocking(move || export_bundle_at(&path))
+        .await
+        .map_err(|error| format!("machine export task failed: {error}"))?
+}
+
+#[tauri::command]
+async fn import_machine_bundle(
+    app: tauri::AppHandle,
+    content: String,
+) -> Result<MachineRollup, String> {
+    let path = machine_database_path(&app)?;
+    tauri::async_runtime::spawn_blocking(move || import_bundle_at(&path, &content))
+        .await
+        .map_err(|error| format!("machine import task failed: {error}"))?
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -36,7 +223,21 @@ pub fn run() {
     let builder = builder.plugin(tauri_plugin_wdio_webdriver::init());
 
     builder
-        .invoke_handler(tauri::generate_handler![list_sources, usage_overview])
+        .invoke_handler(tauri::generate_handler![
+            list_sources,
+            source_diagnostics,
+            codex_quota_overview,
+            usage_overview,
+            usage_overviews,
+            project_drilldown,
+            usage_history,
+            turn_tool_breakdown,
+            export_history,
+            machine_rollup,
+            save_machine_snapshot,
+            export_machine_bundle,
+            import_machine_bundle
+        ])
         .run(tauri::generate_context!())
         .expect("failed to run ccstats desktop");
 }
@@ -61,10 +262,66 @@ mod tests {
     }
 
     #[test]
+    fn diagnostics_command_projects_the_real_registry() {
+        let diagnostics = tauri::async_runtime::block_on(source_diagnostics())
+            .expect("source diagnostics command");
+
+        assert_eq!(diagnostics.len(), 29);
+        assert_eq!(
+            diagnostics.first().map(|row| row.name.as_str()),
+            Some("claude")
+        );
+    }
+
+    #[test]
+    fn quota_overview_fails_clearly_when_codex_home_is_missing() {
+        let missing_home = std::env::temp_dir().join(format!(
+            "ccstats-desktop-missing-quota-home-{}",
+            std::process::id()
+        ));
+
+        let error = load_codex_quota_overview(Some(&missing_home))
+            .expect_err("missing Codex home must fail");
+
+        assert!(error.contains("Codex sessions directory was not found"));
+    }
+
+    #[test]
     fn overview_command_rejects_an_unknown_source() {
         let error = tauri::async_runtime::block_on(usage_overview("not-a-source".to_string()))
             .expect_err("unknown source must fail");
 
         assert!(error.contains("invalid usage source"));
+    }
+
+    #[test]
+    fn batch_overview_command_rejects_an_empty_source_list() {
+        let error = tauri::async_runtime::block_on(usage_overviews(Vec::new()))
+            .expect_err("empty source list must fail");
+
+        assert_eq!(error, "at least one usage source is required");
+    }
+
+    #[test]
+    fn analytics_commands_reject_unknown_ranges_before_scanning() {
+        let error = tauri::async_runtime::block_on(usage_history(
+            "claude".to_string(),
+            "forever".to_string(),
+        ))
+        .expect_err("unknown ranges must fail");
+
+        assert_eq!(error, "invalid usage range 'forever'");
+    }
+
+    #[test]
+    fn history_export_rejects_unknown_formats() {
+        let error = tauri::async_runtime::block_on(export_history(
+            "claude".to_string(),
+            "today".to_string(),
+            "xml".to_string(),
+        ))
+        .expect_err("unknown export formats must fail");
+
+        assert_eq!(error, "unsupported history export format 'xml'");
     }
 }

--- a/desktop/src-tauri/src/machines.rs
+++ b/desktop/src-tauri/src/machines.rs
@@ -557,14 +557,18 @@ pub(crate) fn import_bundle_at(path: &Path, content: &str) -> Result<MachineRoll
             ));
         }
         if snapshot.machine_id == local_id {
-            return Err("an imported bundle cannot replace this machine's snapshot".to_string());
+            continue;
         }
         validate_snapshot(snapshot)?;
     }
     let transaction = connection
         .transaction()
         .map_err(|error| format!("failed to start machine import transaction: {error}"))?;
-    for snapshot in &bundle.machines {
+    for snapshot in bundle
+        .machines
+        .iter()
+        .filter(|snapshot| snapshot.machine_id != local_id)
+    {
         write_snapshot(&transaction, snapshot, true)?;
     }
     let rollup = machine_rollup(&transaction)?;
@@ -735,23 +739,24 @@ mod tests {
     }
 
     #[test]
-    fn import_cannot_replace_the_local_machine() {
-        let path = database("local-id");
-        save_local_snapshot_at(&path, "Studio", vec![sample_source(100, 400, 900)])
-            .expect("save local snapshot");
-        let bundle = export_bundle_at(&path).expect("export local snapshot");
+    fn bundles_round_trip_without_replacing_the_local_machine() {
+        let studio = database("round-trip-studio");
+        let laptop = database("round-trip-laptop");
+        save_local_snapshot_at(&studio, "Studio", vec![sample_source(100, 400, 900)])
+            .expect("save studio snapshot");
+        save_local_snapshot_at(&laptop, "Laptop", vec![sample_source(50, 200, 600)])
+            .expect("save laptop snapshot");
 
-        let error = import_bundle_at(&path, &bundle).expect_err("local identity must be protected");
+        let studio_bundle = export_bundle_at(&studio).expect("export studio");
+        import_bundle_at(&laptop, &studio_bundle).expect("import studio on laptop");
+        let laptop_bundle = export_bundle_at(&laptop).expect("export laptop and studio");
+        let rollup = import_bundle_at(&studio, &laptop_bundle).expect("round-trip to studio");
 
-        assert!(error.contains("cannot replace this machine"));
-        assert_eq!(
-            machine_rollup_at(&path)
-                .expect("rollup")
-                .totals
-                .month_tokens,
-            900
-        );
-        fs::remove_file(path).expect("remove test database");
+        assert_eq!(rollup.machines.len(), 2);
+        assert_eq!(rollup.local_machine_name.as_deref(), Some("Studio"));
+        assert_eq!(rollup.totals.month_tokens, 1_500);
+        fs::remove_file(studio).expect("remove studio database");
+        fs::remove_file(laptop).expect("remove laptop database");
     }
 
     #[test]

--- a/desktop/src-tauri/src/machines.rs
+++ b/desktop/src-tauri/src/machines.rs
@@ -3,12 +3,13 @@ use std::fs;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use ccstats::{MultiCostSummary, UsageRange, current_usage_date_with_cli_config};
-use chrono::{Datelike, Days, NaiveDate};
+use ccstats::{
+    CurrentUsageWindow, MultiCostSummary, UsageRange, current_usage_windows_with_cli_config,
+};
 use rusqlite::{Connection, params};
 use serde::{Deserialize, Serialize};
 
-const SCHEMA_VERSION: i64 = 1;
+const SCHEMA_VERSION: i64 = 2;
 const MAX_BUNDLE_BYTES: usize = 10 * 1024 * 1024;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -16,6 +17,7 @@ struct StoredMachineSnapshot {
     machine_id: String,
     machine_name: String,
     captured_at_ms: i64,
+    windows: Vec<CurrentUsageWindow>,
     sources: Vec<MultiCostSummary>,
 }
 
@@ -61,20 +63,6 @@ pub(crate) struct MachineRollup {
     totals: MachineUsageTotals,
 }
 
-fn current_window(range: UsageRange, today: NaiveDate) -> Result<(NaiveDate, NaiveDate), String> {
-    let since = match range {
-        UsageRange::Today => today,
-        UsageRange::ThisWeek => today
-            .checked_sub_days(Days::new(u64::from(today.weekday().num_days_from_monday())))
-            .ok_or_else(|| "the current week start is not representable".to_string())?,
-        UsageRange::ThisMonth => today
-            .with_day(1)
-            .ok_or_else(|| "the current month start is not representable".to_string())?,
-        _ => return Err("machine snapshots only store rolling ranges".to_string()),
-    };
-    Ok((since, today))
-}
-
 fn open_database(path: &Path) -> Result<Connection, String> {
     let parent = path
         .parent()
@@ -103,9 +91,10 @@ fn open_database(path: &Path) -> Result<Connection, String> {
                    machine_id TEXT PRIMARY KEY,
                    machine_name TEXT NOT NULL,
                    captured_at_ms INTEGER NOT NULL,
+                   windows_json TEXT NOT NULL,
                    payload_json TEXT NOT NULL
                  );
-                 PRAGMA user_version = 1;
+                 PRAGMA user_version = 2;
                  COMMIT;",
             )
             .map_err(|error| format!("failed to initialize machine database: {error}"))?,
@@ -205,34 +194,38 @@ fn summary_for(source: &MultiCostSummary, range: UsageRange) -> Result<(i64, Opt
     Ok((row.tokens.total_tokens, trusted_cost))
 }
 
-fn snapshot_freshness(snapshot: &StoredMachineSnapshot) -> Result<[bool; 3], String> {
-    let mut freshness = [true; 3];
-    let today = current_usage_date_with_cli_config().map_err(|error| error.to_string())?;
-    for source in &snapshot.sources {
-        for (index, range) in [
-            UsageRange::Today,
-            UsageRange::ThisWeek,
-            UsageRange::ThisMonth,
-        ]
-        .into_iter()
-        .enumerate()
-        {
-            let (since, until) = current_window(range.clone(), today)?;
-            let rows: Vec<_> = source
-                .summaries
-                .iter()
-                .filter(|summary| summary.range == range)
-                .collect();
-            if rows.len() != 1 {
-                return Err(format!(
-                    "{} must contain exactly one {range:?} summary",
-                    source.display_name
-                ));
-            }
-            if rows[0].since != Some(since) || rows[0].until != Some(until) {
-                freshness[index] = false;
-            }
-        }
+fn rolling_ranges() -> [UsageRange; 3] {
+    [
+        UsageRange::Today,
+        UsageRange::ThisWeek,
+        UsageRange::ThisMonth,
+    ]
+}
+
+fn window_for<'a>(
+    windows: &'a [CurrentUsageWindow],
+    range: &UsageRange,
+) -> Result<&'a CurrentUsageWindow, String> {
+    let rows: Vec<_> = windows
+        .iter()
+        .filter(|window| window.range == *range)
+        .collect();
+    if rows.len() != 1 {
+        return Err(format!(
+            "machine snapshot must contain exactly one {range:?} window"
+        ));
+    }
+    Ok(rows[0])
+}
+
+fn snapshot_freshness_against(
+    snapshot: &StoredMachineSnapshot,
+    current_windows: &[CurrentUsageWindow],
+) -> Result<[bool; 3], String> {
+    let mut freshness = [false; 3];
+    for (index, range) in rolling_ranges().iter().enumerate() {
+        freshness[index] =
+            window_for(&snapshot.windows, range)? == window_for(current_windows, range)?;
     }
     Ok(freshness)
 }
@@ -252,6 +245,15 @@ fn validate_snapshot(snapshot: &StoredMachineSnapshot) -> Result<(), String> {
     }
     if snapshot.sources.is_empty() {
         return Err(format!("{} has no source summaries", snapshot.machine_name));
+    }
+    for range in rolling_ranges() {
+        let window = window_for(&snapshot.windows, &range)?;
+        if window.since > window.until || window.since_utc_ms >= window.until_exclusive_utc_ms {
+            return Err(format!(
+                "{} contains an invalid {range:?} window",
+                snapshot.machine_name
+            ));
+        }
     }
     let mut source_names = HashSet::new();
     for source in &snapshot.sources {
@@ -278,9 +280,21 @@ fn validate_snapshot(snapshot: &StoredMachineSnapshot) -> Result<(), String> {
                 snapshot.machine_name, source.source_name
             ));
         }
-        summary_for(source, UsageRange::Today)?;
-        summary_for(source, UsageRange::ThisWeek)?;
-        summary_for(source, UsageRange::ThisMonth)?;
+        for range in rolling_ranges() {
+            summary_for(source, range.clone())?;
+            let summary = source
+                .summaries
+                .iter()
+                .find(|summary| summary.range == range)
+                .ok_or_else(|| format!("{} is missing {range:?}", source.display_name))?;
+            let window = window_for(&snapshot.windows, &range)?;
+            if summary.since != Some(window.since) || summary.until != Some(window.until) {
+                return Err(format!(
+                    "{} summary does not match its {range:?} window",
+                    source.display_name
+                ));
+            }
+        }
     }
     Ok(())
 }
@@ -292,20 +306,24 @@ fn write_snapshot(
 ) -> Result<(), String> {
     let payload = serde_json::to_string(&snapshot.sources)
         .map_err(|error| format!("failed to serialize machine snapshot: {error}"))?;
+    let windows = serde_json::to_string(&snapshot.windows)
+        .map_err(|error| format!("failed to serialize machine windows: {error}"))?;
     let query = if only_if_newer {
-        "INSERT INTO machine_snapshots(machine_id, machine_name, captured_at_ms, payload_json)
-         VALUES (?1, ?2, ?3, ?4)
+        "INSERT INTO machine_snapshots(machine_id, machine_name, captured_at_ms, windows_json, payload_json)
+         VALUES (?1, ?2, ?3, ?4, ?5)
          ON CONFLICT(machine_id) DO UPDATE SET
            machine_name = excluded.machine_name,
            captured_at_ms = excluded.captured_at_ms,
+           windows_json = excluded.windows_json,
            payload_json = excluded.payload_json
          WHERE excluded.captured_at_ms > machine_snapshots.captured_at_ms"
     } else {
-        "INSERT INTO machine_snapshots(machine_id, machine_name, captured_at_ms, payload_json)
-         VALUES (?1, ?2, ?3, ?4)
+        "INSERT INTO machine_snapshots(machine_id, machine_name, captured_at_ms, windows_json, payload_json)
+         VALUES (?1, ?2, ?3, ?4, ?5)
          ON CONFLICT(machine_id) DO UPDATE SET
            machine_name = excluded.machine_name,
            captured_at_ms = excluded.captured_at_ms,
+           windows_json = excluded.windows_json,
            payload_json = excluded.payload_json"
     };
     connection
@@ -315,6 +333,7 @@ fn write_snapshot(
                 snapshot.machine_id,
                 snapshot.machine_name.trim(),
                 snapshot.captured_at_ms,
+                windows,
                 payload
             ],
         )
@@ -325,7 +344,7 @@ fn write_snapshot(
 fn read_snapshots(connection: &Connection) -> Result<Vec<StoredMachineSnapshot>, String> {
     let mut statement = connection
         .prepare(
-            "SELECT machine_id, machine_name, captured_at_ms, payload_json
+            "SELECT machine_id, machine_name, captured_at_ms, windows_json, payload_json
              FROM machine_snapshots ORDER BY captured_at_ms DESC, machine_name ASC",
         )
         .map_err(|error| format!("failed to prepare machine snapshot query: {error}"))?;
@@ -336,18 +355,22 @@ fn read_snapshots(connection: &Connection) -> Result<Vec<StoredMachineSnapshot>,
                 row.get::<_, String>(1)?,
                 row.get::<_, i64>(2)?,
                 row.get::<_, String>(3)?,
+                row.get::<_, String>(4)?,
             ))
         })
         .map_err(|error| format!("failed to query machine snapshots: {error}"))?;
     rows.map(|row| {
-        let (machine_id, machine_name, captured_at_ms, payload) =
+        let (machine_id, machine_name, captured_at_ms, windows_json, payload) =
             row.map_err(|error| format!("failed to read machine snapshot: {error}"))?;
+        let windows = serde_json::from_str(&windows_json)
+            .map_err(|error| format!("stored windows for {machine_name} are malformed: {error}"))?;
         let sources = serde_json::from_str(&payload)
             .map_err(|error| format!("stored snapshot for {machine_name} is malformed: {error}"))?;
         let snapshot = StoredMachineSnapshot {
             machine_id,
             machine_name,
             captured_at_ms,
+            windows,
             sources,
         };
         validate_snapshot(&snapshot)?;
@@ -389,8 +412,10 @@ fn add_range(
 fn project_snapshot(
     snapshot: &StoredMachineSnapshot,
     local_id: &str,
+    current_windows: &[CurrentUsageWindow],
 ) -> Result<MachineUsage, String> {
-    let [today_current, week_current, month_current] = snapshot_freshness(snapshot)?;
+    let [today_current, week_current, month_current] =
+        snapshot_freshness_against(snapshot, current_windows)?;
     let mut totals = MachineUsageTotals {
         today_cost: Some(0.0),
         week_cost: Some(0.0),
@@ -424,9 +449,11 @@ fn project_snapshot(
 fn machine_rollup(connection: &Connection) -> Result<MachineRollup, String> {
     let local_id = local_machine_id(connection)?;
     let snapshots = read_snapshots(connection)?;
+    let current_windows =
+        current_usage_windows_with_cli_config().map_err(|error| error.to_string())?;
     let mut machines: Vec<_> = snapshots
         .iter()
-        .map(|snapshot| project_snapshot(snapshot, &local_id))
+        .map(|snapshot| project_snapshot(snapshot, &local_id, &current_windows))
         .collect::<Result<_, _>>()?;
     machines.sort_by(|left, right| {
         right
@@ -508,6 +535,7 @@ pub(crate) fn save_local_snapshot_at(
         machine_id,
         machine_name: machine_name.trim().to_string(),
         captured_at_ms: current_time_ms()?,
+        windows: current_usage_windows_with_cli_config().map_err(|error| error.to_string())?,
         sources,
     };
     validate_snapshot(&snapshot)?;
@@ -579,201 +607,5 @@ pub(crate) fn import_bundle_at(path: &Path, content: &str) -> Result<MachineRoll
 }
 
 #[cfg(test)]
-mod tests {
-    use std::fs;
-
-    use ccstats::{ApiEquivalentCostCoverage, CostSummary, TokenBreakdown, UsageSource};
-
-    use super::*;
-
-    fn database(name: &str) -> std::path::PathBuf {
-        std::env::temp_dir().join(format!(
-            "ccstats-machines-{name}-{}-{}.sqlite3",
-            std::process::id(),
-            current_time_ms().expect("timestamp")
-        ))
-    }
-
-    fn sample_source(today: i64, week: i64, month: i64) -> MultiCostSummary {
-        let current = current_usage_date_with_cli_config().expect("configured current date");
-        let summary = |range: UsageRange, tokens, cost| CostSummary {
-            source: UsageSource::Claude,
-            source_name: "claude".to_string(),
-            display_name: "Claude Code".to_string(),
-            range: range.clone(),
-            since: Some(
-                current_window(range.clone(), current)
-                    .expect("range bounds")
-                    .0,
-            ),
-            until: Some(
-                current_window(range.clone(), current)
-                    .expect("range bounds")
-                    .1,
-            ),
-            currency: "USD".to_string(),
-            cost: Some(cost),
-            cost_usd: Some(cost),
-            estimated_cost: None,
-            estimated_cost_usd: None,
-            cost_kind: "real".to_string(),
-            pricing_source: "recorded".to_string(),
-            api_equivalent_cost_coverage: None,
-            tokens: TokenBreakdown {
-                input_tokens: tokens,
-                total_tokens: tokens,
-                reported_total_adjustment: 0,
-                ..TokenBreakdown::default()
-            },
-            models: Vec::new(),
-            valid_entries: 1,
-            skipped_entries: 0,
-            parse_error_entries: 0,
-            elapsed_ms: 1.0,
-        };
-        MultiCostSummary {
-            source: UsageSource::Claude,
-            source_name: "claude".to_string(),
-            display_name: "Claude Code".to_string(),
-            currency: "USD".to_string(),
-            generated_at: "2026-09-02T00:00:00Z".to_string(),
-            summaries: vec![
-                summary(UsageRange::Today, today, 1.0),
-                summary(UsageRange::ThisWeek, week, 2.0),
-                summary(UsageRange::ThisMonth, month, 3.0),
-            ],
-            elapsed_ms: 3.0,
-        }
-    }
-
-    #[test]
-    fn local_snapshot_persists_across_reopens() {
-        let path = database("persist");
-        let saved = save_local_snapshot_at(&path, "Studio", vec![sample_source(100, 400, 900)])
-            .expect("save snapshot");
-        let reopened = machine_rollup_at(&path).expect("reopen rollup");
-
-        assert_eq!(saved.local_machine_id, reopened.local_machine_id);
-        assert_eq!(reopened.local_machine_name.as_deref(), Some("Studio"));
-        assert_eq!(reopened.totals.month_tokens, 900);
-        fs::remove_file(path).expect("remove test database");
-    }
-
-    #[test]
-    fn imported_older_snapshot_does_not_replace_newer_data() {
-        let origin = database("origin");
-        let target = database("target");
-        save_local_snapshot_at(&origin, "Laptop", vec![sample_source(100, 400, 900)])
-            .expect("save origin");
-        let current = export_bundle_at(&origin).expect("export origin");
-        import_bundle_at(&target, &current).expect("import origin");
-
-        let mut older: SnapshotBundle = serde_json::from_str(&current).expect("parse bundle");
-        older.machines[0].machine_name = "Stale laptop".to_string();
-        older.machines[0].captured_at_ms -= 1;
-        older.machines[0].sources = vec![sample_source(999, 999, 999)];
-        import_bundle_at(
-            &target,
-            &serde_json::to_string(&older).expect("serialize older"),
-        )
-        .expect("import older");
-
-        let rollup = machine_rollup_at(&target).expect("target rollup");
-        assert_eq!(rollup.machines[0].machine_name, "Laptop");
-        assert_eq!(rollup.totals.month_tokens, 900);
-        fs::remove_file(origin).expect("remove origin");
-        fs::remove_file(target).expect("remove target");
-    }
-
-    #[test]
-    fn import_rejects_invalid_currency() {
-        let path = database("currency");
-        let mut source = sample_source(1, 2, 3);
-        source.currency = "INVALID".to_string();
-        let bundle = SnapshotBundle {
-            schema_version: SCHEMA_VERSION,
-            machines: vec![StoredMachineSnapshot {
-                machine_id: "remote".to_string(),
-                machine_name: "Remote".to_string(),
-                captured_at_ms: 1,
-                sources: vec![source],
-            }],
-        };
-        let error = import_bundle_at(&path, &serde_json::to_string(&bundle).expect("bundle"))
-            .expect_err("invalid currency must fail");
-
-        assert!(error.contains("invalid currency"));
-        fs::remove_file(path).expect("remove test database");
-    }
-
-    #[test]
-    fn freshness_and_rollup_are_independent_for_each_range() {
-        let path = database("partial-freshness");
-        save_local_snapshot_at(&path, "Local", vec![sample_source(100, 400, 900)])
-            .expect("save current USD snapshot");
-        let mut source = sample_source(100, 400, 900);
-        source.currency = "EUR".to_string();
-        source
-            .summaries
-            .iter_mut()
-            .for_each(|row| row.currency = "EUR".to_string());
-        source.summaries[0].until = source.summaries[0].until.and_then(|date| date.pred_opt());
-        let bundle = SnapshotBundle {
-            schema_version: SCHEMA_VERSION,
-            machines: vec![StoredMachineSnapshot {
-                machine_id: "remote".to_string(),
-                machine_name: "Remote".to_string(),
-                captured_at_ms: 1,
-                sources: vec![source],
-            }],
-        };
-
-        let rollup = import_bundle_at(&path, &serde_json::to_string(&bundle).expect("bundle"))
-            .expect("import partially fresh snapshot");
-
-        assert_eq!(rollup.today_current_machines, 1);
-        assert_eq!(rollup.week_current_machines, 2);
-        assert_eq!(rollup.totals.today_cost, Some(1.0));
-        assert_eq!(rollup.totals.week_cost, Some(4.0));
-        fs::remove_file(path).expect("remove test database");
-    }
-
-    #[test]
-    fn bundles_round_trip_without_replacing_the_local_machine() {
-        let studio = database("round-trip-studio");
-        let laptop = database("round-trip-laptop");
-        save_local_snapshot_at(&studio, "Studio", vec![sample_source(100, 400, 900)])
-            .expect("save studio snapshot");
-        save_local_snapshot_at(&laptop, "Laptop", vec![sample_source(50, 200, 600)])
-            .expect("save laptop snapshot");
-
-        let studio_bundle = export_bundle_at(&studio).expect("export studio");
-        import_bundle_at(&laptop, &studio_bundle).expect("import studio on laptop");
-        let laptop_bundle = export_bundle_at(&laptop).expect("export laptop and studio");
-        let rollup = import_bundle_at(&studio, &laptop_bundle).expect("round-trip to studio");
-
-        assert_eq!(rollup.machines.len(), 2);
-        assert_eq!(rollup.local_machine_name.as_deref(), Some("Studio"));
-        assert_eq!(rollup.totals.month_tokens, 1_500);
-        fs::remove_file(studio).expect("remove studio database");
-        fs::remove_file(laptop).expect("remove laptop database");
-    }
-
-    #[test]
-    fn lower_bound_cost_is_not_presented_as_a_complete_machine_total() {
-        let path = database("lower-bound");
-        let mut source = sample_source(100, 400, 900);
-        source.summaries[2].api_equivalent_cost_coverage = Some(ApiEquivalentCostCoverage {
-            total_tokens: 900,
-            priced_tokens: 800,
-            percent: 800.0 / 900.0 * 100.0,
-            complete: false,
-            cost_is_lower_bound: true,
-        });
-
-        let rollup = save_local_snapshot_at(&path, "Studio", vec![source]).expect("save snapshot");
-
-        assert_eq!(rollup.totals.month_cost, None);
-        fs::remove_file(path).expect("remove test database");
-    }
-}
+#[path = "machines/tests.rs"]
+mod tests;

--- a/desktop/src-tauri/src/machines.rs
+++ b/desktop/src-tauri/src/machines.rs
@@ -1,0 +1,774 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use ccstats::{MultiCostSummary, UsageRange, current_usage_date_with_cli_config};
+use chrono::{Datelike, Days, NaiveDate};
+use rusqlite::{Connection, params};
+use serde::{Deserialize, Serialize};
+
+const SCHEMA_VERSION: i64 = 1;
+const MAX_BUNDLE_BYTES: usize = 10 * 1024 * 1024;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredMachineSnapshot {
+    machine_id: String,
+    machine_name: String,
+    captured_at_ms: i64,
+    sources: Vec<MultiCostSummary>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct SnapshotBundle {
+    schema_version: i64,
+    machines: Vec<StoredMachineSnapshot>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub(crate) struct MachineUsageTotals {
+    today_tokens: i64,
+    week_tokens: i64,
+    month_tokens: i64,
+    today_cost: Option<f64>,
+    week_cost: Option<f64>,
+    month_cost: Option<f64>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct MachineUsage {
+    machine_id: String,
+    machine_name: String,
+    captured_at_ms: i64,
+    source_count: usize,
+    currency: Option<String>,
+    is_local: bool,
+    today_current: bool,
+    week_current: bool,
+    month_current: bool,
+    totals: MachineUsageTotals,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct MachineRollup {
+    local_machine_id: String,
+    local_machine_name: Option<String>,
+    currency: Option<String>,
+    today_current_machines: usize,
+    week_current_machines: usize,
+    month_current_machines: usize,
+    machines: Vec<MachineUsage>,
+    totals: MachineUsageTotals,
+}
+
+fn current_window(range: UsageRange, today: NaiveDate) -> Result<(NaiveDate, NaiveDate), String> {
+    let since = match range {
+        UsageRange::Today => today,
+        UsageRange::ThisWeek => today
+            .checked_sub_days(Days::new(u64::from(today.weekday().num_days_from_monday())))
+            .ok_or_else(|| "the current week start is not representable".to_string())?,
+        UsageRange::ThisMonth => today
+            .with_day(1)
+            .ok_or_else(|| "the current month start is not representable".to_string())?,
+        _ => return Err("machine snapshots only store rolling ranges".to_string()),
+    };
+    Ok((since, today))
+}
+
+fn open_database(path: &Path) -> Result<Connection, String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("machine database path has no parent: {}", path.display()))?;
+    fs::create_dir_all(parent).map_err(|error| {
+        format!(
+            "failed to create machine database directory {}: {error}",
+            parent.display()
+        )
+    })?;
+    let connection = Connection::open(path).map_err(|error| {
+        format!(
+            "failed to open machine database {}: {error}",
+            path.display()
+        )
+    })?;
+    let version: i64 = connection
+        .pragma_query_value(None, "user_version", |row| row.get(0))
+        .map_err(|error| format!("failed to read machine database schema: {error}"))?;
+    match version {
+        0 => connection
+            .execute_batch(
+                "BEGIN;
+                 CREATE TABLE app_state (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+                 CREATE TABLE machine_snapshots (
+                   machine_id TEXT PRIMARY KEY,
+                   machine_name TEXT NOT NULL,
+                   captured_at_ms INTEGER NOT NULL,
+                   payload_json TEXT NOT NULL
+                 );
+                 PRAGMA user_version = 1;
+                 COMMIT;",
+            )
+            .map_err(|error| format!("failed to initialize machine database: {error}"))?,
+        SCHEMA_VERSION => {}
+        other => {
+            return Err(format!(
+                "unsupported machine database schema version {other}"
+            ));
+        }
+    }
+    Ok(connection)
+}
+
+fn local_machine_id(connection: &Connection) -> Result<String, String> {
+    connection
+        .execute(
+            "INSERT OR IGNORE INTO app_state(key, value) VALUES ('local_machine_id', lower(hex(randomblob(16))))",
+            [],
+        )
+        .map_err(|error| format!("failed to create local machine identity: {error}"))?;
+    connection
+        .query_row(
+            "SELECT value FROM app_state WHERE key = 'local_machine_id'",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|error| format!("failed to read local machine identity: {error}"))
+}
+
+fn current_time_ms() -> Result<i64, String> {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| format!("system clock is before the Unix epoch: {error}"))?
+        .as_millis();
+    i64::try_from(millis)
+        .map_err(|_| "current timestamp does not fit in SQLite INTEGER".to_string())
+}
+
+fn summary_for(source: &MultiCostSummary, range: UsageRange) -> Result<(i64, Option<f64>), String> {
+    let rows: Vec<_> = source
+        .summaries
+        .iter()
+        .filter(|summary| summary.range == range)
+        .collect();
+    if rows.len() != 1 {
+        return Err(format!(
+            "{} must contain exactly one {range:?} summary",
+            source.display_name
+        ));
+    }
+    let row = rows[0];
+    if row.source != source.source
+        || row.source_name != source.source_name
+        || row.display_name != source.display_name
+        || row.currency != source.currency
+    {
+        return Err(format!(
+            "{} contains inconsistent summary identity",
+            source.display_name
+        ));
+    }
+    if row.tokens.total_tokens < 0 {
+        return Err(format!(
+            "{} contains negative token totals",
+            source.display_name
+        ));
+    }
+    if row.cost.is_some_and(|cost| !cost.is_finite() || cost < 0.0)
+        || row
+            .cost_usd
+            .is_some_and(|cost| !cost.is_finite() || cost < 0.0)
+    {
+        return Err(format!("{} contains an invalid cost", source.display_name));
+    }
+    if !matches!(row.cost_kind.as_str(), "real" | "estimated_proxy" | "mixed") {
+        return Err(format!(
+            "{} contains an invalid cost kind",
+            source.display_name
+        ));
+    }
+    if !matches!(
+        row.pricing_source.as_str(),
+        "recorded" | "live" | "cache" | "cache_stale" | "fallback" | "unknown" | "mixed"
+    ) {
+        return Err(format!(
+            "{} contains an invalid pricing source",
+            source.display_name
+        ));
+    }
+    let trusted_cost = row.cost_usd.filter(|_| {
+        !row.api_equivalent_cost_coverage
+            .as_ref()
+            .is_some_and(|coverage| coverage.cost_is_lower_bound)
+            && matches!(row.pricing_source.as_str(), "recorded" | "live" | "cache")
+            && row.cost_kind == "real"
+    });
+    Ok((row.tokens.total_tokens, trusted_cost))
+}
+
+fn snapshot_freshness(snapshot: &StoredMachineSnapshot) -> Result<[bool; 3], String> {
+    let mut freshness = [true; 3];
+    let today = current_usage_date_with_cli_config().map_err(|error| error.to_string())?;
+    for source in &snapshot.sources {
+        for (index, range) in [
+            UsageRange::Today,
+            UsageRange::ThisWeek,
+            UsageRange::ThisMonth,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let (since, until) = current_window(range.clone(), today)?;
+            let rows: Vec<_> = source
+                .summaries
+                .iter()
+                .filter(|summary| summary.range == range)
+                .collect();
+            if rows.len() != 1 {
+                return Err(format!(
+                    "{} must contain exactly one {range:?} summary",
+                    source.display_name
+                ));
+            }
+            if rows[0].since != Some(since) || rows[0].until != Some(until) {
+                freshness[index] = false;
+            }
+        }
+    }
+    Ok(freshness)
+}
+
+fn validate_snapshot(snapshot: &StoredMachineSnapshot) -> Result<(), String> {
+    if snapshot.machine_id.trim().is_empty() || snapshot.machine_name.trim().is_empty() {
+        return Err("machine ID and name must not be empty".to_string());
+    }
+    if snapshot.machine_id.len() > 128 || snapshot.machine_name.len() > 128 {
+        return Err("machine ID and name must be at most 128 bytes".to_string());
+    }
+    if snapshot.captured_at_ms <= 0 {
+        return Err(format!(
+            "{} has an invalid capture time",
+            snapshot.machine_name
+        ));
+    }
+    if snapshot.sources.is_empty() {
+        return Err(format!("{} has no source summaries", snapshot.machine_name));
+    }
+    let mut source_names = HashSet::new();
+    for source in &snapshot.sources {
+        if source.currency.len() != 3
+            || !source
+                .currency
+                .bytes()
+                .all(|byte| byte.is_ascii_uppercase())
+        {
+            return Err(format!(
+                "{} contains an invalid currency",
+                snapshot.machine_name
+            ));
+        }
+        if source.source_name != source.source.as_str() {
+            return Err(format!(
+                "{} contains inconsistent source identity {}",
+                snapshot.machine_name, source.source_name
+            ));
+        }
+        if !source_names.insert(source.source.as_str()) {
+            return Err(format!(
+                "{} contains duplicate source {}",
+                snapshot.machine_name, source.source_name
+            ));
+        }
+        summary_for(source, UsageRange::Today)?;
+        summary_for(source, UsageRange::ThisWeek)?;
+        summary_for(source, UsageRange::ThisMonth)?;
+    }
+    Ok(())
+}
+
+fn write_snapshot(
+    connection: &Connection,
+    snapshot: &StoredMachineSnapshot,
+    only_if_newer: bool,
+) -> Result<(), String> {
+    let payload = serde_json::to_string(&snapshot.sources)
+        .map_err(|error| format!("failed to serialize machine snapshot: {error}"))?;
+    let query = if only_if_newer {
+        "INSERT INTO machine_snapshots(machine_id, machine_name, captured_at_ms, payload_json)
+         VALUES (?1, ?2, ?3, ?4)
+         ON CONFLICT(machine_id) DO UPDATE SET
+           machine_name = excluded.machine_name,
+           captured_at_ms = excluded.captured_at_ms,
+           payload_json = excluded.payload_json
+         WHERE excluded.captured_at_ms > machine_snapshots.captured_at_ms"
+    } else {
+        "INSERT INTO machine_snapshots(machine_id, machine_name, captured_at_ms, payload_json)
+         VALUES (?1, ?2, ?3, ?4)
+         ON CONFLICT(machine_id) DO UPDATE SET
+           machine_name = excluded.machine_name,
+           captured_at_ms = excluded.captured_at_ms,
+           payload_json = excluded.payload_json"
+    };
+    connection
+        .execute(
+            query,
+            params![
+                snapshot.machine_id,
+                snapshot.machine_name.trim(),
+                snapshot.captured_at_ms,
+                payload
+            ],
+        )
+        .map_err(|error| format!("failed to persist machine snapshot: {error}"))?;
+    Ok(())
+}
+
+fn read_snapshots(connection: &Connection) -> Result<Vec<StoredMachineSnapshot>, String> {
+    let mut statement = connection
+        .prepare(
+            "SELECT machine_id, machine_name, captured_at_ms, payload_json
+             FROM machine_snapshots ORDER BY captured_at_ms DESC, machine_name ASC",
+        )
+        .map_err(|error| format!("failed to prepare machine snapshot query: {error}"))?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, String>(3)?,
+            ))
+        })
+        .map_err(|error| format!("failed to query machine snapshots: {error}"))?;
+    rows.map(|row| {
+        let (machine_id, machine_name, captured_at_ms, payload) =
+            row.map_err(|error| format!("failed to read machine snapshot: {error}"))?;
+        let sources = serde_json::from_str(&payload)
+            .map_err(|error| format!("stored snapshot for {machine_name} is malformed: {error}"))?;
+        let snapshot = StoredMachineSnapshot {
+            machine_id,
+            machine_name,
+            captured_at_ms,
+            sources,
+        };
+        validate_snapshot(&snapshot)?;
+        Ok(snapshot)
+    })
+    .collect()
+}
+
+fn add_range(
+    totals: &mut MachineUsageTotals,
+    tokens: i64,
+    cost: Option<f64>,
+    range: UsageRange,
+) -> Result<(), String> {
+    let (token_total, cost_total) = match range {
+        UsageRange::Today => (&mut totals.today_tokens, &mut totals.today_cost),
+        UsageRange::ThisWeek => (&mut totals.week_tokens, &mut totals.week_cost),
+        UsageRange::ThisMonth => (&mut totals.month_tokens, &mut totals.month_cost),
+        _ => return Err("machine rollup received an unsupported range".to_string()),
+    };
+    *token_total = token_total
+        .checked_add(tokens)
+        .ok_or_else(|| "machine token rollup overflowed".to_string())?;
+    if let Some(current) = cost_total {
+        match cost {
+            Some(value) => {
+                *current += value;
+                if !current.is_finite() {
+                    return Err("machine cost rollup overflowed".to_string());
+                }
+            }
+            None if tokens > 0 => *cost_total = None,
+            None => {}
+        }
+    }
+    Ok(())
+}
+
+fn project_snapshot(
+    snapshot: &StoredMachineSnapshot,
+    local_id: &str,
+) -> Result<MachineUsage, String> {
+    let [today_current, week_current, month_current] = snapshot_freshness(snapshot)?;
+    let mut totals = MachineUsageTotals {
+        today_cost: Some(0.0),
+        week_cost: Some(0.0),
+        month_cost: Some(0.0),
+        ..MachineUsageTotals::default()
+    };
+    for source in &snapshot.sources {
+        for range in [
+            UsageRange::Today,
+            UsageRange::ThisWeek,
+            UsageRange::ThisMonth,
+        ] {
+            let (tokens, cost) = summary_for(source, range.clone())?;
+            add_range(&mut totals, tokens, cost, range)?;
+        }
+    }
+    Ok(MachineUsage {
+        machine_id: snapshot.machine_id.clone(),
+        machine_name: snapshot.machine_name.clone(),
+        captured_at_ms: snapshot.captured_at_ms,
+        source_count: snapshot.sources.len(),
+        currency: Some("USD".to_string()),
+        is_local: snapshot.machine_id == local_id,
+        today_current,
+        week_current,
+        month_current,
+        totals,
+    })
+}
+
+fn machine_rollup(connection: &Connection) -> Result<MachineRollup, String> {
+    let local_id = local_machine_id(connection)?;
+    let snapshots = read_snapshots(connection)?;
+    let mut machines: Vec<_> = snapshots
+        .iter()
+        .map(|snapshot| project_snapshot(snapshot, &local_id))
+        .collect::<Result<_, _>>()?;
+    machines.sort_by(|left, right| {
+        right
+            .is_local
+            .cmp(&left.is_local)
+            .then_with(|| left.machine_name.cmp(&right.machine_name))
+    });
+    let today_current_machines = machines
+        .iter()
+        .filter(|machine| machine.today_current)
+        .count();
+    let week_current_machines = machines
+        .iter()
+        .filter(|machine| machine.week_current)
+        .count();
+    let month_current_machines = machines
+        .iter()
+        .filter(|machine| machine.month_current)
+        .count();
+    let mut totals = MachineUsageTotals {
+        today_cost: Some(0.0),
+        week_cost: Some(0.0),
+        month_cost: Some(0.0),
+        ..MachineUsageTotals::default()
+    };
+    for machine in &machines {
+        if machine.today_current {
+            add_range(
+                &mut totals,
+                machine.totals.today_tokens,
+                machine.totals.today_cost,
+                UsageRange::Today,
+            )?;
+        }
+        if machine.week_current {
+            add_range(
+                &mut totals,
+                machine.totals.week_tokens,
+                machine.totals.week_cost,
+                UsageRange::ThisWeek,
+            )?;
+        }
+        if machine.month_current {
+            add_range(
+                &mut totals,
+                machine.totals.month_tokens,
+                machine.totals.month_cost,
+                UsageRange::ThisMonth,
+            )?;
+        }
+    }
+    Ok(MachineRollup {
+        local_machine_name: machines
+            .iter()
+            .find(|machine| machine.is_local)
+            .map(|machine| machine.machine_name.clone()),
+        local_machine_id: local_id,
+        currency: Some("USD".to_string()),
+        today_current_machines,
+        week_current_machines,
+        month_current_machines,
+        machines,
+        totals,
+    })
+}
+
+pub(crate) fn machine_rollup_at(path: &Path) -> Result<MachineRollup, String> {
+    machine_rollup(&open_database(path)?)
+}
+
+pub(crate) fn save_local_snapshot_at(
+    path: &Path,
+    machine_name: &str,
+    sources: Vec<MultiCostSummary>,
+) -> Result<MachineRollup, String> {
+    let mut connection = open_database(path)?;
+    let machine_id = local_machine_id(&connection)?;
+    let snapshot = StoredMachineSnapshot {
+        machine_id,
+        machine_name: machine_name.trim().to_string(),
+        captured_at_ms: current_time_ms()?,
+        sources,
+    };
+    validate_snapshot(&snapshot)?;
+    let transaction = connection
+        .transaction()
+        .map_err(|error| format!("failed to start machine snapshot transaction: {error}"))?;
+    write_snapshot(&transaction, &snapshot, false)?;
+    let rollup = machine_rollup(&transaction)?;
+    transaction
+        .commit()
+        .map_err(|error| format!("failed to commit machine snapshot: {error}"))?;
+    Ok(rollup)
+}
+
+pub(crate) fn export_bundle_at(path: &Path) -> Result<String, String> {
+    let connection = open_database(path)?;
+    local_machine_id(&connection)?;
+    serde_json::to_string_pretty(&SnapshotBundle {
+        schema_version: SCHEMA_VERSION,
+        machines: read_snapshots(&connection)?,
+    })
+    .map_err(|error| format!("failed to export machine snapshots: {error}"))
+}
+
+pub(crate) fn import_bundle_at(path: &Path, content: &str) -> Result<MachineRollup, String> {
+    if content.len() > MAX_BUNDLE_BYTES {
+        return Err(format!(
+            "machine snapshot bundle exceeds {MAX_BUNDLE_BYTES} bytes"
+        ));
+    }
+    let bundle: SnapshotBundle = serde_json::from_str(content)
+        .map_err(|error| format!("machine snapshot bundle is malformed: {error}"))?;
+    if bundle.schema_version != SCHEMA_VERSION {
+        return Err(format!(
+            "unsupported machine snapshot bundle version {}",
+            bundle.schema_version
+        ));
+    }
+    let mut connection = open_database(path)?;
+    let local_id = local_machine_id(&connection)?;
+    let mut ids = HashSet::new();
+    for snapshot in &bundle.machines {
+        if !ids.insert(snapshot.machine_id.as_str()) {
+            return Err(format!(
+                "bundle contains duplicate machine {}",
+                snapshot.machine_id
+            ));
+        }
+        if snapshot.machine_id == local_id {
+            return Err("an imported bundle cannot replace this machine's snapshot".to_string());
+        }
+        validate_snapshot(snapshot)?;
+    }
+    let transaction = connection
+        .transaction()
+        .map_err(|error| format!("failed to start machine import transaction: {error}"))?;
+    for snapshot in &bundle.machines {
+        write_snapshot(&transaction, snapshot, true)?;
+    }
+    let rollup = machine_rollup(&transaction)?;
+    transaction
+        .commit()
+        .map_err(|error| format!("failed to commit machine import: {error}"))?;
+    Ok(rollup)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use ccstats::{ApiEquivalentCostCoverage, CostSummary, TokenBreakdown, UsageSource};
+
+    use super::*;
+
+    fn database(name: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "ccstats-machines-{name}-{}-{}.sqlite3",
+            std::process::id(),
+            current_time_ms().expect("timestamp")
+        ))
+    }
+
+    fn sample_source(today: i64, week: i64, month: i64) -> MultiCostSummary {
+        let current = current_usage_date_with_cli_config().expect("configured current date");
+        let summary = |range: UsageRange, tokens, cost| CostSummary {
+            source: UsageSource::Claude,
+            source_name: "claude".to_string(),
+            display_name: "Claude Code".to_string(),
+            range: range.clone(),
+            since: Some(
+                current_window(range.clone(), current)
+                    .expect("range bounds")
+                    .0,
+            ),
+            until: Some(
+                current_window(range.clone(), current)
+                    .expect("range bounds")
+                    .1,
+            ),
+            currency: "USD".to_string(),
+            cost: Some(cost),
+            cost_usd: Some(cost),
+            estimated_cost: None,
+            estimated_cost_usd: None,
+            cost_kind: "real".to_string(),
+            pricing_source: "recorded".to_string(),
+            api_equivalent_cost_coverage: None,
+            tokens: TokenBreakdown {
+                input_tokens: tokens,
+                total_tokens: tokens,
+                reported_total_adjustment: 0,
+                ..TokenBreakdown::default()
+            },
+            models: Vec::new(),
+            valid_entries: 1,
+            skipped_entries: 0,
+            parse_error_entries: 0,
+            elapsed_ms: 1.0,
+        };
+        MultiCostSummary {
+            source: UsageSource::Claude,
+            source_name: "claude".to_string(),
+            display_name: "Claude Code".to_string(),
+            currency: "USD".to_string(),
+            generated_at: "2026-09-02T00:00:00Z".to_string(),
+            summaries: vec![
+                summary(UsageRange::Today, today, 1.0),
+                summary(UsageRange::ThisWeek, week, 2.0),
+                summary(UsageRange::ThisMonth, month, 3.0),
+            ],
+            elapsed_ms: 3.0,
+        }
+    }
+
+    #[test]
+    fn local_snapshot_persists_across_reopens() {
+        let path = database("persist");
+        let saved = save_local_snapshot_at(&path, "Studio", vec![sample_source(100, 400, 900)])
+            .expect("save snapshot");
+        let reopened = machine_rollup_at(&path).expect("reopen rollup");
+
+        assert_eq!(saved.local_machine_id, reopened.local_machine_id);
+        assert_eq!(reopened.local_machine_name.as_deref(), Some("Studio"));
+        assert_eq!(reopened.totals.month_tokens, 900);
+        fs::remove_file(path).expect("remove test database");
+    }
+
+    #[test]
+    fn imported_older_snapshot_does_not_replace_newer_data() {
+        let origin = database("origin");
+        let target = database("target");
+        save_local_snapshot_at(&origin, "Laptop", vec![sample_source(100, 400, 900)])
+            .expect("save origin");
+        let current = export_bundle_at(&origin).expect("export origin");
+        import_bundle_at(&target, &current).expect("import origin");
+
+        let mut older: SnapshotBundle = serde_json::from_str(&current).expect("parse bundle");
+        older.machines[0].machine_name = "Stale laptop".to_string();
+        older.machines[0].captured_at_ms -= 1;
+        older.machines[0].sources = vec![sample_source(999, 999, 999)];
+        import_bundle_at(
+            &target,
+            &serde_json::to_string(&older).expect("serialize older"),
+        )
+        .expect("import older");
+
+        let rollup = machine_rollup_at(&target).expect("target rollup");
+        assert_eq!(rollup.machines[0].machine_name, "Laptop");
+        assert_eq!(rollup.totals.month_tokens, 900);
+        fs::remove_file(origin).expect("remove origin");
+        fs::remove_file(target).expect("remove target");
+    }
+
+    #[test]
+    fn import_rejects_invalid_currency() {
+        let path = database("currency");
+        let mut source = sample_source(1, 2, 3);
+        source.currency = "INVALID".to_string();
+        let bundle = SnapshotBundle {
+            schema_version: SCHEMA_VERSION,
+            machines: vec![StoredMachineSnapshot {
+                machine_id: "remote".to_string(),
+                machine_name: "Remote".to_string(),
+                captured_at_ms: 1,
+                sources: vec![source],
+            }],
+        };
+        let error = import_bundle_at(&path, &serde_json::to_string(&bundle).expect("bundle"))
+            .expect_err("invalid currency must fail");
+
+        assert!(error.contains("invalid currency"));
+        fs::remove_file(path).expect("remove test database");
+    }
+
+    #[test]
+    fn freshness_and_rollup_are_independent_for_each_range() {
+        let path = database("partial-freshness");
+        save_local_snapshot_at(&path, "Local", vec![sample_source(100, 400, 900)])
+            .expect("save current USD snapshot");
+        let mut source = sample_source(100, 400, 900);
+        source.currency = "EUR".to_string();
+        source
+            .summaries
+            .iter_mut()
+            .for_each(|row| row.currency = "EUR".to_string());
+        source.summaries[0].until = source.summaries[0].until.and_then(|date| date.pred_opt());
+        let bundle = SnapshotBundle {
+            schema_version: SCHEMA_VERSION,
+            machines: vec![StoredMachineSnapshot {
+                machine_id: "remote".to_string(),
+                machine_name: "Remote".to_string(),
+                captured_at_ms: 1,
+                sources: vec![source],
+            }],
+        };
+
+        let rollup = import_bundle_at(&path, &serde_json::to_string(&bundle).expect("bundle"))
+            .expect("import partially fresh snapshot");
+
+        assert_eq!(rollup.today_current_machines, 1);
+        assert_eq!(rollup.week_current_machines, 2);
+        assert_eq!(rollup.totals.today_cost, Some(1.0));
+        assert_eq!(rollup.totals.week_cost, Some(4.0));
+        fs::remove_file(path).expect("remove test database");
+    }
+
+    #[test]
+    fn import_cannot_replace_the_local_machine() {
+        let path = database("local-id");
+        save_local_snapshot_at(&path, "Studio", vec![sample_source(100, 400, 900)])
+            .expect("save local snapshot");
+        let bundle = export_bundle_at(&path).expect("export local snapshot");
+
+        let error = import_bundle_at(&path, &bundle).expect_err("local identity must be protected");
+
+        assert!(error.contains("cannot replace this machine"));
+        assert_eq!(
+            machine_rollup_at(&path)
+                .expect("rollup")
+                .totals
+                .month_tokens,
+            900
+        );
+        fs::remove_file(path).expect("remove test database");
+    }
+
+    #[test]
+    fn lower_bound_cost_is_not_presented_as_a_complete_machine_total() {
+        let path = database("lower-bound");
+        let mut source = sample_source(100, 400, 900);
+        source.summaries[2].api_equivalent_cost_coverage = Some(ApiEquivalentCostCoverage {
+            total_tokens: 900,
+            priced_tokens: 800,
+            percent: 800.0 / 900.0 * 100.0,
+            complete: false,
+            cost_is_lower_bound: true,
+        });
+
+        let rollup = save_local_snapshot_at(&path, "Studio", vec![source]).expect("save snapshot");
+
+        assert_eq!(rollup.totals.month_cost, None);
+        fs::remove_file(path).expect("remove test database");
+    }
+}

--- a/desktop/src-tauri/src/machines/tests.rs
+++ b/desktop/src-tauri/src/machines/tests.rs
@@ -1,0 +1,238 @@
+use std::fs;
+
+use ccstats::{ApiEquivalentCostCoverage, CostSummary, TokenBreakdown, UsageSource};
+
+use super::*;
+
+fn database(name: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!(
+        "ccstats-machines-{name}-{}-{}.sqlite3",
+        std::process::id(),
+        current_time_ms().expect("timestamp")
+    ))
+}
+
+fn sample_source(today: i64, week: i64, month: i64) -> MultiCostSummary {
+    let windows = current_usage_windows_with_cli_config().expect("configured usage windows");
+    let summary = |range: UsageRange, tokens, cost| CostSummary {
+        source: UsageSource::Claude,
+        source_name: "claude".to_string(),
+        display_name: "Claude Code".to_string(),
+        range: range.clone(),
+        since: Some(window_for(&windows, &range).expect("range bounds").since),
+        until: Some(window_for(&windows, &range).expect("range bounds").until),
+        currency: "USD".to_string(),
+        cost: Some(cost),
+        cost_usd: Some(cost),
+        estimated_cost: None,
+        estimated_cost_usd: None,
+        cost_kind: "real".to_string(),
+        pricing_source: "recorded".to_string(),
+        api_equivalent_cost_coverage: None,
+        tokens: TokenBreakdown {
+            input_tokens: tokens,
+            total_tokens: tokens,
+            reported_total_adjustment: 0,
+            ..TokenBreakdown::default()
+        },
+        models: Vec::new(),
+        valid_entries: 1,
+        skipped_entries: 0,
+        parse_error_entries: 0,
+        elapsed_ms: 1.0,
+    };
+    MultiCostSummary {
+        source: UsageSource::Claude,
+        source_name: "claude".to_string(),
+        display_name: "Claude Code".to_string(),
+        currency: "USD".to_string(),
+        generated_at: "2026-09-02T00:00:00Z".to_string(),
+        summaries: vec![
+            summary(UsageRange::Today, today, 1.0),
+            summary(UsageRange::ThisWeek, week, 2.0),
+            summary(UsageRange::ThisMonth, month, 3.0),
+        ],
+        elapsed_ms: 3.0,
+    }
+}
+
+#[test]
+fn local_snapshot_persists_across_reopens() {
+    let path = database("persist");
+    let saved = save_local_snapshot_at(&path, "Studio", vec![sample_source(100, 400, 900)])
+        .expect("save snapshot");
+    let reopened = machine_rollup_at(&path).expect("reopen rollup");
+
+    assert_eq!(saved.local_machine_id, reopened.local_machine_id);
+    assert_eq!(reopened.local_machine_name.as_deref(), Some("Studio"));
+    assert_eq!(reopened.totals.month_tokens, 900);
+    fs::remove_file(path).expect("remove test database");
+}
+
+#[test]
+fn exported_snapshots_include_absolute_usage_windows() {
+    let path = database("absolute-windows");
+    save_local_snapshot_at(&path, "Studio", vec![sample_source(100, 400, 900)])
+        .expect("save snapshot");
+
+    let bundle: serde_json::Value =
+        serde_json::from_str(&export_bundle_at(&path).expect("export snapshot bundle"))
+            .expect("parse snapshot bundle");
+    let windows = bundle["machines"][0]["windows"]
+        .as_array()
+        .expect("snapshot must include usage windows");
+
+    assert_eq!(windows.len(), 3);
+    assert!(windows[0]["since_utc_ms"].is_i64());
+    assert!(windows[0]["until_exclusive_utc_ms"].is_i64());
+    fs::remove_file(path).expect("remove test database");
+}
+
+#[test]
+fn imported_older_snapshot_does_not_replace_newer_data() {
+    let origin = database("origin");
+    let target = database("target");
+    save_local_snapshot_at(&origin, "Laptop", vec![sample_source(100, 400, 900)])
+        .expect("save origin");
+    let current = export_bundle_at(&origin).expect("export origin");
+    import_bundle_at(&target, &current).expect("import origin");
+
+    let mut older: SnapshotBundle = serde_json::from_str(&current).expect("parse bundle");
+    older.machines[0].machine_name = "Stale laptop".to_string();
+    older.machines[0].captured_at_ms -= 1;
+    older.machines[0].sources = vec![sample_source(999, 999, 999)];
+    import_bundle_at(
+        &target,
+        &serde_json::to_string(&older).expect("serialize older"),
+    )
+    .expect("import older");
+
+    let rollup = machine_rollup_at(&target).expect("target rollup");
+    assert_eq!(rollup.machines[0].machine_name, "Laptop");
+    assert_eq!(rollup.totals.month_tokens, 900);
+    fs::remove_file(origin).expect("remove origin");
+    fs::remove_file(target).expect("remove target");
+}
+
+#[test]
+fn import_rejects_invalid_currency() {
+    let path = database("currency");
+    let mut source = sample_source(1, 2, 3);
+    source.currency = "INVALID".to_string();
+    let bundle = SnapshotBundle {
+        schema_version: SCHEMA_VERSION,
+        machines: vec![StoredMachineSnapshot {
+            machine_id: "remote".to_string(),
+            machine_name: "Remote".to_string(),
+            captured_at_ms: 1,
+            windows: current_usage_windows_with_cli_config().expect("usage windows"),
+            sources: vec![source],
+        }],
+    };
+    let error = import_bundle_at(&path, &serde_json::to_string(&bundle).expect("bundle"))
+        .expect_err("invalid currency must fail");
+
+    assert!(error.contains("invalid currency"));
+    fs::remove_file(path).expect("remove test database");
+}
+
+#[test]
+fn freshness_and_rollup_are_independent_for_each_range() {
+    let path = database("partial-freshness");
+    save_local_snapshot_at(&path, "Local", vec![sample_source(100, 400, 900)])
+        .expect("save current USD snapshot");
+    let mut source = sample_source(100, 400, 900);
+    source.currency = "EUR".to_string();
+    source
+        .summaries
+        .iter_mut()
+        .for_each(|row| row.currency = "EUR".to_string());
+    let mut windows = current_usage_windows_with_cli_config().expect("usage windows");
+    windows[0].since = windows[0].since.pred_opt().expect("previous day");
+    windows[0].until = windows[0].until.pred_opt().expect("previous day");
+    windows[0].since_utc_ms -= 24 * 60 * 60 * 1_000;
+    windows[0].until_exclusive_utc_ms -= 24 * 60 * 60 * 1_000;
+    source.summaries[0].since = Some(windows[0].since);
+    source.summaries[0].until = Some(windows[0].until);
+    let bundle = SnapshotBundle {
+        schema_version: SCHEMA_VERSION,
+        machines: vec![StoredMachineSnapshot {
+            machine_id: "remote".to_string(),
+            machine_name: "Remote".to_string(),
+            captured_at_ms: 1,
+            windows,
+            sources: vec![source],
+        }],
+    };
+
+    let rollup = import_bundle_at(&path, &serde_json::to_string(&bundle).expect("bundle"))
+        .expect("import partially fresh snapshot");
+
+    assert_eq!(rollup.today_current_machines, 1);
+    assert_eq!(rollup.week_current_machines, 2);
+    assert_eq!(rollup.totals.today_cost, Some(1.0));
+    assert_eq!(rollup.totals.week_cost, Some(4.0));
+    fs::remove_file(path).expect("remove test database");
+}
+
+#[test]
+fn equal_date_labels_with_different_utc_boundaries_are_not_current() {
+    let current = current_usage_windows_with_cli_config().expect("usage windows");
+    let mut shifted = current.clone();
+    for window in &mut shifted {
+        window.since_utc_ms -= 8 * 60 * 60 * 1_000;
+        window.until_exclusive_utc_ms -= 8 * 60 * 60 * 1_000;
+    }
+    let snapshot = StoredMachineSnapshot {
+        machine_id: "remote".to_string(),
+        machine_name: "Remote".to_string(),
+        captured_at_ms: 1,
+        windows: shifted,
+        sources: vec![sample_source(100, 400, 900)],
+    };
+
+    validate_snapshot(&snapshot).expect("same date labels are internally valid");
+    assert_eq!(
+        snapshot_freshness_against(&snapshot, &current).expect("freshness"),
+        [false, false, false]
+    );
+}
+
+#[test]
+fn bundles_round_trip_without_replacing_the_local_machine() {
+    let studio = database("round-trip-studio");
+    let laptop = database("round-trip-laptop");
+    save_local_snapshot_at(&studio, "Studio", vec![sample_source(100, 400, 900)])
+        .expect("save studio snapshot");
+    save_local_snapshot_at(&laptop, "Laptop", vec![sample_source(50, 200, 600)])
+        .expect("save laptop snapshot");
+
+    let studio_bundle = export_bundle_at(&studio).expect("export studio");
+    import_bundle_at(&laptop, &studio_bundle).expect("import studio on laptop");
+    let laptop_bundle = export_bundle_at(&laptop).expect("export laptop and studio");
+    let rollup = import_bundle_at(&studio, &laptop_bundle).expect("round-trip to studio");
+
+    assert_eq!(rollup.machines.len(), 2);
+    assert_eq!(rollup.local_machine_name.as_deref(), Some("Studio"));
+    assert_eq!(rollup.totals.month_tokens, 1_500);
+    fs::remove_file(studio).expect("remove studio database");
+    fs::remove_file(laptop).expect("remove laptop database");
+}
+
+#[test]
+fn lower_bound_cost_is_not_presented_as_a_complete_machine_total() {
+    let path = database("lower-bound");
+    let mut source = sample_source(100, 400, 900);
+    source.summaries[2].api_equivalent_cost_coverage = Some(ApiEquivalentCostCoverage {
+        total_tokens: 900,
+        priced_tokens: 800,
+        percent: 800.0 / 900.0 * 100.0,
+        complete: false,
+        cost_is_lower_bound: true,
+    });
+
+    let rollup = save_local_snapshot_at(&path, "Studio", vec![source]).expect("save snapshot");
+
+    assert_eq!(rollup.totals.month_cost, None);
+    fs::remove_file(path).expect("remove test database");
+}

--- a/desktop/src/ActivityView.tsx
+++ b/desktop/src/ActivityView.tsx
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { DesktopBridge, TurnToolBreakdown, UsageRange } from "./bridge";
+import { errorMessage, formatTokens } from "./format";
+
+function localTimestamp(value: string) {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+}
+
+export function ActivityView({ bridge, source, range }: {
+  bridge: DesktopBridge;
+  source: string;
+  range: UsageRange;
+}) {
+  const [data, setData] = useState<TurnToolBreakdown | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const requestId = useRef(0);
+
+  const load = useCallback(async () => {
+    if (source === "all") {
+      setData(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+    const currentRequest = ++requestId.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await bridge.turnToolBreakdown(source, range);
+      if (requestId.current === currentRequest) setData(next);
+    } catch (nextError) {
+      if (requestId.current === currentRequest) {
+        setData(null);
+        setError(errorMessage(nextError));
+      }
+    } finally {
+      if (requestId.current === currentRequest) setLoading(false);
+    }
+  }, [bridge, range, source]);
+
+  useEffect(() => {
+    void load();
+    return () => { requestId.current += 1; };
+  }, [load]);
+
+  if (source === "all") {
+    return <section className="state-pane empty-state"><span aria-hidden="true">↳</span><div><h2>Choose one source</h2><p>Turn evidence belongs to one source ledger. Choose a concrete source to inspect it.</p></div></section>;
+  }
+  if (loading) {
+    return <section className="loading-state" aria-live="polite"><div><i /><i /><i /></div><strong>Resolving turns and tool calls…</strong><span>Parse · deduplicate · order</span></section>;
+  }
+  if (error) {
+    return <section className="state-pane error-state" role="alert"><span aria-hidden="true">!</span><div><h2>Could not read activity evidence.</h2><p>{error}</p><button type="button" onClick={() => void load()}>Try again</button></div></section>;
+  }
+  if (!data) return null;
+
+  const qualityWarning = data.quality.dedup_skipped_entries > 0 || data.quality.parse_error_entries > 0;
+  const maxCalls = Math.max(data.tools[0]?.calls ?? 0, 1);
+
+  return (
+    <section className="activity-workbench" aria-labelledby="activity-title">
+      <header className="work-pane activity-heading">
+        <div>
+          <h2 id="activity-title">Turn and tool evidence</h2>
+          <p>One turn is one deduplicated usage-bearing model response.</p>
+        </div>
+        <button type="button" className="refresh-button" onClick={() => void load()}>↻ Refresh activity</button>
+      </header>
+
+      <dl className="activity-summary">
+        <div><dt>Model turns</dt><dd data-testid="activity-turn-count">{formatTokens(data.total_turns)}</dd><small>{data.turns.length < data.total_turns ? `Latest ${data.turns.length} shown` : "Complete window"}</small></div>
+        <div><dt>Tool calls</dt><dd data-testid="activity-tool-count">{data.tool_calls_supported ? formatTokens(data.tool_calls_total) : "—"}</dd><small>{data.tool_calls_supported ? `${data.tools.length} tools observed` : "Not reported by source"}</small></div>
+        <div><dt>Data quality</dt><dd className={qualityWarning ? "unknown-cost" : "known-cost"}>{qualityWarning ? "Review" : "Clean"}</dd><small>{formatTokens(data.quality.parse_error_entries)} malformed · {formatTokens(data.quality.dedup_skipped_entries)} deduped</small></div>
+      </dl>
+
+      <div className="activity-grid">
+        <section className="work-pane tool-evidence" aria-labelledby="tools-title">
+          <header className="pane-heading"><div><h2 id="tools-title">Tool calls</h2><p>Call frequency only; no token cost is assigned to tools.</p></div><span>{data.tool_calls_supported ? `${data.tool_calls_total} total` : "Unsupported"}</span></header>
+          {!data.tool_calls_supported ? (
+            <div className="evidence-note"><strong>This source does not expose tool-call records.</strong><p>Turn tokens remain available below. ccstats will not infer tools from transcript text.</p></div>
+          ) : data.tools.length === 0 ? (
+            <div className="evidence-note"><strong>No tool calls in this window.</strong><p>Choose a wider period if you expected tool activity.</p></div>
+          ) : (
+            <ol className="tool-list">
+              {data.tools.map((tool) => (
+                <li key={tool.name}>
+                  <div><strong>{tool.name}</strong><span>{formatTokens(tool.calls)} · {((tool.calls / data.tool_calls_total) * 100).toFixed(1)}%</span></div>
+                  <i><span style={{ width: `${tool.calls / maxCalls * 100}%` }} /></i>
+                </li>
+              ))}
+            </ol>
+          )}
+        </section>
+
+        <aside className="work-pane evidence-method" aria-label="Evidence method">
+          <header className="pane-heading"><div><h2>Method</h2><p>What this page can prove.</p></div></header>
+          <dl>
+            <div><dt>Turn identity</dt><dd>Session + message ID</dd></div>
+            <div><dt>Streaming</dt><dd>Completed entry wins</dd></div>
+            <div><dt>Tool identity</dt><dd>Session + message + tool-use ID</dd></div>
+            <div><dt>Attribution limit</dt><dd>Tool tokens remain unknown</dd></div>
+          </dl>
+        </aside>
+      </div>
+
+      <section className="work-pane table-pane turn-table" aria-labelledby="turns-title">
+        <header className="pane-heading"><div><h2 id="turns-title">Recent model turns</h2><p>Newest first, capped at 100 rows.</p></div><span>{data.turns.length} shown</span></header>
+        {data.turns.length === 0 ? (
+          <div className="evidence-note"><strong>No usage-bearing turns in this window.</strong><p>Run the source once or choose a wider period.</p></div>
+        ) : (
+          <div className="table-scroll">
+            <table>
+              <thead><tr><th>Turn</th><th>Model</th><th>Input</th><th>Output</th><th>Cache</th><th>Reasoning</th><th>Total</th></tr></thead>
+              <tbody>
+                {data.turns.map((turn, index) => (
+                  <tr key={`${turn.session_id}:${turn.message_id ?? turn.timestamp}:${index}`}>
+                    <td className="identity-cell turn-identity"><strong>{localTimestamp(turn.timestamp)}</strong><small>{turn.session_id || "No session ID"}{turn.project_path ? ` · ${turn.project_path}` : ""}</small></td>
+                    <td>{turn.model || "Unknown"}{turn.model_call_count > 1 ? <small className="call-badge">{turn.model_call_count} calls</small> : null}</td>
+                    <td>{formatTokens(turn.tokens.input_tokens)}</td>
+                    <td>{formatTokens(turn.tokens.output_tokens)}</td>
+                    <td>{formatTokens(turn.tokens.cache_read_tokens + turn.tokens.cache_creation_tokens)}</td>
+                    <td>{formatTokens(turn.tokens.reasoning_tokens)}</td>
+                    <td className="known-cost">{formatTokens(turn.tokens.total_tokens)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </section>
+  );
+}

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1,152 +1,167 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  aggregateUsageOverviews,
+  detectUsageAnomaly,
   desktopBridge,
+  hasExactCost,
+  type AnalyticsQuality,
+  rankConsumers,
+  type CodexQuotaOverview,
   type CostSummary,
+  type ProjectDrilldownSummary,
+  type RankedConsumer,
   type SourceDescriptor,
+  type SourceDiagnosticDescriptor,
   type TokenBreakdown,
+  type UsageHistory,
   type UsageOverview,
   type UsageRange,
 } from "./bridge";
+import { errorMessage, formatCost, formatTokens } from "./format";
+import { ActivityView } from "./ActivityView";
+import { CostTrustView } from "./CostTrustView";
+import { LiveView, useLiveUsage } from "./LiveView";
+import { MachinesView } from "./MachinesView";
 
-const RANGE_OPTIONS: ReadonlyArray<{ value: UsageRange; label: string; eyebrow: string }> = [
-  { value: "today", label: "Today", eyebrow: "Live window" },
-  { value: "this_week", label: "This week", eyebrow: "Since Monday" },
-  { value: "this_month", label: "This month", eyebrow: "Month to date" },
+type AnalyticsView = "overview" | "trust" | "live" | "top" | "limits" | "machines" | "activity" | "projects" | "history" | "diagnostics";
+const VIEW_GROUPS: ReadonlyArray<{ label: string; views: ReadonlyArray<{ value: AnalyticsView; label: string; detail: string }> }> = [
+  { label: "Observe", views: [
+    { value: "overview", label: "Overview", detail: "Source totals" },
+    { value: "live", label: "Live", detail: "15-second watch" },
+    { value: "top", label: "Top consumers", detail: "Rankings and spikes" },
+  ] },
+  { label: "Explain", views: [
+    { value: "activity", label: "Turns & tools", detail: "Evidence trace" },
+    { value: "projects", label: "Projects", detail: "Session trace" },
+    { value: "history", label: "History", detail: "Daily movement" },
+  ] },
+  { label: "Trust", views: [
+    { value: "trust", label: "Cost evidence", detail: "Pricing provenance" },
+    { value: "limits", label: "Limits", detail: "Quota and budget" },
+    { value: "diagnostics", label: "Diagnostics", detail: "Source readiness" },
+  ] },
+  { label: "Devices", views: [
+    { value: "machines", label: "Machines", detail: "Cross-device rollup" },
+  ] },
 ];
 
-const integer = new Intl.NumberFormat("en-US");
+const RANGE_OPTIONS: ReadonlyArray<{ value: UsageRange; label: string }> = [
+  { value: "today", label: "Today" }, { value: "this_week", label: "This week" }, { value: "this_month", label: "This month" },
+];
 
-function formatTokens(value: number) {
-  return integer.format(value);
-}
-
-function formatCost(value: number | null, currency: string) {
-  if (value === null) return "Unknown";
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency,
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(value);
-}
-
-function errorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error);
-}
-
-function TokenComposition({ tokens }: { tokens: TokenBreakdown }) {
-  const buckets = [
-    { label: "Input", value: tokens.input_tokens, tone: "acid" },
-    { label: "Output", value: tokens.output_tokens, tone: "paper" },
-    { label: "Reasoning", value: tokens.reasoning_tokens, tone: "amber" },
-    { label: "Cache write", value: tokens.cache_creation_tokens, tone: "blue" },
-    { label: "Cache read", value: tokens.cache_read_tokens, tone: "mint" },
-  ];
-  const max = Math.max(...buckets.map((bucket) => bucket.value), 1);
-
-  return (
-    <section className="ledger-panel composition-panel" aria-labelledby="composition-title">
-      <div className="section-heading">
-        <div>
-          <p className="section-kicker">Token taxonomy</p>
-          <h2 id="composition-title">Composition</h2>
-        </div>
-        {tokens.cache_hit_rate !== null ? (
-          <span className="cache-rate">{tokens.cache_hit_rate.toFixed(1)}% cache hit</span>
-        ) : (
-          <span className="muted-badge">Cache rate unavailable</span>
-        )}
-      </div>
-      <div className="bucket-list">
-        {buckets.map((bucket) => (
-          <div className="bucket-row" key={bucket.label}>
-            <div className="bucket-label">
-              <span>{bucket.label}</span>
-              <strong>{formatTokens(bucket.value)}</strong>
-            </div>
-            <div className="bucket-track" aria-hidden="true">
-              <span
-                className={`bucket-fill bucket-${bucket.tone}`}
-                style={{ width: `${Math.max((bucket.value / max) * 100, bucket.value > 0 ? 1 : 0)}%` }}
-              />
-            </div>
-          </div>
-        ))}
-      </div>
-    </section>
-  );
-}
-
-function QualityPanel({ summary }: { summary: CostSummary }) {
+function QualityStatus({ summary }: { summary: CostSummary }) {
   const hasWarnings = summary.skipped_entries > 0 || summary.parse_error_entries > 0;
 
   return (
-    <section
-      className={`ledger-panel quality-panel ${hasWarnings ? "quality-warning" : "quality-clean"}`}
-      aria-labelledby="quality-title"
-      role="status"
-    >
-      <div className="quality-mark" aria-hidden="true">{hasWarnings ? "!" : "✓"}</div>
+    <aside className={`quality-status ${hasWarnings ? "quality-warning" : ""}`} role="status">
+      <span className="quality-symbol" aria-hidden="true">{hasWarnings ? "!" : "✓"}</span>
       <div>
-        <p className="section-kicker">Data quality</p>
-        <h2 id="quality-title">{hasWarnings ? "Review needed" : "Ledger healthy"}</h2>
+        <strong>{hasWarnings ? "Review needed" : "Ledger healthy"}</strong>
         <p>
           {hasWarnings
             ? `${summary.skipped_entries} deduplicated · ${summary.parse_error_entries} malformed in combined scan`
             : `${summary.valid_entries} records reconciled with no parse warnings`}
         </p>
       </div>
-      <dl className="quality-facts">
-        <div>
-          <dt>Valid</dt>
-          <dd>{formatTokens(summary.valid_entries)}</dd>
-        </div>
-        <div>
-          <dt>Deduped</dt>
-          <dd>{formatTokens(summary.skipped_entries)}</dd>
-        </div>
-        <div>
-          <dt>Scan malformed</dt>
-          <dd>{formatTokens(summary.parse_error_entries)}</dd>
-        </div>
+      <dl>
+        <div><dt>Valid</dt><dd>{formatTokens(summary.valid_entries)}</dd></div>
+        <div><dt>Deduped</dt><dd>{formatTokens(summary.skipped_entries)}</dd></div>
+        <div><dt>Scan malformed</dt><dd>{formatTokens(summary.parse_error_entries)}</dd></div>
       </dl>
-    </section>
+    </aside>
+  );
+}
+
+function AnalysisQualityNotice({ quality, combinedScan = false }: { quality: AnalyticsQuality; combinedScan?: boolean }) {
+  if (quality.parse_error_entries === 0 && quality.dedup_skipped_entries === 0) return null;
+  const noValidRecords = !combinedScan && quality.valid_entries === 0 && quality.parse_error_entries > 0;
+  return (
+    <aside className={`quality-notice ${noValidRecords ? "quality-notice-error" : ""}`} role={noValidRecords ? "alert" : "status"}>
+      <strong>{noValidRecords ? "No valid records could be parsed." : "Data quality needs review."}</strong>
+      <span>
+        {formatTokens(quality.parse_error_entries)} malformed · {formatTokens(quality.dedup_skipped_entries)} deduplicated
+        {combinedScan ? " in the combined scan; malformed dates are not attributable to this selected period." : " in this period."}
+      </span>
+    </aside>
+  );
+}
+
+function costIsLowerBound(summary: CostSummary) {
+  return summary.cost !== null && summary.api_equivalent_cost_coverage?.cost_is_lower_bound === true;
+}
+
+function costSummaryQuality(summary: CostSummary): AnalyticsQuality { return { valid_entries: summary.valid_entries, dedup_skipped_entries: summary.skipped_entries, parse_error_entries: summary.parse_error_entries }; }
+
+function displayedCost(summary: CostSummary) {
+  return `${costIsLowerBound(summary) ? "≥ " : summary.cost !== null && !hasExactCost(summary) ? "≈ " : ""}${formatCost(summary.cost, summary.currency)}`;
+}
+
+function TokenMap({ tokens }: { tokens: TokenBreakdown }) {
+  const adjustment = tokens.reported_total_adjustment;
+  const namedBuckets = [
+    { label: "Input", value: tokens.input_tokens, tone: "input" },
+    { label: "Output", value: tokens.output_tokens, tone: "output" },
+    { label: "Reasoning", value: tokens.reasoning_tokens, tone: "reasoning" },
+    { label: "Cache write", value: tokens.cache_creation_tokens, tone: "cache-write" },
+    { label: "Cache read", value: tokens.cache_read_tokens, tone: "cache-read" },
+  ];
+  const componentTotal = namedBuckets.reduce((sum, bucket) => sum + Math.max(bucket.value, 0), 0);
+  const total = Math.max(tokens.total_tokens, componentTotal, 1);
+  const buckets = adjustment > 0
+    ? [...namedBuckets, { label: "Provider adjustment", value: adjustment, tone: "adjustment" }]
+    : namedBuckets;
+
+  return (
+    <>
+      <div className="token-map" aria-label="Token composition">
+        {buckets.map((bucket) => {
+          const percentage = (bucket.value / total) * 100;
+          return bucket.value > 0 ? (
+            <div
+              className={`token-map-segment map-${bucket.tone}`}
+              key={bucket.label}
+              style={{ flexBasis: `${percentage}%` }}
+            >
+              {percentage >= 10 ? (
+                <><span>{bucket.label}</span><strong>{formatTokens(bucket.value)}</strong></>
+              ) : null}
+            </div>
+          ) : null;
+        })}
+      </div>
+      <dl className="token-key">
+        {[...namedBuckets, ...(adjustment !== 0 ? [{ label: "Provider adjustment", value: adjustment, tone: "adjustment" }] : [])].map((bucket) => (
+          <div key={bucket.label}>
+            <dt><i className={`key-${bucket.tone}`} />{bucket.label}</dt>
+            <dd>{formatTokens(bucket.value)}</dd>
+            <small>{((bucket.value / total) * 100).toFixed(1)}%</small>
+          </div>
+        ))}
+      </dl>
+      {adjustment < 0 ? <p className="token-adjustment-note">The provider-reported total is {formatTokens(Math.abs(adjustment))} tokens below the named components. The total remains authoritative.</p> : null}
+    </>
   );
 }
 
 function ModelTable({ summary }: { summary: CostSummary }) {
   return (
-    <section className="ledger-panel model-panel" aria-labelledby="models-title">
-      <div className="section-heading">
-        <div>
-          <p className="section-kicker">Attribution</p>
-          <h2 id="models-title">Models</h2>
-        </div>
-        <span className="row-count">{summary.models.length} observed</span>
-      </div>
+    <section className="work-pane table-pane" aria-labelledby="models-title">
+      <header className="pane-heading">
+        <div><h2 id="models-title">Models</h2><p>Provider model attribution for this period.</p></div>
+        <span>{summary.models.length} observed</span>
+      </header>
       <div className="table-scroll">
         <table>
-          <thead>
-            <tr>
-              <th>Model</th>
-              <th>Input</th>
-              <th>Output</th>
-              <th>Cache</th>
-              <th>Total</th>
-              <th>Cost</th>
-            </tr>
-          </thead>
+          <thead><tr><th>Model</th><th>Input</th><th>Output</th><th>Cache</th><th>Total</th><th>Cost</th></tr></thead>
           <tbody>
             {summary.models.map((model) => (
               <tr key={model.model}>
-                <td className="model-name">{model.model}</td>
+                <td className="identity-cell">{model.model}</td>
                 <td>{formatTokens(model.tokens.input_tokens)}</td>
                 <td>{formatTokens(model.tokens.output_tokens)}</td>
                 <td>{formatTokens(model.tokens.cache_read_tokens)}</td>
                 <td>{formatTokens(model.tokens.total_tokens)}</td>
-                <td className={model.cost === null ? "unknown-cost" : "known-cost"}>
-                  {formatCost(model.cost, summary.currency)}
-                </td>
+                <td className={hasExactCost(summary) && hasExactCost(model) ? "known-cost" : "unknown-cost"}>{costIsLowerBound(summary) ? "≥ " : model.cost !== null && (!hasExactCost(summary) || !hasExactCost(model)) ? "≈ " : ""}{formatCost(model.cost, summary.currency)}</td>
               </tr>
             ))}
           </tbody>
@@ -156,37 +171,361 @@ function ModelTable({ summary }: { summary: CostSummary }) {
   );
 }
 
-function EmptyState({
-  source,
-  rangeLabel,
-  parseErrors,
+function SourceTable({ overview, range }: { overview: UsageOverview; range: UsageRange }) {
+  const rows = overview.source_overviews?.map((source) => ({
+    source,
+    summary: source.summaries.find((candidate) => candidate.range === range),
+  })).filter((row): row is { source: UsageOverview; summary: CostSummary } => row.summary !== undefined) ?? [];
+
+  if (rows.length === 0) return null;
+  return (
+    <section className="work-pane table-pane" aria-labelledby="sources-title">
+      <header className="pane-heading">
+        <div><h2 id="sources-title">Sources</h2><p>Every ready AI ledger included in the total.</p></div>
+        <span>{rows.length} scanned</span>
+      </header>
+      <div className="table-scroll">
+        <table>
+          <thead><tr><th>Source</th><th>Records</th><th>Tokens</th><th>Cost</th></tr></thead>
+          <tbody>
+            {rows.map(({ source, summary }) => (
+              <tr key={source.source_name}>
+                <td className="identity-cell">{source.display_name}</td>
+                <td>{formatTokens(summary.valid_entries)}</td>
+                <td>{formatTokens(summary.tokens.total_tokens)}</td>
+                <td className={hasExactCost(summary) ? "known-cost" : "unknown-cost"}>{displayedCost(summary)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+function EmptyState({ source, range, parseErrors }: { source: string; range: string; parseErrors: number }) {
+  return (
+    <section className="state-pane empty-state">
+      <span aria-hidden="true">○</span>
+      <div>
+        <h2>{parseErrors > 0 ? `No valid ${source} records in this window.` : `The ${source} ledger is quiet in this window.`}</h2>
+        {parseErrors > 0
+          ? <p data-testid="unattributed-parse-errors">{formatTokens(parseErrors)} malformed records were rejected during the combined scan. Their dates are unavailable, so they cannot be assigned to {range}.</p>
+          : <p>Run the source once or choose a wider period. ccstats never invents missing usage.</p>}
+      </div>
+    </section>
+  );
+}
+
+function OverviewView({
+  overview,
+  summary,
+  sourceDescriptor,
+  range,
 }: {
-  source: string;
-  rangeLabel: string;
-  parseErrors: number;
+  overview: UsageOverview;
+  summary: CostSummary;
+  sourceDescriptor: SourceDescriptor | null;
+  range: UsageRange;
 }) {
-  const hasUnattributedErrors = parseErrors > 0;
+  return (
+    <>
+      <div className="report-meta">
+        <div><span className="source-beacon" /><strong>{overview.display_name}</strong><span>{summary.range.replaceAll("_", " ")}</span></div>
+        <span>Scanned in {overview.elapsed_ms.toFixed(1)} ms · {new Date(overview.generated_at).toLocaleString()}</span>
+      </div>
+
+      {summary.valid_entries === 0 && summary.tokens.total_tokens === 0 ? (
+        <EmptyState source={overview.display_name} range={range.replaceAll("_", " ")} parseErrors={summary.parse_error_entries} />
+      ) : (
+        <>
+          <section className="overview-workbench">
+            <article className="work-pane token-map-pane">
+              <header className="pane-heading">
+                <div><h2>Token map</h2><p>Reported components reconciled on one shared scale.</p></div>
+                <span>{summary.currency}</span>
+              </header>
+              <div className="primary-reading">
+                <span>Total tokens</span>
+                <strong data-testid="total-tokens">{formatTokens(summary.tokens.total_tokens)}</strong>
+              </div>
+              <TokenMap tokens={summary.tokens} />
+              <QualityStatus summary={summary} />
+            </article>
+
+            <aside className="work-pane snapshot-pane" aria-label="Usage snapshot">
+              <header className="pane-heading"><div><h2>Snapshot</h2><p>Trust and accounting signals.</p></div></header>
+              <dl className="snapshot-list">
+                <div>
+                  <dt>{costIsLowerBound(summary) ? "Cost lower bound" : hasExactCost(summary) ? "Total cost" : "Cost to review"}</dt>
+                  <dd data-testid="total-cost" className={hasExactCost(summary) ? "known-cost" : "unknown-cost"}>{displayedCost(summary)}</dd>
+                  <small data-testid={costIsLowerBound(summary) ? "cost-coverage" : undefined}>{costIsLowerBound(summary) && summary.api_equivalent_cost_coverage ? `${formatTokens(summary.api_equivalent_cost_coverage.priced_tokens)} / ${formatTokens(summary.api_equivalent_cost_coverage.total_tokens)} tokens priced (${summary.api_equivalent_cost_coverage.percent.toFixed(1)}%)` : summary.cost === null ? "No trustworthy price" : hasExactCost(summary) ? summary.cost_kind : summary.pricing_source}</small>
+                </div>
+                <div><dt>Records</dt><dd>{formatTokens(summary.valid_entries)}</dd><small>Parsed source events</small></div>
+                <div><dt>Cache hit</dt><dd>{summary.tokens.cache_hit_rate === null ? "—" : `${summary.tokens.cache_hit_rate.toFixed(1)}%`}</dd><small>Input-side reuse</small></div>
+              </dl>
+              <div className="capability-block">
+                <span>Available evidence</span>
+                <div>
+                  {sourceDescriptor?.has_projects ? <em>Projects</em> : null}
+                  {sourceDescriptor?.has_reasoning_tokens ? <em>Reasoning</em> : null}
+                  {sourceDescriptor?.has_cache_read ? <em>Cache read</em> : null}
+                  {sourceDescriptor?.has_cache_creation ? <em>Cache write</em> : null}
+                </div>
+              </div>
+            </aside>
+          </section>
+          <SourceTable overview={overview} range={range} />
+          <ModelTable summary={summary} />
+        </>
+      )}
+    </>
+  );
+}
+
+function ProjectView({ data }: { data: ProjectDrilldownSummary }) {
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const selected = data.projects.find((project) => project.project_path === selectedPath) ?? null;
+
+  if (data.projects.length === 0 && data.quality.parse_error_entries > 0) return <AnalysisQualityNotice quality={data.quality} />;
+  if (data.projects.length === 0) return <EmptyState source={data.display_name} range={data.range.replaceAll("_", " ")} parseErrors={0} />;
+  return (
+    <><AnalysisQualityNotice quality={data.quality} /><section className="project-workbench" aria-labelledby="projects-title">
+      <div className="work-pane project-master">
+        <header className="pane-heading">
+          <div><h2 id="projects-title">Projects &amp; sessions</h2><p>Select a project to inspect its sessions.</p></div>
+          <span>{data.projects.length} projects</span>
+        </header>
+        <div className="table-scroll">
+          <table>
+            <thead><tr><th>Project</th><th>Sessions</th><th>Tokens</th><th>Cost</th></tr></thead>
+            <tbody>
+              {data.projects.map((project) => (
+                <tr className={selectedPath === project.project_path ? "selected-row" : ""} key={project.project_path}>
+                  <td className="project-cell">
+                    <button type="button" aria-pressed={selectedPath === project.project_path} onClick={() => setSelectedPath(project.project_path)}>{project.project_name}</button>
+                    <small>{project.project_path}</small>
+                  </td>
+                  <td>{formatTokens(project.session_count)}</td>
+                  <td>{formatTokens(project.metrics.tokens.total_tokens)}</td>
+                  <td className={hasExactCost(project.metrics) ? "known-cost" : "unknown-cost"}>{project.metrics.api_equivalent_cost_coverage?.cost_is_lower_bound ? "≥ " : project.metrics.cost !== null && !hasExactCost(project.metrics) ? "≈ " : ""}{formatCost(project.metrics.cost, data.currency)}<small>{project.metrics.pricing_source}</small></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <aside className="work-pane session-inspector">
+        {selected ? (
+          <>
+            <header className="pane-heading">
+              <div><h2>{selected.project_name}</h2><p className="mono-detail">{selected.project_path}</p></div>
+              <span>{selected.session_count} sessions</span>
+            </header>
+            <div className="session-list">
+              {selected.sessions.map((session) => (
+                <article key={session.session_id}>
+                  <div><strong>{session.session_id}</strong><span>{new Date(session.last_timestamp).toLocaleString()}</span></div>
+                  <dl><div><dt>Tokens</dt><dd>{formatTokens(session.metrics.tokens.total_tokens)}</dd></div><div><dt>Cost</dt><dd className={hasExactCost(session.metrics) ? "known-cost" : "unknown-cost"}>{session.metrics.api_equivalent_cost_coverage?.cost_is_lower_bound ? "≥ " : session.metrics.cost !== null && !hasExactCost(session.metrics) ? "≈ " : ""}{formatCost(session.metrics.cost, data.currency)}<small>{session.metrics.pricing_source}</small></dd></div></dl>
+                </article>
+              ))}
+            </div>
+          </>
+        ) : (
+          <div className="inspector-empty"><span aria-hidden="true">↳</span><h2>Select a project</h2><p>Its session IDs, last activity, tokens, and cost will appear here.</p></div>
+        )}
+      </aside>
+    </section></>
+  );
+}
+
+function HistoryView({ data, exporting, onExport }: { data: UsageHistory; exporting: boolean; onExport: (format: "csv" | "json") => void }) {
+  const maxTokens = Math.max(...data.points.map((point) => point.tokens.total_tokens), 1);
+
+  if (data.points.length === 0 && data.quality.parse_error_entries > 0) return <AnalysisQualityNotice quality={data.quality} />;
+  if (data.points.length === 0) return <EmptyState source={data.display_name} range={data.range.replaceAll("_", " ")} parseErrors={0} />;
+  return (
+    <><AnalysisQualityNotice quality={data.quality} /><section className="work-pane history-workbench" aria-labelledby="history-title">
+      <header className="pane-heading history-heading">
+        <div><h2 id="history-title">History</h2><p>Daily token totals with exact records below.</p></div>
+        <div className="export-actions"><button type="button" disabled={exporting} onClick={() => onExport("csv")}>Export CSV</button><button type="button" disabled={exporting} onClick={() => onExport("json")}>Export JSON</button></div>
+      </header>
+      <figure className="history-chart">
+        <div className="chart-plot" aria-label="Token history chart">
+          {data.points.map((point) => (
+            <div className="chart-slot" key={point.date}>
+              <span className="chart-value">{formatTokens(point.tokens.total_tokens)}</span>
+              <i style={{ height: `${Math.max((point.tokens.total_tokens / maxTokens) * 100, 3)}%` }} />
+              <small>{point.date.slice(5)}</small>
+            </div>
+          ))}
+        </div>
+        <figcaption>All bars share a zero baseline. Dates without records are not fabricated.</figcaption>
+      </figure>
+      <div className="table-scroll">
+        <table>
+          <thead><tr><th>Date</th><th>Records</th><th>Input</th><th>Output</th><th>Total</th><th>Cost</th></tr></thead>
+          <tbody>
+            {data.points.map((point) => (
+              <tr key={point.date}>
+                <td className="identity-cell">{point.date}</td>
+                <td>{formatTokens(point.records)}</td>
+                <td>{formatTokens(point.tokens.input_tokens)}</td>
+                <td>{formatTokens(point.tokens.output_tokens)}</td>
+                <td>{formatTokens(point.tokens.total_tokens)}</td>
+                <td className={point.cost_status === "known" ? "known-cost" : "unknown-cost"}>{point.api_equivalent_cost_coverage?.cost_is_lower_bound ? "≥ " : point.cost_status === "partial" ? "≈ " : ""}{formatCost(point.cost, point.currency)}<small>{point.pricing_source}</small></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section></>
+  );
+}
+
+function ConsumerTable({ title, rows, currency }: { title: string; rows: RankedConsumer[]; currency: string }) {
+  if (rows.length === 0) return null;
+  return (
+    <section className="work-pane table-pane consumer-pane">
+      <header className="pane-heading"><div><h3>{title}</h3><p>Share uses {rows[0].share_basis} across this complete ranking.</p></div></header>
+      <div className="table-scroll"><table>
+        <thead><tr><th>#</th><th>Consumer</th><th>Tokens</th><th>Share</th><th>Cost</th></tr></thead>
+        <tbody>{rows.map((row) => <tr key={row.name}><td>{row.rank}</td><td className="identity-cell">{row.name}</td><td>{formatTokens(row.tokens)}</td><td>{row.share.toFixed(1)}%</td><td className={row.cost === null ? "unknown-cost" : "known-cost"}>{formatCost(row.cost, currency)}</td></tr>)}</tbody>
+      </table></div>
+    </section>
+  );
+}
+
+function TopInsightsView({ overview, summary, history, projects, warnings }: { overview: UsageOverview; summary: CostSummary; history: UsageHistory | null; projects: ProjectDrilldownSummary | null; warnings: string[] }) {
+  const models = rankConsumers(summary.models.map((model) => ({ name: model.model, tokens: model.tokens.total_tokens, cost: hasExactCost(summary) && hasExactCost(model) ? model.cost : null })));
+  const sources = rankConsumers(overview.source_overviews?.flatMap((source) => {
+    const row = source.summaries.find((candidate) => candidate.range === summary.range);
+    return row ? [{ name: source.display_name, tokens: row.tokens.total_tokens, cost: hasExactCost(row) ? row.cost : null }] : [];
+  }) ?? []);
+  const projectRows = rankConsumers(projects?.projects.map((project) => ({ name: project.project_name, tokens: project.metrics.tokens.total_tokens, cost: hasExactCost(project.metrics) ? project.metrics.cost : null })) ?? []);
+  const anomaly = detectUsageAnomaly(history);
+  return (
+    <section className="top-workbench" aria-labelledby="top-title">
+      <AnalysisQualityNotice quality={costSummaryQuality(summary)} combinedScan />
+      <header className="work-pane pane-heading top-heading"><div><h2 id="top-title">Top consumers</h2><p>Ranked by cost when every row is priced; otherwise by tokens.</p></div></header>
+      <aside className={`work-pane anomaly-pane anomaly-${anomaly.status}`} role="status">
+        <div><strong>{anomaly.status === "spike" ? "Usage spike detected" : anomaly.status === "normal" ? "No usage spike" : "Not enough history"}</strong><p>{anomaly.date ?? "A concrete source needs at least four complete usage days."}</p></div>
+        <dl><div><dt>Latest</dt><dd>{anomaly.tokens === null ? "—" : formatTokens(anomaly.tokens)}</dd></div><div><dt>7-day baseline</dt><dd>{anomaly.baseline_tokens === null ? "—" : formatTokens(Math.round(anomaly.baseline_tokens))}</dd></div><div><dt>Change</dt><dd data-testid="anomaly-change">{anomaly.change_pct === null ? "—" : `${anomaly.change_pct.toFixed(1)}%`}</dd></div></dl>
+      </aside>
+      {warnings.map((warning) => <p className="inline-warning" key={warning}>{warning}</p>)}
+      <div className="consumer-grid"><ConsumerTable title="Models" rows={models} currency={summary.currency} /><ConsumerTable title="Sources" rows={sources} currency={summary.currency} /><ConsumerTable title="Projects" rows={projectRows} currency={summary.currency} /></div>
+    </section>
+  );
+}
+
+function DiagnosticsView({ rows }: { rows: SourceDiagnosticDescriptor[] }) {
+  const detected = rows.filter((row) => row.status === "detected").length;
+  const configured = rows.filter((row) => row.status === "configured").length;
+  const missing = rows.filter((row) => row.status === "missing").length;
 
   return (
-    <section className="empty-state">
-      <span className="empty-index">00</span>
-      <div>
-        <p className="section-kicker">
-          {hasUnattributedErrors ? "Unattributed parse warnings" : "No local records"}
-        </p>
-        <h2>
-          {hasUnattributedErrors
-            ? `No valid ${source} records in this window.`
-            : `The ${source} ledger is quiet in this window.`}
-        </h2>
-        {hasUnattributedErrors ? (
-          <p data-testid="unattributed-parse-errors">
-            {formatTokens(parseErrors)} malformed records were rejected during the combined range
-            scan. The summary does not expose their dates, so they cannot be assigned to {rangeLabel}.
-          </p>
-        ) : (
-          <p>Run the source once or choose a wider time window. ccstats never invents missing usage.</p>
-        )}
+    <section className="work-pane table-pane diagnostics-pane" aria-labelledby="diagnostics-title">
+      <header className="pane-heading">
+        <div><h2 id="diagnostics-title">Source diagnostics</h2><p>Read-only discovery; remote providers are not contacted.</p></div>
+        <span>{rows.length} registered</span>
+      </header>
+      <div className="diagnostic-summary" aria-label="Diagnostic totals">
+        <strong>{`${detected} detected`}</strong>
+        <strong>{`${configured} configured`}</strong>
+        <strong>{`${missing} missing`}</strong>
+      </div>
+      <div className="table-scroll">
+        <table>
+          <thead><tr><th>Source</th><th>Status</th><th>Files</th><th>Detail and next step</th></tr></thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.name}>
+                <td className="identity-cell">{row.display_name}</td>
+                <td><span className={`diagnostic-status status-${row.status}`}>{row.status}</span></td>
+                <td>{formatTokens(row.files)}</td>
+                <td className="diagnostic-detail"><span>{row.detail}</span>{row.status === "missing" ? <small>{row.setup}</small> : null}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+function formatPercent(value: number) {
+  return `${value.toFixed(1)}%`;
+}
+
+function formatTimestamp(value: string | null) {
+  if (value === null) return "Not projected";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+}
+
+function QuotaBudgetView({ quota, quotaError, monthly, budget, onBudgetChange }: {
+  quota: CodexQuotaOverview | null;
+  quotaError: string | null;
+  monthly: CostSummary | null;
+  budget: string;
+  onBudgetChange: (value: string) => void;
+}) {
+  const limit = Number(budget);
+  const validLimit = Number.isFinite(limit) && limit > 0;
+  const spent = monthly?.cost ?? null;
+  const spentIsLowerBound = monthly?.api_equivalent_cost_coverage?.cost_is_lower_bound === true;
+  const spentIsExact = monthly !== null && hasExactCost(monthly);
+  const spentPrefix = spentIsLowerBound ? "≥ " : spent !== null && !spentIsExact ? "≈ " : "";
+  const [asOfYear, asOfMonth, daysElapsed] = monthly?.until?.split("-").map(Number) ?? [];
+  const daysInMonth = asOfYear && asOfMonth ? new Date(Date.UTC(asOfYear, asOfMonth, 0)).getUTCDate() : 0;
+  const projected = spent === null || !daysElapsed || !daysInMonth ? null : spent * daysInMonth / daysElapsed;
+  const remaining = spent === null || !validLimit || !spentIsExact ? null : limit - spent;
+  const budgetStatus = spentIsLowerBound ? "Lower bound" : spent !== null && !spentIsExact ? "Review" : spent === null || projected === null || !validLimit
+    ? "Unavailable"
+    : projected > limit
+      ? "Over budget"
+      : projected >= limit * 0.9 ? "Watch" : "On track";
+
+  return (
+    <section className="limits-workbench" aria-labelledby="limits-title">
+      {monthly ? <AnalysisQualityNotice quality={costSummaryQuality(monthly)} combinedScan /> : null}
+      <header className="work-pane pane-heading limits-heading">
+        <div><h2 id="limits-title">Quota and budget</h2><p>Provider quota stays separate from local cost forecasting.</p></div>
+      </header>
+      <div className="limits-grid">
+        <section className="work-pane limit-pane" aria-labelledby="quota-title">
+          <header className="pane-heading"><div><h3 id="quota-title">Codex weekly quota</h3><p>Latest provider-reported weekly window.</p></div></header>
+          {quota ? (
+            <>
+              <dl className="limit-metrics">
+                <div><dt>Used</dt><dd data-testid="quota-used">{formatPercent(quota.quota.used_pct)}</dd></div>
+                <div><dt>Remaining</dt><dd data-testid="quota-remaining">{formatPercent(quota.quota.remaining_pct)}</dd></div>
+                <div><dt>Projected at reset</dt><dd>{formatPercent(quota.quota.projected_pct_at_reset)}</dd></div>
+                <div><dt>Status</dt><dd>{quota.quota.status.replaceAll("_", " ")}</dd></div>
+              </dl>
+              <dl className="limit-details">
+                <div><dt>Resets</dt><dd>{formatTimestamp(quota.quota.resets_at)}</dd></div>
+                <div><dt>Projected depletion</dt><dd>{formatTimestamp(quota.quota.estimated_depletion_at)}</dd></div>
+                <div><dt>API-equivalent weekly value</dt><dd data-testid="quota-value">{quota.value_estimate ? formatCost(quota.value_estimate.estimated_weekly_value_usd, "USD") : "Unavailable"}</dd></div>
+              </dl>
+              {quota.value_estimate_error ? <p className="inline-warning">{quota.value_estimate_error}</p> : null}
+            </>
+          ) : <p className="inline-warning">{quotaError ?? "Quota snapshot unavailable"}</p>}
+        </section>
+
+        <section className="work-pane limit-pane" aria-labelledby="budget-title">
+          <header className="pane-heading"><div><h3 id="budget-title">Monthly budget</h3><p>Forecast from confirmed month-to-date cost.</p></div></header>
+          <label className="budget-input">Monthly budget<input aria-label="Monthly budget" type="number" min="0.01" step="1" value={budget} onChange={(event) => onBudgetChange(event.target.value)} /></label>
+          {!validLimit ? <p className="inline-warning">Enter a positive monthly budget.</p> : null}
+          <dl className="limit-metrics">
+            <div><dt>Spent</dt><dd data-testid="budget-spent">{spentPrefix}{formatCost(spent, monthly?.currency ?? "USD")}</dd></div>
+            <div><dt>Remaining</dt><dd data-testid="budget-remaining">{formatCost(remaining, monthly?.currency ?? "USD")}</dd></div>
+            <div><dt>Month-end forecast</dt><dd>{spentPrefix}{formatCost(projected, monthly?.currency ?? "USD")}</dd></div>
+            <div><dt>Status</dt><dd>{budgetStatus}</dd></div>
+          </dl>
+          <p className="limit-note">{daysElapsed} of {daysInMonth} days elapsed. Unknown costs remain unknown.</p>
+        </section>
       </div>
     </section>
   );
@@ -194,224 +533,267 @@ function EmptyState({
 
 export default function App() {
   const bridge = useMemo(() => desktopBridge(), []);
+  const requestId = useRef(0);
   const [sources, setSources] = useState<SourceDescriptor[]>([]);
   const [selectedSource, setSelectedSource] = useState("");
   const [selectedRange, setSelectedRange] = useState<UsageRange>("today");
+  const [view, setView] = useState<AnalyticsView>("overview");
   const [overview, setOverview] = useState<UsageOverview | null>(null);
+  const [drilldown, setDrilldown] = useState<ProjectDrilldownSummary | null>(null);
+  const [history, setHistory] = useState<UsageHistory | null>(null);
+  const [diagnostics, setDiagnostics] = useState<SourceDiagnosticDescriptor[] | null>(null);
+  const [quotaOverview, setQuotaOverview] = useState<CodexQuotaOverview | null>(null);
+  const [quotaError, setQuotaError] = useState<string | null>(null);
+  const [monthlyBudget, setMonthlyBudget] = useState("100");
+  const [insightHistory, setInsightHistory] = useState<UsageHistory | null>(null);
+  const [insightProjects, setInsightProjects] = useState<ProjectDrilldownSummary | null>(null);
+  const [insightWarnings, setInsightWarnings] = useState<string[]>([]);
+  const [exporting, setExporting] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const loadOverview = useCallback(
-    async (source: string) => {
-      setLoading(true);
-      setError(null);
-      try {
-        setOverview(await bridge.usageOverview(source));
-      } catch (nextError) {
-        setOverview(null);
-        setError(errorMessage(nextError));
-      } finally {
-        setLoading(false);
+  const readySourceNames = useMemo(() => {
+    const ready = new Set(diagnostics?.filter((row) => row.status !== "missing").map((row) => row.name) ?? []);
+    return sources.filter((source) => source.name !== "all" && ready.has(source.name)).map((source) => source.name);
+  }, [diagnostics, sources]);
+  const readOverview = useCallback(async (source: string) => {
+    if (source !== "all") return bridge.usageOverview(source);
+    const findings = await bridge.sourceDiagnostics(); setDiagnostics(findings);
+    const ready = new Set(findings.filter((row) => row.status !== "missing").map((row) => row.name));
+    const names = sources.filter((item) => item.name !== "all" && ready.has(item.name)).map((item) => item.name);
+    if (names.length === 0) throw new Error("No detected or configured sources are ready to aggregate.");
+    return aggregateUsageOverviews(await bridge.usageOverviews(names));
+  }, [bridge, sources]);
+
+  const loadView = useCallback(async (nextView: AnalyticsView, source: string, range: UsageRange) => {
+    const request = ++requestId.current;
+    setView(nextView);
+    if (nextView === "live" || nextView === "machines" || nextView === "activity") { setLoading(false); setError(null); return; }
+    setLoading(true);
+    setError(null);
+    try {
+      if (nextView === "overview" || nextView === "trust") {
+        const nextOverview = await readOverview(source);
+        if (request !== requestId.current) return;
+        setOverview(nextOverview);
+      } else if (nextView === "top") {
+        const supportsProjects = sources.find((item) => item.name === source)?.has_projects ?? false;
+        const [nextOverview, nextHistory, nextProjects] = await Promise.allSettled([
+          readOverview(source),
+          source === "all" ? Promise.resolve(null) : bridge.usageHistory(source, "this_month"),
+          source !== "all" && supportsProjects ? bridge.projectDrilldown(source, range) : Promise.resolve(null),
+        ]);
+        if (request !== requestId.current) return;
+        if (nextOverview.status === "rejected") throw nextOverview.reason;
+        setOverview(nextOverview.value);
+        setInsightHistory(nextHistory.status === "fulfilled" ? nextHistory.value : null);
+        setInsightProjects(nextProjects.status === "fulfilled" ? nextProjects.value : null);
+        setInsightWarnings([nextHistory, nextProjects].flatMap((result) => result.status === "rejected" ? [errorMessage(result.reason)] : []));
+      } else if (nextView === "projects") {
+        const next = source === "all" ? null : await bridge.projectDrilldown(source, range);
+        if (request !== requestId.current) return;
+        setHistory(null); setDrilldown(next);
+      } else if (nextView === "history") {
+        const next = source === "all" ? null : await bridge.usageHistory(source, range);
+        if (request !== requestId.current) return;
+        setDrilldown(null); setHistory(next);
+      } else if (nextView === "diagnostics") {
+        const next = await bridge.sourceDiagnostics();
+        if (request !== requestId.current) return;
+        setDrilldown(null); setHistory(null); setDiagnostics(next);
+      } else {
+        const [nextOverview, nextQuota] = await Promise.allSettled([
+          readOverview(source),
+          bridge.codexQuotaOverview(),
+        ]);
+        if (request !== requestId.current) return;
+        if (nextOverview.status === "rejected") throw nextOverview.reason;
+        setOverview(nextOverview.value);
+        if (nextQuota.status === "fulfilled") {
+          setQuotaOverview(nextQuota.value);
+          setQuotaError(null);
+        } else {
+          setQuotaOverview(null);
+          setQuotaError(errorMessage(nextQuota.reason));
+        }
       }
-    },
-    [bridge],
-  );
+    } catch (nextError) {
+      if (request !== requestId.current) return;
+      if (nextView === "top") { setOverview(null); setInsightHistory(null); setInsightProjects(null); }
+      else if (nextView === "projects") setDrilldown(null);
+      else if (nextView === "history") setHistory(null);
+      else if (nextView === "diagnostics") setDiagnostics(null);
+      else setOverview(null);
+      setError(errorMessage(nextError));
+    } finally {
+      if (request === requestId.current) setLoading(false);
+    }
+  }, [bridge, readOverview, sources]);
 
   const initialize = useCallback(async () => {
+    const request = ++requestId.current;
     setLoading(true);
     setError(null);
     setOverview(null);
     try {
-      const catalog = await bridge.listSources();
+      const [catalog, findings] = await Promise.all([bridge.listSources(), bridge.sourceDiagnostics()]);
       if (catalog.length === 0) throw new Error("No usage sources are registered");
-      const initial = catalog.find((source) => source.name === "claude") ?? catalog[0];
-      setSources(catalog);
-      setSelectedSource(initial.name);
-      setOverview(await bridge.usageOverview(initial.name));
+      const allSources: SourceDescriptor = {
+        source: "all",
+        name: "all",
+        display_name: "All Sources",
+        aliases: [],
+        has_projects: false,
+        has_reasoning_tokens: catalog.some((source) => source.has_reasoning_tokens),
+        has_cache_creation: catalog.some((source) => source.has_cache_creation),
+        has_cache_read: catalog.some((source) => source.has_cache_read),
+      };
+      if (request !== requestId.current) return;
+      const ready = new Set(findings.filter((row) => row.status !== "missing").map((row) => row.name));
+      const initial = catalog.find((source) => ready.has(source.name));
+      setSources([allSources, ...catalog]);
+      setDiagnostics(findings);
+      setSelectedSource((initial ?? catalog.find((source) => source.name === "claude") ?? catalog[0]).name);
+      if (!initial) { setView("diagnostics"); setOverview(null); return; }
+      const nextOverview = await bridge.usageOverview(initial.name);
+      if (request === requestId.current) setOverview(nextOverview);
     } catch (nextError) {
-      setError(errorMessage(nextError));
+      if (request === requestId.current) setError(errorMessage(nextError));
     } finally {
-      setLoading(false);
+      if (request === requestId.current) setLoading(false);
     }
   }, [bridge]);
 
-  useEffect(() => {
-    void initialize();
-  }, [initialize]);
+  useEffect(() => { void initialize(); }, [initialize]);
+  const live = useLiveUsage(bridge, sources, selectedSource, view === "live");
 
   const summary = overview?.summaries.find((item) => item.range === selectedRange) ?? null;
+  const monthlySummary = overview?.summaries.find((item) => item.range === "this_month") ?? null;
   const sourceDescriptor = sources.find((source) => source.name === selectedSource) ?? null;
-  const selectedRangeLabel = RANGE_OPTIONS.find((range) => range.value === selectedRange)?.label;
-  const missingRangeError =
-    overview && !summary ? `${selectedRangeLabel} is missing from the usage response.` : null;
-  const costCoverage = summary?.api_equivalent_cost_coverage ?? null;
-  const costIsLowerBound =
-    summary !== null && summary.cost !== null && costCoverage?.cost_is_lower_bound === true;
+  const selectedRangeLabel = RANGE_OPTIONS.find((range) => range.value === selectedRange)?.label ?? "";
+  const selectedSourceLabel = sources.find((source) => source.name === selectedSource)?.display_name ?? "Usage source";
+  const missingRangeError = (view === "overview" || view === "trust" || view === "top") && overview && !summary
+    ? `${selectedRangeLabel} is missing from the usage response.`
+    : null;
 
   function changeSource(source: string) {
     setSelectedSource(source);
-    void loadOverview(source);
+    void loadView(view, source, selectedRange);
+  }
+
+  function changeRange(range: UsageRange) {
+    setSelectedRange(range);
+    if (view === "top" || view === "projects" || view === "history") void loadView(view, selectedSource, range);
   }
 
   function retry() {
-    if (sources.length === 0) {
-      void initialize();
-    } else {
-      void loadOverview(selectedSource);
+    if (sources.length === 0) void initialize();
+    else void loadView(view, selectedSource, selectedRange);
+  }
+
+  async function exportHistory(format: "csv" | "json") {
+    setExporting(true);
+    setError(null);
+    try {
+      const content = await bridge.exportHistory(selectedSource, selectedRange, format);
+      const url = URL.createObjectURL(new Blob([content], { type: format === "csv" ? "text/csv" : "application/json" }));
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `ccstats-${selectedSource}-${selectedRange}.${format}`;
+      link.click();
+      URL.revokeObjectURL(url);
+    } catch (nextError) {
+      setError(errorMessage(nextError));
+    } finally {
+      setExporting(false);
     }
   }
 
+  const pageTitle = view === "overview" ? "Usage overview" : view === "trust" ? "Cost trust" : view === "live" ? "Live usage" : view === "top" ? "Top consumers" : view === "limits" ? "Quota and budget" : view === "machines" ? "Machine rollup" : view === "activity" ? "Turns and tools" : view === "projects" ? "Project explorer" : view === "history" ? "Usage history" : "Source diagnostics";
+  const pageDescription = view === "overview"
+    ? "Reconcile tokens, cost, and provider evidence."
+    : view === "trust"
+      ? "Trace every displayed amount to its usage basis, pricing source, and coverage boundary."
+    : view === "live"
+      ? "Watch today’s local ledger and measure growth from a trusted baseline."
+    : view === "top"
+      ? "Find dominant consumers and compare the latest complete day with its baseline."
+      : view === "limits"
+      ? "Track the provider quota window and forecast monthly spend."
+      : view === "machines"
+      ? "Persist aggregate snapshots and combine usage from your other devices."
+      : view === "activity"
+      ? "Inspect deduplicated model responses and independently counted tool calls."
+      : view === "projects"
+      ? "Trace a project total into the sessions that produced it."
+      : view === "history"
+        ? "Inspect daily movement and export the underlying ledger."
+        : "Check every registered source and see the next setup action.";
+
   return (
-    <div className="app-shell">
-      <header className="topbar">
-        <div className="brand-lockup">
-          <span className="brand-glyph" aria-hidden="true">c.</span>
+    <div className="polar-shell">
+      <aside className="sidebar">
+        <div className="brand-lockup"><span aria-hidden="true">c</span><div><strong>ccstats</strong><small>Usage intelligence</small></div></div>
+        <nav className="side-nav" aria-label="Analytics view">
+          {VIEW_GROUPS.map((group) => <section className="nav-group" aria-label={group.label} key={group.label}><h2>{group.label}</h2>{group.views.map((item) => <button type="button" key={item.value} className={view === item.value ? "active" : ""} aria-label={item.label} aria-pressed={view === item.value} disabled={loading || sources.length === 0} onClick={() => void loadView(item.value, selectedSource, selectedRange)}><div><strong>{item.label}</strong><small>{item.detail}</small></div></button>)}</section>)}
+        </nav>
+        <div className="sidebar-source">
+          <label htmlFor="source-select">Usage source</label>
           <div>
-            <strong>ccstats</strong>
-            <span>local audit console</span>
+            <select id="source-select" value={selectedSource} onChange={(event) => changeSource(event.target.value)} disabled={loading || sources.length === 0}>
+              {sources.map((source) => <option key={source.name} value={source.name}>{source.display_name}</option>)}
+            </select>
+            <span aria-hidden="true">⌄</span>
           </div>
+          <small>{Math.max(sources.length - 1, 0)} registered · {readySourceNames.length} ready</small>
         </div>
-        <div className="privacy-note"><i /> Usage files stay local · no transcript upload</div>
-      </header>
+        <div className="local-status"><i aria-hidden="true" /><div><strong>Local only</strong><small>No transcript upload</small></div></div>
+      </aside>
 
-      <main>
-        <section className="hero">
-          <div className="hero-copy">
-            <p className="hero-index">LEDGER / OVERVIEW / 01</p>
-            <h1>Usage overview</h1>
-            <p>Inspect authoritative token records, model attribution, and accounting quality from one usage source.</p>
+      <div className="workspace">
+        <header className="workspace-toolbar">
+          <div className="page-heading"><span>{view === "machines" ? "Local snapshot store" : selectedSourceLabel}</span><h1>{pageTitle}</h1><p>{pageDescription}</p></div>
+          <div className="toolbar-actions">
+            {view !== "diagnostics" && view !== "limits" && view !== "live" && view !== "machines" ? <div className="period-control" aria-label="Usage period">
+              {RANGE_OPTIONS.map((range) => <button type="button" key={range.value} aria-label={range.label} aria-pressed={selectedRange === range.value} className={selectedRange === range.value ? "active" : ""} onClick={() => changeRange(range.value)}>{range.label}</button>)}
+            </div> : null}
+            {view !== "machines" && view !== "activity" ? <button type="button" className="refresh-button" aria-label="Refresh ledger" onClick={() => view === "live" ? void live.refresh(false) : void loadView(view, selectedSource, selectedRange)} disabled={loading || live.refreshing || selectedSource.length === 0}><span aria-hidden="true">↻</span> Refresh</button> : null}
           </div>
-          <div className="source-control">
-            <label htmlFor="source-select">Usage source</label>
-            <div className="select-frame">
-              <select
-                id="source-select"
-                value={selectedSource}
-                onChange={(event) => changeSource(event.target.value)}
-                disabled={loading || sources.length === 0}
-              >
-                {sources.map((source) => (
-                  <option key={source.name} value={source.name}>{source.display_name}</option>
-                ))}
-              </select>
-              <span aria-hidden="true">↓</span>
-            </div>
-            <p>{sources.length} registered usage sources</p>
-          </div>
-        </section>
+        </header>
 
-        <section className="command-strip" aria-label="Overview controls">
-          <div className="range-switcher">
-            {RANGE_OPTIONS.map((range) => (
-              <button
-                type="button"
-                key={range.value}
-                className={selectedRange === range.value ? "active" : ""}
-                onClick={() => setSelectedRange(range.value)}
-                aria-pressed={selectedRange === range.value}
-              >
-                <small>{range.eyebrow}</small>
-                {range.label}
-              </button>
-            ))}
-          </div>
-          <button
-            type="button"
-            className="refresh-button"
-            aria-label="Refresh ledger"
-            onClick={() => void loadOverview(selectedSource)}
-            disabled={loading || selectedSource.length === 0}
-          >
-            <span aria-hidden="true">↻</span> Refresh ledger
-          </button>
-        </section>
-
-        {loading ? (
-          <section className="loading-state" aria-live="polite">
-            <div className="scanner" aria-hidden="true"><span /></div>
-            <p>Auditing registered sources…</p>
-            <small>Discovery → parse → deduplicate → price</small>
-          </section>
-        ) : error || missingRangeError ? (
-          <section className="error-state" role="alert">
-            <span className="error-code">ERR / LEDGER</span>
-            <h2>Could not read this source.</h2>
-            <p>{error ?? missingRangeError}</p>
-            <button type="button" onClick={retry}>Try again</button>
-          </section>
-        ) : summary ? (
-          <div data-testid="overview-content">
-            <section className="report-meta">
-              <div>
-                <span className="live-dot" />
-                <strong>{overview?.display_name}</strong>
-                <span>{selectedRangeLabel}</span>
-              </div>
-              <p>
-                Generated {overview ? new Date(overview.generated_at).toLocaleString() : "—"}
-                <span>·</span>
-                {overview?.elapsed_ms.toFixed(1)} ms scan
-              </p>
-            </section>
-
-            {summary.valid_entries === 0 && summary.tokens.total_tokens === 0 ? (
-              <EmptyState
-                source={overview?.display_name ?? selectedSource}
-                rangeLabel={selectedRangeLabel ?? selectedRange}
-                parseErrors={summary.parse_error_entries}
-              />
-            ) : (
-              <>
-                <section className="metric-rack" aria-label="Usage totals">
-                  <article className="metric-primary">
-                    <p>Total tokens</p>
-                    <strong data-testid="total-tokens">{formatTokens(summary.tokens.total_tokens)}</strong>
-                    <span>Provider-reported components</span>
-                  </article>
-                  <article>
-                    <p>{costIsLowerBound ? "Cost lower bound" : "Total cost"}</p>
-                    <strong data-testid="total-cost" className={summary.cost === null ? "unknown-cost" : ""}>
-                      {costIsLowerBound ? "≥ " : ""}{formatCost(summary.cost, summary.currency)}
-                    </strong>
-                    {costIsLowerBound && costCoverage ? (
-                      <span data-testid="cost-coverage">
-                        {formatTokens(costCoverage.priced_tokens)} / {formatTokens(costCoverage.total_tokens)} tokens priced ({costCoverage.percent.toFixed(1)}%)
-                      </span>
-                    ) : (
-                      <span>{summary.cost === null ? "No trustworthy price" : summary.cost_kind}</span>
-                    )}
-                  </article>
-                  <article>
-                    <p>Records</p>
-                    <strong>{formatTokens(summary.valid_entries)}</strong>
-                    <span>Parsed source events</span>
-                  </article>
-                  <article>
-                    <p>Capabilities</p>
-                    <div className="capability-list">
-                      {sourceDescriptor?.has_projects ? <span>Projects</span> : null}
-                      {sourceDescriptor?.has_reasoning_tokens ? <span>Reasoning</span> : null}
-                      {sourceDescriptor?.has_cache_read ? <span>Cache read</span> : null}
-                      {sourceDescriptor?.has_cache_creation ? <span>Cache write</span> : null}
-                    </div>
-                    <span>Only source-backed fields</span>
-                  </article>
-                </section>
-
-                <div className="analysis-grid">
-                  <TokenComposition tokens={summary.tokens} />
-                  <QualityPanel summary={summary} />
-                </div>
-                <ModelTable summary={summary} />
-              </>
-            )}
-          </div>
-        ) : null}
-      </main>
-      <footer>
-        <span>ccstats desktop · audit surface</span>
-        <span>Authoritative fields over inferred totals</span>
-      </footer>
+        <main className="workspace-content">
+          {loading ? (
+            <section className="loading-state" aria-live="polite"><div><i /><i /><i /></div><strong>{view === "overview" ? "Auditing registered sources…" : view === "limits" ? "Reading quota and budget evidence…" : view === "projects" ? "Resolving projects and sessions…" : view === "history" ? "Building daily history…" : "Checking source readiness…"}</strong><span>Discover · parse · deduplicate · price</span></section>
+          ) : error || missingRangeError ? (
+            <section className="state-pane error-state" role="alert"><span aria-hidden="true">!</span><div><h2>Could not read this source.</h2><p>{error ?? missingRangeError}</p><button type="button" onClick={retry}>Try again</button></div></section>
+          ) : view === "live" ? (
+            <LiveView live={live} />
+          ) : view === "machines" ? (
+            <MachinesView bridge={bridge} sources={sources} />
+          ) : view === "activity" ? (
+            <ActivityView bridge={bridge} source={selectedSource} range={selectedRange} />
+          ) : view === "trust" ? (
+            summary && overview ? <><AnalysisQualityNotice quality={costSummaryQuality(summary)} combinedScan /><CostTrustView overview={overview} summary={summary} range={selectedRange} /></> : null
+          ) : view === "top" ? (
+            summary && overview ? <TopInsightsView overview={overview} summary={summary} history={insightHistory} projects={insightProjects} warnings={insightWarnings} /> : null
+          ) : view === "limits" ? (
+            <QuotaBudgetView quota={quotaOverview} quotaError={quotaError} monthly={monthlySummary} budget={monthlyBudget} onBudgetChange={setMonthlyBudget} />
+          ) : view === "diagnostics" ? (
+            diagnostics ? <DiagnosticsView rows={diagnostics} /> : null
+          ) : view === "projects" ? (
+            selectedSource === "all"
+              ? <section className="state-pane empty-state"><span aria-hidden="true">↳</span><div><h2>Choose one source</h2><p>Choose a concrete source to inspect projects and sessions.</p></div></section>
+              : drilldown ? <ProjectView data={drilldown} /> : null
+          ) : view === "history" ? (
+            selectedSource === "all"
+              ? <section className="state-pane empty-state"><span aria-hidden="true">↳</span><div><h2>Choose one source</h2><p>Choose a concrete source to inspect and export daily history.</p></div></section>
+              : history ? <HistoryView data={history} exporting={exporting} onExport={(format) => void exportHistory(format)} /> : null
+          ) : summary && overview ? (
+            <div data-testid="overview-content"><OverviewView overview={overview} summary={summary} sourceDescriptor={sourceDescriptor} range={selectedRange} /></div>
+          ) : null}
+        </main>
+        <footer className="workspace-footer"><span>Authoritative fields over inferred totals</span><span>{selectedRangeLabel}</span></footer>
+      </div>
     </div>
   );
 }

--- a/desktop/src/CostTrustView.tsx
+++ b/desktop/src/CostTrustView.tsx
@@ -1,0 +1,124 @@
+import { hasExactCost, type CostSummary, type UsageOverview, type UsageRange } from "./bridge";
+import { formatCost, formatTokens } from "./format";
+
+const PRICING_EVIDENCE: Record<string, { label: string; detail: string }> = {
+  recorded: { label: "Source-recorded", detail: "The source supplied the monetary amount. It is preserved as recorded, not described as an invoice." },
+  live: { label: "Live price catalog", detail: "Token usage was priced with the current downloaded model catalog." },
+  cache: { label: "Cached price catalog", detail: "Token usage was priced with a recent local copy of the model catalog." },
+  cache_stale: { label: "Stale price catalog", detail: "Token usage was priced with an older local catalog. Review before treating it as current." },
+  fallback: { label: "Fallback price", detail: "The exact model was absent, so ccstats used its model-family fallback price." },
+  unknown: { label: "Unknown", detail: "No trustworthy monetary amount or matching price was available." },
+  mixed: { label: "Mixed evidence", detail: "More than one pricing source contributed to this total." },
+};
+
+function pricingEvidence(source: string) {
+  return PRICING_EVIDENCE[source] ?? {
+    label: source.replaceAll("_", " "),
+    detail: "This pricing source was returned by the local ccstats ledger.",
+  };
+}
+
+function usageBasis(kind: string) {
+  if (kind === "real") return "Observed usage";
+  if (kind === "estimated_proxy") return "Proxy estimate";
+  if (kind === "mixed") return "Observed + proxy estimate";
+  return kind.replaceAll("_", " ");
+}
+
+function coverageLabel(summary: CostSummary) {
+  const coverage = summary.api_equivalent_cost_coverage;
+  if (!coverage) return "Not applicable";
+  return `${coverage.percent.toFixed(1)}%`;
+}
+
+function trustStatus(summary: CostSummary) {
+  if (summary.cost === null) return { label: "Unpriced", tone: "unknown-cost" };
+  if (summary.api_equivalent_cost_coverage?.cost_is_lower_bound) return { label: "Lower bound", tone: "unknown-cost" };
+  if (!hasExactCost(summary)) return { label: "Review", tone: "unknown-cost" };
+  return { label: "Cost available", tone: "known-cost" };
+}
+
+function evidenceCost(summary: CostSummary) {
+  return `${summary.api_equivalent_cost_coverage?.cost_is_lower_bound ? "≥ " : ""}${formatCost(summary.cost, summary.currency)}`;
+}
+
+export function CostTrustView({ overview, summary, range }: {
+  overview: UsageOverview;
+  summary: CostSummary;
+  range: UsageRange;
+}) {
+  const evidence = pricingEvidence(summary.pricing_source);
+  const status = trustStatus(summary);
+  const sourceRows = overview.source_overviews
+    ? overview.source_overviews.flatMap((source) => {
+      const sourceSummary = source.summaries.find((candidate) => candidate.range === range);
+      return sourceSummary ? [{ name: source.display_name, summary: sourceSummary }] : [];
+    })
+    : [{ name: overview.display_name, summary }];
+
+  return (
+    <section className="trust-workbench" aria-labelledby="trust-title">
+      <header className="work-pane trust-heading">
+        <div><h2 id="trust-title">Cost evidence</h2><p>Separate usage basis, pricing origin, and coverage before trusting a total.</p></div>
+        <span className={status.tone}>{status.label}</span>
+      </header>
+
+      <dl className="trust-summary">
+        <div><dt>Displayed cost</dt><dd data-testid="trust-displayed-cost">{evidenceCost(summary)}</dd><small>{summary.currency}</small></div>
+        <div><dt>Pricing evidence</dt><dd data-testid="trust-pricing-source">{evidence.label}</dd><small>{summary.pricing_source}</small></div>
+        <div><dt>Usage basis</dt><dd>{usageBasis(summary.cost_kind)}</dd><small>{summary.cost_kind}</small></div>
+        <div><dt>API-equivalent coverage</dt><dd data-testid="trust-coverage">{coverageLabel(summary)}</dd><small>{summary.api_equivalent_cost_coverage?.cost_is_lower_bound ? "Displayed cost is a lower bound" : "Only shown when the source defines this boundary"}</small></div>
+      </dl>
+
+      <section className="work-pane trust-explanation" aria-label="Pricing evidence explanation">
+        <span aria-hidden="true">i</span>
+        <div><strong>{evidence.label}</strong><p>{evidence.detail}</p></div>
+      </section>
+
+      <section className="work-pane table-pane trust-table" aria-labelledby="source-trust-title">
+        <header className="pane-heading"><div><h2 id="source-trust-title">Source evidence</h2><p>Every source contributing to this window.</p></div><span>{sourceRows.length} sources</span></header>
+        <div className="table-scroll">
+          <table>
+            <thead><tr><th>Source</th><th>Usage basis</th><th>Pricing evidence</th><th>Coverage</th><th>Tokens</th><th>Cost</th><th>Proxy estimate</th></tr></thead>
+            <tbody>
+              {sourceRows.map((row) => (
+                <tr key={row.name}>
+                  <td className="identity-cell">{row.name}</td>
+                  <td>{usageBasis(row.summary.cost_kind)}</td>
+                  <td>{pricingEvidence(row.summary.pricing_source).label}</td>
+                  <td>{coverageLabel(row.summary)}</td>
+                  <td>{formatTokens(row.summary.tokens.total_tokens)}</td>
+                  <td className={row.summary.cost === null || row.summary.api_equivalent_cost_coverage?.cost_is_lower_bound ? "unknown-cost" : "known-cost"}>{evidenceCost(row.summary)}</td>
+                  <td>{row.summary.estimated_cost === null ? "—" : formatCost(row.summary.estimated_cost, row.summary.currency)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="work-pane table-pane trust-table" aria-labelledby="model-trust-title">
+        <header className="pane-heading"><div><h2 id="model-trust-title">Model evidence</h2><p>Pricing origin and usage basis for each model.</p></div><span>{summary.models.length} models</span></header>
+        {summary.models.length === 0 ? <div className="evidence-note"><strong>No model cost evidence in this window.</strong><p>Choose a wider period or another source.</p></div> : (
+          <div className="table-scroll">
+            <table>
+              <thead><tr><th>Model</th><th>Usage basis</th><th>Pricing evidence</th><th>Tokens</th><th>Cost</th><th>Proxy estimate</th></tr></thead>
+              <tbody>
+                {summary.models.map((model) => (
+                  <tr key={model.model}>
+                    <td className="identity-cell">{model.model}</td>
+                    <td>{usageBasis(model.cost_kind)}</td>
+                    <td>{pricingEvidence(model.pricing_source).label}</td>
+                    <td>{formatTokens(model.tokens.total_tokens)}</td>
+                    <td className={hasExactCost(summary) && hasExactCost(model) ? "known-cost" : "unknown-cost"}>{summary.api_equivalent_cost_coverage?.cost_is_lower_bound ? "≥ " : model.cost !== null && (!hasExactCost(summary) || !hasExactCost(model)) ? "≈ " : ""}{formatCost(model.cost, summary.currency)}</td>
+                    <td>{model.estimated_cost === null ? "—" : formatCost(model.estimated_cost, summary.currency)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </section>
+  );
+}

--- a/desktop/src/LiveView.tsx
+++ b/desktop/src/LiveView.tsx
@@ -1,0 +1,121 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  aggregateUsageOverviews,
+  hasExactCost,
+  type CostSummary,
+  type DesktopBridge,
+  type SourceDescriptor,
+  type UsageOverview,
+} from "./bridge";
+import { errorMessage, formatCost, formatTokens } from "./format";
+
+export function useLiveUsage(
+  bridge: DesktopBridge,
+  sources: SourceDescriptor[],
+  selectedSource: string,
+  active: boolean,
+) {
+  const [overview, setOverview] = useState<UsageOverview | null>(null);
+  const [baseline, setBaseline] = useState<CostSummary | null>(null);
+  const [startedAt, setStartedAt] = useState<string | null>(null);
+  const [updatedAt, setUpdatedAt] = useState<string | null>(null);
+  const [monitoring, setMonitoring] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const requestId = useRef(0);
+  const refreshingRef = useRef(false);
+
+  const refresh = useCallback(async (resetBaseline = false) => {
+    if (!selectedSource || (!resetBaseline && refreshingRef.current)) return;
+    const request = ++requestId.current;
+    refreshingRef.current = true;
+    setRefreshing(true);
+    setError(null);
+    if (resetBaseline) {
+      setOverview(null);
+      setBaseline(null);
+      setStartedAt(null);
+      setUpdatedAt(null);
+    }
+    try {
+      const findings = selectedSource === "all" ? await bridge.sourceDiagnostics() : [];
+      const ready = new Set(findings.filter((row) => row.status !== "missing").map((row) => row.name));
+      const names = sources.filter((source) => source.name !== "all" && ready.has(source.name)).map((source) => source.name);
+      if (selectedSource === "all" && names.length === 0) throw new Error("No detected or configured sources are ready to aggregate.");
+      const next = selectedSource === "all" ? aggregateUsageOverviews(await bridge.usageOverviews(names)) : await bridge.usageOverview(selectedSource);
+      const today = next.summaries.find((summary) => summary.range === "today");
+      if (!today) throw new Error("Today is missing from the usage response.");
+      if (request !== requestId.current) return;
+      const now = new Date().toISOString();
+      setOverview(next);
+      setUpdatedAt(now);
+      if (resetBaseline) {
+        setBaseline(today);
+        setStartedAt(now);
+      }
+    } catch (nextError) {
+      if (request === requestId.current) setError(errorMessage(nextError));
+    } finally {
+      if (request === requestId.current) {
+        refreshingRef.current = false;
+        setRefreshing(false);
+      }
+    }
+  }, [bridge, selectedSource, sources]);
+
+  useEffect(() => {
+    if (!active || !selectedSource) return;
+    setMonitoring(true);
+    void refresh(true);
+    return () => {
+      requestId.current += 1;
+      refreshingRef.current = false;
+      setRefreshing(false);
+    };
+  }, [active, refresh, selectedSource]);
+
+  useEffect(() => {
+    if (!active || !monitoring) return;
+    const timer = window.setInterval(() => void refresh(false), 15_000);
+    return () => window.clearInterval(timer);
+  }, [active, monitoring, refresh]);
+
+  return {
+    summary: useMemo(() => overview?.summaries.find((summary) => summary.range === "today") ?? null, [overview]),
+    baseline,
+    startedAt,
+    updatedAt,
+    monitoring,
+    refreshing,
+    error,
+    refresh,
+    toggleMonitoring: () => setMonitoring((current) => !current),
+  };
+}
+
+export type LiveUsage = ReturnType<typeof useLiveUsage>;
+
+export function LiveView({ live }: { live: LiveUsage }) {
+  if (!live.summary) {
+    return live.error
+      ? <section className="state-pane error-state" role="alert"><span aria-hidden="true">!</span><div><h2>Live monitoring could not start.</h2><p>{live.error}</p><button type="button" onClick={() => void live.refresh(true)}>Try again</button></div></section>
+      : <section className="loading-state" aria-live="polite"><div><i /><i /><i /></div><strong>Establishing live baseline…</strong><span>Scanning today’s local ledger</span></section>;
+  }
+
+  const tokenDelta = live.summary.tokens.total_tokens - (live.baseline?.tokens.total_tokens ?? live.summary.tokens.total_tokens);
+  const exactCost = hasExactCost(live.summary);
+  const costDelta = live.baseline && exactCost && hasExactCost(live.baseline)
+    ? live.summary.cost! - live.baseline.cost!
+    : null;
+  const costPrefix = live.summary.api_equivalent_cost_coverage?.cost_is_lower_bound ? "≥ " : exactCost ? "" : "≈ ";
+
+  return (
+    <section className="live-workbench" aria-labelledby="live-title">
+      <header className="work-pane pane-heading live-heading"><div><h2 id="live-title">Live usage</h2><p>Today’s local ledger, rescanned every 15 seconds while monitoring.</p></div><div className={`live-state ${live.monitoring ? "active" : "paused"}`}><i aria-hidden="true" /><strong>{live.monitoring ? "Monitoring" : "Paused"}</strong></div></header>
+      {live.error ? <p className="inline-warning" role="alert">Refresh failed; showing the last trusted snapshot. {live.error}</p> : null}
+      {live.summary.parse_error_entries > 0 ? <p className="inline-warning" role="status">{formatTokens(live.summary.parse_error_entries)} malformed records were rejected in the combined scan; their dates cannot be assigned to Today.</p> : null}
+      <div className="live-reading-grid"><article className="work-pane live-primary"><span>Tokens today</span><strong data-testid="live-total-tokens">{formatTokens(live.summary.tokens.total_tokens)}</strong><small>{live.summary.valid_entries} parsed records</small></article><article className="work-pane live-metric"><span>Since monitoring started</span><strong data-testid="live-token-delta">{`${tokenDelta >= 0 ? "+" : "−"}${formatTokens(Math.abs(tokenDelta))}`}</strong><small>Token change</small></article><article className="work-pane live-metric"><span>Cost today</span><strong>{costPrefix}{formatCost(live.summary.cost, live.summary.currency)}</strong><small data-testid="live-cost-delta">{costDelta === null ? `Cost delta unavailable · ${live.summary.pricing_source}` : `${costDelta >= 0 ? "+" : "−"}${formatCost(Math.abs(costDelta), live.summary.currency)}`}</small></article></div>
+      <aside className="work-pane live-control"><dl><div><dt>Started</dt><dd>{live.startedAt ? new Date(live.startedAt).toLocaleTimeString() : "—"}</dd></div><div><dt>Last refresh</dt><dd>{live.updatedAt ? new Date(live.updatedAt).toLocaleTimeString() : "—"}</dd></div><div><dt>Scan duration</dt><dd>{live.summary.elapsed_ms.toFixed(1)} ms</dd></div></dl><button type="button" aria-label={live.monitoring ? "Pause monitoring" : "Resume monitoring"} onClick={live.toggleMonitoring}>{live.monitoring ? "Pause" : "Resume"}</button></aside>
+    </section>
+  );
+}

--- a/desktop/src/MachinesView.tsx
+++ b/desktop/src/MachinesView.tsx
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useState } from "react";
+import type { ChangeEvent } from "react";
+import type { DesktopBridge, MachineRollup, SourceDescriptor } from "./bridge";
+import { errorMessage, formatCost, formatTokens } from "./format";
+
+const MAX_BUNDLE_BYTES = 10 * 1024 * 1024;
+
+export function MachinesView({ bridge, sources }: { bridge: DesktopBridge; sources: SourceDescriptor[] }) {
+  const [rollup, setRollup] = useState<MachineRollup | null>(null);
+  const [machineName, setMachineName] = useState("This machine");
+  const [loading, setLoading] = useState(true);
+  const [working, setWorking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await bridge.machineRollup();
+      setRollup(next);
+      setMachineName(next.local_machine_name ?? "This machine");
+    } catch (nextError) {
+      setError(errorMessage(nextError));
+    } finally {
+      setLoading(false);
+    }
+  }, [bridge]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  async function capture() {
+    setWorking(true);
+    setError(null);
+    try {
+      const findings = await bridge.sourceDiagnostics();
+      const ready = new Set(findings.filter((row) => row.status !== "missing").map((row) => row.name));
+      const names = sources.filter((source) => source.name !== "all" && ready.has(source.name)).map((source) => source.name);
+      if (names.length === 0) throw new Error("No registered sources are available to capture.");
+      setRollup(await bridge.saveMachineSnapshot(machineName, await bridge.usageOverviews(names)));
+    } catch (nextError) {
+      setError(errorMessage(nextError));
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  async function exportBundle() {
+    setWorking(true);
+    setError(null);
+    try {
+      const content = await bridge.exportMachineBundle();
+      const url = URL.createObjectURL(new Blob([content], { type: "application/json" }));
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = "ccstats-machine-snapshots.json";
+      link.click();
+      URL.revokeObjectURL(url);
+    } catch (nextError) {
+      setError(errorMessage(nextError));
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  async function importBundle(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file) return;
+    setWorking(true);
+    setError(null);
+    try {
+      if (file.size > MAX_BUNDLE_BYTES) throw new Error("Machine snapshot bundle must be 10 MB or smaller.");
+      setRollup(await bridge.importMachineBundle(await file.text()));
+    } catch (nextError) {
+      setError(errorMessage(nextError));
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  if (loading) return <section className="loading-state" aria-live="polite"><div><i /><i /><i /></div><strong>Opening machine snapshots…</strong><span>Local SQLite store</span></section>;
+  if (!rollup && error) return <section className="state-pane error-state" role="alert"><span aria-hidden="true">!</span><div><h2>Could not open machine snapshots.</h2><p>{error}</p><button type="button" onClick={() => void load()}>Try again</button></div></section>;
+  if (!rollup) return null;
+
+  const currency = rollup.currency ?? "USD";
+  const hasStaleRange = [rollup.today_current_machines, rollup.week_current_machines, rollup.month_current_machines].some((count) => count < rollup.machines.length);
+  return (
+    <section className="machines-workbench" aria-labelledby="machines-title">
+      <header className="work-pane pane-heading machines-heading"><div><h2 id="machines-title">Machine rollup</h2><p>Persist aggregate snapshots locally, then exchange one JSON file between devices.</p></div><span>T {rollup.today_current_machines}/{rollup.machines.length} · W {rollup.week_current_machines}/{rollup.machines.length} · M {rollup.month_current_machines}/{rollup.machines.length}</span></header>
+      {error ? <p className="inline-warning" role="alert">{error}</p> : null}
+      {hasStaleRange ? <p className="inline-warning" role="status">Stale ranges remain visible below but are excluded from their current totals. Capture and exchange a fresh snapshot to include them.</p> : null}
+      <div className="machine-totals"><article className="work-pane"><span>Today</span><strong data-testid="machines-today">{formatTokens(rollup.totals.today_tokens)}</strong><small>{formatCost(rollup.totals.today_cost, currency)}</small></article><article className="work-pane"><span>This week</span><strong>{formatTokens(rollup.totals.week_tokens)}</strong><small>{formatCost(rollup.totals.week_cost, currency)}</small></article><article className="work-pane"><span>This month</span><strong data-testid="machines-month">{formatTokens(rollup.totals.month_tokens)}</strong><small>{formatCost(rollup.totals.month_cost, currency)}</small></article></div>
+      <section className="work-pane machine-actions" aria-label="Machine snapshot controls"><label>Local machine name<input value={machineName} maxLength={128} onChange={(event) => setMachineName(event.target.value)} /></label><button type="button" disabled={working || machineName.trim().length === 0} onClick={() => void capture()}>Capture this machine</button><button type="button" disabled={working} onClick={() => void exportBundle()}>Export snapshots</button><label className="file-action">Import snapshots<input type="file" accept="application/json,.json" disabled={working} aria-label="Import machine snapshots" onChange={(event) => void importBundle(event)} /></label></section>
+      <p className="limit-note">Machine costs are combined in canonical USD. Only complete costs backed by recorded, live, or current cached pricing contribute; lower bounds and review-only prices remain unknown.</p>
+      {rollup.machines.length === 0 ? <section className="state-pane empty-state"><span aria-hidden="true">○</span><div><h2>No machine snapshots yet.</h2><p>Capture this machine first, then import snapshot files from your other devices.</p></div></section> : <section className="work-pane table-pane machine-table"><div className="table-scroll"><table><thead><tr><th>Machine</th><th>Current ranges</th><th>Captured</th><th>Sources</th><th>Month tokens</th><th>Month cost</th></tr></thead><tbody>{rollup.machines.map((machine) => <tr key={machine.machine_id}><td className="identity-cell">{machine.machine_name}{machine.is_local ? <small>Local</small> : null}</td><td><span className={`diagnostic-status status-${machine.today_current && machine.week_current && machine.month_current ? "detected" : "missing"}`}>T {machine.today_current ? "✓" : "—"} · W {machine.week_current ? "✓" : "—"} · M {machine.month_current ? "✓" : "—"}</span></td><td>{new Date(machine.captured_at_ms).toLocaleString()}</td><td>{machine.source_count}</td><td>{formatTokens(machine.totals.month_tokens)}</td><td className={machine.totals.month_cost === null ? "unknown-cost" : "known-cost"}>{formatCost(machine.totals.month_cost, machine.currency ?? currency)}</td></tr>)}</tbody></table></div></section>}
+    </section>
+  );
+}

--- a/desktop/src/bridge.ts
+++ b/desktop/src/bridge.ts
@@ -359,6 +359,16 @@ function aggregateCoverage(summaries: CostSummary[]): ApiEquivalentCostCoverage 
   };
 }
 
+function aggregateCacheHitRate(rows: ReadonlyArray<TokenBreakdown>): number | null {
+  const supported = rows.filter((row) => row.cache_hit_rate !== null);
+  const inputSide = supported.reduce(
+    (sum, row) => sum + row.input_tokens + row.cache_creation_tokens + row.cache_read_tokens,
+    0,
+  );
+  if (inputSide === 0) return null;
+  return supported.reduce((sum, row) => sum + row.cache_read_tokens, 0) / inputSide * 100;
+}
+
 function aggregateModels(summaries: CostSummary[]): ModelCostSummary[] {
   const models = new Map<string, ModelCostSummary[]>();
   for (const summary of summaries) {
@@ -383,8 +393,7 @@ function aggregateModels(summaries: CostSummary[]): ModelCostSummary[] {
         total_tokens: 0,
       };
       for (const row of rows) addTokens(tokens, row.tokens);
-      const inputSide = tokens.input_tokens + tokens.cache_creation_tokens + tokens.cache_read_tokens;
-      tokens.cache_hit_rate = inputSide > 0 ? (tokens.cache_read_tokens / inputSide) * 100 : null;
+      tokens.cache_hit_rate = aggregateCacheHitRate(rows.map((row) => row.tokens));
       const kinds = new Set(rows.map((row) => row.cost_kind));
       return {
         model,
@@ -424,8 +433,7 @@ export function aggregateUsageOverviews(overviews: UsageOverview[]): UsageOvervi
       total_tokens: 0,
     };
     for (const summary of sourceSummaries) addTokens(tokens, summary.tokens);
-    const inputSide = tokens.input_tokens + tokens.cache_creation_tokens + tokens.cache_read_tokens;
-    tokens.cache_hit_rate = inputSide > 0 ? (tokens.cache_read_tokens / inputSide) * 100 : null;
+    tokens.cache_hit_rate = aggregateCacheHitRate(sourceSummaries.map((summary) => summary.tokens));
     const evidenceSummaries = sourceSummaries.filter((summary) =>
       summary.valid_entries > 0
       || summary.models.length > 0

--- a/desktop/src/bridge.ts
+++ b/desktop/src/bridge.ts
@@ -13,12 +13,56 @@ export interface SourceDescriptor {
   has_cache_read: boolean;
 }
 
+export type SourceDiagnosticStatus = "detected" | "configured" | "missing";
+
+export interface SourceDiagnosticDescriptor {
+  source: string;
+  name: string;
+  display_name: string;
+  status: SourceDiagnosticStatus;
+  files: number;
+  detail: string;
+  setup: string;
+}
+
+export interface CodexWeeklyQuota {
+  observed_at: string;
+  resets_at: string;
+  estimated_depletion_at: string | null;
+  window_minutes: number;
+  used_pct: number;
+  remaining_pct: number;
+  projected_pct_at_reset: number;
+  status: "on_track" | "watch" | "likely_exhausted" | "exhausted";
+}
+
+export interface CodexWeeklyValueEstimate {
+  observed_at: string;
+  window_started_at: string;
+  resets_at: string;
+  used_pct: number;
+  observed_cost_usd: number;
+  estimated_weekly_value_usd: number;
+  observed_tokens: number;
+  estimated_weekly_tokens: number;
+  valid_entries: number;
+  dedup_skipped_entries: number;
+}
+
+export interface CodexQuotaOverview {
+  quota: CodexWeeklyQuota;
+  value_estimate: CodexWeeklyValueEstimate | null;
+  value_estimate_error: string | null;
+}
+
 export interface TokenBreakdown {
   input_tokens: number;
   output_tokens: number;
   reasoning_tokens: number;
   cache_creation_tokens: number;
+  cache_creation_1h_tokens: number;
   cache_read_tokens: number;
+  reported_total_adjustment: number;
   cache_hit_rate: number | null;
   total_tokens: number;
 }
@@ -30,6 +74,7 @@ export interface ModelCostSummary {
   estimated_cost: number | null;
   estimated_cost_usd: number | null;
   cost_kind: string;
+  pricing_source: string;
   tokens: TokenBreakdown;
 }
 
@@ -47,7 +92,11 @@ export interface CostSummary {
   until: string | null;
   currency: string;
   cost: number | null;
+  cost_usd: number | null;
+  estimated_cost: number | null;
+  estimated_cost_usd: number | null;
   cost_kind: string;
+  pricing_source: string;
   api_equivalent_cost_coverage: ApiEquivalentCostCoverage | null;
   tokens: TokenBreakdown;
   models: ModelCostSummary[];
@@ -65,11 +114,378 @@ export interface UsageOverview {
   generated_at: string;
   summaries: CostSummary[];
   elapsed_ms: number;
+  source_overviews?: UsageOverview[];
+}
+
+export interface AnalyticsQuality {
+  valid_entries: number;
+  dedup_skipped_entries: number;
+  parse_error_entries: number;
+}
+
+export interface UsageMetrics {
+  currency: string;
+  cost: number | null;
+  cost_usd: number | null;
+  estimated_cost: number | null;
+  estimated_cost_usd: number | null;
+  cost_kind: string;
+  pricing_source: string;
+  api_equivalent_cost_coverage: ApiEquivalentCostCoverage | null;
+  tokens: TokenBreakdown;
+  models: ModelCostSummary[];
+}
+
+export interface SessionDrilldown {
+  session_id: string;
+  project_path: string;
+  first_timestamp: string;
+  last_timestamp: string;
+  metrics: UsageMetrics;
+}
+
+export interface ProjectDrilldown {
+  project_path: string;
+  project_name: string;
+  session_count: number;
+  metrics: UsageMetrics;
+  sessions: SessionDrilldown[];
+}
+
+export interface ProjectDrilldownSummary {
+  source: string;
+  source_name: string;
+  display_name: string;
+  range: UsageRange;
+  currency: string;
+  quality: AnalyticsQuality;
+  projects: ProjectDrilldown[];
+}
+
+export interface DailyUsagePoint {
+  date: string;
+  currency: string;
+  tokens: TokenBreakdown;
+  records: number;
+  cost: number | null;
+  cost_usd: number | null;
+  cost_status: "known" | "partial" | "unknown";
+  cost_kind: string;
+  pricing_source: string;
+  api_equivalent_cost_coverage: ApiEquivalentCostCoverage | null;
+}
+
+export interface UsageHistory {
+  source: string;
+  source_name: string;
+  display_name: string;
+  range: UsageRange;
+  as_of_date: string;
+  currency: string;
+  points: DailyUsagePoint[];
+  quality: AnalyticsQuality;
+}
+
+export type CostEvidence = Pick<CostSummary, "cost" | "cost_kind" | "pricing_source"> & { api_equivalent_cost_coverage?: ApiEquivalentCostCoverage | null };
+
+export function hasExactCost(evidence: CostEvidence) {
+  return evidence.cost !== null
+    && evidence.cost_kind === "real"
+    && ["recorded", "live", "cache"].includes(evidence.pricing_source)
+    && evidence.api_equivalent_cost_coverage?.cost_is_lower_bound !== true;
+}
+
+export interface ToolUsage {
+  name: string;
+  calls: number;
+}
+
+export interface ModelTurnUsage {
+  timestamp: string;
+  session_id: string;
+  message_id: string | null;
+  project_path: string;
+  model: string;
+  model_call_count: number;
+  tokens: TokenBreakdown;
+}
+
+export interface TurnToolBreakdown {
+  source: string;
+  source_name: string;
+  display_name: string;
+  range: UsageRange;
+  total_turns: number;
+  turns: ModelTurnUsage[];
+  tool_calls_supported: boolean;
+  tool_calls_total: number;
+  tools: ToolUsage[];
+  quality: AnalyticsQuality;
+}
+
+export interface ConsumerInput {
+  name: string;
+  tokens: number;
+  cost: number | null;
+}
+
+export interface RankedConsumer extends ConsumerInput {
+  rank: number;
+  share: number;
+  share_basis: "cost" | "tokens";
+}
+
+export interface UsageAnomaly {
+  status: "spike" | "normal" | "insufficient";
+  date: string | null;
+  tokens: number | null;
+  baseline_tokens: number | null;
+  change_pct: number | null;
+  sample_days: number;
+}
+
+export interface MachineUsageTotals {
+  today_tokens: number;
+  week_tokens: number;
+  month_tokens: number;
+  today_cost: number | null;
+  week_cost: number | null;
+  month_cost: number | null;
+}
+
+export interface MachineUsage {
+  machine_id: string;
+  machine_name: string;
+  captured_at_ms: number;
+  source_count: number;
+  currency: string | null;
+  is_local: boolean;
+  today_current: boolean;
+  week_current: boolean;
+  month_current: boolean;
+  totals: MachineUsageTotals;
+}
+
+export interface MachineRollup {
+  local_machine_id: string;
+  local_machine_name: string | null;
+  currency: string | null;
+  today_current_machines: number;
+  week_current_machines: number;
+  month_current_machines: number;
+  machines: MachineUsage[];
+  totals: MachineUsageTotals;
+}
+
+export function rankConsumers(rows: ConsumerInput[], limit = 5): RankedConsumer[] {
+  const shareBasis = rows.length > 0 && rows.every((row) => row.cost !== null && row.cost >= 0) ? "cost" : "tokens";
+  const total = rows.reduce((sum, row) => sum + (shareBasis === "cost" ? row.cost ?? 0 : row.tokens), 0);
+  return [...rows]
+    .sort((left, right) => {
+      if (shareBasis === "cost") {
+        return (right.cost ?? 0) - (left.cost ?? 0)
+          || right.tokens - left.tokens
+          || left.name.localeCompare(right.name);
+      }
+      return right.tokens - left.tokens || left.name.localeCompare(right.name);
+    })
+    .slice(0, Math.max(limit, 0))
+    .map((row, index) => ({
+      ...row,
+      rank: index + 1,
+      share: total > 0 ? (shareBasis === "cost" ? row.cost ?? 0 : row.tokens) / total * 100 : 0,
+      share_basis: shareBasis,
+    }));
+}
+
+export function detectUsageAnomaly(history: UsageHistory | null): UsageAnomaly {
+  if (!history) return { status: "insufficient", date: null, tokens: null, baseline_tokens: null, change_pct: null, sample_days: 0 };
+  const complete = [...history.points]
+    .filter((point) => point.date < history.as_of_date && point.tokens.total_tokens > 0)
+    .sort((left, right) => left.date.localeCompare(right.date));
+  const latest = complete.at(-1);
+  const baselineDays = complete.slice(0, -1).slice(-7);
+  if (!latest || baselineDays.length < 3) {
+    return { status: "insufficient", date: latest?.date ?? null, tokens: latest?.tokens.total_tokens ?? null, baseline_tokens: null, change_pct: null, sample_days: baselineDays.length };
+  }
+  const baseline = baselineDays.reduce((sum, point) => sum + point.tokens.total_tokens, 0) / baselineDays.length;
+  if (baseline <= 0) return { status: "insufficient", date: latest.date, tokens: latest.tokens.total_tokens, baseline_tokens: null, change_pct: null, sample_days: baselineDays.length };
+  const change = (latest.tokens.total_tokens - baseline) / baseline * 100;
+  return { status: change >= 100 ? "spike" : "normal", date: latest.date, tokens: latest.tokens.total_tokens, baseline_tokens: baseline, change_pct: change, sample_days: baselineDays.length };
+}
+
+function addTokens(target: TokenBreakdown, source: TokenBreakdown) {
+  target.input_tokens += source.input_tokens;
+  target.output_tokens += source.output_tokens;
+  target.reasoning_tokens += source.reasoning_tokens;
+  target.cache_creation_tokens += source.cache_creation_tokens;
+  target.cache_creation_1h_tokens += source.cache_creation_1h_tokens;
+  target.cache_read_tokens += source.cache_read_tokens;
+  target.reported_total_adjustment = (target.reported_total_adjustment ?? 0)
+    + (source.reported_total_adjustment ?? 0);
+  target.total_tokens += source.total_tokens;
+}
+
+function sumCost(
+  summaries: ReadonlyArray<{ cost: number | null; tokens: TokenBreakdown }>,
+) {
+  let total = 0;
+  for (const summary of summaries) {
+    if (summary.cost === null) {
+      if (summary.tokens.total_tokens > 0) return null;
+      continue;
+    }
+    total += summary.cost;
+  }
+  return total;
+}
+
+function sumOptionalAmounts(values: ReadonlyArray<number | null>) {
+  const known = values.filter((value): value is number => value !== null);
+  return known.length === 0 ? null : known.reduce((sum, value) => sum + value, 0);
+}
+
+function aggregateCoverage(summaries: CostSummary[]): ApiEquivalentCostCoverage | null {
+  const rows = summaries.flatMap((summary) => summary.api_equivalent_cost_coverage ? [summary.api_equivalent_cost_coverage] : []);
+  if (rows.length === 0) return null;
+  const totalTokens = rows.reduce((sum, row) => sum + row.total_tokens, 0);
+  const pricedTokens = rows.reduce((sum, row) => sum + row.priced_tokens, 0);
+  return {
+    total_tokens: totalTokens,
+    priced_tokens: pricedTokens,
+    percent: totalTokens > 0 ? Math.min(Math.max(pricedTokens, 0), totalTokens) / totalTokens * 100 : 0,
+    complete: rows.every((row) => row.complete),
+    cost_is_lower_bound: rows.some((row) => row.cost_is_lower_bound),
+  };
+}
+
+function aggregateModels(summaries: CostSummary[]): ModelCostSummary[] {
+  const models = new Map<string, ModelCostSummary[]>();
+  for (const summary of summaries) {
+    for (const model of summary.models) {
+      const rows = models.get(model.model) ?? [];
+      rows.push(model);
+      models.set(model.model, rows);
+    }
+  }
+
+  return [...models.entries()]
+    .map(([model, rows]) => {
+      const tokens: TokenBreakdown = {
+        input_tokens: 0,
+        output_tokens: 0,
+        reasoning_tokens: 0,
+        cache_creation_tokens: 0,
+        cache_creation_1h_tokens: 0,
+        cache_read_tokens: 0,
+        reported_total_adjustment: 0,
+        cache_hit_rate: null,
+        total_tokens: 0,
+      };
+      for (const row of rows) addTokens(tokens, row.tokens);
+      const inputSide = tokens.input_tokens + tokens.cache_creation_tokens + tokens.cache_read_tokens;
+      tokens.cache_hit_rate = inputSide > 0 ? (tokens.cache_read_tokens / inputSide) * 100 : null;
+      const kinds = new Set(rows.map((row) => row.cost_kind));
+      return {
+        model,
+        cost: sumCost(rows),
+        cost_usd: sumCost(rows.map((row) => ({ cost: row.cost_usd, tokens: row.tokens }))),
+        estimated_cost: sumOptionalAmounts(rows.map((row) => row.estimated_cost)),
+        estimated_cost_usd: sumOptionalAmounts(rows.map((row) => row.estimated_cost_usd)),
+        cost_kind: kinds.size === 1 ? rows[0].cost_kind : "mixed",
+        pricing_source: new Set(rows.map((row) => row.pricing_source)).size === 1 ? rows[0].pricing_source : "mixed",
+        tokens,
+      };
+    })
+    .sort((left, right) => right.tokens.total_tokens - left.tokens.total_tokens || left.model.localeCompare(right.model));
+}
+
+export function aggregateUsageOverviews(overviews: UsageOverview[]): UsageOverview {
+  if (overviews.length === 0) throw new Error("All Sources requires at least one registered source");
+  const currencies = new Set(overviews.map((overview) => overview.currency));
+  if (currencies.size !== 1) throw new Error("All Sources received inconsistent currencies");
+  const ranges: UsageRange[] = ["today", "this_week", "this_month"];
+
+  const summaries = ranges.map((range) => {
+    const sourceSummaries = overviews.map((overview) => {
+      const summary = overview.summaries.find((candidate) => candidate.range === range);
+      if (!summary) throw new Error(`${overview.display_name} is missing ${range}`);
+      return summary;
+    });
+    const tokens: TokenBreakdown = {
+      input_tokens: 0,
+      output_tokens: 0,
+      reasoning_tokens: 0,
+      cache_creation_tokens: 0,
+      cache_creation_1h_tokens: 0,
+      cache_read_tokens: 0,
+      reported_total_adjustment: 0,
+      cache_hit_rate: null,
+      total_tokens: 0,
+    };
+    for (const summary of sourceSummaries) addTokens(tokens, summary.tokens);
+    const inputSide = tokens.input_tokens + tokens.cache_creation_tokens + tokens.cache_read_tokens;
+    tokens.cache_hit_rate = inputSide > 0 ? (tokens.cache_read_tokens / inputSide) * 100 : null;
+    const evidenceSummaries = sourceSummaries.filter((summary) =>
+      summary.valid_entries > 0
+      || summary.models.length > 0
+      || summary.api_equivalent_cost_coverage !== null,
+    );
+    return {
+      range,
+      since: sourceSummaries[0].since,
+      until: sourceSummaries[0].until,
+      currency: overviews[0].currency,
+      cost: sumCost(sourceSummaries),
+      cost_usd: sumCost(sourceSummaries.map((summary) => ({ cost: summary.cost_usd, tokens: summary.tokens }))),
+      estimated_cost: sumOptionalAmounts(sourceSummaries.map((summary) => summary.estimated_cost)),
+      estimated_cost_usd: sumOptionalAmounts(sourceSummaries.map((summary) => summary.estimated_cost_usd)),
+      cost_kind: evidenceSummaries.length === 0
+        ? "unknown"
+        : new Set(evidenceSummaries.map((summary) => summary.cost_kind)).size === 1
+          ? evidenceSummaries[0].cost_kind
+          : "mixed",
+      pricing_source: evidenceSummaries.length === 0
+        ? "unknown"
+        : new Set(evidenceSummaries.map((summary) => summary.pricing_source)).size === 1
+          ? evidenceSummaries[0].pricing_source
+          : "mixed",
+      api_equivalent_cost_coverage: aggregateCoverage(sourceSummaries),
+      tokens,
+      models: aggregateModels(sourceSummaries),
+      valid_entries: sourceSummaries.reduce((sum, summary) => sum + summary.valid_entries, 0),
+      skipped_entries: sourceSummaries.reduce((sum, summary) => sum + summary.skipped_entries, 0),
+      parse_error_entries: sourceSummaries.reduce((sum, summary) => sum + summary.parse_error_entries, 0),
+      elapsed_ms: sourceSummaries.reduce((sum, summary) => sum + summary.elapsed_ms, 0),
+    } satisfies CostSummary;
+  });
+
+  return {
+    source: "all",
+    source_name: "all",
+    display_name: "All Sources",
+    currency: overviews[0].currency,
+    generated_at: overviews.map((overview) => overview.generated_at).sort().at(-1) ?? overviews[0].generated_at,
+    summaries,
+    elapsed_ms: overviews.reduce((sum, overview) => sum + overview.elapsed_ms, 0),
+    source_overviews: overviews,
+  };
 }
 
 export interface DesktopBridge {
   listSources: () => Promise<SourceDescriptor[]>;
+  sourceDiagnostics: () => Promise<SourceDiagnosticDescriptor[]>;
+  codexQuotaOverview: () => Promise<CodexQuotaOverview>;
   usageOverview: (source: string) => Promise<UsageOverview>;
+  usageOverviews: (sources: string[]) => Promise<UsageOverview[]>;
+  projectDrilldown: (source: string, range: UsageRange) => Promise<ProjectDrilldownSummary>;
+  usageHistory: (source: string, range: UsageRange) => Promise<UsageHistory>;
+  turnToolBreakdown: (source: string, range: UsageRange) => Promise<TurnToolBreakdown>;
+  exportHistory: (source: string, range: UsageRange, format: "csv" | "json") => Promise<string>;
+  machineRollup: () => Promise<MachineRollup>;
+  saveMachineSnapshot: (machineName: string, sources: UsageOverview[]) => Promise<MachineRollup>;
+  exportMachineBundle: () => Promise<string>;
+  importMachineBundle: (content: string) => Promise<MachineRollup>;
 }
 
 declare global {
@@ -77,12 +493,24 @@ declare global {
     __CCSTATS_TEST_BRIDGE__?: DesktopBridge;
     __CCSTATS_TEST_CALLS__?: string[];
     __CCSTATS_TEST_CATALOG_CALLS__?: number;
+    __CCSTATS_TEST_EXPORT_CALLS__?: string[];
   }
 }
 
 const tauriBridge: DesktopBridge = {
   listSources: () => invoke<SourceDescriptor[]>("list_sources"),
+  sourceDiagnostics: () => invoke<SourceDiagnosticDescriptor[]>("source_diagnostics"),
+  codexQuotaOverview: () => invoke<CodexQuotaOverview>("codex_quota_overview"),
   usageOverview: (source) => invoke<UsageOverview>("usage_overview", { source }),
+  usageOverviews: (sources) => invoke<UsageOverview[]>("usage_overviews", { sources }),
+  projectDrilldown: (source, range) => invoke<ProjectDrilldownSummary>("project_drilldown", { source, range }),
+  usageHistory: (source, range) => invoke<UsageHistory>("usage_history", { source, range }),
+  turnToolBreakdown: (source, range) => invoke<TurnToolBreakdown>("turn_tool_breakdown", { source, range }),
+  exportHistory: (source, range, format) => invoke<string>("export_history", { source, range, format }),
+  machineRollup: () => invoke<MachineRollup>("machine_rollup"),
+  saveMachineSnapshot: (machineName, sources) => invoke<MachineRollup>("save_machine_snapshot", { machineName, sources }),
+  exportMachineBundle: () => invoke<string>("export_machine_bundle"),
+  importMachineBundle: (content) => invoke<MachineRollup>("import_machine_bundle", { content }),
 };
 
 export function desktopBridge(): DesktopBridge {

--- a/desktop/src/format.ts
+++ b/desktop/src/format.ts
@@ -1,0 +1,23 @@
+const integer = new Intl.NumberFormat("en-US");
+
+export function formatTokens(value: number) {
+  return integer.format(value);
+}
+
+export function formatCost(value: number | null, currency: string) {
+  if (value === null) return "Unknown";
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(value);
+  } catch {
+    return "Invalid currency";
+  }
+}
+
+export function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -1,175 +1,538 @@
 :root {
   font-family: "Manrope", sans-serif;
-  color: #edf8f2;
-  background: #07100d;
+  color: #162438;
+  background: #edf2f7;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
-  --ink: #07100d;
-  --surface: #0b1612;
-  --surface-raised: #101e18;
-  --line: #21342b;
-  --line-bright: #385646;
-  --muted: #82958b;
-  --acid: #a8ff60;
-  --acid-dim: #5e943d;
-  --amber: #f4b64b;
-  --danger: #ff7d68;
-  --paper: #edf8f2;
+  --ink: #162438;
+  --ink-soft: #526176;
+  --muted: #59687c;
+  --workspace: #edf2f7;
+  --rail: #e2eaf2;
+  --panel: #fbfcfe;
+  --panel-alt: #f4f7fa;
+  --line: #d4dde7;
+  --line-strong: #bcc9d6;
+  --accent: #2563c7;
+  --accent-soft: #d9e8fb;
+  --accent-deep: #16488f;
+  --warning: #a76100;
+  --warning-bg: #fff3dc;
+  --danger: #b73a3a;
+  --danger-bg: #fff0f0;
+  --success: #267458;
   --mono: "IBM Plex Mono", monospace;
 }
 
 * { box-sizing: border-box; }
-
-body {
-  margin: 0;
-  min-width: 980px;
-  min-height: 100vh;
-  background:
-    linear-gradient(rgba(168, 255, 96, 0.025) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(168, 255, 96, 0.018) 1px, transparent 1px),
-    var(--ink);
-  background-size: 40px 40px;
-}
-
+html, body, #root { min-width: 0; min-height: 100%; }
+body { margin: 0; min-height: 100vh; background: var(--workspace); }
 button, select { font: inherit; }
 button { cursor: pointer; }
-button:disabled { cursor: wait; opacity: 0.5; }
+button:disabled { cursor: wait; opacity: .55; }
+button:focus-visible, select:focus-visible, input:focus-visible, .file-action:focus-within { outline: 3px solid rgba(37, 99, 199, .28); outline-offset: 2px; }
 
-.app-shell { min-height: 100vh; display: flex; flex-direction: column; }
+.polar-shell { min-height: 100vh; display: grid; grid-template-columns: 228px minmax(0, 1fr); }
 
-.topbar {
-  height: 72px;
-  padding: 0 34px;
+.sidebar {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 22px 16px 18px;
+  background: var(--rail);
+  border-right: 1px solid var(--line-strong);
+}
+
+.brand-lockup { display: flex; align-items: center; gap: 11px; padding: 0 8px 24px; }
+.brand-lockup > span {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  background: var(--accent-deep);
+  border-radius: 10px;
+  font: 500 15px var(--mono);
+  box-shadow: 0 5px 14px rgba(22, 72, 143, .18);
+}
+.brand-lockup > div { display: grid; gap: 1px; }
+.brand-lockup strong { font-size: 15px; font-weight: 700; letter-spacing: -.02em; }
+.brand-lockup small { color: var(--ink-soft); font-size: 11px; }
+
+.side-nav { min-height: 0; display: grid; gap: 13px; overflow-y: auto; }
+.nav-group { display: grid; gap: 4px; }
+.nav-group h2 { margin: 0 10px 3px; color: var(--muted); font: 600 9px var(--mono); letter-spacing: .08em; text-transform: uppercase; }
+.side-nav button {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: center;
+  gap: 5px;
+  padding: 11px 10px;
+  color: var(--ink-soft);
+  text-align: left;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 9px;
+}
+.side-nav button > span { color: var(--muted); font: 400 10px var(--mono); }
+.side-nav button > div { min-width: 0; display: grid; gap: 2px; }
+.side-nav button strong { font-size: 13px; font-weight: 600; }
+.side-nav button small { color: var(--muted); font-size: 10px; }
+.side-nav button:hover { color: var(--ink); background: rgba(255, 255, 255, .45); }
+.side-nav button.active {
+  color: var(--accent-deep);
+  background: #fff;
+  border-color: #c9d5e1;
+  box-shadow: 0 4px 13px rgba(39, 57, 79, .08);
+}
+.side-nav button.active > span, .side-nav button.active small { color: var(--accent); }
+
+.sidebar-source { margin-top: auto; padding: 16px 8px 18px; border-top: 1px solid var(--line-strong); }
+.sidebar-source label { display: block; margin-bottom: 7px; color: var(--ink-soft); font-size: 11px; font-weight: 600; }
+.sidebar-source > div { position: relative; }
+.sidebar-source select {
+  width: 100%;
+  height: 42px;
+  appearance: none;
+  padding: 0 32px 0 11px;
+  color: var(--ink);
+  background: rgba(255, 255, 255, .74);
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  outline: none;
+}
+.sidebar-source > div > span { position: absolute; top: 9px; right: 11px; color: var(--muted); pointer-events: none; }
+.sidebar-source > small { display: block; margin-top: 7px; color: var(--muted); font-size: 10px; }
+
+.local-status { display: flex; align-items: center; gap: 9px; padding: 12px 8px 0; border-top: 1px solid var(--line-strong); }
+.local-status > i { width: 8px; height: 8px; border-radius: 50%; background: var(--success); box-shadow: 0 0 0 4px rgba(38, 116, 88, .1); }
+.local-status > div { display: grid; gap: 1px; }
+.local-status strong { color: var(--ink-soft); font-size: 11px; font-weight: 600; }
+.local-status small { color: var(--muted); font-size: 10px; }
+
+.workspace { min-width: 0; height: 100vh; display: flex; flex-direction: column; overflow: hidden; }
+
+.workspace-toolbar {
+  min-height: 126px;
+  flex: 0 0 auto;
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 32px;
+  padding: 22px 28px;
+  background: rgba(251, 252, 254, .92);
   border-bottom: 1px solid var(--line);
-  background: rgba(7, 16, 13, 0.93);
 }
+.page-heading { min-width: 0; }
+.page-heading > span { color: var(--accent); font-size: 11px; font-weight: 600; }
+.page-heading h1 { margin: 4px 0 5px; color: var(--ink); font-size: 27px; line-height: 1.1; font-weight: 700; letter-spacing: -.035em; }
+.page-heading p { margin: 0; color: var(--ink-soft); font-size: 12px; }
 
-.brand-lockup { display: flex; align-items: center; gap: 13px; }
-.brand-glyph {
-  width: 36px;
-  height: 36px;
-  display: grid;
-  place-items: center;
+.toolbar-actions { display: flex; align-items: center; gap: 10px; }
+.period-control { display: flex; padding: 3px; background: #e7edf4; border: 1px solid var(--line); border-radius: 10px; }
+.period-control button {
+  min-height: 36px;
+  padding: 0 13px;
+  color: var(--ink-soft);
+  background: transparent;
+  border: 0;
+  border-radius: 7px;
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.period-control button.active { color: var(--accent-deep); background: #fff; box-shadow: 0 2px 6px rgba(39, 57, 79, .1); }
+
+.refresh-button, .export-actions button, .state-pane button {
+  height: 42px;
+  padding: 0 14px;
   color: var(--ink);
-  background: var(--acid);
-  border-radius: 4px 13px 4px 4px;
-  font: 600 18px var(--mono);
+  background: #fff;
+  border: 1px solid var(--line-strong);
+  border-radius: 9px;
+  font-size: 11px;
+  font-weight: 600;
 }
-.brand-lockup div { display: grid; gap: 1px; }
-.brand-lockup strong { letter-spacing: -0.02em; font-size: 17px; }
-.brand-lockup div span { color: var(--muted); font: 400 10px var(--mono); text-transform: uppercase; letter-spacing: 0.14em; }
+.refresh-button:hover, .export-actions button:hover, .state-pane button:hover { border-color: var(--accent); color: var(--accent-deep); }
+.refresh-button span { margin-right: 6px; color: var(--accent); }
 
-.privacy-note { color: #a8b8af; font: 400 11px var(--mono); letter-spacing: 0.04em; }
-.privacy-note i { display: inline-block; width: 6px; height: 6px; margin-right: 9px; border-radius: 50%; background: var(--acid); box-shadow: 0 0 12px rgba(168,255,96,.7); }
+.workspace-content {
+  min-width: 0;
+  flex: 1;
+  overflow: auto;
+  padding: 22px 28px 30px;
+  background: var(--workspace);
+}
 
-main { width: min(1360px, calc(100% - 68px)); margin: 0 auto; flex: 1; }
+.report-meta {
+  min-height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 12px;
+  color: var(--muted);
+  font: 400 10px var(--mono);
+}
+.report-meta > div { display: flex; align-items: center; gap: 8px; }
+.report-meta strong { color: var(--ink); font-family: "Manrope", sans-serif; font-size: 12px; font-weight: 600; }
+.source-beacon { width: 7px; height: 7px; border-radius: 50%; background: var(--accent); box-shadow: 0 0 0 4px rgba(37, 99, 199, .09); }
 
-.hero { min-height: 218px; display: flex; align-items: end; justify-content: space-between; gap: 48px; padding: 48px 0 34px; border-bottom: 1px solid var(--line-bright); }
-.hero-copy { max-width: 720px; }
-.hero-index, .section-kicker { margin: 0 0 10px; color: var(--acid); font: 500 10px var(--mono); letter-spacing: .17em; text-transform: uppercase; }
-.hero h1 { margin: 0; font-size: clamp(42px, 5vw, 68px); line-height: .95; letter-spacing: -.055em; }
-.hero-copy > p:last-child { max-width: 690px; margin: 22px 0 0; color: #a3b4aa; line-height: 1.65; font-size: 14px; }
+.work-pane {
+  min-width: 0;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(49, 67, 87, .055);
+}
 
-.source-control { width: 312px; }
-.source-control label { display: block; margin-bottom: 9px; color: #c8d7cf; font: 500 10px var(--mono); text-transform: uppercase; letter-spacing: .12em; }
-.select-frame { position: relative; }
-.select-frame select { width: 100%; appearance: none; color: var(--paper); background: var(--surface-raised); border: 1px solid var(--line-bright); border-radius: 3px; padding: 14px 43px 14px 15px; outline: none; }
-.select-frame select:focus { border-color: var(--acid); box-shadow: 0 0 0 2px rgba(168,255,96,.12); }
-.select-frame > span { position: absolute; right: 15px; top: 12px; color: var(--acid); pointer-events: none; font-family: var(--mono); }
-.source-control > p { margin: 8px 0 0; color: var(--muted); font: 400 10px var(--mono); }
+.pane-heading {
+  min-height: 68px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 16px 18px;
+  border-bottom: 1px solid var(--line);
+}
+.pane-heading > div { min-width: 0; }
+.pane-heading h2 { margin: 0; color: var(--ink); font-size: 16px; font-weight: 700; letter-spacing: -.02em; }
+.pane-heading p { margin: 3px 0 0; color: var(--muted); font-size: 11px; }
+.pane-heading > span { color: var(--muted); font: 400 10px var(--mono); white-space: nowrap; }
 
-.command-strip { display: flex; justify-content: space-between; align-items: center; min-height: 90px; border-bottom: 1px solid var(--line); }
-.range-switcher { display: flex; align-items: stretch; gap: 2px; }
-.range-switcher button { position: relative; min-width: 138px; padding: 12px 17px; text-align: left; color: #92a59b; background: transparent; border: 0; border-left: 1px solid var(--line); }
-.range-switcher button:last-child { border-right: 1px solid var(--line); }
-.range-switcher button::after { content: ""; position: absolute; left: 17px; right: 17px; bottom: 5px; height: 2px; transform: scaleX(0); transform-origin: left; background: var(--acid); transition: transform 160ms ease; }
-.range-switcher button.active { color: var(--paper); background: rgba(168,255,96,.035); }
-.range-switcher button.active::after { transform: scaleX(1); }
-.range-switcher small { display: block; margin-bottom: 4px; color: var(--muted); font: 400 8px var(--mono); text-transform: uppercase; letter-spacing: .1em; }
-.range-switcher .active small { color: var(--acid-dim); }
+.overview-workbench { min-width: 0; display: grid; grid-template-columns: minmax(0, 2.15fr) minmax(260px, .85fr); gap: 16px; }
+.token-map-pane { overflow: hidden; }
+.primary-reading { display: flex; align-items: end; justify-content: space-between; gap: 16px; padding: 20px 20px 17px; }
+.primary-reading > span { padding-bottom: 8px; color: var(--ink-soft); font-size: 11px; font-weight: 600; }
+.primary-reading strong { color: var(--accent-deep); font: 500 clamp(46px, 5.2vw, 68px)/.95 var(--mono); letter-spacing: -.06em; font-variant-numeric: tabular-nums; }
 
-.refresh-button, .error-state button { padding: 10px 14px; color: var(--acid); background: transparent; border: 1px solid var(--acid-dim); border-radius: 3px; font: 500 11px var(--mono); text-transform: uppercase; letter-spacing: .06em; transition: background 140ms ease, color 140ms ease; }
-.refresh-button:hover, .error-state button:hover { color: var(--ink); background: var(--acid); }
-.refresh-button span { margin-right: 7px; font-size: 15px; }
+.token-map { min-height: 132px; display: flex; gap: 2px; margin: 0 20px; overflow: hidden; border-radius: 9px; background: #e4ebf2; }
+.token-map-segment { min-width: 2px; flex-grow: 0; display: flex; flex-direction: column; justify-content: end; gap: 2px; overflow: hidden; padding: 13px; color: #fff; }
+.token-map-segment span { font-size: 10px; font-weight: 600; white-space: nowrap; }
+.token-map-segment strong { font: 500 15px var(--mono); white-space: nowrap; }
+.map-input { background: #2d6dc4; }
+.map-output { background: #5c8fca; }
+.map-reasoning { background: #729bbf; }
+.map-cache-write { background: #9aafc4; }
+.map-cache-read { background: #3f7d9e; }
+.map-adjustment { background: #7d65a8; }
 
-.loading-state { min-height: 480px; display: grid; place-content: center; justify-items: center; }
-.loading-state p { margin: 24px 0 6px; font: 500 13px var(--mono); color: var(--paper); }
-.loading-state small { color: var(--muted); font: 400 10px var(--mono); }
-.scanner { position: relative; width: 86px; height: 86px; border: 1px solid var(--line-bright); border-radius: 50%; }
-.scanner::before, .scanner::after { content: ""; position: absolute; inset: 10px; border: 1px solid var(--line); border-radius: 50%; }
-.scanner::after { inset: 29px; background: var(--acid); border: 0; box-shadow: 0 0 22px rgba(168,255,96,.65); }
-.scanner span { position: absolute; inset: -1px; border-radius: 50%; border-top: 1px solid var(--acid); animation: scan 900ms linear infinite; }
-@keyframes scan { to { transform: rotate(360deg); } }
+.token-key { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); margin: 16px 20px 18px; }
+.token-key > div { min-width: 0; padding-right: 10px; }
+.token-key dt { color: var(--ink-soft); font-size: 10px; white-space: nowrap; }
+.token-key dt i { width: 7px; height: 7px; display: inline-block; margin-right: 6px; border-radius: 2px; }
+.key-input { background: #2d6dc4; }
+.key-output { background: #5c8fca; }
+.key-reasoning { background: #729bbf; }
+.key-cache-write { background: #9aafc4; }
+.key-cache-read { background: #3f7d9e; }
+.key-adjustment { background: #7d65a8; }
+.token-adjustment-note { margin: 12px 0 0; padding: 9px 11px; color: var(--warning); background: var(--warning-bg); border-radius: 6px; font-size: 10px; }
+.token-key dd { margin: 7px 0 1px; color: var(--ink); font: 500 15px var(--mono); }
+.token-key small { color: var(--muted); font: 400 9px var(--mono); }
 
-.error-state, .empty-state { margin: 58px 0; padding: 48px; border: 1px solid #683b32; background: rgba(255,125,104,.045); }
-.error-code, .empty-index { color: var(--danger); font: 500 10px var(--mono); letter-spacing: .14em; }
-.error-state h2, .empty-state h2 { margin: 14px 0 8px; font-size: 28px; letter-spacing: -.035em; }
-.error-state p, .empty-state p { max-width: 700px; margin: 0 0 24px; color: #b6a09b; }
+.quality-status {
+  min-height: 76px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 20px;
+  background: var(--panel-alt);
+  border-top: 1px solid var(--line);
+}
+.quality-symbol { width: 30px; height: 30px; display: grid; place-items: center; color: var(--success); background: #e8f4ef; border-radius: 50%; font: 500 12px var(--mono); }
+.quality-status strong { font-size: 12px; font-weight: 700; }
+.quality-status p { margin: 2px 0 0; color: var(--muted); font-size: 10px; }
+.quality-status dl { display: flex; gap: 15px; margin: 0; }
+.quality-status dl div { text-align: right; }
+.quality-status dt { color: var(--muted); font-size: 9px; }
+.quality-status dd { margin: 2px 0 0; color: var(--ink); font: 500 11px var(--mono); }
+.quality-status.quality-warning { background: var(--warning-bg); }
+.quality-warning .quality-symbol { color: var(--warning); background: #ffe6b8; }
 
-.report-meta { min-height: 70px; display: flex; align-items: center; justify-content: space-between; color: var(--muted); border-bottom: 1px solid var(--line); font: 400 10px var(--mono); }
-.report-meta div { display: flex; align-items: center; gap: 10px; }
-.report-meta strong { color: var(--paper); font-family: Manrope, sans-serif; font-size: 13px; }
-.report-meta p { display: flex; gap: 8px; }
-.live-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--acid); box-shadow: 0 0 10px rgba(168,255,96,.6); }
+.snapshot-pane { overflow: hidden; }
+.snapshot-list { margin: 0; }
+.snapshot-list > div { padding: 17px 18px; border-bottom: 1px solid var(--line); }
+.snapshot-list dt { color: var(--ink-soft); font-size: 10px; font-weight: 600; }
+.snapshot-list dd { margin: 6px 0 2px; color: var(--ink); font: 500 23px var(--mono); letter-spacing: -.03em; }
+.snapshot-list small { color: var(--muted); font-size: 10px; }
+.unknown-cost { color: var(--warning) !important; }
+.known-cost { color: var(--accent-deep) !important; }
+.capability-block { padding: 15px 18px 18px; }
+.capability-block > span { color: var(--muted); font-size: 10px; }
+.capability-block > div { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 9px; }
+.capability-block em { padding: 4px 7px; color: var(--ink-soft); background: var(--panel-alt); border: 1px solid var(--line); border-radius: 6px; font-size: 9px; font-style: normal; }
 
-.metric-rack { display: grid; grid-template-columns: 1.25fr 1fr .8fr 1.2fr; border-left: 1px solid var(--line); border-bottom: 1px solid var(--line); }
-.metric-rack article { min-height: 154px; padding: 24px; border-right: 1px solid var(--line); background: rgba(11,22,18,.6); }
-.metric-rack article p { margin: 0 0 15px; color: var(--muted); font: 400 10px var(--mono); text-transform: uppercase; letter-spacing: .12em; }
-.metric-rack article > strong { display: block; color: var(--paper); font: 500 29px var(--mono); letter-spacing: -.055em; }
-.metric-rack .metric-primary > strong { color: var(--acid); font-size: 39px; }
-.metric-rack article > span { display: block; margin-top: 10px; color: #71857a; font: 400 9px var(--mono); }
-.metric-rack .unknown-cost, .unknown-cost { color: var(--amber); }
-.capability-list { display: flex; flex-wrap: wrap; gap: 6px; min-height: 42px; align-content: start; }
-.capability-list span { padding: 5px 7px; color: #b9d4c4; border: 1px solid var(--line-bright); border-radius: 2px; font: 400 9px var(--mono); }
-
-.analysis-grid { display: grid; grid-template-columns: 1.45fr .85fr; gap: 18px; margin-top: 18px; }
-.ledger-panel { background: rgba(11,22,18,.76); border: 1px solid var(--line); }
-.composition-panel { padding: 24px; }
-.section-heading { display: flex; align-items: start; justify-content: space-between; padding-bottom: 20px; border-bottom: 1px solid var(--line); }
-.section-heading h2, .quality-panel h2 { margin: 0; font-size: 20px; letter-spacing: -.035em; }
-.section-kicker { margin-bottom: 6px; font-size: 8px; }
-.cache-rate, .muted-badge, .row-count { color: var(--acid); font: 400 9px var(--mono); }
-.muted-badge, .row-count { color: var(--muted); }
-.bucket-list { display: grid; gap: 17px; padding-top: 21px; }
-.bucket-label { display: flex; justify-content: space-between; margin-bottom: 7px; font: 400 10px var(--mono); }
-.bucket-label span { color: #9eb0a6; }
-.bucket-label strong { font-weight: 500; color: var(--paper); }
-.bucket-track { height: 5px; overflow: hidden; background: #17261f; }
-.bucket-fill { display: block; height: 100%; transition: width 300ms ease; }
-.bucket-acid { background: var(--acid); }.bucket-paper { background: #dce9e1; }.bucket-amber { background: var(--amber); }.bucket-blue { background: #6aa5bf; }.bucket-mint { background: #57c995; }
-
-.quality-panel { padding: 24px; display: grid; grid-template-columns: 46px 1fr; align-content: start; column-gap: 15px; }
-.quality-mark { width: 42px; height: 42px; display: grid; place-items: center; border: 1px solid currentColor; border-radius: 50%; color: var(--acid); font: 500 18px var(--mono); }
-.quality-warning .quality-mark, .quality-warning .section-kicker { color: var(--amber); }
-.quality-panel p:not(.section-kicker) { margin: 9px 0 0; color: var(--muted); font-size: 11px; line-height: 1.5; }
-.quality-facts { grid-column: 1 / -1; display: grid; grid-template-columns: repeat(3,1fr); margin: 29px 0 0; border-top: 1px solid var(--line); border-left: 1px solid var(--line); }
-.quality-facts div { padding: 15px; border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); }
-.quality-facts dt { color: var(--muted); font: 400 8px var(--mono); text-transform: uppercase; }
-.quality-facts dd { margin: 7px 0 0; color: var(--paper); font: 500 15px var(--mono); }
-
-.model-panel { margin: 18px 0 38px; padding: 24px; }
-.table-scroll { overflow: auto; }
-table { width: 100%; border-collapse: collapse; font: 400 11px var(--mono); }
-th { padding: 14px 12px; color: var(--muted); font-size: 8px; font-weight: 500; letter-spacing: .12em; text-transform: uppercase; text-align: right; border-bottom: 1px solid var(--line-bright); }
+.table-pane { margin-top: 16px; overflow: hidden; }
+.table-scroll { width: 100%; overflow: auto; }
+table { width: 100%; min-width: 600px; border-collapse: collapse; font: 400 11px var(--mono); font-variant-numeric: tabular-nums; }
+th { padding: 10px 14px; color: var(--muted); background: var(--panel-alt); border-bottom: 1px solid var(--line); font-size: 9px; font-weight: 500; text-align: right; }
 th:first-child, td:first-child { text-align: left; }
-td { padding: 15px 12px; color: #a9bbb1; text-align: right; border-bottom: 1px solid var(--line); }
+td { padding: 13px 14px; color: var(--ink-soft); border-bottom: 1px solid var(--line); text-align: right; vertical-align: baseline; }
 tbody tr:last-child td { border-bottom: 0; }
-tbody tr:hover { background: rgba(168,255,96,.025); }
-.model-name { color: var(--paper); font-weight: 500; }
-.known-cost { color: var(--acid); }
+tbody tr:hover { background: #f7faff; }
+.identity-cell { color: var(--ink); font-weight: 500; }
 
-.empty-state { display: flex; align-items: start; gap: 28px; border-color: var(--line-bright); background: var(--surface); }
-.empty-index { color: var(--acid); font-size: 28px; }
-.empty-state p { color: var(--muted); }
+.project-workbench { min-width: 0; height: 100%; display: grid; grid-template-columns: minmax(0, 1.35fr) minmax(310px, .85fr); gap: 16px; }
+.project-master, .session-inspector { min-height: 430px; overflow: hidden; }
+.project-cell { min-width: 240px; display: grid; gap: 4px; }
+.project-cell button { width: fit-content; padding: 0; color: var(--accent-deep); background: transparent; border: 0; font: 500 11px var(--mono); }
+.project-cell small, .mono-detail { overflow: hidden; color: var(--muted); font: 400 9px var(--mono) !important; text-overflow: ellipsis; white-space: nowrap; }
+.selected-row { background: var(--accent-soft) !important; box-shadow: inset 3px 0 var(--accent); }
 
-footer { min-height: 54px; padding: 0 34px; display: flex; align-items: center; justify-content: space-between; color: #5e7367; border-top: 1px solid var(--line); font: 400 9px var(--mono); text-transform: uppercase; letter-spacing: .08em; }
+.session-inspector { display: flex; flex-direction: column; }
+.session-list { overflow: auto; }
+.session-list article { padding: 15px 17px; border-bottom: 1px solid var(--line); }
+.session-list article > div { display: grid; gap: 3px; }
+.session-list strong { color: var(--ink); font: 500 11px var(--mono); }
+.session-list article > div span { color: var(--muted); font: 400 9px var(--mono); }
+.session-list dl { display: flex; gap: 26px; margin: 13px 0 0; }
+.session-list dl div { display: grid; gap: 3px; }
+.session-list dt { color: var(--muted); font-size: 9px; }
+.session-list dd { margin: 0; color: var(--ink); font: 500 12px var(--mono); }
+.inspector-empty { flex: 1; display: grid; place-content: center; justify-items: center; padding: 30px; text-align: center; }
+.inspector-empty > span { width: 38px; height: 38px; display: grid; place-items: center; color: var(--accent); background: var(--accent-soft); border-radius: 10px; }
+.inspector-empty h2 { margin: 13px 0 5px; font-size: 16px; }
+.inspector-empty p { max-width: 280px; margin: 0; color: var(--muted); font-size: 11px; line-height: 1.5; }
 
-@media (max-width: 1100px) {
-  .metric-rack { grid-template-columns: repeat(2, 1fr); }
-  .analysis-grid { grid-template-columns: 1fr; }
+.history-workbench { overflow: hidden; }
+.history-heading { min-height: 76px; }
+.export-actions { display: flex; gap: 7px; }
+.export-actions button { height: 36px; background: var(--panel-alt); }
+.history-chart { margin: 0; padding: 18px 20px 0; overflow-x: auto; }
+.chart-plot { position: relative; height: 245px; display: flex; align-items: end; gap: 8px; padding: 23px 8px 23px; border-bottom: 1px solid var(--line-strong); }
+.chart-plot::before, .chart-plot::after { content: ""; position: absolute; left: 8px; right: 8px; height: 1px; background: var(--line); }
+.chart-plot::before { top: 33%; }
+.chart-plot::after { top: 66%; }
+.chart-slot { position: relative; z-index: 1; min-width: 34px; height: 100%; flex: 1; display: flex; align-items: center; flex-direction: column; justify-content: end; gap: 6px; }
+.chart-slot i { width: min(34px, 70%); display: block; background: var(--accent); border-radius: 5px 5px 1px 1px; }
+.chart-value { color: var(--ink-soft); font: 400 9px var(--mono); }
+.chart-slot small { color: var(--muted); font: 400 9px var(--mono); }
+.history-chart figcaption { margin: 9px 0 16px; color: var(--muted); font-size: 10px; }
+
+.activity-workbench { display: grid; gap: 14px; }
+.activity-heading { display: flex; align-items: center; justify-content: space-between; gap: 18px; padding: 17px 18px; }
+.activity-heading h2 { margin: 0; font-size: 16px; }
+.activity-heading p { margin: 4px 0 0; color: var(--muted); font-size: 11px; }
+.activity-summary { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 1px; margin: 0; overflow: hidden; background: var(--line); border: 1px solid var(--line); border-radius: 12px; }
+.activity-summary > div { padding: 16px 18px; background: var(--panel); }
+.activity-summary dt { color: var(--muted); font: 500 9px var(--mono); text-transform: uppercase; }
+.activity-summary dd { margin: 6px 0 2px; color: var(--ink); font: 600 23px var(--mono); }
+.activity-summary small { color: var(--muted); font-size: 9px; }
+.activity-grid { min-width: 0; display: grid; grid-template-columns: minmax(0, 1.6fr) minmax(250px, .7fr); gap: 14px; }
+.tool-evidence, .evidence-method { overflow: hidden; }
+.tool-list { display: grid; gap: 13px; margin: 0; padding: 17px 18px 19px; list-style: none; }
+.tool-list li > div { display: flex; justify-content: space-between; gap: 12px; margin-bottom: 6px; }
+.tool-list strong { color: var(--ink); font: 500 11px var(--mono); }
+.tool-list span { color: var(--muted); font: 400 9px var(--mono); }
+.tool-list i { height: 4px; display: block; overflow: hidden; background: var(--panel-alt); border-radius: 999px; }
+.tool-list i span { height: 100%; display: block; background: var(--accent); border-radius: inherit; }
+.evidence-note { padding: 22px 18px; }
+.evidence-note strong { color: var(--ink); font-size: 12px; }
+.evidence-note p { margin: 5px 0 0; color: var(--muted); font-size: 10px; line-height: 1.5; }
+.evidence-method dl { display: grid; gap: 0; margin: 0; }
+.evidence-method dl > div { display: grid; gap: 4px; padding: 11px 16px; border-bottom: 1px solid var(--line); }
+.evidence-method dl > div:last-child { border-bottom: 0; }
+.evidence-method dt { color: var(--muted); font-size: 9px; }
+.evidence-method dd { margin: 0; color: var(--ink); font: 500 10px var(--mono); }
+.turn-table { margin-top: 0; }
+.turn-table table { min-width: 900px; }
+.turn-identity { min-width: 280px; text-align: left; }
+.turn-identity strong, .turn-identity small { display: block; }
+.turn-identity small { max-width: 420px; margin-top: 4px; overflow: hidden; color: var(--muted); font: 400 9px var(--mono); text-overflow: ellipsis; white-space: nowrap; }
+.call-badge { display: block; margin-top: 4px; color: var(--accent); font: 500 8px var(--mono); }
+
+.trust-workbench { display: grid; gap: 14px; }
+.trust-heading { display: flex; align-items: center; justify-content: space-between; gap: 18px; padding: 17px 18px; }
+.trust-heading h2 { margin: 0; font-size: 16px; }
+.trust-heading p { margin: 4px 0 0; color: var(--muted); font-size: 11px; }
+.trust-heading > span { padding: 5px 8px; background: var(--panel-alt); border-radius: 6px; font: 500 9px var(--mono); }
+.trust-summary { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 1px; margin: 0; overflow: hidden; background: var(--line); border: 1px solid var(--line); border-radius: 12px; }
+.trust-summary > div { min-width: 0; padding: 16px 18px; background: var(--panel); }
+.trust-summary dt { color: var(--muted); font: 500 9px var(--mono); text-transform: uppercase; }
+.trust-summary dd { margin: 6px 0 2px; overflow: hidden; color: var(--ink); font: 600 18px var(--mono); text-overflow: ellipsis; white-space: nowrap; }
+.trust-summary small { color: var(--muted); font-size: 9px; }
+.trust-explanation { display: flex; align-items: center; gap: 12px; padding: 15px 18px; }
+.trust-explanation > span { width: 28px; height: 28px; flex: 0 0 auto; display: grid; place-items: center; color: var(--accent-deep); background: var(--accent-soft); border-radius: 50%; font: 500 10px var(--mono); }
+.trust-explanation strong { color: var(--ink); font-size: 11px; }
+.trust-explanation p { margin: 3px 0 0; color: var(--muted); font-size: 10px; line-height: 1.5; }
+.trust-table { margin-top: 0; }
+.trust-table table { min-width: 820px; }
+
+.state-pane {
+  min-height: 220px;
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 34px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(49, 67, 87, .055);
+}
+.state-pane > span { width: 42px; height: 42px; flex: 0 0 auto; display: grid; place-items: center; color: var(--accent); background: var(--accent-soft); border-radius: 12px; font: 500 15px var(--mono); }
+.state-pane h2 { margin: 0 0 6px; color: var(--ink); font-size: 18px; }
+.state-pane p { max-width: 600px; margin: 0; color: var(--ink-soft); font-size: 12px; line-height: 1.55; }
+.state-pane button { margin-top: 16px; }
+.error-state { background: var(--danger-bg); border-color: #eccaca; }
+.error-state > span { color: var(--danger); background: #f8dede; }
+
+.loading-state { min-height: 430px; display: grid; place-content: center; justify-items: center; text-align: center; }
+.loading-state > div { display: flex; gap: 5px; margin-bottom: 15px; }
+.loading-state i { width: 8px; height: 8px; border-radius: 50%; background: var(--accent); animation: pulse 900ms ease-in-out infinite alternate; }
+.loading-state i:nth-child(2) { animation-delay: 160ms; }
+.loading-state i:nth-child(3) { animation-delay: 320ms; }
+.loading-state strong { font-size: 13px; }
+.loading-state span { margin-top: 5px; color: var(--muted); font: 400 10px var(--mono); }
+@keyframes pulse { to { opacity: .28; transform: translateY(-4px); } }
+
+.diagnostic-summary { display: flex; gap: 8px; padding: 12px 16px; border-bottom: 1px solid var(--line); }
+.diagnostic-summary strong, .diagnostic-status { padding: 4px 8px; border-radius: 999px; background: var(--panel-alt); font: 500 10px var(--mono); }
+.status-detected { color: var(--success); background: var(--success-bg); }
+.status-configured { color: var(--accent); background: var(--accent-soft); }
+.status-missing { color: var(--muted); }
+.diagnostic-detail span, .diagnostic-detail small { display: block; }
+.diagnostic-detail small { margin-top: 4px; color: var(--muted); }
+
+.limits-workbench { display: grid; gap: 14px; }
+.limits-heading { padding: 18px; }
+.limits-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; }
+.limit-pane { padding: 18px; }
+.limit-pane h3 { margin: 0; font-size: 14px; }
+.limit-metrics { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1px; margin: 18px 0; background: var(--line); border: 1px solid var(--line); }
+.limit-metrics > div { padding: 14px; background: var(--panel); }
+.limit-metrics dt, .limit-details dt { color: var(--muted); font: 500 9px var(--mono); text-transform: uppercase; }
+.limit-metrics dd { margin: 5px 0 0; color: var(--ink); font: 600 20px var(--mono); text-transform: capitalize; }
+.limit-details { display: grid; gap: 10px; margin: 0; }
+.limit-details > div { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; }
+.limit-details dd { margin: 0; color: var(--ink-soft); font: 500 11px var(--mono); text-align: right; }
+.budget-input { display: grid; gap: 6px; margin-top: 18px; color: var(--muted); font: 500 9px var(--mono); text-transform: uppercase; }
+.budget-input input { width: 100%; height: 38px; padding: 0 10px; color: var(--ink); background: var(--panel-alt); border: 1px solid var(--line-strong); border-radius: 6px; font: 500 13px var(--mono); }
+.inline-warning { margin: 14px 0 0; padding: 10px 12px; color: var(--danger); background: var(--danger-bg); border-radius: 6px; font-size: 11px; }
+.quality-notice { display: grid; gap: 3px; margin: 0 0 14px; padding: 11px 13px; color: var(--warning); background: var(--warning-bg); border: 1px solid #ebce98; border-radius: 8px; font-size: 10px; }
+.quality-notice-error { color: var(--danger); background: var(--danger-bg); border-color: #eccaca; }
+.project-workbench td > small, .session-list dd > small { display: block; margin-top: 3px; color: var(--muted); font-size: 8px; }
+.limit-note { margin: 0; color: var(--muted); font-size: 10px; }
+
+.top-workbench { display: grid; gap: 14px; }
+.top-heading { padding: 18px; }
+.consumer-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; }
+.consumer-pane h3 { margin: 0; font-size: 14px; }
+.anomaly-pane { display: flex; align-items: center; justify-content: space-between; gap: 20px; padding: 18px; }
+.anomaly-pane strong { color: var(--ink); font-size: 14px; }
+.anomaly-pane p { margin: 4px 0 0; color: var(--muted); font-size: 11px; }
+.anomaly-pane dl { display: flex; gap: 24px; margin: 0; }
+.anomaly-pane dt { color: var(--muted); font: 500 9px var(--mono); text-transform: uppercase; }
+.anomaly-pane dd { margin: 5px 0 0; color: var(--ink); font: 600 15px var(--mono); }
+.anomaly-spike { border-color: #eccaca; background: var(--danger-bg); }
+
+.live-workbench { display: grid; gap: 14px; }
+.live-heading { padding: 18px; }
+.live-state { display: flex; align-items: center; gap: 7px; color: var(--muted); }
+.live-state i { width: 8px; height: 8px; border-radius: 50%; background: currentColor; }
+.live-state strong { font-size: 11px; }
+.live-state.active { color: var(--success); }
+.live-reading-grid { display: grid; grid-template-columns: minmax(0, 1.5fr) repeat(2, minmax(0, 1fr)); gap: 14px; }
+.live-primary, .live-metric { min-height: 168px; display: flex; flex-direction: column; justify-content: end; padding: 20px; }
+.live-primary > span, .live-metric > span { margin-bottom: auto; color: var(--muted); font-size: 10px; }
+.live-primary strong { color: var(--accent-deep); font: 500 clamp(38px, 5vw, 60px)/1 var(--mono); letter-spacing: -.05em; }
+.live-metric strong { color: var(--ink); font: 600 27px/1.1 var(--mono); }
+.live-primary small, .live-metric small { margin-top: 9px; color: var(--muted); font: 400 10px var(--mono); }
+.live-control { display: flex; align-items: center; justify-content: space-between; gap: 20px; padding: 16px 18px; }
+.live-control dl { display: flex; gap: 30px; margin: 0; }
+.live-control dt { color: var(--muted); font-size: 9px; }
+.live-control dd { margin: 4px 0 0; color: var(--ink); font: 500 11px var(--mono); }
+.live-control button { height: 36px; padding: 0 14px; color: var(--accent-deep); background: var(--accent-soft); border: 1px solid #bdd2ee; border-radius: 8px; font-size: 11px; font-weight: 600; }
+
+.machines-workbench { display: grid; gap: 14px; }
+.machines-heading { padding: 18px; }
+.machine-totals { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 14px; }
+.machine-totals article { min-height: 132px; display: flex; flex-direction: column; justify-content: end; padding: 18px; }
+.machine-totals span { margin-bottom: auto; color: var(--muted); font-size: 10px; }
+.machine-totals strong { color: var(--ink); font: 600 26px var(--mono); }
+.machine-totals small { margin-top: 5px; color: var(--accent-deep); font: 500 11px var(--mono); }
+.machine-actions { display: grid; grid-template-columns: minmax(190px, 1fr) repeat(3, auto); align-items: end; gap: 10px; padding: 16px 18px; }
+.machine-actions > label:first-child { display: grid; gap: 6px; color: var(--muted); font-size: 10px; }
+.machine-actions input[type="text"], .machine-actions > label:first-child input { height: 38px; padding: 0 10px; color: var(--ink); background: var(--panel-alt); border: 1px solid var(--line-strong); border-radius: 7px; }
+.machine-actions button, .file-action { height: 38px; display: grid; place-items: center; padding: 0 13px; color: var(--ink); background: var(--panel-alt); border: 1px solid var(--line-strong); border-radius: 7px; font-size: 10px; font-weight: 600; }
+.file-action { position: relative; cursor: pointer; }
+.file-action input { position: absolute; width: 1px; height: 1px; opacity: 0; }
+.machine-table { margin-top: 0; }
+.machine-table .identity-cell small { display: inline-block; margin-left: 7px; padding: 2px 5px; color: var(--success); background: #e8f4ef; border-radius: 4px; font: 500 8px var(--mono); }
+
+.workspace-footer { min-height: 38px; flex: 0 0 auto; display: flex; align-items: center; justify-content: space-between; padding: 0 28px; color: var(--muted); background: var(--panel-alt); border-top: 1px solid var(--line); font-size: 9px; }
+
+@media (max-width: 980px) {
+  .polar-shell { grid-template-columns: 196px minmax(0, 1fr); }
+  .workspace-toolbar { align-items: flex-start; flex-direction: column; gap: 16px; }
+  .toolbar-actions { width: 100%; justify-content: space-between; }
+  .overview-workbench { grid-template-columns: 1fr; }
+  .snapshot-list { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .snapshot-list > div { border-right: 1px solid var(--line); }
+  .project-workbench { grid-template-columns: 1fr; height: auto; }
+  .activity-grid { grid-template-columns: 1fr; }
+  .trust-summary { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .project-master, .session-inspector { min-height: 320px; }
+}
+
+@media (max-width: 720px) {
+  .polar-shell { display: block; }
+  .sidebar { position: static; width: 100%; height: auto; display: grid; grid-template-columns: 1fr auto; gap: 14px; padding: 14px 16px; border-right: 0; border-bottom: 1px solid var(--line-strong); }
+  .brand-lockup { padding: 0; }
+  .side-nav { grid-column: 1 / -1; grid-row: 2; display: flex; gap: 5px; overflow-x: auto; }
+  .nav-group { display: contents; }
+  .nav-group h2 { display: none; }
+  .side-nav button { min-width: 92px; flex: 0 0 auto; }
+  .side-nav button { grid-template-columns: 1fr; justify-items: center; padding: 9px 5px; text-align: center; }
+  .side-nav button > span, .side-nav button small { display: none; }
+  .sidebar-source { grid-column: 1 / -1; grid-row: 3; margin: 0; padding: 13px 0 0; }
+  .sidebar-source > small { display: none; }
+  .local-status { grid-column: 2; grid-row: 1; padding: 0; border: 0; }
+  .local-status small { display: none; }
+  .workspace { height: auto; min-height: calc(100vh - 188px); overflow: visible; }
+  .workspace-toolbar { min-height: 0; padding: 20px 16px; }
+  .toolbar-actions { align-items: stretch; flex-direction: column; }
+  .period-control { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .period-control button { min-width: 0; padding: 0 6px; }
+  .refresh-button { width: 100%; }
+  .workspace-content { overflow: visible; padding: 16px; }
+  .report-meta { align-items: flex-start; flex-direction: column; }
+  .overview-workbench { display: block; }
+  .snapshot-pane, .table-pane { margin-top: 14px; }
+  .primary-reading { align-items: flex-start; flex-direction: column; }
+  .primary-reading strong { font-size: 48px; }
+  .token-map { min-height: 105px; }
+  .token-map-segment { padding: 8px; }
+  .token-key { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px 0; }
+  .quality-status { grid-template-columns: auto 1fr; }
+  .quality-status dl { grid-column: 1 / -1; justify-content: space-between; }
+  .limits-grid { grid-template-columns: 1fr; }
+  .consumer-grid { grid-template-columns: 1fr; }
+  .live-reading-grid { grid-template-columns: 1fr; }
+  .live-primary, .live-metric { min-height: 140px; }
+  .live-control { align-items: stretch; flex-direction: column; }
+  .live-control dl { justify-content: space-between; gap: 12px; }
+  .machine-totals { grid-template-columns: 1fr; }
+  .machine-actions { grid-template-columns: 1fr; align-items: stretch; }
+  .anomaly-pane { align-items: flex-start; flex-direction: column; }
+  .snapshot-list { grid-template-columns: 1fr; }
+  .snapshot-list > div { border-right: 0; }
+  .project-workbench { display: block; }
+  .session-inspector { margin-top: 14px; }
+  .pane-heading { align-items: flex-start; }
+  .history-heading { flex-direction: column; }
+  .activity-heading { align-items: stretch; flex-direction: column; }
+  .activity-summary { grid-template-columns: 1fr; }
+  .trust-heading { align-items: flex-start; flex-direction: column; }
+  .trust-summary { grid-template-columns: 1fr; }
+  .export-actions { width: 100%; }
+  .export-actions button { flex: 1; }
+  .workspace-footer { padding: 0 16px; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/desktop/tests/bridge.spec.ts
+++ b/desktop/tests/bridge.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "@playwright/test";
+import {
+  aggregateUsageOverviews,
+  type CostSummary,
+  type TokenBreakdown,
+  type UsageOverview,
+  type UsageRange,
+} from "../src/bridge";
+
+function tokens(input: number, cacheRead: number, cacheHitRate: number | null): TokenBreakdown {
+  return {
+    input_tokens: input,
+    output_tokens: 0,
+    reasoning_tokens: 0,
+    cache_creation_tokens: 0,
+    cache_creation_1h_tokens: 0,
+    cache_read_tokens: cacheRead,
+    reported_total_adjustment: 0,
+    cache_hit_rate: cacheHitRate,
+    total_tokens: input + cacheRead,
+  };
+}
+
+function overview(name: string, tokenCounts: TokenBreakdown): UsageOverview {
+  const summary = (range: UsageRange): CostSummary => ({
+    range,
+    since: "2026-09-02",
+    until: "2026-09-02",
+    currency: "USD",
+    cost: 0,
+    cost_usd: 0,
+    estimated_cost: null,
+    estimated_cost_usd: null,
+    cost_kind: "real",
+    pricing_source: "recorded",
+    api_equivalent_cost_coverage: null,
+    tokens: { ...tokenCounts },
+    models: [{
+      model: "shared-model",
+      cost: 0,
+      cost_usd: 0,
+      estimated_cost: null,
+      estimated_cost_usd: null,
+      cost_kind: "real",
+      pricing_source: "recorded",
+      tokens: { ...tokenCounts },
+    }],
+    valid_entries: 1,
+    skipped_entries: 0,
+    parse_error_entries: 0,
+    elapsed_ms: 1,
+  });
+
+  return {
+    source: name,
+    source_name: name,
+    display_name: name,
+    currency: "USD",
+    generated_at: "2026-09-02T00:00:00Z",
+    summaries: [summary("today"), summary("this_week"), summary("this_month")],
+    elapsed_ms: 3,
+  };
+}
+
+test("cache aggregation excludes sources without cache-hit evidence", () => {
+  const aggregate = aggregateUsageOverviews([
+    overview("cache-aware", tokens(50, 50, 50)),
+    overview("cache-opaque", tokens(900, 0, null)),
+  ]);
+
+  for (const summary of aggregate.summaries) {
+    expect(summary.tokens.total_tokens).toBe(1_000);
+    expect(summary.tokens.cache_hit_rate).toBe(50);
+    expect(summary.models[0].tokens.total_tokens).toBe(1_000);
+    expect(summary.models[0].tokens.cache_hit_rate).toBe(50);
+  }
+});

--- a/desktop/tests/overview.spec.ts
+++ b/desktop/tests/overview.spec.ts
@@ -6,10 +6,21 @@ import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { rankConsumers } from "../src/bridge";
 
 const WEB_ELEMENT_ID = "element-6066-11e4-a52e-4f735466cecf";
 
 type WebDriverElement = { [WEB_ELEMENT_ID]: string };
+
+test("token rankings do not prioritize a smaller priced row", () => {
+  const rows = rankConsumers([
+    { name: "small priced", tokens: 10, cost: 1 },
+    { name: "large unpriced", tokens: 1_000_000, cost: null },
+  ]);
+
+  expect(rows.map((row) => row.name)).toEqual(["large unpriced", "small priced"]);
+  expect(rows[0].share_basis).toBe("tokens");
+});
 
 async function webdriverRequest<T>(port: number, path: string, init?: RequestInit): Promise<T> {
   const response = await fetch(`http://127.0.0.1:${port}${path}`, {
@@ -88,17 +99,25 @@ async function reserveAvailablePort(): Promise<number> {
 type MockOptions = {
   delay?: number;
   qualityWarning?: boolean;
-  partialCostCoverage?: boolean;
   fail?: boolean;
   omitWeek?: boolean;
   allMalformed?: boolean;
   failCatalogOnce?: boolean;
+  quotaFail?: boolean;
+  liveGrowth?: boolean;
+  liveFailAfterGrowth?: boolean;
+  noReadySources?: boolean;
+  totalAdjustment?: boolean;
 };
 
 async function injectBridge(page: Page, options: MockOptions = {}) {
-  await page.addInitScript(({ delay, qualityWarning, partialCostCoverage, fail, omitWeek, allMalformed, failCatalogOnce }) => {
+  await page.addInitScript(({ delay, qualityWarning, fail, omitWeek, allMalformed, failCatalogOnce, quotaFail, liveGrowth, liveFailAfterGrowth, noReadySources, totalAdjustment }) => {
     const calls: string[] = [];
+    const exportCalls: string[] = [];
     let catalogCalls = 0;
+    type MockMachine = { machine_id: string; machine_name: string; captured_at_ms: number; source_count: number; currency: string | null; is_local: boolean; today_current: boolean; week_current: boolean; month_current: boolean; totals: { today_tokens: number; week_tokens: number; month_tokens: number; today_cost: number | null; week_cost: number | null; month_cost: number | null } };
+    type MockRollup = { local_machine_id: string; local_machine_name: string | null; currency: string | null; today_current_machines: number; week_current_machines: number; month_current_machines: number; machines: MockMachine[]; totals: MockMachine["totals"] };
+    let machineState: MockRollup = { local_machine_id: "local-1", local_machine_name: null, currency: null, today_current_machines: 0, week_current_machines: 0, month_current_machines: 0, machines: [], totals: { today_tokens: 0, week_tokens: 0, month_tokens: 0, today_cost: 0, week_cost: 0, month_cost: 0 } };
     const summaries = [
       { range: "today", total: 1_240, records: 4 },
       { range: "this_week", total: 8_420, records: 18 },
@@ -133,10 +152,60 @@ async function injectBridge(page: Page, options: MockOptions = {}) {
           },
         ];
       },
+      sourceDiagnostics: async () => [
+        {
+          source: "claude",
+          name: "claude",
+          display_name: "Claude Code",
+          status: noReadySources ? "missing" : "detected",
+          files: noReadySources ? 0 : 12,
+          detail: noReadySources ? "No local usage files found" : "Found 12 local usage files",
+          setup: "Run Claude Code once",
+        },
+        {
+          source: "codex",
+          name: "codex",
+          display_name: "OpenAI Codex",
+          status: "missing",
+          files: 0,
+          detail: "No local usage files found",
+          setup: "Run Codex once",
+        },
+      ],
+      codexQuotaOverview: async () => {
+        if (quotaFail) throw new Error("No current Codex weekly quota snapshot");
+        return {
+          quota: {
+            observed_at: "2026-09-01T02:00:00Z",
+            resets_at: "2026-09-07T02:00:00Z",
+            estimated_depletion_at: "2026-09-05T02:00:00Z",
+            window_minutes: 10_080,
+            used_pct: 25,
+            remaining_pct: 75,
+            projected_pct_at_reset: 140,
+            status: "likely_exhausted",
+          },
+          value_estimate: {
+            observed_at: "2026-09-01T02:00:00Z",
+            window_started_at: "2026-08-31T02:00:00Z",
+            resets_at: "2026-09-07T02:00:00Z",
+            used_pct: 25,
+            observed_cost_usd: 10,
+            estimated_weekly_value_usd: 40,
+            observed_tokens: 1_100_000,
+            estimated_weekly_tokens: 4_400_000,
+            valid_entries: 4,
+            dedup_skipped_entries: 1,
+          },
+          value_estimate_error: null,
+        };
+      },
       usageOverview: async (source: string) => {
         calls.push(source);
         if (fail) throw new Error("ledger is unavailable");
+        if (liveFailAfterGrowth && calls.length >= 4) throw new Error("live scan is unavailable");
         if (delay) await new Promise((resolve) => setTimeout(resolve, delay));
+        const liveStep = liveGrowth ? Math.max(calls.length - 2, 0) : 0;
         return {
           source,
           source_name: source,
@@ -146,7 +215,9 @@ async function injectBridge(page: Page, options: MockOptions = {}) {
           elapsed_ms: 12.4,
           summaries: summaries
             .filter(({ range }) => !omitWeek || range !== "this_week")
-            .map(({ range, total, records }, index) => ({
+            .map(({ range, total, records }, index) => {
+            const currentTotal = range === "today" ? total + liveStep * 250 : total;
+            return {
             source,
             source_name: source,
             display_name: source === "codex" ? "OpenAI Codex" : "Claude Code",
@@ -154,28 +225,29 @@ async function injectBridge(page: Page, options: MockOptions = {}) {
             since: "2026-08-01",
             until: "2026-08-31",
             currency: "USD",
-            cost: index === 0 ? null : index === 1 ? 7.42 : 18.9,
-            cost_usd: index === 0 ? null : index === 1 ? 7.42 : 18.9,
+            cost: index === 0 ? liveGrowth ? 2 + liveStep * 0.5 : null : index === 1 ? 7.42 : 18.9,
+            cost_usd: index === 0 ? liveGrowth ? 2 + liveStep * 0.5 : null : index === 1 ? 7.42 : 18.9,
             estimated_cost: null,
             estimated_cost_usd: null,
-            cost_kind: index === 0 ? "unknown" : "priced",
-            api_equivalent_cost_coverage: partialCostCoverage && index === 1
-              ? {
-                  total_tokens: 8_420,
-                  priced_tokens: 5_000,
-                  percent: 59.382_422_802_850_36,
-                  complete: false,
-                  cost_is_lower_bound: true,
-                }
-              : null,
+            cost_kind: "real",
+            pricing_source: index === 0 ? liveGrowth ? "recorded" : "unknown" : index === 1 ? "cache_stale" : "recorded",
+            api_equivalent_cost_coverage: index === 1 ? {
+              total_tokens: 8_420,
+              priced_tokens: 6_315,
+              percent: 75,
+              complete: false,
+              cost_is_lower_bound: true,
+            } : null,
             tokens: {
-              input_tokens: allMalformed ? 0 : total - 300,
+              input_tokens: allMalformed ? 0 : currentTotal - (totalAdjustment ? 400 : 300),
               output_tokens: allMalformed ? 0 : 180,
               reasoning_tokens: allMalformed ? 0 : 20,
               cache_creation_tokens: 0,
+              cache_creation_1h_tokens: 0,
               cache_read_tokens: allMalformed ? 0 : 100,
+              reported_total_adjustment: allMalformed ? 0 : totalAdjustment ? 100 : 0,
               cache_hit_rate: allMalformed ? null : 12.5,
-              total_tokens: allMalformed ? 0 : total,
+              total_tokens: allMalformed ? 0 : currentTotal,
             },
             models: [
               {
@@ -184,15 +256,18 @@ async function injectBridge(page: Page, options: MockOptions = {}) {
                 cost_usd: index === 0 ? null : 7.42,
                 estimated_cost: null,
                 estimated_cost_usd: null,
-                cost_kind: index === 0 ? "unknown" : "priced",
+                cost_kind: "real",
+                pricing_source: index === 0 ? "unknown" : index === 1 ? "cache_stale" : "recorded",
                 tokens: {
-                  input_tokens: total - 300,
+                  input_tokens: currentTotal - 300,
                   output_tokens: 180,
                   reasoning_tokens: 20,
                   cache_creation_tokens: 0,
+                  cache_creation_1h_tokens: 0,
                   cache_read_tokens: 100,
+                  reported_total_adjustment: 0,
                   cache_hit_rate: 12.5,
-                  total_tokens: total,
+                  total_tokens: currentTotal,
                 },
               },
             ],
@@ -200,23 +275,335 @@ async function injectBridge(page: Page, options: MockOptions = {}) {
             skipped_entries: qualityWarning ? 2 : 0,
             parse_error_entries: allMalformed ? 3 : qualityWarning ? 1 : 0,
             elapsed_ms: 12.4,
-            })),
+            };
+            }),
         };
+      },
+      usageOverviews: async (sources: string[]) => Promise.all(
+        sources.map((source) => window.__CCSTATS_TEST_BRIDGE__!.usageOverview(source)),
+      ),
+      projectDrilldown: async (source, range) => ({
+        source,
+        source_name: source,
+        display_name: "Claude Code",
+        range,
+        currency: "USD",
+        quality: { valid_entries: 4, dedup_skipped_entries: 0, parse_error_entries: 0 },
+        projects: [{
+          project_path: "/work/ccstats",
+          project_name: "ccstats",
+          session_count: 1,
+          metrics: {
+            currency: "USD",
+            cost: 2.4,
+            cost_usd: 2.4,
+            estimated_cost: null,
+            estimated_cost_usd: null,
+            cost_kind: "real",
+            pricing_source: "recorded",
+            api_equivalent_cost_coverage: null,
+            tokens: { input_tokens: 900, output_tokens: 180, reasoning_tokens: 20, cache_creation_tokens: 0, cache_creation_1h_tokens: 0, cache_read_tokens: 100, reported_total_adjustment: 0, cache_hit_rate: 10, total_tokens: 1_200 },
+            models: [],
+          },
+          sessions: [{
+            session_id: "session-abc123",
+            project_path: "/work/ccstats",
+            first_timestamp: "2026-08-31T06:00:00Z",
+            last_timestamp: "2026-08-31T08:00:00Z",
+            metrics: {
+              currency: "USD",
+              cost: 2.4,
+              cost_usd: 2.4,
+              estimated_cost: null,
+              estimated_cost_usd: null,
+              cost_kind: "real",
+              pricing_source: "recorded",
+              api_equivalent_cost_coverage: null,
+              tokens: { input_tokens: 900, output_tokens: 180, reasoning_tokens: 20, cache_creation_tokens: 0, cache_creation_1h_tokens: 0, cache_read_tokens: 100, reported_total_adjustment: 0, cache_hit_rate: 10, total_tokens: 1_200 },
+              models: [],
+            },
+          }],
+        }],
+      }),
+      usageHistory: async (source, range) => ({
+        source,
+        source_name: source,
+        display_name: "Claude Code",
+        range,
+        as_of_date: "2026-09-02",
+        currency: "USD",
+        quality: { valid_entries: 4, dedup_skipped_entries: 0, parse_error_entries: 0 },
+        points: [
+          { date: "2026-08-27", currency: "USD", tokens: { input_tokens: 80, output_tokens: 20, reasoning_tokens: 0, cache_creation_tokens: 0, cache_creation_1h_tokens: 0, cache_read_tokens: 0, reported_total_adjustment: 0, cache_hit_rate: 0, total_tokens: 100 }, records: 1, cost: 0.2, cost_usd: 0.2, cost_status: "known", cost_kind: "real", pricing_source: "recorded", api_equivalent_cost_coverage: null },
+          { date: "2026-08-28", currency: "USD", tokens: { input_tokens: 90, output_tokens: 30, reasoning_tokens: 0, cache_creation_tokens: 0, cache_creation_1h_tokens: 0, cache_read_tokens: 0, reported_total_adjustment: 0, cache_hit_rate: 0, total_tokens: 120 }, records: 1, cost: 0.25, cost_usd: 0.25, cost_status: "known", cost_kind: "real", pricing_source: "recorded", api_equivalent_cost_coverage: null },
+          { date: "2026-08-29", currency: "USD", tokens: { input_tokens: 85, output_tokens: 25, reasoning_tokens: 0, cache_creation_tokens: 0, cache_creation_1h_tokens: 0, cache_read_tokens: 0, reported_total_adjustment: 0, cache_hit_rate: 0, total_tokens: 110 }, records: 1, cost: 0.22, cost_usd: 0.22, cost_status: "known", cost_kind: "real", pricing_source: "recorded", api_equivalent_cost_coverage: null },
+          { date: "2026-08-30", currency: "USD", tokens: { input_tokens: 300, output_tokens: 100, reasoning_tokens: 0, cache_creation_tokens: 0, cache_creation_1h_tokens: 0, cache_read_tokens: 0, reported_total_adjustment: 0, cache_hit_rate: 0, total_tokens: 400 }, records: 1, cost: null, cost_usd: null, cost_status: "unknown", cost_kind: "real", pricing_source: "unknown", api_equivalent_cost_coverage: null },
+          { date: "2026-08-31", currency: "USD", tokens: { input_tokens: 600, output_tokens: 180, reasoning_tokens: 20, cache_creation_tokens: 0, cache_creation_1h_tokens: 0, cache_read_tokens: 100, reported_total_adjustment: 0, cache_hit_rate: 12.5, total_tokens: 900 }, records: 3, cost: 2.4, cost_usd: 2.4, cost_status: "known", cost_kind: "real", pricing_source: "recorded", api_equivalent_cost_coverage: null },
+        ],
+      }),
+      turnToolBreakdown: async (source, range) => ({
+        source,
+        source_name: source,
+        display_name: source === "claude" ? "Claude Code" : "OpenAI Codex",
+        range,
+        total_turns: 2,
+        turns: [
+          {
+            timestamp: "2026-09-02T08:00:00Z",
+            session_id: "session-abc123",
+            message_id: "message-2",
+            project_path: "/work/ccstats",
+            model: "claude-sonnet-4-5",
+            model_call_count: 1,
+            tokens: { input_tokens: 400, output_tokens: 120, reasoning_tokens: 0, cache_creation_tokens: 0, cache_creation_1h_tokens: 0, cache_read_tokens: 80, reported_total_adjustment: 0, cache_hit_rate: 16.7, total_tokens: 600 },
+          },
+          {
+            timestamp: "2026-09-02T07:00:00Z",
+            session_id: "session-abc123",
+            message_id: "message-1",
+            project_path: "/work/ccstats",
+            model: "claude-sonnet-4-5",
+            model_call_count: 1,
+            tokens: { input_tokens: 420, output_tokens: 160, reasoning_tokens: 20, cache_creation_tokens: 0, cache_creation_1h_tokens: 0, cache_read_tokens: 0, reported_total_adjustment: 0, cache_hit_rate: 0, total_tokens: 600 },
+          },
+        ],
+        tool_calls_supported: source === "claude",
+        tool_calls_total: source === "claude" ? 5 : 0,
+        tools: source === "claude" ? [{ name: "Read", calls: 3 }, { name: "Bash", calls: 2 }] : [],
+        quality: { valid_entries: 2, dedup_skipped_entries: 1, parse_error_entries: 0 },
+      }),
+      exportHistory: async (source, range, format) => {
+        exportCalls.push(`${source}:${range}:${format}`);
+        return format === "csv" ? "date,total_tokens\r\n2026-08-31,900\r\n" : "{\"points\":[]}";
+      },
+      machineRollup: async () => machineState,
+      saveMachineSnapshot: async (machineName, machineSources) => {
+        const totalsFor = (range: string) => ({
+          tokens: machineSources.reduce((sum, source) => sum + (source.summaries.find((summary) => summary.range === range)?.tokens.total_tokens ?? 0), 0),
+          cost: machineSources.reduce<number | null>((sum, source) => { const cost = source.summaries.find((summary) => summary.range === range)?.cost; return sum === null || cost === null || cost === undefined ? null : sum + cost; }, 0),
+        });
+        const today = totalsFor("today"); const week = totalsFor("this_week"); const month = totalsFor("this_month");
+        const totals = { today_tokens: today.tokens, week_tokens: week.tokens, month_tokens: month.tokens, today_cost: today.cost, week_cost: week.cost, month_cost: month.cost };
+        machineState = { local_machine_id: "local-1", local_machine_name: machineName, currency: "USD", today_current_machines: 1, week_current_machines: 1, month_current_machines: 1, totals, machines: [{ machine_id: "local-1", machine_name: machineName, captured_at_ms: 1_788_316_800_000, source_count: machineSources.length, currency: "USD", is_local: true, today_current: true, week_current: true, month_current: true, totals }] };
+        return machineState;
+      },
+      exportMachineBundle: async () => JSON.stringify({ schema_version: 1, machines: machineState.machines }),
+      importMachineBundle: async () => {
+        const remoteTotals = { today_tokens: 1_240, week_tokens: 8_420, month_tokens: 24_900, today_cost: null, week_cost: 7.42, month_cost: 18.9 };
+        const local = machineState.machines[0];
+        const totals = { today_tokens: machineState.totals.today_tokens + remoteTotals.today_tokens, week_tokens: machineState.totals.week_tokens + remoteTotals.week_tokens, month_tokens: machineState.totals.month_tokens + remoteTotals.month_tokens, today_cost: null, week_cost: (machineState.totals.week_cost ?? 0) + 7.42, month_cost: (machineState.totals.month_cost ?? 0) + 18.9 };
+        machineState = { ...machineState, today_current_machines: 2, week_current_machines: 2, month_current_machines: 2, totals, machines: [local, { machine_id: "remote-1", machine_name: "Remote laptop", captured_at_ms: 1_788_230_400_000, source_count: 1, currency: "USD", is_local: false, today_current: true, week_current: true, month_current: true, totals: remoteTotals }] };
+        return machineState;
       },
     };
     window.__CCSTATS_TEST_CALLS__ = calls;
+    window.__CCSTATS_TEST_EXPORT_CALLS__ = exportCalls;
   }, options);
 }
 
 test("loads the audit overview and preserves unknown cost", async ({ page }) => {
-  await injectBridge(page, { delay: 300 });
-  await page.goto("/");
+  await injectBridge(page, { delay: 2_000 });
+  await page.goto("/", { waitUntil: "domcontentloaded" });
 
   await expect(page.getByText("Auditing registered sources…")).toBeVisible();
   await expect(page.getByRole("heading", { name: "Usage overview" })).toBeVisible();
   await expect(page.getByTestId("total-tokens")).toHaveText("1,240");
   await expect(page.getByTestId("total-cost")).toHaveText("Unknown");
   await expect(page.getByRole("cell", { name: "Unknown" })).toBeVisible();
+});
+
+test("reconciles a provider-authoritative total adjustment", async ({ page }) => {
+  await injectBridge(page, { totalAdjustment: true });
+  await page.goto("/");
+
+  await expect(page.getByText("Provider adjustment")).toBeVisible();
+  await expect(page.getByTestId("total-tokens")).toHaveText("1,240");
+});
+
+test("explains pricing provenance and partial API-equivalent coverage", async ({ page }) => {
+  await injectBridge(page);
+  await page.addInitScript(() => {
+    const bridge = window.__CCSTATS_TEST_BRIDGE__!;
+    const original = bridge.usageOverview;
+    bridge.usageOverview = async (source) => {
+      const result = await original(source);
+      return { ...result, summaries: result.summaries.map((summary) => summary.range === "this_month" ? { ...summary, pricing_source: "fallback" } : summary) };
+    };
+  });
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Cost evidence" }).click();
+  await expect(page.getByRole("heading", { name: "Cost evidence" })).toBeVisible();
+  await expect(page.getByTestId("trust-displayed-cost")).toHaveText("Unknown");
+  await expect(page.getByTestId("trust-pricing-source")).toHaveText("Unknown");
+
+  await page.getByRole("button", { name: "This week" }).click();
+  await expect(page.getByTestId("trust-pricing-source")).toHaveText("Stale price catalog");
+  await expect(page.getByTestId("trust-coverage")).toHaveText("75.0%");
+  await expect(page.getByText("Displayed cost is a lower bound")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Source evidence" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Model evidence" })).toBeVisible();
+  await expect(page.getByRole("row", { name: /claude-sonnet-4-6/ })).toContainText("≥ $7.42");
+
+  await page.getByRole("button", { name: "This month" }).click();
+  await page.getByRole("button", { name: "Overview" }).click();
+  await expect(page.getByTestId("total-cost")).toHaveText("≈ $18.90");
+  await page.getByRole("button", { name: "Top" }).click();
+  await expect(page.getByText("Share uses tokens across this complete ranking.").first()).toBeVisible();
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
+});
+
+test("separates model turns from independently counted tool calls", async ({ page }) => {
+  await injectBridge(page);
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Turns & tools" }).click();
+
+  await expect(page.getByRole("heading", { name: "Turn and tool evidence" })).toBeVisible();
+  await expect(page.getByTestId("activity-turn-count")).toHaveText("2");
+  await expect(page.getByTestId("activity-tool-count")).toHaveText("5");
+  await expect(page.getByText("Read", { exact: true })).toBeVisible();
+  await expect(page.getByText("Tool tokens remain unknown")).toBeVisible();
+
+  await page.getByLabel("Usage source").selectOption("codex");
+  await expect(page.getByText("This source does not expose tool-call records.")).toBeVisible();
+  await expect(page.getByTestId("activity-turn-count")).toHaveText("2");
+});
+
+test("shows source diagnostics and actionable setup guidance", async ({ page }) => {
+  await injectBridge(page);
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Diagnostics" }).click();
+
+  await expect(page.getByRole("heading", { name: "Source diagnostics", level: 2 })).toBeVisible();
+  await expect(page.getByText("1 detected")).toBeVisible();
+  await expect(page.getByText("1 missing")).toBeVisible();
+  await expect(page.getByRole("cell", { name: "Claude Code" })).toBeVisible();
+  await expect(page.getByText("Run Codex once")).toBeVisible();
+});
+
+test("shows Codex quota and calculates a monthly budget", async ({ page }) => {
+  await injectBridge(page);
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Limits" }).click();
+
+  await expect(page.getByRole("heading", { name: "Quota and budget", level: 2 })).toBeVisible();
+  await expect(page.getByTestId("quota-used")).toHaveText("25.0%");
+  await expect(page.getByTestId("quota-remaining")).toHaveText("75.0%");
+  await expect(page.getByTestId("quota-value")).toHaveText("$40.00");
+  await expect(page.getByTestId("budget-spent")).toHaveText("$18.90");
+
+  await page.getByRole("spinbutton", { name: "Monthly budget" }).fill("1000");
+  await expect(page.getByTestId("budget-remaining")).toHaveText("$981.10");
+});
+
+test("keeps monthly budget available when quota is unavailable", async ({ page }) => {
+  await injectBridge(page, { quotaFail: true });
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Limits" }).click();
+
+  await expect(page.getByText("No current Codex weekly quota snapshot")).toBeVisible();
+  await expect(page.getByTestId("budget-spent")).toHaveText("$18.90");
+});
+
+test("does not present a lower-bound monthly cost as exact budget spend", async ({ page }) => {
+  await injectBridge(page);
+  await page.addInitScript(() => {
+    const bridge = window.__CCSTATS_TEST_BRIDGE__!;
+    const original = bridge.usageOverview;
+    bridge.usageOverview = async (source) => {
+      const result = await original(source);
+      return { ...result, summaries: result.summaries.map((summary) => summary.range === "this_month" ? { ...summary, api_equivalent_cost_coverage: { total_tokens: summary.tokens.total_tokens, priced_tokens: summary.tokens.total_tokens - 100, percent: 99.6, complete: false, cost_is_lower_bound: true } } : summary) };
+    };
+  });
+  await page.goto("/");
+  await page.getByRole("button", { name: "Limits" }).click();
+
+  await expect(page.getByTestId("budget-spent")).toHaveText("≥ $18.90");
+  await expect(page.getByTestId("budget-remaining")).toHaveText("Unknown");
+  await expect(page.getByRole("definition").filter({ hasText: "Lower bound" })).toBeVisible();
+});
+
+test("ranks consumers and flags a daily usage spike", async ({ page }) => {
+  await injectBridge(page);
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Top" }).click();
+
+  await expect(page.getByRole("heading", { name: "Top consumers", level: 2 })).toBeVisible();
+  await expect(page.getByRole("cell", { name: "claude-sonnet-4-6" })).toBeVisible();
+  await expect(page.getByRole("cell", { name: "ccstats" })).toBeVisible();
+  await expect(page.getByText("Usage spike detected")).toBeVisible();
+  await expect(page.getByTestId("anomaly-change")).toContainText("393.2%");
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
+});
+
+test("monitors live growth, preserves trusted data on failure, and pauses polling", async ({ page }) => {
+  await page.clock.install();
+  await injectBridge(page, { liveGrowth: true, liveFailAfterGrowth: true });
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Live" }).click();
+  await expect(page.getByRole("heading", { name: "Live usage", level: 2 })).toBeVisible();
+  await expect(page.getByTestId("live-total-tokens")).toHaveText("1,240");
+  await expect(page.getByText("Monitoring", { exact: true })).toBeVisible();
+
+  await page.clock.fastForward(15_000);
+  await expect(page.getByTestId("live-total-tokens")).toHaveText("1,490");
+  await expect(page.getByTestId("live-token-delta")).toHaveText("+250");
+  await expect(page.getByTestId("live-cost-delta")).toHaveText("+$0.50");
+
+  await page.clock.fastForward(15_000);
+  await expect(page.getByRole("alert")).toContainText("Refresh failed; showing the last trusted snapshot");
+  await expect(page.getByTestId("live-total-tokens")).toHaveText("1,490");
+
+  await page.getByRole("button", { name: "Pause monitoring" }).click();
+  await page.clock.fastForward(30_000);
+  await expect.poll(() => page.evaluate(() => window.__CCSTATS_TEST_CALLS__?.length)).toBe(4);
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
+});
+
+test("persists this machine and imports a remote machine rollup", async ({ page }) => {
+  await injectBridge(page);
+  await page.goto("/");
+  await page.getByRole("button", { name: "Machines" }).click();
+
+  await expect(page.getByRole("heading", { name: "Machine rollup", level: 2 })).toBeVisible();
+  await expect(page.getByText("No machine snapshots yet.")).toBeVisible();
+  await page.getByLabel("Local machine name").fill("Studio Mac");
+  await page.getByRole("button", { name: "Capture this machine" }).click();
+  await expect(page.getByRole("row", { name: /Studio Mac/ })).toBeVisible();
+  await expect(page.getByTestId("machines-month")).toHaveText("24,900");
+
+  const download = page.waitForEvent("download");
+  await page.getByRole("button", { name: "Export snapshots" }).click();
+  expect((await download).suggestedFilename()).toBe("ccstats-machine-snapshots.json");
+  await page.getByLabel("Import machine snapshots").setInputFiles({ name: "remote.json", mimeType: "application/json", buffer: Buffer.from('{"schema_version":1}') });
+  await expect(page.getByRole("row", { name: /Remote laptop/ })).toBeVisible();
+  await expect(page.getByTestId("machines-month")).toHaveText("49,800");
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
+});
+
+test("keeps core evidence in the first viewport and reflows without page overflow", async ({ page }) => {
+  await injectBridge(page);
+  await page.goto("/");
+
+  const total = await page.getByTestId("total-tokens").boundingBox();
+  expect(total?.y).toBeLessThan(650);
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect(page.getByLabel("Usage source")).toBeVisible();
+  await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
 });
 
 test("switches windows and sources, then refreshes", async ({ page }) => {
@@ -235,25 +622,101 @@ test("switches windows and sources, then refreshes", async ({ page }) => {
     .toEqual(["claude", "codex", "codex"]);
 });
 
+test("refreshes discovery before aggregating all sources", async ({ page }) => {
+  await injectBridge(page);
+  await page.addInitScript(() => {
+    const bridge = window.__CCSTATS_TEST_BRIDGE__!;
+    const original = bridge.sourceDiagnostics;
+    let scans = 0;
+    bridge.sourceDiagnostics = async () => {
+      const findings = await original();
+      scans += 1;
+      return scans === 1 ? findings : findings.map((row) => row.name === "codex" ? { ...row, status: "detected", files: 1 } : row);
+    };
+  });
+  await page.goto("/");
+
+  await page.getByLabel("Usage source").selectOption("all");
+  await expect.poll(() => page.evaluate(() => window.__CCSTATS_TEST_CALLS__)).toContain("codex");
+  await expect(page.getByTestId("total-tokens")).toHaveText("2,480");
+});
+
+test("aggregates ready sources without scanning missing ledgers", async ({ page }) => {
+  await injectBridge(page);
+  await page.goto("/");
+
+  await page.getByLabel("Usage source").selectOption("all");
+  await page.getByRole("button", { name: "This week" }).click();
+
+  await expect(page.getByTestId("total-tokens")).toHaveText("8,420");
+  await expect(page.getByTestId("total-cost")).toContainText("7.42");
+  await expect(page.getByRole("heading", { name: "Sources" })).toBeVisible();
+  await expect(page.getByRole("row", { name: /Claude Code/ })).toBeVisible();
+  await expect(page.getByRole("row", { name: /OpenAI Codex/ })).toHaveCount(0);
+});
+
+test("drills from a project into its real sessions", async ({ page }) => {
+  await injectBridge(page);
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Projects" }).click();
+  await expect(page.getByRole("heading", { name: "Projects & sessions" })).toBeVisible();
+  await expect(page.getByRole("row", { name: /ccstats/ })).toContainText("1,200");
+  await page.getByRole("button", { name: /ccstats/ }).click();
+  await expect(page.getByText("session-abc123")).toBeVisible();
+});
+
+test("shows real history dates and exports CSV and JSON", async ({ page }) => {
+  await injectBridge(page);
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "History" }).click();
+  await expect(page.getByRole("heading", { name: "History", exact: true })).toBeVisible();
+  await expect(page.getByRole("row", { name: /2026-08-30/ })).toContainText("Unknown");
+  await page.getByRole("button", { name: "Export CSV" }).click();
+  await page.getByRole("button", { name: "Export JSON" }).click();
+  await expect.poll(() => page.evaluate(() => window.__CCSTATS_TEST_EXPORT_CALLS__)).toEqual([
+    "claude:today:csv",
+    "claude:today:json",
+  ]);
+});
+
+test("keeps the latest history request when an older range finishes later", async ({ page }) => {
+  await injectBridge(page);
+  await page.addInitScript(() => {
+    const bridge = window.__CCSTATS_TEST_BRIDGE__!;
+    const original = bridge.usageHistory;
+    bridge.usageHistory = async (source, range) => {
+      const result = await original(source, range);
+      await new Promise((resolve) => setTimeout(resolve, range === "today" ? 120 : 10));
+      return { ...result, range, points: result.points.map((point, index) => ({ ...point, date: range === "today" ? `2026-09-${String(index + 1).padStart(2, "0")}` : `2026-08-${String(index + 27).padStart(2, "0")}` })) };
+    };
+  });
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "History" }).click();
+  await page.getByRole("button", { name: "This week" }).click();
+  await expect(page.getByRole("cell", { name: "2026-08-31", exact: true }).first()).toBeVisible();
+  await page.waitForTimeout(150);
+  await expect(page.getByRole("cell", { name: "2026-09-01", exact: true })).toHaveCount(0);
+});
+
+test("requires a concrete source for project drilldown", async ({ page }) => {
+  await injectBridge(page);
+  await page.goto("/");
+
+  await page.getByLabel("Usage source").selectOption("all");
+  await page.getByRole("button", { name: "Projects" }).click();
+  await expect(page.getByText("Choose a concrete source to inspect projects and sessions.")).toBeVisible();
+});
+
 test("surfaces data quality warnings", async ({ page }) => {
   await injectBridge(page, { qualityWarning: true });
   await page.goto("/");
 
   await expect(page.getByRole("status")).toContainText("Review needed");
   await expect(page.getByRole("status")).toContainText("2 deduplicated");
-  await expect(page.getByRole("status")).toContainText("1 malformed in combined scan");
-});
-
-test("labels partial API-equivalent cost as a lower bound", async ({ page }) => {
-  await injectBridge(page, { partialCostCoverage: true });
-  await page.goto("/");
-
-  await page.getByRole("button", { name: "This week" }).click();
-  await expect(page.getByText("Cost lower bound")).toBeVisible();
-  await expect(page.getByTestId("total-cost")).toHaveText("≥ $7.42");
-  await expect(page.getByTestId("cost-coverage")).toHaveText(
-    "5,000 / 8,420 tokens priced (59.4%)",
-  );
+  await expect(page.getByRole("status")).toContainText("1 malformed");
 });
 
 test("shows a recoverable error without fallback data", async ({ page }) => {
@@ -273,20 +736,15 @@ test("reports a missing requested range instead of leaving the page blank", asyn
   await expect(page.getByRole("alert")).toContainText("This week is missing from the usage response");
 });
 
-test("does not attribute combined-scan parse errors to the selected range", async ({ page }) => {
+test("does not attribute combined-scan parse errors to the selected period", async ({ page }) => {
   await injectBridge(page, { allMalformed: true });
   await page.goto("/");
 
   await expect(page.getByRole("alert")).toHaveCount(0);
-  await expect(
-    page.getByRole("heading", { name: "No valid Claude Code records in this window." }),
-  ).toBeVisible();
-  await expect(page.getByTestId("unattributed-parse-errors")).toContainText(
-    "3 malformed records were rejected during the combined range scan",
-  );
-  await expect(page.getByTestId("unattributed-parse-errors")).toContainText(
-    "cannot be assigned to Today",
-  );
+  await expect(page.getByRole("heading", { name: "No valid Claude Code records in this window." })).toBeVisible();
+  await expect(page.getByTestId("unattributed-parse-errors")).toContainText("3 malformed records were rejected during the combined scan");
+  await expect(page.getByTestId("unattributed-parse-errors")).toContainText("cannot be assigned to today");
+  await expect(page.getByText("ledger is quiet")).toHaveCount(0);
 });
 
 test("retries source discovery when catalog initialization fails", async ({ page }) => {
@@ -301,6 +759,15 @@ test("retries source discovery when catalog initialization fails", async ({ page
     .toBe(2);
 });
 
+test("opens diagnostics when no source is detected or configured", async ({ page }) => {
+  await injectBridge(page, { noReadySources: true });
+  await page.goto("/");
+
+  await expect(page.getByRole("heading", { name: "Source diagnostics", level: 1 })).toBeVisible();
+  await expect.poll(() => page.evaluate(() => window.__CCSTATS_TEST_CALLS__)).toEqual([]);
+  await expect(page.getByText("2 registered · 0 ready")).toBeVisible();
+});
+
 test("native Tauri app crosses IPC into the real Rust SDK", async () => {
   test.setTimeout(180_000);
   const port = await reserveAvailablePort();
@@ -312,6 +779,7 @@ test("native Tauri app crosses IPC into the real Rust SDK", async () => {
     new URL("../src-tauri/target/debug/ccstats-desktop", import.meta.url),
   );
   const nativeProcess = spawn(binary, [], {
+    cwd: isolatedHome,
     env: {
       HOME: isolatedHome,
       LANG: process.env.LANG,
@@ -336,9 +804,9 @@ test("native Tauri app crosses IPC into the real Rust SDK", async () => {
       })
       .toBe("ccstats · Local ledger");
     const heading = await waitForElement(port, sessionId, "h1");
-    expect(
+    expect(["Source diagnostics", "Usage overview"]).toContain(
       await webdriverRequest<string>(port, `/session/${sessionId}/element/${heading}/text`),
-    ).toBe("Usage overview");
+    );
 
     const sourceSelect = await waitForElement(port, sessionId, "#source-select");
     await expect
@@ -356,7 +824,7 @@ test("native Tauri app crosses IPC into the real Rust SDK", async () => {
           ).length,
         { timeout: 120_000, message: "all Rust-registered sources did not cross the Tauri IPC boundary" },
       )
-      .toBe(29);
+      .toBe(30);
 
     await webdriverRequest<null>(port, `/session/${sessionId}/execute/sync`, {
       method: "POST",
@@ -376,21 +844,73 @@ test("native Tauri app crosses IPC into the real Rust SDK", async () => {
         { timeout: 120_000 },
       )
       .toBe("dsh");
-    await expect
-      .poll(
-        async () => {
-          const reportSource = await findElement(port, sessionId!, ".report-meta strong");
-          return webdriverRequest<string>(
-            port,
-            `/session/${sessionId}/element/${reportSource}/text`,
-          );
-        },
-        {
-          timeout: 120_000,
-          message: `DSH overview did not load through the native command: ${nativeStderr}`,
-        },
-      )
-      .toBe("DeepSeek Harness");
+    const overviewButton = await waitForElement(port, sessionId, "button[aria-label='Overview']");
+    await webdriverRequest<null>(
+      port,
+      `/session/${sessionId}/element/${overviewButton}/click`,
+      { method: "POST", body: "{}" },
+    );
+    const reportSource = await waitForElement(port, sessionId, ".report-meta strong");
+    expect(
+      await webdriverRequest<string>(
+        port,
+        `/session/${sessionId}/element/${reportSource}/text`,
+      ),
+      `DSH overview did not load through the native command: ${nativeStderr}`,
+    ).toBe("DeepSeek Harness");
+
+    const trustButton = await waitForElement(port, sessionId, "button[aria-label='Cost evidence']");
+    await webdriverRequest<null>(
+      port,
+      `/session/${sessionId}/element/${trustButton}/click`,
+      { method: "POST", body: "{}" },
+    );
+    const trustTitle = await waitForElement(port, sessionId, "#trust-title");
+    expect(
+      await webdriverRequest<string>(
+        port,
+        `/session/${sessionId}/element/${trustTitle}/text`,
+      ),
+      `cost provenance did not cross IPC: ${nativeStderr}`,
+    ).toBe("Cost evidence");
+
+    const activityButton = await waitForElement(port, sessionId, "button[aria-label='Turns & tools']");
+    await webdriverRequest<null>(
+      port,
+      `/session/${sessionId}/element/${activityButton}/click`,
+      { method: "POST", body: "{}" },
+    );
+    const activityTitle = await waitForElement(port, sessionId, "#activity-title");
+    expect(
+      await webdriverRequest<string>(
+        port,
+        `/session/${sessionId}/element/${activityTitle}/text`,
+      ),
+      `turn and tool command did not cross IPC: ${nativeStderr}`,
+    ).toBe("Turn and tool evidence");
+    const activityTurnCount = await waitForElement(port, sessionId, "[data-testid='activity-turn-count']");
+    expect(
+      await webdriverRequest<string>(
+        port,
+        `/session/${sessionId}/element/${activityTurnCount}/text`,
+      ),
+    ).toBe("0");
+
+    const machinesButton = await waitForElement(port, sessionId, "button[aria-label='Machines']");
+    await webdriverRequest<null>(
+      port,
+      `/session/${sessionId}/element/${machinesButton}/click`,
+      { method: "POST", body: "{}" },
+    );
+    const machineTitle = await waitForElement(port, sessionId, "#machines-title");
+    expect(
+      await webdriverRequest<string>(
+        port,
+        `/session/${sessionId}/element/${machineTitle}/text`,
+      ),
+      `machine SQLite command did not cross IPC: ${nativeStderr}`,
+    ).toBe("Machine rollup");
+    expect(await findElement(port, sessionId, ".empty-state")).toBeTruthy();
   } finally {
     if (sessionId) {
       await webdriverRequest<null>(port, `/session/${sessionId}`, { method: "DELETE" }).catch(

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -39,7 +39,14 @@ ccstats writes only operational data needed to make repeated reports reliable:
   under `~/.cache/ccstats/`;
 - a Grok inference ledger under the ccstats cache directory because Grok may
   trim its live log in place;
+- desktop machine snapshots under the app data directory. These snapshots
+  contain only aggregate source/model token and cost summaries. The optional
+  JSON export uses the same aggregate-only payload so users can move it between
+  their own devices;
 - no prompt, response, or source-code archive.
+
+The desktop app does not send machine snapshots itself. Cross-device rollups
+require an explicit JSON export on one device and an explicit import on another.
 
 The optional TOML config is user-created. ccstats reads the first configured
 path documented in the README and fails clearly if that file is malformed.

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::catalog::{AnalyticsQuality, apply_cli_config};
 use crate::core::{DateFilter, RawEntry, aggregate_tools};
 use crate::sdk::{SdkError, SummaryOptions, TokenBreakdown, UsageRange, UsageSource};
-use crate::source::{get_source, load_deduped_entries, load_tool_calls};
+use crate::source::{get_source, load_entries, load_tool_calls};
 use crate::utils::Timezone;
 
 const MAX_RECENT_TURNS: usize = 100;
@@ -88,7 +88,7 @@ pub fn turn_tool_breakdown(options: &SummaryOptions) -> Result<TurnToolBreakdown
     }
 
     let (mut entries, dedup_skipped_entries, parse_error_entries) =
-        load_deduped_entries(source, &filter, timezone);
+        load_entries(source, &filter, timezone);
     let total_turns = entries.len();
     entries.sort_by(|left, right| {
         right

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -1,0 +1,190 @@
+//! Per-model-turn and tool-call evidence for graphical and SDK consumers.
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+
+use crate::catalog::{AnalyticsQuality, apply_cli_config};
+use crate::core::{DateFilter, RawEntry, aggregate_tools};
+use crate::sdk::{SdkError, SummaryOptions, TokenBreakdown, UsageRange, UsageSource};
+use crate::source::{get_source, load_deduped_entries, load_tool_calls};
+use crate::utils::Timezone;
+
+const MAX_RECENT_TURNS: usize = 100;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolUsage {
+    pub name: String,
+    pub calls: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ModelTurnUsage {
+    pub timestamp: String,
+    pub session_id: String,
+    pub message_id: Option<String>,
+    pub project_path: String,
+    pub model: String,
+    pub model_call_count: i64,
+    pub tokens: TokenBreakdown,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TurnToolBreakdown {
+    pub source: UsageSource,
+    pub source_name: String,
+    pub display_name: String,
+    pub range: UsageRange,
+    pub total_turns: usize,
+    pub turns: Vec<ModelTurnUsage>,
+    pub tool_calls_supported: bool,
+    pub tool_calls_total: u64,
+    pub tools: Vec<ToolUsage>,
+    pub quality: AnalyticsQuality,
+}
+
+fn turn_usage(entry: RawEntry, supports_cache_read: bool) -> ModelTurnUsage {
+    let stats = entry.to_stats();
+    ModelTurnUsage {
+        timestamp: entry.timestamp,
+        session_id: entry.session_id,
+        message_id: entry.message_id,
+        project_path: entry.project_path,
+        model: entry.model,
+        model_call_count: stats.count,
+        tokens: TokenBreakdown {
+            input_tokens: stats.input_tokens,
+            output_tokens: stats.output_tokens,
+            reasoning_tokens: stats.reasoning_tokens,
+            cache_creation_tokens: stats.cache_creation,
+            cache_creation_1h_tokens: stats.cache_creation_1h,
+            cache_read_tokens: stats.cache_read,
+            reported_total_adjustment: stats.reported_total_adjustment,
+            cache_hit_rate: stats.cache_hit_rate(supports_cache_read),
+            total_tokens: stats.total_tokens(),
+        },
+    }
+}
+
+/// Returns recent deduplicated model turns and independently counted tool calls.
+///
+/// Tool calls are intentionally not assigned token counts because the supported
+/// source logs do not provide trustworthy per-tool token attribution.
+///
+/// # Errors
+///
+/// Returns an error when the source, date range, timezone, or local usage data
+/// cannot be loaded.
+pub fn turn_tool_breakdown(options: &SummaryOptions) -> Result<TurnToolBreakdown, SdkError> {
+    let source = get_source(options.source.as_str()).ok_or_else(|| SdkError::InvalidSource {
+        name: options.source.as_str().to_string(),
+    })?;
+    let timezone = Timezone::parse(options.timezone.as_deref())
+        .map_err(|error| SdkError::Configuration(error.to_string()))?;
+    let today = timezone.to_fixed_offset(Utc::now()).date_naive();
+    let (since, until) = options.range.resolve(today)?;
+    let mut filter = DateFilter::new(since, until);
+    if let Some((since_timestamp, until_timestamp)) = options.range.timestamp_bounds() {
+        filter = filter.with_exact_timestamp_range(since_timestamp, until_timestamp);
+    }
+
+    let (mut entries, dedup_skipped_entries, parse_error_entries) =
+        load_deduped_entries(source, &filter, timezone);
+    let total_turns = entries.len();
+    entries.sort_by(|left, right| {
+        right
+            .timestamp_ms
+            .cmp(&left.timestamp_ms)
+            .then_with(|| left.session_id.cmp(&right.session_id))
+            .then_with(|| left.message_id.cmp(&right.message_id))
+    });
+    entries.truncate(MAX_RECENT_TURNS);
+
+    let capabilities = source.capabilities();
+    let tool_summary = aggregate_tools(&load_tool_calls(source, &filter, timezone));
+    let mut tools = tool_summary
+        .tools
+        .into_iter()
+        .map(|tool| ToolUsage {
+            name: tool.name,
+            calls: tool.calls,
+        })
+        .collect::<Vec<_>>();
+    tools.sort_by(|left, right| {
+        right
+            .calls
+            .cmp(&left.calls)
+            .then_with(|| left.name.cmp(&right.name))
+    });
+
+    Ok(TurnToolBreakdown {
+        source: options.source,
+        source_name: source.name().to_string(),
+        display_name: source.display_name().to_string(),
+        range: options.range.clone(),
+        total_turns,
+        turns: entries
+            .into_iter()
+            .map(|entry| turn_usage(entry, capabilities.has_cache_read))
+            .collect(),
+        tool_calls_supported: capabilities.has_tool_calls,
+        tool_calls_total: tool_summary.total,
+        tools,
+        quality: AnalyticsQuality {
+            valid_entries: i64::try_from(total_turns).unwrap_or(i64::MAX),
+            dedup_skipped_entries,
+            parse_error_entries,
+        },
+    })
+}
+
+/// Returns turn and tool evidence using persisted CLI configuration.
+///
+/// # Errors
+///
+/// Returns an error when configuration or source usage data cannot be loaded.
+pub fn turn_tool_breakdown_with_cli_config(
+    options: SummaryOptions,
+) -> Result<TurnToolBreakdown, SdkError> {
+    turn_tool_breakdown(&apply_cli_config(options)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::{CostKind, Endpoint};
+
+    #[test]
+    fn turn_preserves_source_authoritative_total() {
+        let turn = turn_usage(
+            RawEntry {
+                timestamp: "2026-09-02T08:00:00Z".to_string(),
+                timestamp_ms: 1,
+                date_str: "2026-09-02".to_string(),
+                message_id: Some("message-1".to_string()),
+                session_key: "session-1".to_string(),
+                session_id: "session-1".to_string(),
+                project_path: "/work/ccstats".to_string(),
+                model: "test-model".to_string(),
+                input_tokens: 10,
+                output_tokens: 5,
+                cache_creation: 0,
+                cache_creation_1h: 0,
+                cache_read: 3,
+                reasoning_tokens: 2,
+                reported_total_tokens: Some(25),
+                stop_reason: Some("end_turn".to_string()),
+                cost_kind: CostKind::Real,
+                endpoint: Endpoint::Unknown,
+                call_count: 1,
+                recorded_cost_usd: None,
+                api_equivalent_priced_tokens: 0,
+                api_equivalent_coverage_tokens: 0,
+            },
+            true,
+        );
+
+        assert_eq!(turn.tokens.total_tokens, 25);
+        assert_eq!(turn.model_call_count, 1);
+        assert_eq!(turn.tokens.cache_hit_rate, Some(3.0 / 13.0 * 100.0));
+    }
+}

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -356,7 +356,9 @@ fn usage_metrics(
     let model_rows = model_summaries(models, context, supports_cache_read);
     let active_rows = model_rows
         .iter()
-        .filter(|model| model.tokens.total_tokens > 0)
+        .filter(|model| {
+            model.tokens.total_tokens > 0 || model.cost_usd.is_some_and(|cost| cost > 0.0)
+        })
         .collect::<Vec<_>>();
     let known_cost = active_rows.iter().all(|model| model.cost_usd.is_some());
     let cost_usd = known_cost.then(|| active_rows.iter().filter_map(|model| model.cost_usd).sum());
@@ -656,9 +658,35 @@ impl UsageHistory {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
 
     use super::*;
+
+    #[test]
+    fn usage_metrics_preserve_recorded_cost_without_tokens() {
+        let stats = Stats {
+            count: 1,
+            records: 1,
+            recorded_cost_usd: 1.25,
+            recorded_cost_entries: 1,
+            ..Stats::default()
+        };
+        let models = HashMap::from([("provider-recorded".to_string(), stats.clone())]);
+        let context = AnalysisContext {
+            range: UsageRange::Today,
+            as_of_date: NaiveDate::from_ymd_opt(2026, 9, 2).expect("valid date"),
+            filter: DateFilter::default(),
+            timezone: Timezone::parse(Some("UTC")).expect("valid timezone"),
+            pricing_db: PricingDb::default(),
+            currency: None,
+            currency_code: "USD".to_string(),
+        };
+
+        let metrics = usage_metrics(&stats, &models, &context, false);
+
+        assert_eq!(metrics.cost_usd, Some(1.25));
+        assert_eq!(metrics.cost, Some(1.25));
+    }
 
     #[test]
     fn source_diagnostics_project_every_registered_source() {

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -1,9 +1,27 @@
-//! Public projection of the internal usage-source registry.
+//! Public projections for graphical and SDK consumers.
 
+use std::cmp::Ordering;
+use std::collections::HashMap;
+
+use chrono::{NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
-use crate::sdk::{SdkError, UsageSource};
-use crate::source::all_sources;
+use crate::config::Config;
+use crate::consts::DATE_FORMAT;
+use crate::core::{DateFilter, SessionStats, Stats, aggregate_projects};
+use crate::pricing::{
+    CurrencyConverter, PricingDb, calculate_cost, calculate_estimated_proxy_cost, model_cost_kind,
+    pricing_source_for_model_stats, pricing_source_for_models,
+};
+use crate::sdk::{
+    ApiEquivalentCostCoverage, ModelCostSummary, SdkError, SummaryOptions, TokenBreakdown,
+    UsageRange, UsageSource,
+};
+use crate::source::{
+    CostCoverage, DiagnosticStatus, all_sources, get_source, load_daily, load_sessions,
+};
+use crate::utils::Timezone;
 
 /// Stable source metadata for graphical and SDK consumers.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -20,6 +38,35 @@ pub struct SourceDescriptor {
     pub has_reasoning_tokens: bool,
     pub has_cache_creation: bool,
     pub has_cache_read: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceDiagnosticStatus {
+    Detected,
+    Configured,
+    Missing,
+}
+
+impl From<DiagnosticStatus> for SourceDiagnosticStatus {
+    fn from(status: DiagnosticStatus) -> Self {
+        match status {
+            DiagnosticStatus::Detected => Self::Detected,
+            DiagnosticStatus::Configured => Self::Configured,
+            DiagnosticStatus::Missing => Self::Missing,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceDiagnosticDescriptor {
+    pub source: UsageSource,
+    pub name: String,
+    pub display_name: String,
+    pub status: SourceDiagnosticStatus,
+    pub files: usize,
+    pub detail: String,
+    pub setup: String,
 }
 
 /// List every source currently registered by ccstats.
@@ -50,11 +97,581 @@ pub fn list_usage_sources() -> Result<Vec<SourceDescriptor>, SdkError> {
         .collect()
 }
 
+/// Diagnose every registered source without parsing usage records.
+///
+/// This performs the same read-only discovery used by `ccstats doctor` and
+/// does not contact remote providers.
+///
+/// # Errors
+///
+/// Returns [`SdkError::InvalidSource`] when a registry entry has no matching
+/// public [`UsageSource`] variant.
+pub fn diagnose_usage_sources() -> Result<Vec<SourceDiagnosticDescriptor>, SdkError> {
+    all_sources()
+        .map(|source| {
+            let diagnostic = source.diagnose();
+            Ok(SourceDiagnosticDescriptor {
+                source: source.name().parse::<UsageSource>()?,
+                name: source.name().to_string(),
+                display_name: source.display_name().to_string(),
+                status: diagnostic.status.into(),
+                files: diagnostic.files,
+                detail: diagnostic.detail,
+                setup: source.setup_hint().to_string(),
+            })
+        })
+        .collect()
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AnalyticsQuality {
+    pub valid_entries: i64,
+    pub dedup_skipped_entries: i64,
+    pub parse_error_entries: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UsageMetrics {
+    pub currency: String,
+    pub cost: Option<f64>,
+    pub cost_usd: Option<f64>,
+    pub estimated_cost: Option<f64>,
+    pub estimated_cost_usd: Option<f64>,
+    pub cost_kind: String,
+    pub pricing_source: String,
+    pub api_equivalent_cost_coverage: Option<ApiEquivalentCostCoverage>,
+    pub tokens: TokenBreakdown,
+    pub models: Vec<ModelCostSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionDrilldown {
+    pub session_id: String,
+    pub project_path: String,
+    pub first_timestamp: String,
+    pub last_timestamp: String,
+    pub metrics: UsageMetrics,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProjectDrilldown {
+    pub project_path: String,
+    pub project_name: String,
+    pub session_count: usize,
+    pub metrics: UsageMetrics,
+    pub sessions: Vec<SessionDrilldown>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProjectDrilldownSummary {
+    pub source: UsageSource,
+    pub source_name: String,
+    pub display_name: String,
+    pub range: UsageRange,
+    pub currency: String,
+    pub quality: AnalyticsQuality,
+    pub projects: Vec<ProjectDrilldown>,
+}
+
+#[derive(Debug, Error)]
+pub enum DrilldownError {
+    #[error("usage source '{source_name}' does not support project drilldown")]
+    ProjectsUnsupported {
+        usage_source: UsageSource,
+        source_name: String,
+    },
+    #[error(transparent)]
+    Sdk(#[from] SdkError),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HistoryCostStatus {
+    Known,
+    Partial,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DailyUsagePoint {
+    pub date: NaiveDate,
+    pub currency: String,
+    pub tokens: TokenBreakdown,
+    pub records: i64,
+    pub cost: Option<f64>,
+    pub cost_usd: Option<f64>,
+    pub cost_status: HistoryCostStatus,
+    pub cost_kind: String,
+    pub pricing_source: String,
+    pub api_equivalent_cost_coverage: Option<ApiEquivalentCostCoverage>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UsageHistory {
+    pub source: UsageSource,
+    pub source_name: String,
+    pub display_name: String,
+    pub range: UsageRange,
+    pub as_of_date: NaiveDate,
+    pub currency: String,
+    pub points: Vec<DailyUsagePoint>,
+    pub quality: AnalyticsQuality,
+}
+
+struct AnalysisContext {
+    range: UsageRange,
+    as_of_date: NaiveDate,
+    filter: DateFilter,
+    timezone: Timezone,
+    pricing_db: PricingDb,
+    currency: Option<CurrencyConverter>,
+    currency_code: String,
+}
+
+pub(crate) fn apply_cli_config(mut options: SummaryOptions) -> Result<SummaryOptions, SdkError> {
+    let config =
+        Config::try_load_quiet().map_err(|error| SdkError::Configuration(error.to_string()))?;
+    if !options.offline && config.offline {
+        options.offline = true;
+    }
+    if !options.strict_pricing && config.strict_pricing {
+        options.strict_pricing = true;
+    }
+    if options.timezone.is_none() {
+        options.timezone = config.timezone;
+    }
+    if options.currency.is_none() {
+        options.currency = config.currency;
+    }
+    Ok(options)
+}
+
+fn analysis_context(options: &SummaryOptions) -> Result<AnalysisContext, SdkError> {
+    let timezone = Timezone::parse(options.timezone.as_deref())
+        .map_err(|error| SdkError::Configuration(error.to_string()))?;
+    let today = timezone.to_fixed_offset(Utc::now()).date_naive();
+    let (since, until) = options.range.resolve(today)?;
+    let mut filter = DateFilter::new(since, until);
+    if let Some((since_timestamp, until_timestamp)) = options.range.timestamp_bounds() {
+        filter = filter.with_exact_timestamp_range(since_timestamp, until_timestamp);
+    }
+    let pricing_db = PricingDb::try_load_quiet(options.offline, options.strict_pricing)
+        .map_err(|error| SdkError::Configuration(error.to_string()))?;
+    let currency = options
+        .currency
+        .as_deref()
+        .map(|code| {
+            CurrencyConverter::load(code, options.offline).ok_or_else(|| {
+                SdkError::Configuration(format!("failed to load exchange rate for '{code}'"))
+            })
+        })
+        .transpose()?;
+    let currency_code = currency.as_ref().map_or_else(
+        || "USD".to_string(),
+        |converter| converter.currency_code().to_string(),
+    );
+    Ok(AnalysisContext {
+        range: options.range.clone(),
+        as_of_date: today,
+        filter,
+        timezone,
+        pricing_db,
+        currency,
+        currency_code,
+    })
+}
+
+fn finite(value: f64) -> Option<f64> {
+    value.is_finite().then_some(value)
+}
+
+fn converted(value: Option<f64>, currency: Option<&CurrencyConverter>) -> Option<f64> {
+    match (value, currency) {
+        (Some(value), Some(converter)) => Some(converter.convert(value)),
+        (value, None) => value,
+        (None, Some(_)) => None,
+    }
+}
+
+fn token_breakdown(stats: &Stats, supports_cache_read: bool) -> TokenBreakdown {
+    TokenBreakdown {
+        input_tokens: stats.input_tokens,
+        output_tokens: stats.output_tokens,
+        reasoning_tokens: stats.reasoning_tokens,
+        cache_creation_tokens: stats.cache_creation,
+        cache_creation_1h_tokens: stats.cache_creation_1h,
+        cache_read_tokens: stats.cache_read,
+        reported_total_adjustment: stats.reported_total_adjustment,
+        cache_hit_rate: stats.cache_hit_rate(supports_cache_read),
+        total_tokens: stats.total_tokens(),
+    }
+}
+
+fn model_summaries(
+    models: &HashMap<String, Stats>,
+    context: &AnalysisContext,
+    supports_cache_read: bool,
+) -> Vec<ModelCostSummary> {
+    let mut rows = models
+        .iter()
+        .map(|(model, stats)| {
+            let cost_usd = finite(calculate_cost(stats, model, &context.pricing_db));
+            let estimated_cost_usd = finite(calculate_estimated_proxy_cost(
+                stats,
+                model,
+                &context.pricing_db,
+            ))
+            .filter(|cost| *cost > 0.0);
+            ModelCostSummary {
+                model: model.clone(),
+                cost: converted(cost_usd, context.currency.as_ref()),
+                cost_usd,
+                estimated_cost: converted(estimated_cost_usd, context.currency.as_ref()),
+                estimated_cost_usd,
+                cost_kind: stats.cost_kind().as_str().to_string(),
+                pricing_source: pricing_source_for_model_stats(model, stats, &context.pricing_db)
+                    .as_str()
+                    .to_string(),
+                tokens: token_breakdown(stats, supports_cache_read),
+            }
+        })
+        .collect::<Vec<_>>();
+    rows.sort_by(|left, right| {
+        right
+            .cost_usd
+            .partial_cmp(&left.cost_usd)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| right.tokens.total_tokens.cmp(&left.tokens.total_tokens))
+            .then_with(|| left.model.cmp(&right.model))
+    });
+    rows
+}
+
+fn usage_metrics(
+    stats: &Stats,
+    models: &HashMap<String, Stats>,
+    context: &AnalysisContext,
+    supports_cache_read: bool,
+) -> UsageMetrics {
+    let model_rows = model_summaries(models, context, supports_cache_read);
+    let active_rows = model_rows
+        .iter()
+        .filter(|model| model.tokens.total_tokens > 0)
+        .collect::<Vec<_>>();
+    let known_cost = active_rows.iter().all(|model| model.cost_usd.is_some());
+    let cost_usd = known_cost.then(|| active_rows.iter().filter_map(|model| model.cost_usd).sum());
+    let estimated_cost_usd = finite(crate::pricing::sum_estimated_proxy_model_costs(
+        models,
+        &context.pricing_db,
+    ))
+    .filter(|cost| *cost > 0.0);
+    UsageMetrics {
+        currency: context.currency_code.clone(),
+        cost: converted(cost_usd, context.currency.as_ref()),
+        cost_usd,
+        estimated_cost: converted(estimated_cost_usd, context.currency.as_ref()),
+        estimated_cost_usd,
+        cost_kind: model_cost_kind(models).as_str().to_string(),
+        pricing_source: crate::pricing::pricing_source_for_models(models, &context.pricing_db)
+            .as_str()
+            .to_string(),
+        api_equivalent_cost_coverage: CostCoverage::from_stats(std::iter::once(stats))
+            .map(Into::into),
+        tokens: token_breakdown(stats, supports_cache_read),
+        models: model_rows,
+    }
+}
+
+/// Summarizes project totals and their contributing sessions for one source.
+///
+/// # Errors
+///
+/// Returns an error when the source lacks project metadata or its usage data,
+/// pricing, range, or configuration cannot be loaded.
+pub fn summarize_project_drilldown(
+    options: &SummaryOptions,
+) -> Result<ProjectDrilldownSummary, DrilldownError> {
+    let source = get_source(options.source.as_str()).ok_or_else(|| SdkError::InvalidSource {
+        name: options.source.as_str().to_string(),
+    })?;
+    if !source.capabilities().has_projects {
+        return Err(DrilldownError::ProjectsUnsupported {
+            usage_source: options.source,
+            source_name: source.name().to_string(),
+        });
+    }
+    let context = analysis_context(options)?;
+    let daily = load_daily(source, &context.filter, context.timezone, true, false);
+    let sessions = load_sessions(source, &context.filter, context.timezone, true);
+    let projects = aggregate_projects(sessions.clone());
+    let mut sessions_by_project: HashMap<String, Vec<SessionStats>> = HashMap::new();
+    for session in sessions {
+        sessions_by_project
+            .entry(session.project_path.clone())
+            .or_default()
+            .push(session);
+    }
+    let supports_cache_read = source.capabilities().has_cache_read;
+    let projects = projects
+        .into_iter()
+        .map(|project| {
+            let mut sessions = sessions_by_project
+                .remove(&project.project_path)
+                .unwrap_or_default();
+            sessions.sort_by(|left, right| {
+                right
+                    .last_timestamp
+                    .cmp(&left.last_timestamp)
+                    .then_with(|| left.session_id.cmp(&right.session_id))
+            });
+            let sessions = sessions
+                .into_iter()
+                .map(|session| SessionDrilldown {
+                    session_id: session.session_id,
+                    project_path: session.project_path,
+                    first_timestamp: session.first_timestamp,
+                    last_timestamp: session.last_timestamp,
+                    metrics: usage_metrics(
+                        &session.stats,
+                        &session.models,
+                        &context,
+                        supports_cache_read,
+                    ),
+                })
+                .collect();
+            ProjectDrilldown {
+                project_path: project.project_path,
+                project_name: project.project_name,
+                session_count: project.session_count,
+                metrics: usage_metrics(
+                    &project.stats,
+                    &project.models,
+                    &context,
+                    supports_cache_read,
+                ),
+                sessions,
+            }
+        })
+        .collect();
+    Ok(ProjectDrilldownSummary {
+        source: options.source,
+        source_name: source.name().to_string(),
+        display_name: source.display_name().to_string(),
+        range: context.range,
+        currency: context.currency_code,
+        quality: AnalyticsQuality {
+            valid_entries: daily.valid,
+            dedup_skipped_entries: daily.skipped,
+            parse_error_entries: daily.parse_errors,
+        },
+        projects,
+    })
+}
+
+/// Summarizes project and session usage using persisted CLI configuration.
+///
+/// # Errors
+///
+/// Returns an error when configuration cannot be loaded, the source lacks
+/// project metadata, or its usage data cannot be summarized.
+pub fn summarize_project_drilldown_with_cli_config(
+    options: SummaryOptions,
+) -> Result<ProjectDrilldownSummary, DrilldownError> {
+    summarize_project_drilldown(&apply_cli_config(options)?)
+}
+
+/// Builds chronological daily usage points for one source and range.
+///
+/// # Errors
+///
+/// Returns an error when source data, pricing, range, or currency settings
+/// cannot be loaded or interpreted.
+pub fn usage_history(options: &SummaryOptions) -> Result<UsageHistory, SdkError> {
+    let source = get_source(options.source.as_str()).ok_or_else(|| SdkError::InvalidSource {
+        name: options.source.as_str().to_string(),
+    })?;
+    let context = analysis_context(options)?;
+    let result = load_daily(source, &context.filter, context.timezone, true, false);
+    let supports_cache_read = source.capabilities().has_cache_read;
+    let mut points = result
+        .day_stats
+        .iter()
+        .map(|(date, day)| {
+            let date = NaiveDate::parse_from_str(date, DATE_FORMAT).map_err(|error| {
+                SdkError::Configuration(format!(
+                    "invalid aggregated history date '{date}': {error}"
+                ))
+            })?;
+            let costs = day
+                .models
+                .iter()
+                .map(|(model, stats)| finite(calculate_cost(stats, model, &context.pricing_db)))
+                .collect::<Vec<_>>();
+            let known_count = costs.iter().filter(|cost| cost.is_some()).count();
+            let cost_kind = model_cost_kind(&day.models).as_str().to_string();
+            let pricing_source = pricing_source_for_models(&day.models, &context.pricing_db)
+                .as_str()
+                .to_string();
+            let coverage = CostCoverage::from_stats(std::iter::once(&day.stats)).map(Into::into);
+            let exact = (day.models.is_empty() || known_count == day.models.len())
+                && cost_kind == "real"
+                && matches!(pricing_source.as_str(), "recorded" | "live" | "cache")
+                && !coverage
+                    .as_ref()
+                    .is_some_and(|row: &ApiEquivalentCostCoverage| row.cost_is_lower_bound);
+            let status = if known_count == 0 && !day.models.is_empty() {
+                HistoryCostStatus::Unknown
+            } else if exact {
+                HistoryCostStatus::Known
+            } else {
+                HistoryCostStatus::Partial
+            };
+            let cost_usd = (known_count > 0 || day.models.is_empty())
+                .then(|| costs.into_iter().flatten().sum());
+            Ok(DailyUsagePoint {
+                date,
+                currency: context.currency_code.clone(),
+                tokens: token_breakdown(&day.stats, supports_cache_read),
+                records: day.stats.records,
+                cost: converted(cost_usd, context.currency.as_ref()),
+                cost_usd,
+                cost_status: status,
+                cost_kind,
+                pricing_source,
+                api_equivalent_cost_coverage: coverage,
+            })
+        })
+        .collect::<Result<Vec<_>, SdkError>>()?;
+    points.sort_by_key(|point| point.date);
+    Ok(UsageHistory {
+        source: options.source,
+        source_name: source.name().to_string(),
+        display_name: source.display_name().to_string(),
+        range: context.range,
+        as_of_date: context.as_of_date,
+        currency: context.currency_code,
+        points,
+        quality: AnalyticsQuality {
+            valid_entries: result.valid,
+            dedup_skipped_entries: result.skipped,
+            parse_error_entries: result.parse_errors,
+        },
+    })
+}
+
+/// Builds daily usage history using persisted CLI configuration.
+///
+/// # Errors
+///
+/// Returns an error when configuration or source usage data cannot be loaded.
+pub fn usage_history_with_cli_config(options: SummaryOptions) -> Result<UsageHistory, SdkError> {
+    usage_history(&apply_cli_config(options)?)
+}
+
+fn validate_history_floats(history: &UsageHistory) -> Result<(), SdkError> {
+    let valid = history.points.iter().all(|point| {
+        point.cost.is_none_or(f64::is_finite)
+            && point.cost_usd.is_none_or(f64::is_finite)
+            && point.tokens.cache_hit_rate.is_none_or(f64::is_finite)
+    });
+    if valid {
+        Ok(())
+    } else {
+        Err(SdkError::Configuration(
+            "history contains non-finite values".to_string(),
+        ))
+    }
+}
+
+fn csv_cell(value: &str) -> String {
+    if value.contains([',', '"', '\r', '\n']) {
+        format!("\"{}\"", value.replace('"', "\"\""))
+    } else {
+        value.to_string()
+    }
+}
+
+impl UsageHistory {
+    /// Serializes this history as deterministic, pretty-printed JSON.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the history contains non-finite numeric values or
+    /// JSON serialization fails.
+    pub fn to_json(&self) -> Result<String, SdkError> {
+        validate_history_floats(self)?;
+        serde_json::to_string_pretty(self)
+            .map_err(|error| SdkError::Configuration(error.to_string()))
+    }
+
+    /// Serializes this history as deterministic RFC 4180-style CSV.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the history contains non-finite numeric values.
+    pub fn to_csv(&self) -> Result<String, SdkError> {
+        validate_history_floats(self)?;
+        let mut csv = String::from(
+            "date,currency,input_tokens,output_tokens,reasoning_tokens,cache_creation_tokens,cache_read_tokens,cache_hit_rate,total_tokens,records,cost,cost_usd,cost_status,cost_kind,pricing_source,cost_is_lower_bound,valid_entries,dedup_skipped_entries,parse_error_entries\r\n",
+        );
+        for point in &self.points {
+            let values = [
+                point.date.to_string(),
+                csv_cell(&point.currency),
+                point.tokens.input_tokens.to_string(),
+                point.tokens.output_tokens.to_string(),
+                point.tokens.reasoning_tokens.to_string(),
+                point.tokens.cache_creation_tokens.to_string(),
+                point.tokens.cache_read_tokens.to_string(),
+                point
+                    .tokens
+                    .cache_hit_rate
+                    .map_or_else(String::new, |value| value.to_string()),
+                point.tokens.total_tokens.to_string(),
+                point.records.to_string(),
+                point
+                    .cost
+                    .map_or_else(|| "unknown".to_string(), |value| value.to_string()),
+                point
+                    .cost_usd
+                    .map_or_else(|| "unknown".to_string(), |value| value.to_string()),
+                format!("{:?}", point.cost_status).to_ascii_lowercase(),
+                csv_cell(&point.cost_kind),
+                csv_cell(&point.pricing_source),
+                point
+                    .api_equivalent_cost_coverage
+                    .as_ref()
+                    .is_some_and(|coverage| coverage.cost_is_lower_bound)
+                    .to_string(),
+                self.quality.valid_entries.to_string(),
+                self.quality.dedup_skipped_entries.to_string(),
+                self.quality.parse_error_entries.to_string(),
+            ];
+            csv.push_str(&values.join(","));
+            csv.push_str("\r\n");
+        }
+        Ok(csv)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
 
     use super::*;
+
+    #[test]
+    fn source_diagnostics_project_every_registered_source() {
+        let diagnostics = diagnose_usage_sources().expect("source diagnostics");
+
+        assert_eq!(diagnostics.len(), 29);
+        assert_eq!(
+            diagnostics.first().map(|row| row.name.as_str()),
+            Some("claude")
+        );
+        assert_eq!(diagnostics.last().map(|row| row.name.as_str()), Some("dsh"));
+        assert!(diagnostics.iter().all(|row| !row.setup.is_empty()));
+    }
 
     #[test]
     fn catalog_is_a_complete_unique_registry_projection() {
@@ -75,5 +692,58 @@ mod tests {
                 .map(crate::source::Source::name)
                 .collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn project_drilldown_rejects_sources_without_project_capability() {
+        let options = crate::sdk::SummaryOptions {
+            source: UsageSource::Codex,
+            range: crate::sdk::UsageRange::Today,
+            offline: true,
+            ..crate::sdk::SummaryOptions::default()
+        };
+        let error = summarize_project_drilldown(&options)
+            .expect_err("Codex project drilldown must fail clearly");
+
+        assert!(
+            error
+                .to_string()
+                .contains("does not support project drilldown")
+        );
+    }
+
+    #[test]
+    fn history_exports_are_deterministic_and_preserve_unknown_cost() {
+        let history = UsageHistory {
+            source: UsageSource::Claude,
+            source_name: "claude".to_string(),
+            display_name: "Claude Code".to_string(),
+            range: crate::sdk::UsageRange::ThisMonth,
+            as_of_date: chrono::NaiveDate::from_ymd_opt(2026, 9, 2).unwrap(),
+            currency: "USD".to_string(),
+            points: vec![DailyUsagePoint {
+                date: chrono::NaiveDate::from_ymd_opt(2026, 9, 1).unwrap(),
+                currency: "USD".to_string(),
+                tokens: crate::sdk::TokenBreakdown::default(),
+                records: 2,
+                cost: None,
+                cost_usd: None,
+                cost_status: HistoryCostStatus::Unknown,
+                cost_kind: "unknown".to_string(),
+                pricing_source: "unknown".to_string(),
+                api_equivalent_cost_coverage: None,
+            }],
+            quality: AnalyticsQuality {
+                valid_entries: 2,
+                dedup_skipped_entries: 1,
+                parse_error_entries: 0,
+            },
+        };
+
+        assert_eq!(history.to_json().unwrap(), history.to_json().unwrap());
+        let csv = history.to_csv().unwrap();
+        assert!(csv.contains("cost_status"));
+        assert!(csv.contains(",unknown,unknown,"));
+        assert!(csv.ends_with("\r\n"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
     clippy::cast_sign_loss
 )]
 
+mod activity;
 mod app;
 mod catalog;
 mod cli;
@@ -40,15 +41,25 @@ mod source;
 mod sources_cmd;
 mod utils;
 
-pub use catalog::{SourceDescriptor, list_usage_sources};
+pub use activity::{
+    ModelTurnUsage, ToolUsage, TurnToolBreakdown, turn_tool_breakdown,
+    turn_tool_breakdown_with_cli_config,
+};
+pub use catalog::{
+    AnalyticsQuality, DailyUsagePoint, DrilldownError, HistoryCostStatus, ProjectDrilldown,
+    ProjectDrilldownSummary, SessionDrilldown, SourceDescriptor, SourceDiagnosticDescriptor,
+    SourceDiagnosticStatus, UsageHistory, UsageMetrics, diagnose_usage_sources, list_usage_sources,
+    summarize_project_drilldown, summarize_project_drilldown_with_cli_config, usage_history,
+    usage_history_with_cli_config,
+};
 pub use sdk::{
     ApiEquivalentCostCoverage, CodexQuotaError, CodexQuotaStatus, CodexWeeklyQuota,
     CodexWeeklyValueError, CodexWeeklyValueEstimate, CodexWeeklyValueWindow,
     CodexWeeklyValueWindowError, CostSummary, ModelCostSummary, MultiCostSummary,
     MultiSummaryOptions, SdkError, SummaryOptions, TokenBreakdown, UsageRange, UsageSource,
-    estimate_codex_weekly_value, estimate_codex_weekly_value_for_window, load_codex_weekly_quota,
-    summarize_cost, summarize_cost_ranges, summarize_cost_ranges_with_cli_config,
-    summarize_cost_with_cli_config,
+    current_usage_date_with_cli_config, estimate_codex_weekly_value,
+    estimate_codex_weekly_value_for_window, load_codex_weekly_quota, summarize_cost,
+    summarize_cost_ranges, summarize_cost_ranges_with_cli_config, summarize_cost_with_cli_config,
 };
 
 use chrono::{NaiveDate, Utc};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,11 +55,12 @@ pub use catalog::{
 pub use sdk::{
     ApiEquivalentCostCoverage, CodexQuotaError, CodexQuotaStatus, CodexWeeklyQuota,
     CodexWeeklyValueError, CodexWeeklyValueEstimate, CodexWeeklyValueWindow,
-    CodexWeeklyValueWindowError, CostSummary, ModelCostSummary, MultiCostSummary,
-    MultiSummaryOptions, SdkError, SummaryOptions, TokenBreakdown, UsageRange, UsageSource,
-    current_usage_date_with_cli_config, estimate_codex_weekly_value,
-    estimate_codex_weekly_value_for_window, load_codex_weekly_quota, summarize_cost,
-    summarize_cost_ranges, summarize_cost_ranges_with_cli_config, summarize_cost_with_cli_config,
+    CodexWeeklyValueWindowError, CostSummary, CurrentUsageWindow, ModelCostSummary,
+    MultiCostSummary, MultiSummaryOptions, SdkError, SummaryOptions, TokenBreakdown, UsageRange,
+    UsageSource, current_usage_date_with_cli_config, current_usage_windows_with_cli_config,
+    estimate_codex_weekly_value, estimate_codex_weekly_value_for_window, load_codex_weekly_quota,
+    summarize_cost, summarize_cost_ranges, summarize_cost_ranges_with_cli_config,
+    summarize_cost_with_cli_config,
 };
 
 use chrono::{NaiveDate, Utc};

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -15,7 +15,8 @@ use crate::config::Config;
 use crate::core::{DateFilter, DayStats, LoadResult, Stats};
 use crate::pricing::{
     CurrencyConverter, PricingDb, calculate_cost, calculate_estimated_proxy_cost, model_cost_kind,
-    sum_estimated_proxy_model_costs, sum_model_costs,
+    pricing_source_for_model_stats, pricing_source_for_models, sum_estimated_proxy_model_costs,
+    sum_model_costs,
 };
 use crate::source::{CostCoverage, Source, get_source, load_daily};
 use crate::utils::Timezone;
@@ -85,14 +86,14 @@ pub enum UsageRange {
 }
 
 impl UsageRange {
-    fn timestamp_bounds(&self) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+    pub(crate) fn timestamp_bounds(&self) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
         match self {
             UsageRange::TimestampRange { since, until } => Some((*since, *until)),
             _ => None,
         }
     }
 
-    pub(in crate::sdk) fn resolve(
+    pub(crate) fn resolve(
         &self,
         today: NaiveDate,
     ) -> Result<(Option<NaiveDate>, Option<NaiveDate>), SdkError> {
@@ -176,6 +177,8 @@ pub struct TokenBreakdown {
     #[serde(default)]
     pub cache_creation_1h_tokens: i64,
     pub cache_read_tokens: i64,
+    /// Difference between the source-authoritative total and the named buckets.
+    pub reported_total_adjustment: i64,
     /// Reported prompt-cache hit rate as a percentage from 0 to 100.
     /// `None` means the source does not expose trustworthy cache-read data or
     /// the summary has no input-side tokens.
@@ -194,6 +197,7 @@ pub struct ModelCostSummary {
     pub estimated_cost: Option<f64>,
     pub estimated_cost_usd: Option<f64>,
     pub cost_kind: String,
+    pub pricing_source: String,
     pub tokens: TokenBreakdown,
 }
 
@@ -234,6 +238,7 @@ pub struct CostSummary {
     pub estimated_cost: Option<f64>,
     pub estimated_cost_usd: Option<f64>,
     pub cost_kind: String,
+    pub pricing_source: String,
     pub api_equivalent_cost_coverage: Option<ApiEquivalentCostCoverage>,
     pub tokens: TokenBreakdown,
     pub models: Vec<ModelCostSummary>,
@@ -321,6 +326,18 @@ pub fn summarize_cost_with_cli_config(options: SummaryOptions) -> Result<CostSum
     summarize_cost(apply_cli_config(options, &config))
 }
 
+/// Resolves today's date using the persisted CLI timezone.
+///
+/// # Errors
+///
+/// Returns an error when CLI configuration cannot be loaded or its timezone is invalid.
+pub fn current_usage_date_with_cli_config() -> Result<NaiveDate, SdkError> {
+    let config = load_cli_config()?;
+    let timezone = Timezone::parse(config.timezone.as_deref())
+        .map_err(|error| SdkError::Configuration(error.to_string()))?;
+    Ok(timezone.to_fixed_offset(Utc::now()).date_naive())
+}
+
 pub(super) fn load_cli_config() -> Result<Config, SdkError> {
     Config::try_load_quiet().map_err(|err| SdkError::Configuration(err.to_string()))
 }
@@ -351,6 +368,7 @@ impl TokenBreakdown {
             cache_creation_tokens: stats.cache_creation,
             cache_creation_1h_tokens: stats.cache_creation_1h,
             cache_read_tokens: stats.cache_read,
+            reported_total_adjustment: stats.reported_total_adjustment,
             cache_hit_rate: stats.cache_hit_rate(supports_cache_read),
             total_tokens: stats.total_tokens(),
         }
@@ -389,6 +407,9 @@ pub(in crate::sdk) fn build_cost_summary(
         estimated_cost: convert_cost(estimated_cost_usd, currency),
         estimated_cost_usd,
         cost_kind: model_cost_kind(&models).as_str().to_string(),
+        pricing_source: pricing_source_for_models(&models, pricing_db)
+            .as_str()
+            .to_string(),
         api_equivalent_cost_coverage: cost_coverage.map(Into::into),
         tokens: TokenBreakdown::from_stats(&stats, supports_cache_read),
         models: summarize_models(&models, pricing_db, currency, supports_cache_read),
@@ -465,6 +486,9 @@ fn summarize_models(
                 estimated_cost: convert_cost(estimated_cost_usd, currency),
                 estimated_cost_usd,
                 cost_kind: stats.cost_kind().as_str().to_string(),
+                pricing_source: pricing_source_for_model_stats(model, stats, pricing_db)
+                    .as_str()
+                    .to_string(),
                 tokens: TokenBreakdown::from_stats(stats, supports_cache_read),
             }
         })
@@ -487,253 +511,5 @@ fn summarize_models(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use std::collections::BTreeSet;
-
-    #[test]
-    fn usage_source_accepts_registry_names_and_aliases() {
-        for source in crate::source::all_sources() {
-            let expected = UsageSource::from_name(source.name()).expect("SDK source variant");
-            assert_eq!(source.name().parse::<UsageSource>().unwrap(), expected);
-            assert_eq!(
-                source
-                    .name()
-                    .to_ascii_uppercase()
-                    .parse::<UsageSource>()
-                    .unwrap(),
-                expected
-            );
-            assert_eq!(
-                format!(" {} ", source.name())
-                    .parse::<UsageSource>()
-                    .unwrap(),
-                expected
-            );
-
-            for alias in source.aliases() {
-                assert_eq!(alias.parse::<UsageSource>().unwrap(), expected);
-            }
-        }
-
-        let err = " unknown ".parse::<UsageSource>().unwrap_err();
-        assert!(matches!(err, SdkError::InvalidSource { name } if name == "unknown"));
-    }
-
-    #[test]
-    fn extension_usage_sources_use_canonical_serde_names() {
-        assert_eq!(
-            serde_json::to_string(&UsageSource::RooCode).unwrap(),
-            r#""roocode""#
-        );
-        assert_eq!(
-            serde_json::to_string(&UsageSource::KiloCode).unwrap(),
-            r#""kilocode""#
-        );
-        assert_eq!(
-            serde_json::from_str::<UsageSource>(r#""roocode""#).unwrap(),
-            UsageSource::RooCode
-        );
-        assert_eq!(
-            serde_json::from_str::<UsageSource>(r#""kilocode""#).unwrap(),
-            UsageSource::KiloCode
-        );
-    }
-
-    #[test]
-    fn registry_concrete_sources_match_sdk_usage_sources() {
-        let registry_sources = crate::source::all_sources()
-            .map(Source::name)
-            .collect::<BTreeSet<_>>();
-        let sdk_sources = UsageSource::VARIANTS
-            .iter()
-            .map(|source| source.as_str())
-            .collect::<BTreeSet<_>>();
-
-        assert_eq!(registry_sources, sdk_sources);
-        assert!(crate::source::source_choices().contains(&crate::source::ALL_SOURCES));
-        assert!(crate::source::ALL_SOURCES.parse::<UsageSource>().is_err());
-
-        for source in crate::source::all_sources() {
-            assert_eq!(
-                source.name().parse::<UsageSource>().unwrap().as_str(),
-                source.name()
-            );
-            for alias in source.aliases() {
-                assert_eq!(
-                    alias.parse::<UsageSource>().unwrap().as_str(),
-                    source.name()
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn usage_range_this_week_starts_on_monday() {
-        let today = NaiveDate::from_ymd_opt(2026, 5, 9).unwrap();
-        let (since, until) = UsageRange::ThisWeek.resolve(today).unwrap();
-        assert_eq!(since, Some(NaiveDate::from_ymd_opt(2026, 5, 4).unwrap()));
-        assert_eq!(until, Some(today));
-    }
-
-    #[test]
-    fn usage_range_rejects_reversed_dates() {
-        let range = UsageRange::DateRange {
-            since: Some(NaiveDate::from_ymd_opt(2026, 5, 10).unwrap()),
-            until: Some(NaiveDate::from_ymd_opt(2026, 5, 9).unwrap()),
-        };
-        assert!(
-            range
-                .resolve(NaiveDate::from_ymd_opt(2026, 5, 9).unwrap())
-                .is_err()
-        );
-    }
-
-    #[test]
-    fn usage_range_accepts_exact_utc_timestamps_and_rejects_reversed_bounds() {
-        let payload = serde_json::json!({
-            "timestamp_range": {
-                "since": "2026-08-21T05:41:00Z",
-                "until": "2026-08-21T05:43:00Z"
-            }
-        });
-        let range: UsageRange = serde_json::from_value(payload.clone()).expect("timestamp range");
-
-        assert_eq!(
-            serde_json::to_value(&range).expect("serialize range"),
-            payload
-        );
-
-        let reversed: UsageRange = serde_json::from_value(serde_json::json!({
-            "timestamp_range": {
-                "since": "2026-08-21T05:43:00Z",
-                "until": "2026-08-21T05:41:00Z"
-            }
-        }))
-        .expect("deserialize reversed range");
-        assert!(
-            reversed
-                .resolve(NaiveDate::from_ymd_opt(2026, 8, 21).expect("valid date"))
-                .is_err()
-        );
-    }
-
-    #[test]
-    fn token_breakdown_deserializes_legacy_json_without_cache_hit_rate() {
-        let legacy = r#"{
-            "input_tokens": 10,
-            "output_tokens": 5,
-            "reasoning_tokens": 0,
-            "cache_creation_tokens": 3,
-            "cache_read_tokens": 2,
-            "total_tokens": 20
-        }"#;
-        let tokens: TokenBreakdown =
-            serde_json::from_str(legacy).expect("legacy breakdown without cache_hit_rate");
-        assert_eq!(tokens.cache_hit_rate, None);
-        assert_eq!(tokens.cache_creation_1h_tokens, 0);
-        assert_eq!(tokens.total_tokens, 20);
-    }
-
-    #[test]
-    fn token_breakdown_treats_cache_creation_1h_as_subset() {
-        let stats = Stats {
-            input_tokens: 10,
-            output_tokens: 5,
-            cache_creation: 30,
-            cache_creation_1h: 25,
-            cache_read: 2,
-            ..Stats::default()
-        };
-        let tokens = TokenBreakdown::from_stats(&stats, true);
-        let serialized = serde_json::to_value(&tokens).expect("serialize breakdown");
-
-        assert_eq!(tokens.cache_creation_tokens, 30);
-        assert_eq!(tokens.cache_creation_1h_tokens, 25);
-        assert_eq!(serialized["cache_creation_tokens"], 30);
-        assert_eq!(serialized["cache_creation_1h_tokens"], 25);
-        // 1h tokens are already inside cache_creation; total must not add them again.
-        assert_eq!(tokens.total_tokens, 47);
-        assert_eq!(serialized["total_tokens"], 47);
-    }
-
-    #[test]
-    fn model_summaries_use_model_name_as_equal_cost_tiebreaker() {
-        let pricing_db = PricingDb::default();
-        let mut models = HashMap::new();
-        models.insert(
-            "gpt-5-zeta".to_string(),
-            Stats {
-                input_tokens: 10,
-                ..Stats::default()
-            },
-        );
-        models.insert(
-            "gpt-5-alpha".to_string(),
-            Stats {
-                input_tokens: 10,
-                ..Stats::default()
-            },
-        );
-
-        let rows = summarize_models(&models, &pricing_db, None, true);
-
-        assert_eq!(rows[0].model, "gpt-5-alpha");
-        assert_eq!(rows[1].model, "gpt-5-zeta");
-        assert_eq!(rows[0].cost_usd, rows[1].cost_usd);
-    }
-
-    #[test]
-    fn cli_config_fills_sdk_summary_defaults() {
-        let config = Config {
-            offline: true,
-            strict_pricing: true,
-            timezone: Some("Asia/Shanghai".to_string()),
-            currency: Some("CNY".to_string()),
-            ..Config::default()
-        };
-
-        let options = apply_cli_config(
-            SummaryOptions {
-                source: UsageSource::Codex,
-                range: UsageRange::Today,
-                ..SummaryOptions::default()
-            },
-            &config,
-        );
-
-        assert_eq!(options.source, UsageSource::Codex);
-        assert_eq!(options.range, UsageRange::Today);
-        assert!(options.offline);
-        assert!(options.strict_pricing);
-        assert_eq!(options.timezone.as_deref(), Some("Asia/Shanghai"));
-        assert_eq!(options.currency.as_deref(), Some("CNY"));
-    }
-
-    #[test]
-    fn explicit_sdk_summary_options_win_over_cli_config() {
-        let config = Config {
-            timezone: Some("Asia/Shanghai".to_string()),
-            currency: Some("CNY".to_string()),
-            ..Config::default()
-        };
-
-        let options = apply_cli_config(
-            SummaryOptions {
-                timezone: Some("UTC".to_string()),
-                currency: Some("EUR".to_string()),
-                ..SummaryOptions::default()
-            },
-            &config,
-        );
-
-        assert_eq!(options.timezone.as_deref(), Some("UTC"));
-        assert_eq!(options.currency.as_deref(), Some("EUR"));
-    }
-
-    #[test]
-    fn requested_currency_requires_available_rate() {
-        let err = load_requested_currency(Some("ZZZ"), true).expect_err("currency should fail");
-        assert!(err.to_string().contains("failed to load exchange rate"));
-    }
-}
+#[path = "sdk/tests.rs"]
+mod tests;

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -85,6 +85,16 @@ pub enum UsageRange {
     },
 }
 
+/// Absolute UTC boundaries for a rolling usage range in the configured timezone.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CurrentUsageWindow {
+    pub range: UsageRange,
+    pub since: NaiveDate,
+    pub until: NaiveDate,
+    pub since_utc_ms: i64,
+    pub until_exclusive_utc_ms: i64,
+}
+
 impl UsageRange {
     pub(crate) fn timestamp_bounds(&self) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
         match self {
@@ -336,6 +346,60 @@ pub fn current_usage_date_with_cli_config() -> Result<NaiveDate, SdkError> {
     let timezone = Timezone::parse(config.timezone.as_deref())
         .map_err(|error| SdkError::Configuration(error.to_string()))?;
     Ok(timezone.to_fixed_offset(Utc::now()).date_naive())
+}
+
+fn current_usage_windows(
+    timezone: Timezone,
+    now: DateTime<Utc>,
+) -> Result<Vec<CurrentUsageWindow>, SdkError> {
+    let today = timezone.to_fixed_offset(now).date_naive();
+    [
+        UsageRange::Today,
+        UsageRange::ThisWeek,
+        UsageRange::ThisMonth,
+    ]
+    .into_iter()
+    .map(|range| {
+        let (Some(since), Some(until)) = range.resolve(today)? else {
+            return Err(SdkError::Configuration(
+                "rolling usage range did not resolve to bounded dates".to_string(),
+            ));
+        };
+        let until_exclusive = until.checked_add_days(Days::new(1)).ok_or_else(|| {
+            SdkError::Configuration("usage window end is not representable".to_string())
+        })?;
+        let since_utc_ms = timezone.date_start_utc_millis(since).ok_or_else(|| {
+            SdkError::Configuration("usage window start is not representable".to_string())
+        })?;
+        let until_exclusive_utc_ms =
+            timezone
+                .date_start_utc_millis(until_exclusive)
+                .ok_or_else(|| {
+                    SdkError::Configuration("usage window end is not representable".to_string())
+                })?;
+        Ok(CurrentUsageWindow {
+            range,
+            since,
+            until,
+            since_utc_ms,
+            until_exclusive_utc_ms,
+        })
+    })
+    .collect()
+}
+
+/// Resolves the current day, week, and month with absolute UTC boundaries using
+/// the persisted CLI timezone.
+///
+/// # Errors
+///
+/// Returns an error when CLI configuration or its timezone is invalid, or a
+/// date boundary cannot be represented.
+pub fn current_usage_windows_with_cli_config() -> Result<Vec<CurrentUsageWindow>, SdkError> {
+    let config = load_cli_config()?;
+    let timezone = Timezone::parse(config.timezone.as_deref())
+        .map_err(|error| SdkError::Configuration(error.to_string()))?;
+    current_usage_windows(timezone, Utc::now())
 }
 
 pub(super) fn load_cli_config() -> Result<Config, SdkError> {

--- a/src/sdk/tests.rs
+++ b/src/sdk/tests.rs
@@ -1,0 +1,267 @@
+use super::*;
+use std::collections::BTreeSet;
+
+#[test]
+fn usage_source_accepts_registry_names_and_aliases() {
+    for source in crate::source::all_sources() {
+        let expected = UsageSource::from_name(source.name()).expect("SDK source variant");
+        assert_eq!(source.name().parse::<UsageSource>().unwrap(), expected);
+        assert_eq!(
+            source
+                .name()
+                .to_ascii_uppercase()
+                .parse::<UsageSource>()
+                .unwrap(),
+            expected
+        );
+        assert_eq!(
+            format!(" {} ", source.name())
+                .parse::<UsageSource>()
+                .unwrap(),
+            expected
+        );
+
+        for alias in source.aliases() {
+            assert_eq!(alias.parse::<UsageSource>().unwrap(), expected);
+        }
+    }
+
+    let err = " unknown ".parse::<UsageSource>().unwrap_err();
+    assert!(matches!(err, SdkError::InvalidSource { name } if name == "unknown"));
+}
+
+#[test]
+fn extension_usage_sources_use_canonical_serde_names() {
+    assert_eq!(
+        serde_json::to_string(&UsageSource::RooCode).unwrap(),
+        r#""roocode""#
+    );
+    assert_eq!(
+        serde_json::to_string(&UsageSource::KiloCode).unwrap(),
+        r#""kilocode""#
+    );
+    assert_eq!(
+        serde_json::from_str::<UsageSource>(r#""roocode""#).unwrap(),
+        UsageSource::RooCode
+    );
+    assert_eq!(
+        serde_json::from_str::<UsageSource>(r#""kilocode""#).unwrap(),
+        UsageSource::KiloCode
+    );
+}
+
+#[test]
+fn registry_concrete_sources_match_sdk_usage_sources() {
+    let registry_sources = crate::source::all_sources()
+        .map(Source::name)
+        .collect::<BTreeSet<_>>();
+    let sdk_sources = UsageSource::VARIANTS
+        .iter()
+        .map(|source| source.as_str())
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(registry_sources, sdk_sources);
+    assert!(crate::source::source_choices().contains(&crate::source::ALL_SOURCES));
+    assert!(crate::source::ALL_SOURCES.parse::<UsageSource>().is_err());
+
+    for source in crate::source::all_sources() {
+        assert_eq!(
+            source.name().parse::<UsageSource>().unwrap().as_str(),
+            source.name()
+        );
+        for alias in source.aliases() {
+            assert_eq!(
+                alias.parse::<UsageSource>().unwrap().as_str(),
+                source.name()
+            );
+        }
+    }
+}
+
+#[test]
+fn usage_range_this_week_starts_on_monday() {
+    let today = NaiveDate::from_ymd_opt(2026, 5, 9).unwrap();
+    let (since, until) = UsageRange::ThisWeek.resolve(today).unwrap();
+    assert_eq!(since, Some(NaiveDate::from_ymd_opt(2026, 5, 4).unwrap()));
+    assert_eq!(until, Some(today));
+}
+
+#[test]
+fn usage_range_rejects_reversed_dates() {
+    let range = UsageRange::DateRange {
+        since: Some(NaiveDate::from_ymd_opt(2026, 5, 10).unwrap()),
+        until: Some(NaiveDate::from_ymd_opt(2026, 5, 9).unwrap()),
+    };
+    assert!(
+        range
+            .resolve(NaiveDate::from_ymd_opt(2026, 5, 9).unwrap())
+            .is_err()
+    );
+}
+
+#[test]
+fn usage_range_accepts_exact_utc_timestamps_and_rejects_reversed_bounds() {
+    let payload = serde_json::json!({
+        "timestamp_range": {
+            "since": "2026-08-21T05:41:00Z",
+            "until": "2026-08-21T05:43:00Z"
+        }
+    });
+    let range: UsageRange = serde_json::from_value(payload.clone()).expect("timestamp range");
+
+    assert_eq!(
+        serde_json::to_value(&range).expect("serialize range"),
+        payload
+    );
+
+    let reversed: UsageRange = serde_json::from_value(serde_json::json!({
+        "timestamp_range": {
+            "since": "2026-08-21T05:43:00Z",
+            "until": "2026-08-21T05:41:00Z"
+        }
+    }))
+    .expect("deserialize reversed range");
+    assert!(
+        reversed
+            .resolve(NaiveDate::from_ymd_opt(2026, 8, 21).expect("valid date"))
+            .is_err()
+    );
+}
+
+#[test]
+fn token_breakdown_deserializes_legacy_json_without_cache_hit_rate() {
+    let legacy = r#"{
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "reasoning_tokens": 0,
+        "cache_creation_tokens": 3,
+        "cache_read_tokens": 2,
+        "reported_total_adjustment": 0,
+        "total_tokens": 20
+    }"#;
+    let tokens: TokenBreakdown =
+        serde_json::from_str(legacy).expect("legacy breakdown without cache_hit_rate");
+    assert_eq!(tokens.cache_hit_rate, None);
+    assert_eq!(tokens.total_tokens, 20);
+}
+
+#[test]
+fn token_breakdown_treats_cache_creation_1h_as_subset() {
+    let stats = Stats {
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_creation: 30,
+        cache_creation_1h: 25,
+        cache_read: 2,
+        ..Stats::default()
+    };
+    let tokens = TokenBreakdown::from_stats(&stats, true);
+    let serialized = serde_json::to_value(&tokens).expect("serialize breakdown");
+
+    assert_eq!(tokens.cache_creation_tokens, 30);
+    assert_eq!(tokens.cache_creation_1h_tokens, 25);
+    assert_eq!(serialized["cache_creation_tokens"], 30);
+    assert_eq!(serialized["cache_creation_1h_tokens"], 25);
+    assert_eq!(tokens.total_tokens, 47);
+    assert_eq!(serialized["total_tokens"], 47);
+}
+
+#[test]
+fn model_summaries_use_model_name_as_equal_cost_tiebreaker() {
+    let pricing_db = PricingDb::default();
+    let mut models = HashMap::new();
+    models.insert(
+        "gpt-5-zeta".to_string(),
+        Stats {
+            input_tokens: 10,
+            ..Stats::default()
+        },
+    );
+    models.insert(
+        "gpt-5-alpha".to_string(),
+        Stats {
+            input_tokens: 10,
+            ..Stats::default()
+        },
+    );
+
+    let rows = summarize_models(&models, &pricing_db, None, true);
+
+    assert_eq!(rows[0].model, "gpt-5-alpha");
+    assert_eq!(rows[1].model, "gpt-5-zeta");
+    assert_eq!(rows[0].cost_usd, rows[1].cost_usd);
+}
+
+#[test]
+fn model_summary_exposes_recorded_cost_provenance() {
+    let pricing_db = PricingDb::default();
+    let models = HashMap::from([(
+        "source-priced-model".to_string(),
+        Stats {
+            input_tokens: 10,
+            count: 1,
+            recorded_cost_usd: 0.25,
+            recorded_cost_entries: 1,
+            ..Stats::default()
+        },
+    )]);
+
+    let rows = summarize_models(&models, &pricing_db, None, false);
+
+    assert_eq!(rows[0].cost_usd, Some(0.25));
+    assert_eq!(rows[0].pricing_source, "recorded");
+}
+
+#[test]
+fn cli_config_fills_sdk_summary_defaults() {
+    let config = Config {
+        offline: true,
+        strict_pricing: true,
+        timezone: Some("Asia/Shanghai".to_string()),
+        currency: Some("CNY".to_string()),
+        ..Config::default()
+    };
+
+    let options = apply_cli_config(
+        SummaryOptions {
+            source: UsageSource::Codex,
+            range: UsageRange::Today,
+            ..SummaryOptions::default()
+        },
+        &config,
+    );
+
+    assert_eq!(options.source, UsageSource::Codex);
+    assert_eq!(options.range, UsageRange::Today);
+    assert!(options.offline);
+    assert!(options.strict_pricing);
+    assert_eq!(options.timezone.as_deref(), Some("Asia/Shanghai"));
+    assert_eq!(options.currency.as_deref(), Some("CNY"));
+}
+
+#[test]
+fn explicit_sdk_summary_options_win_over_cli_config() {
+    let config = Config {
+        timezone: Some("Asia/Shanghai".to_string()),
+        currency: Some("CNY".to_string()),
+        ..Config::default()
+    };
+
+    let options = apply_cli_config(
+        SummaryOptions {
+            timezone: Some("UTC".to_string()),
+            currency: Some("EUR".to_string()),
+            ..SummaryOptions::default()
+        },
+        &config,
+    );
+
+    assert_eq!(options.timezone.as_deref(), Some("UTC"));
+    assert_eq!(options.currency.as_deref(), Some("EUR"));
+}
+
+#[test]
+fn requested_currency_requires_available_rate() {
+    let err = load_requested_currency(Some("ZZZ"), true).expect_err("currency should fail");
+    assert!(err.to_string().contains("failed to load exchange rate"));
+}

--- a/src/sdk/tests.rs
+++ b/src/sdk/tests.rs
@@ -2,6 +2,24 @@ use super::*;
 use std::collections::BTreeSet;
 
 #[test]
+fn usage_windows_record_timezone_specific_utc_boundaries() {
+    let now = "2026-09-02T12:00:00Z".parse::<DateTime<Utc>>().unwrap();
+    let utc = current_usage_windows(Timezone::Named(chrono_tz::UTC), now).unwrap();
+    let shanghai = current_usage_windows(Timezone::Named(chrono_tz::Asia::Shanghai), now).unwrap();
+
+    assert_eq!(utc[0].since, shanghai[0].since);
+    assert_eq!(utc[0].until, shanghai[0].until);
+    assert_eq!(
+        utc[0].since_utc_ms - shanghai[0].since_utc_ms,
+        8 * 60 * 60 * 1_000
+    );
+    assert_eq!(
+        utc[0].until_exclusive_utc_ms - shanghai[0].until_exclusive_utc_ms,
+        8 * 60 * 60 * 1_000
+    );
+}
+
+#[test]
 fn usage_source_accepts_registry_names_and_aliases() {
     for source in crate::source::all_sources() {
         let expected = UsageSource::from_name(source.name()).expect("SDK source variant");

--- a/src/source/loader.rs
+++ b/src/source/loader.rs
@@ -1,5 +1,7 @@
 //! Unified data loader for all sources
 
+mod entries;
+
 use rayon::prelude::*;
 use std::collections::HashMap;
 use std::time::Instant;

--- a/src/source/loader.rs
+++ b/src/source/loader.rs
@@ -216,7 +216,7 @@ impl<'a> DataLoader<'a> {
     }
 
     /// Load and deduplicate entries incrementally to avoid buffering all raw records in memory.
-    fn load_deduped_entries_incremental(
+    pub(super) fn load_deduped_entries_incremental(
         &self,
         filter: &DateFilter,
         timezone: Timezone,

--- a/src/source/loader/entries.rs
+++ b/src/source/loader/entries.rs
@@ -1,0 +1,32 @@
+use crate::core::{DateFilter, RawEntry};
+use crate::utils::Timezone;
+
+use super::DataLoader;
+
+impl DataLoader<'_> {
+    pub(in crate::source) fn load_entries(
+        &self,
+        filter: &DateFilter,
+        timezone: Timezone,
+    ) -> (Vec<RawEntry>, i64, usize) {
+        if self.source.capabilities().needs_dedup {
+            return self.load_deduped_entries_incremental(filter, timezone);
+        }
+
+        match self.par_process(
+            filter,
+            timezone,
+            |filtered| filtered,
+            Vec::new,
+            |mut entries, partial| {
+                entries.extend(partial);
+                entries
+            },
+        ) {
+            Some((entries, parse_errors)) => {
+                (self.source.finalize_entries(entries), 0, parse_errors)
+            }
+            None => (Vec::new(), 0, 0),
+        }
+    }
+}

--- a/src/source/loader_quality_tests.rs
+++ b/src/source/loader_quality_tests.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use chrono::{DateTime, NaiveDate, Utc};
 
 use crate::core::{DateFilter, RawEntry};
-use crate::source::{Capabilities, ParseOutput, Source};
+use crate::source::{Capabilities, ParseOutput, Source, load_entries};
 use crate::utils::Timezone;
 
 use super::load_daily;
@@ -122,6 +122,24 @@ fn load_daily_dedup_reports_skipped_and_parse_errors() {
     assert_eq!(result.valid, 1);
     assert_eq!(result.skipped, 1);
     assert_eq!(result.parse_errors, 3);
+}
+
+#[test]
+fn load_entries_preserves_non_deduplicated_records_without_message_identity() {
+    let mut record = entry("unused", 10);
+    record.message_id = None;
+    record.stop_reason = None;
+    let source = TestSource {
+        needs_dedup: false,
+        files: vec![(PathBuf::from("usage.jsonl"), vec![record], 2)],
+    };
+
+    let (entries, skipped, parse_errors) = load_entries(&source, &filter(), tz());
+
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].input_tokens, 10);
+    assert_eq!(skipped, 0);
+    assert_eq!(parse_errors, 2);
 }
 
 #[test]

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -628,12 +628,12 @@ pub(crate) fn all_capabilities() -> Capabilities {
 pub(crate) use loader::{load_blocks, load_daily, load_projects, load_sessions};
 pub(crate) use tool_loader::load_tool_calls;
 
-pub(crate) fn load_deduped_entries(
+pub(crate) fn load_entries(
     source: &dyn Source,
     filter: &DateFilter,
     timezone: Timezone,
 ) -> (Vec<RawEntry>, i64, usize) {
-    loader::DataLoader::new(source, true, false).load_deduped_entries_incremental(filter, timezone)
+    loader::DataLoader::new(source, true, false).load_entries(filter, timezone)
 }
 
 /// Load per-endpoint stats (native vs proxy) for a source. Claude-only; other

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -628,6 +628,14 @@ pub(crate) fn all_capabilities() -> Capabilities {
 pub(crate) use loader::{load_blocks, load_daily, load_projects, load_sessions};
 pub(crate) use tool_loader::load_tool_calls;
 
+pub(crate) fn load_deduped_entries(
+    source: &dyn Source,
+    filter: &DateFilter,
+    timezone: Timezone,
+) -> (Vec<RawEntry>, i64, usize) {
+    loader::DataLoader::new(source, true, false).load_deduped_entries_incremental(filter, timezone)
+}
+
 /// Load per-endpoint stats (native vs proxy) for a source. Claude-only; other
 /// sources return empty. Lives here (not in `loader.rs`) to keep that file
 /// under the module size limit.


### PR DESCRIPTION
## Dependency

Stacked on #129. Merge #129 first, then retarget this PR to main.

## What this completes

- organize the desktop product around Observe, Explain, Trust, and Devices workflows
- discover all 29 registered providers and aggregate only sources that are ready at the time of refresh
- preserve provider total adjustments, parse quality, pricing source, usage basis, and API-equivalent coverage across Overview, Live, Projects, History, Top, Limits, and Cost evidence
- treat fallback, stale cache, mixed, proxy, and lower-bound amounts as review evidence instead of exact spend
- add local SQLite machine snapshots with guarded JSON import, canonical USD costs, CLI-timezone boundaries, and independent Today, Week, and Month freshness
- add activity evidence, responsive navigation, startup and request race guards, README coverage, and the product design contract

## Verification

- cargo fmt --all --check
- cargo clippy --all-targets -- -D warnings
- cargo test --all --no-fail-fast
- desktop Tauri fmt, clippy, and all tests: 13 passed
- npm run build
- renderer Playwright E2E: 26 passed
- native Tauri IPC E2E: 1 passed

Two independent final reviews reported no remaining P0 or P1 findings.