### PR TITLE
feat(desktop): publish installers on GitHub Releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ jobs:
         uses: EmbarkStudios/cargo-deny-action@v2
       - name: Test
         run: cargo test
+      - name: Release metadata
+        run: |
+          unset GITHUB_REF_NAME
+          scripts/check-release.sh
+          python3 scripts/stage-desktop-artifacts.py --self-test
 
   coverage:
     name: Coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,15 +136,6 @@ jobs:
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             args: --bundles msi
-    env:
-      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-      APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-      APPLE_ID: ${{ secrets.APPLE_ID }}
-      APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-      WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
-      WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
 
     steps:
       - uses: actions/checkout@v6
@@ -177,44 +168,6 @@ jobs:
         working-directory: desktop
         run: npm ci
 
-      - name: Use ad-hoc macOS signature without Developer ID
-        if: runner.os == 'macOS'
-        run: |
-          if [ -z "${APPLE_CERTIFICATE}" ]; then
-            echo "APPLE_SIGNING_IDENTITY=-" >> "$GITHUB_ENV"
-            echo "APPLE_CERTIFICATE is unset; using ad-hoc signing so Apple Silicon DMGs are not marked damaged."
-          fi
-
-      - name: Import Windows signing certificate
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          if ([string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE)) {
-            Write-Host "WINDOWS_CERTIFICATE is unset; building an unsigned MSI."
-            exit 0
-          }
-          $dir = Join-Path $env:RUNNER_TEMP "windows-cert"
-          New-Item -ItemType Directory -Force -Path $dir | Out-Null
-          $pfxPath = Join-Path $dir "certificate.pfx"
-          $bytes = [Convert]::FromBase64String($env:WINDOWS_CERTIFICATE.Trim())
-          [IO.File]::WriteAllBytes($pfxPath, $bytes)
-          $secure = ConvertTo-SecureString -String $env:WINDOWS_CERTIFICATE_PASSWORD -Force -AsPlainText
-          $imported = @(Import-PfxCertificate -FilePath $pfxPath -CertStoreLocation Cert:\CurrentUser\My -Password $secure)
-          $cert = $imported | Where-Object { $_.HasPrivateKey } | Select-Object -First 1
-          if (-not $cert) {
-            $cert = $imported | Select-Object -First 1
-          }
-          $thumb = $cert.Thumbprint
-          if (-not $thumb) {
-            throw "Imported WINDOWS_CERTIFICATE but could not read a thumbprint."
-          }
-          $configPath = Join-Path $pwd "desktop/src-tauri/ci-windows-signing.json"
-          $json = '{"bundle":{"windows":{"certificateThumbprint":"' + $thumb + '","digestAlgorithm":"sha256","timestampUrl":"http://timestamp.digicert.com"}}}'
-          $utf8 = New-Object System.Text.UTF8Encoding $false
-          [System.IO.File]::WriteAllText($configPath, $json, $utf8)
-          Add-Content -Path $env:GITHUB_ENV -Value "TAURI_EXTRA_ARGS=--config src-tauri/ci-windows-signing.json"
-          Write-Host "Imported Windows certificate $thumb"
-
       - name: Build desktop installer
         uses: tauri-apps/tauri-action@v1
         env:
@@ -222,7 +175,7 @@ jobs:
         with:
           projectPath: desktop
           includeUpdaterJson: false
-          args: ${{ matrix.args }} ${{ env.TAURI_EXTRA_ARGS }}
+          args: ${{ matrix.args }}
 
       - name: Stage desktop artifacts
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Validate release metadata
         run: scripts/check-release.sh
 
+      - name: Stage-artifact helper self-test
+        run: python3 scripts/stage-desktop-artifacts.py --self-test
+
       - name: Test
         run: cargo test --locked
 
@@ -26,7 +29,7 @@ jobs:
 
   publish:
     name: Publish crate
-    needs: [preflight, build]
+    needs: [preflight, build, desktop]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -110,9 +113,134 @@ jobs:
           name: ccstats-${{ matrix.target }}
           path: ccstats-${{ matrix.target }}.*
 
+  desktop:
+    name: Desktop ${{ matrix.target }}
+    needs: preflight
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            args: --target aarch64-apple-darwin --bundles dmg
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            args: --target x86_64-apple-darwin --bundles dmg
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-22.04
+            args: --bundles appimage
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-22.04-arm
+            args: --bundles appimage
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            args: --bundles msi
+    env:
+      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+      WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Linux bundle dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libfuse2 xdg-utils
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache Rust
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: desktop/src-tauri
+          prefix-key: desktop-${{ matrix.target }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: desktop/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: desktop
+        run: npm ci
+
+      - name: Use ad-hoc macOS signature without Developer ID
+        if: runner.os == 'macOS'
+        run: |
+          if [ -z "${APPLE_CERTIFICATE}" ]; then
+            echo "APPLE_SIGNING_IDENTITY=-" >> "$GITHUB_ENV"
+            echo "APPLE_CERTIFICATE is unset; using ad-hoc signing so Apple Silicon DMGs are not marked damaged."
+          fi
+
+      - name: Import Windows signing certificate
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE)) {
+            Write-Host "WINDOWS_CERTIFICATE is unset; building an unsigned MSI."
+            exit 0
+          }
+          $dir = Join-Path $env:RUNNER_TEMP "windows-cert"
+          New-Item -ItemType Directory -Force -Path $dir | Out-Null
+          $pfxPath = Join-Path $dir "certificate.pfx"
+          $bytes = [Convert]::FromBase64String($env:WINDOWS_CERTIFICATE.Trim())
+          [IO.File]::WriteAllBytes($pfxPath, $bytes)
+          $secure = ConvertTo-SecureString -String $env:WINDOWS_CERTIFICATE_PASSWORD -Force -AsPlainText
+          $imported = @(Import-PfxCertificate -FilePath $pfxPath -CertStoreLocation Cert:\CurrentUser\My -Password $secure)
+          $cert = $imported | Where-Object { $_.HasPrivateKey } | Select-Object -First 1
+          if (-not $cert) {
+            $cert = $imported | Select-Object -First 1
+          }
+          $thumb = $cert.Thumbprint
+          if (-not $thumb) {
+            throw "Imported WINDOWS_CERTIFICATE but could not read a thumbprint."
+          }
+          $configPath = Join-Path $pwd "desktop/src-tauri/ci-windows-signing.json"
+          $json = '{"bundle":{"windows":{"certificateThumbprint":"' + $thumb + '","digestAlgorithm":"sha256","timestampUrl":"http://timestamp.digicert.com"}}}'
+          $utf8 = New-Object System.Text.UTF8Encoding $false
+          [System.IO.File]::WriteAllText($configPath, $json, $utf8)
+          Add-Content -Path $env:GITHUB_ENV -Value "TAURI_EXTRA_ARGS=--config src-tauri/ci-windows-signing.json"
+          Write-Host "Imported Windows certificate $thumb"
+
+      - name: Build desktop installer
+        uses: tauri-apps/tauri-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          projectPath: desktop
+          includeUpdaterJson: false
+          args: ${{ matrix.args }} ${{ env.TAURI_EXTRA_ARGS }}
+
+      - name: Stage desktop artifacts
+        shell: bash
+        run: |
+          python3 scripts/stage-desktop-artifacts.py \
+            --search-root desktop/src-tauri/target \
+            --output-dir staged-desktop \
+            --target "${{ matrix.target }}"
+
+      - name: Upload desktop artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: ccstats-desktop-${{ matrix.target }}
+          path: staged-desktop/ccstats-desktop-${{ matrix.target }}.*
+
   release:
     name: Create Release
-    needs: [build, publish]
+    needs: [build, desktop, publish]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,8 @@ jobs:
     name: Desktop ${{ matrix.target }}
     needs: preflight
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -131,7 +133,7 @@ jobs:
             os: ubuntu-22.04
             args: --bundles appimage
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-22.04-arm
+            os: ubuntu-24.04-arm
             args: --bundles appimage
           - target: x86_64-pc-windows-msvc
             os: windows-latest
@@ -168,14 +170,100 @@ jobs:
         working-directory: desktop
         run: npm ci
 
-      - name: Build desktop installer
-        uses: tauri-apps/tauri-action@v1
+      - name: Build Linux installer
+        if: runner.os == 'Linux'
+        working-directory: desktop
+        run: npm run tauri -- build ${{ matrix.args }}
+
+      - name: Build signed and notarized macOS installer
+        if: runner.os == 'macOS'
+        working-directory: desktop
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          projectPath: desktop
-          includeUpdaterJson: false
-          args: ${{ matrix.args }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          for name in APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_SIGNING_IDENTITY APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID; do
+            if [ -z "$(printenv "$name")" ]; then
+              echo "::error::$name must be configured for signed macOS releases"
+              exit 1
+            fi
+          done
+          npm run tauri -- build ${{ matrix.args }}
+          dmg_path="$(find src-tauri/target -type f -name '*.dmg' -print -quit)"
+          if [ -z "$dmg_path" ]; then
+            echo "::error::Signed macOS build did not produce a DMG."
+            exit 1
+          fi
+          xcrun stapler validate "$dmg_path"
+          spctl --assess --type open --context context:primary-signature --verbose=2 "$dmg_path"
+
+      - name: Build signed Windows installer
+        if: runner.os == 'Windows'
+        working-directory: desktop
+        shell: pwsh
+        env:
+          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE)) {
+            throw "WINDOWS_CERTIFICATE must be configured for signed Windows releases"
+          }
+          if ([string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE_PASSWORD)) {
+            throw "WINDOWS_CERTIFICATE_PASSWORD must be configured for signed Windows releases"
+          }
+
+          $certificatePath = Join-Path $env:RUNNER_TEMP "ccstats-code-signing.pfx"
+          $configPath = Join-Path $env:RUNNER_TEMP "ccstats-windows-signing.json"
+          $importedCertificates = @()
+          $certificate = $null
+          try {
+            [IO.File]::WriteAllBytes(
+              $certificatePath,
+              [Convert]::FromBase64String($env:WINDOWS_CERTIFICATE)
+            )
+            $password = ConvertTo-SecureString $env:WINDOWS_CERTIFICATE_PASSWORD -AsPlainText -Force
+            $importedCertificates = @(Import-PfxCertificate `
+                -FilePath $certificatePath `
+                -CertStoreLocation Cert:\CurrentUser\My `
+                -Password $password)
+            $certificate = $importedCertificates |
+              Where-Object { $_.HasPrivateKey } |
+              Select-Object -First 1
+            if ($null -eq $certificate -or [string]::IsNullOrWhiteSpace($certificate.Thumbprint)) {
+              throw "The Windows code-signing certificate could not be imported."
+            }
+            @{
+              bundle = @{
+                windows = @{
+                  certificateThumbprint = $certificate.Thumbprint
+                  digestAlgorithm = "sha256"
+                  timestampUrl = "http://timestamp.digicert.com"
+                }
+              }
+            } | ConvertTo-Json -Depth 4 -Compress | Set-Content -Encoding utf8 $configPath
+            Remove-Item Env:WINDOWS_CERTIFICATE, Env:WINDOWS_CERTIFICATE_PASSWORD
+            npm run tauri -- build ${{ matrix.args }} --config $configPath
+            if ($LASTEXITCODE -ne 0) {
+              throw "Tauri Windows build failed with exit code $LASTEXITCODE"
+            }
+            $installers = @(Get-ChildItem src-tauri/target -Recurse -Filter *.msi)
+            if ($installers.Count -ne 1) {
+              throw "Expected exactly one Windows MSI, found $($installers.Count)."
+            }
+            $signature = Get-AuthenticodeSignature $installers[0].FullName
+            if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid) {
+              throw "Windows MSI Authenticode verification failed: $($signature.StatusMessage)"
+            }
+          } finally {
+            Remove-Item $certificatePath, $configPath -Force -ErrorAction SilentlyContinue
+            foreach ($importedCertificate in $importedCertificates) {
+              Remove-Item "Cert:\CurrentUser\My\$($importedCertificate.Thumbprint)" -Force
+            }
+          }
 
       - name: Stage desktop artifacts
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,9 +132,11 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-22.04
             args: --bundles appimage
+            fuse_package: libfuse2
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
             args: --bundles appimage
+            fuse_package: libfuse2t64
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             args: --bundles msi
@@ -146,7 +148,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libfuse2 xdg-utils
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf ${{ matrix.fuse_package }} xdg-utils
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,5 @@
 /desktop/playwright-report/
 /desktop/src-tauri/gen/
 /desktop/src-tauri/target/
-/desktop/src-tauri/ci-windows-signing.json
 src/**/CLAUDE.md
 tests/CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 /desktop/playwright-report/
 /desktop/src-tauri/gen/
 /desktop/src-tauri/target/
+/desktop/src-tauri/ci-windows-signing.json
 src/**/CLAUDE.md
 tests/CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- Desktop DMG, MSI, and AppImage installers on the existing `v*` GitHub Release workflow. Developer ID notarization and Windows Authenticode signing run when repository secrets are configured.
+- Desktop DMG, MSI, and AppImage installers on the existing `v*` GitHub Release workflow.
 - `--source-breakdown` for `--source all` (per-source subtotals + combined total). Default combined output unchanged. Monthly `--monthly-budget --csv` keeps budget columns.
 - Expose `cache_creation_1h_tokens` in JSON, CSV, and SDK `TokenBreakdown`. `cache_creation_tokens` remains the inclusive cache-creation total; the 1-hour figure is a billed subset, not a sixth token bucket.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Desktop DMG, MSI, and AppImage installers on the existing `v*` GitHub Release workflow. Developer ID notarization and Windows Authenticode signing run when repository secrets are configured.
 - `--source-breakdown` for `--source all` (per-source subtotals + combined total). Default combined output unchanged. Monthly `--monthly-budget --csv` keeps budget columns.
 - Expose `cache_creation_1h_tokens` in JSON, CSV, and SDK `TokenBreakdown`. `cache_creation_tokens` remains the inclusive cache-creation total; the 1-hour figure is a billed subset, not a sixth token bucket.
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ npm run tauri -- build
 ```
 
 macOS produces a DMG, Windows an MSI, and Linux an AppImage. See
-[docs/RELEASING.md](docs/RELEASING.md) for signed GitHub Release artifacts.
+[docs/RELEASING.md](docs/RELEASING.md) for GitHub Release artifacts.
 
 Focused desktop checks:
 
@@ -179,10 +179,6 @@ Download installers and SHA-256 checksums from [GitHub Releases](https://github.
 
 The desktop app is a local investigation surface over the same accounting
 engine as the CLI. It does not create a ccstats account or upload transcripts.
-
-Until Apple Developer ID and Windows Authenticode secrets are configured,
-macOS Gatekeeper and Windows SmartScreen may require a manual allow. See
-[docs/RELEASING.md](docs/RELEASING.md) for the signing setup.
 
 ### Manual download
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,13 @@ Download installers and SHA-256 checksums from [GitHub Releases](https://github.
 - Linux x64: `ccstats-desktop-x86_64-unknown-linux-gnu.AppImage`
 - Linux ARM64: `ccstats-desktop-aarch64-unknown-linux-gnu.AppImage`
 
+Make an AppImage executable before launching it:
+
+```bash
+chmod +x ccstats-desktop-*.AppImage
+./ccstats-desktop-x86_64-unknown-linux-gnu.AppImage
+```
+
 The desktop app is a local investigation surface over the same accounting
 engine as the CLI. It does not create a ccstats account or upload transcripts.
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,18 @@ usage backed by recorded, live, or fresh cached pricing with complete coverage
 as exact cost. Machine totals use canonical USD and evaluate Today, This week,
 and This month freshness independently using the configured CLI timezone.
 
+Production installers are built from `desktop/` by the tag-triggered Release
+workflow. Local packaging:
+
+```bash
+cd desktop
+npm ci
+npm run tauri -- build
+```
+
+macOS produces a DMG, Windows an MSI, and Linux an AppImage. See
+[docs/RELEASING.md](docs/RELEASING.md) for signed GitHub Release artifacts.
+
 Focused desktop checks:
 
 ```bash
@@ -91,10 +103,6 @@ before the page loads. Rust tests cover the command boundary, and the native tes
 launches a debug app through an embedded WebDriver before crossing Tauri IPC into
 the real ccstats SDK. Production builds call those commands directly and have no
 sample-data fallback.
-
-The desktop target is currently a development target in this repository; the
-CLI remains the installable release artifact until signed desktop packages are
-added to the release workflow.
 
 Usage files and transcripts remain local; pricing refreshes and sources configured
 with remote APIs may still make their documented network requests.
@@ -159,9 +167,26 @@ curl -fsSL https://raw.githubusercontent.com/majiayu000/ccstats/main/install.sh 
 curl -fsSL https://raw.githubusercontent.com/majiayu000/ccstats/main/install.sh | VERSION=v0.5.0 sh
 ```
 
+### Desktop app
+
+Download installers and SHA-256 checksums from [GitHub Releases](https://github.com/majiayu000/ccstats/releases):
+
+- macOS Apple Silicon: `ccstats-desktop-aarch64-apple-darwin.dmg`
+- macOS Intel: `ccstats-desktop-x86_64-apple-darwin.dmg`
+- Windows: `ccstats-desktop-x86_64-pc-windows-msvc.msi`
+- Linux x64: `ccstats-desktop-x86_64-unknown-linux-gnu.AppImage`
+- Linux ARM64: `ccstats-desktop-aarch64-unknown-linux-gnu.AppImage`
+
+The desktop app is a local investigation surface over the same accounting
+engine as the CLI. It does not create a ccstats account or upload transcripts.
+
+Until Apple Developer ID and Windows Authenticode secrets are configured,
+macOS Gatekeeper and Windows SmartScreen may require a manual allow. See
+[docs/RELEASING.md](docs/RELEASING.md) for the signing setup.
+
 ### Manual download
 
-Download prebuilt archives and SHA-256 checksums from [GitHub Releases](https://github.com/majiayu000/ccstats/releases).
+Download prebuilt CLI archives and SHA-256 checksums from [GitHub Releases](https://github.com/majiayu000/ccstats/releases).
 
 ### Upgrade and uninstall
 

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccstats-desktop",
-  "version": "0.1.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccstats-desktop",
-      "version": "0.1.0",
+      "version": "0.5.1",
       "dependencies": {
         "@fontsource/ibm-plex-mono": "5.3.0",
         "@fontsource/manrope": "5.3.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ccstats-desktop",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "ccstats-desktop"
-version = "0.1.0"
+version = "0.5.1"
 dependencies = [
  "ccstats",
  "chrono",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccstats-desktop"
-version = "0.1.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -27,7 +27,6 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["dmg", "msi", "appimage"],
     "createUpdaterArtifacts": false,
     "category": "DeveloperTool",
     "shortDescription": "Local AI coding usage analytics",
@@ -39,8 +38,7 @@
     ],
     "macOS": {
       "hardenedRuntime": true,
-      "minimumSystemVersion": "11.0",
-      "signingIdentity": "-"
+      "minimumSystemVersion": "11.0"
     },
     "linux": {
       "appimage": {

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ccstats",
-  "version": "0.1.0",
+  "version": "0.5.1",
   "identifier": "io.ccstats.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -27,11 +27,28 @@
   },
   "bundle": {
     "active": true,
+    "targets": ["dmg", "msi", "appimage"],
+    "createUpdaterArtifacts": false,
+    "category": "DeveloperTool",
+    "shortDescription": "Local AI coding usage analytics",
     "icon": [
       "../../docs/branding/final/icon-32.png",
       "../../docs/branding/final/icon-128.png",
       "../../docs/branding/final/icon-256.png",
       "../../docs/branding/final/icon-512.png"
-    ]
+    ],
+    "macOS": {
+      "hardenedRuntime": true,
+      "minimumSystemVersion": "11.0"
+    },
+    "windows": {
+      "digestAlgorithm": "sha256",
+      "timestampUrl": "http://timestamp.digicert.com"
+    },
+    "linux": {
+      "appimage": {
+        "bundleMediaFramework": false
+      }
+    }
   }
 }

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -39,11 +39,8 @@
     ],
     "macOS": {
       "hardenedRuntime": true,
-      "minimumSystemVersion": "11.0"
-    },
-    "windows": {
-      "digestAlgorithm": "sha256",
-      "timestampUrl": "http://timestamp.digicert.com"
+      "minimumSystemVersion": "11.0",
+      "signingIdentity": "-"
     },
     "linux": {
       "appimage": {

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,9 +1,59 @@
 # Releasing ccstats
 
-Releases are tag-driven. A successful release publishes the crate first, then
-creates the multi-platform GitHub Release and updates the Homebrew formula.
-This ordering prevents the Homebrew formula from pointing at a crate version
-that does not exist.
+Releases are tag-driven. A successful release builds CLI binaries and desktop
+installers in parallel, publishes the crate, then creates the GitHub Release
+and updates the Homebrew formula. Crate publish waits for both CLI and desktop
+artifacts so a failed installer build cannot ship a crate without matching
+GitHub assets. Homebrew still waits for the crates.io `.crate` to exist.
+
+## Desktop installers
+
+The same `v*` tag also builds desktop installers and attaches them to the
+GitHub Release:
+
+- macOS: `ccstats-desktop-aarch64-apple-darwin.dmg` and
+  `ccstats-desktop-x86_64-apple-darwin.dmg`
+- Windows: `ccstats-desktop-x86_64-pc-windows-msvc.msi`
+- Linux: `ccstats-desktop-x86_64-unknown-linux-gnu.AppImage` and
+  `ccstats-desktop-aarch64-unknown-linux-gnu.AppImage`
+
+Each installer has a matching `.sha256` sidecar. The workflow builds unsigned
+or ad-hoc packages when signing secrets are missing so the pipeline can be
+tested without certificates. Gatekeeper and SmartScreen stay noisy until the
+secrets below are set.
+
+Do not enable app sandboxing. The desktop app reads local agent logs under the
+user home directory.
+
+### Signing secrets
+
+Configure these GitHub Actions secrets on `majiayu000/ccstats`. Leave them
+unset to publish ad-hoc macOS DMGs and unsigned Windows MSIs.
+
+#### macOS Developer ID + notarization
+
+| Secret | Value |
+| --- | --- |
+| `APPLE_CERTIFICATE` | Base64-encoded Developer ID Application `.p12` |
+| `APPLE_CERTIFICATE_PASSWORD` | Password for that `.p12` |
+| `APPLE_SIGNING_IDENTITY` | Identity string from `security find-identity -v -p codesigning`, for example `Developer ID Application: Name (TEAMID)` |
+| `APPLE_ID` | Apple ID email |
+| `APPLE_PASSWORD` | App-specific password, not the account password |
+| `APPLE_TEAM_ID` | 10-character Team ID |
+
+All six are required for a notarized DMG. A Developer ID certificate without
+notarization credentials will fail the macOS desktop job.
+
+#### Windows Authenticode
+
+| Secret | Value |
+| --- | --- |
+| `WINDOWS_CERTIFICATE` | Base64-encoded `.pfx` |
+| `WINDOWS_CERTIFICATE_PASSWORD` | Export password for that `.pfx` |
+
+The Windows job imports the certificate into the runner certificate store and
+passes the thumbprint into Tauri for the MSI. Linux AppImages are checksummed
+only; do not add a GPG signing step in this workflow.
 
 ## One-time crates.io setup
 
@@ -25,7 +75,10 @@ The existing `HOMEBREW_TAP_TOKEN` secret must retain permission to update
 
 ## Release checklist
 
-1. Update the version in `Cargo.toml` and `Cargo.lock`.
+1. Update the version in `Cargo.toml`, `Cargo.lock`, `desktop/package.json`,
+   `desktop/package-lock.json`, `desktop/src-tauri/Cargo.toml`,
+   `desktop/src-tauri/Cargo.lock`, and `desktop/src-tauri/tauri.conf.json`.
+   `scripts/check-release.sh` rejects a tag if any of these drift.
 2. Move the relevant entries from `Unreleased` into a dated version section in
    `CHANGELOG.md`.
 3. Run the same preflight checks used by CI:
@@ -36,6 +89,8 @@ The existing `HOMEBREW_TAP_TOKEN` secret must retain permission to update
    cargo test --all-targets --all-features
    cargo deny check
    cargo publish --dry-run --locked
+   scripts/check-release.sh
+   python3 scripts/stage-desktop-artifacts.py --self-test
    ```
 
 4. Create and push the matching tag, for example `v0.5.1` for version `0.5.1`.
@@ -49,11 +104,16 @@ workflow as sufficient:
 ```bash
 cargo search ccstats --limit 1
 gh release view v0.5.1 --repo majiayu000/ccstats
+gh release view v0.5.1 --repo majiayu000/ccstats --json assets --jq '.assets[].name'
 brew update
 brew info majiayu000/tap/ccstats
 cargo binstall ccstats --no-confirm
 ccstats --version
 ```
+
+Confirm the GitHub Release includes both CLI archives and the five desktop
+installers plus checksums. On macOS, a notarized build reports
+`source=Notarized Developer ID` from `spctl --assess --verbose`.
 
 crates.io indexing and Homebrew tap updates can lag briefly. The published
 version, release assets, and formula must all agree before announcing a

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -17,43 +17,13 @@ GitHub Release:
 - Linux: `ccstats-desktop-x86_64-unknown-linux-gnu.AppImage` and
   `ccstats-desktop-aarch64-unknown-linux-gnu.AppImage`
 
-Each installer has a matching `.sha256` sidecar. The workflow builds unsigned
-or ad-hoc packages when signing secrets are missing so the pipeline can be
-tested without certificates. Gatekeeper and SmartScreen stay noisy until the
-secrets below are set.
+Each installer has a matching `.sha256` sidecar. macOS DMGs use an ad-hoc
+signature so Apple Silicon downloads are not marked damaged. Windows MSIs are
+unsigned. macOS Gatekeeper or Windows SmartScreen may ask for a manual allow
+on first open.
 
 Do not enable app sandboxing. The desktop app reads local agent logs under the
 user home directory.
-
-### Signing secrets
-
-Configure these GitHub Actions secrets on `majiayu000/ccstats`. Leave them
-unset to publish ad-hoc macOS DMGs and unsigned Windows MSIs.
-
-#### macOS Developer ID + notarization
-
-| Secret | Value |
-| --- | --- |
-| `APPLE_CERTIFICATE` | Base64-encoded Developer ID Application `.p12` |
-| `APPLE_CERTIFICATE_PASSWORD` | Password for that `.p12` |
-| `APPLE_SIGNING_IDENTITY` | Identity string from `security find-identity -v -p codesigning`, for example `Developer ID Application: Name (TEAMID)` |
-| `APPLE_ID` | Apple ID email |
-| `APPLE_PASSWORD` | App-specific password, not the account password |
-| `APPLE_TEAM_ID` | 10-character Team ID |
-
-All six are required for a notarized DMG. A Developer ID certificate without
-notarization credentials will fail the macOS desktop job.
-
-#### Windows Authenticode
-
-| Secret | Value |
-| --- | --- |
-| `WINDOWS_CERTIFICATE` | Base64-encoded `.pfx` |
-| `WINDOWS_CERTIFICATE_PASSWORD` | Export password for that `.pfx` |
-
-The Windows job imports the certificate into the runner certificate store and
-passes the thumbprint into Tauri for the MSI. Linux AppImages are checksummed
-only; do not add a GPG signing step in this workflow.
 
 ## One-time crates.io setup
 
@@ -112,8 +82,7 @@ ccstats --version
 ```
 
 Confirm the GitHub Release includes both CLI archives and the five desktop
-installers plus checksums. On macOS, a notarized build reports
-`source=Notarized Developer ID` from `spctl --assess --verbose`.
+installers plus checksums.
 
 crates.io indexing and Homebrew tap updates can lag briefly. The published
 version, release assets, and formula must all agree before announcing a

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -17,10 +17,34 @@ GitHub Release:
 - Linux: `ccstats-desktop-x86_64-unknown-linux-gnu.AppImage` and
   `ccstats-desktop-aarch64-unknown-linux-gnu.AppImage`
 
-Each installer has a matching `.sha256` sidecar. macOS DMGs use an ad-hoc
-signature so Apple Silicon downloads are not marked damaged. Windows MSIs are
-unsigned. macOS Gatekeeper or Windows SmartScreen may ask for a manual allow
-on first open.
+Each installer has a matching `.sha256` sidecar. macOS apps use a Developer ID
+certificate and are notarized before the DMG is created. Windows MSIs use an
+Authenticode certificate and a trusted timestamp. The release fails instead
+of publishing unsigned macOS or Windows installers when credentials are absent.
+
+Configure these GitHub Actions secrets before pushing a release tag:
+
+- `APPLE_CERTIFICATE`: base64-encoded Developer ID Application `.p12`
+- `APPLE_CERTIFICATE_PASSWORD`: password for that `.p12`
+- `APPLE_SIGNING_IDENTITY`: full Developer ID Application identity
+- `APPLE_ID`: Apple account used for notarization
+- `APPLE_PASSWORD`: app-specific password for that account
+- `APPLE_TEAM_ID`: Apple Developer team identifier
+- `WINDOWS_CERTIFICATE`: base64-encoded Authenticode `.pfx`
+- `WINDOWS_CERTIFICATE_PASSWORD`: password for that `.pfx`
+
+Rotate a certificate by replacing its certificate and password secrets before
+the old certificate expires, then verify the next release with `codesign` and
+`Get-AuthenticodeSignature`. Revoke the old certificate after verification.
+Certificate contents and passwords must never be committed or printed in logs.
+
+Contributors can build unsigned packages locally without release credentials:
+
+```bash
+cd desktop
+npm ci
+npm run tauri -- build
+```
 
 Do not enable app sandboxing. The desktop app reads local agent logs under the
 user home directory.
@@ -64,7 +88,9 @@ The existing `HOMEBREW_TAP_TOKEN` secret must retain permission to update
    ```
 
 4. Create and push the matching tag, for example `v0.5.1` for version `0.5.1`.
-5. Confirm every job in the Release workflow succeeds.
+5. Confirm every job in the Release workflow succeeds. The workflow validates
+   the macOS notarization staple and Gatekeeper assessment, and rejects a
+   Windows MSI unless PowerShell reports a valid Authenticode signature.
 
 ## Public verification
 

--- a/scripts/check-release.sh
+++ b/scripts/check-release.sh
@@ -3,34 +3,60 @@
 
 set -eu
 
-manifest_version() {
-    sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)"/\1/p' Cargo.toml | head -n 1
+toml_version() {
+    sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)"/\1/p' "$1" | head -n 1
 }
 
-lock_version() {
-    awk '
-        /^\[\[package\]\]/ { in_pkg = 0; name = ""; version = "" }
-        /^name = "ccstats"$/ { in_pkg = 1; name = "ccstats" }
-        in_pkg && /^version = / {
-            gsub(/version = "/, "");
-            gsub(/"/, "");
-            print;
-            exit;
+package_lock_version() {
+    lockfile=$1
+    package=$2
+    awk -v pkg="$package" '
+        /^\[\[package\]\]/ { in_pkg = 0 }
+        /^name = "/ {
+            name = $0
+            sub(/^name = "/, "", name)
+            sub(/"$/, "", name)
+            in_pkg = (name == pkg)
         }
-    ' Cargo.lock
+        in_pkg && /^version = "/ {
+            gsub(/version = "/, "")
+            gsub(/"/, "")
+            print
+            exit
+        }
+    ' "$lockfile"
 }
 
-version="$(manifest_version)"
+json_top_version() {
+    python3 -c 'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["version"])' "$1"
+}
+
+require_same() {
+    label=$1
+    actual=$2
+    expected=$3
+    if [ -z "$actual" ]; then
+        echo "Failed to read version from $label." >&2
+        exit 1
+    fi
+    if [ "$actual" != "$expected" ]; then
+        echo "$label version ($actual) does not match crate version ($expected)." >&2
+        exit 1
+    fi
+}
+
+version="$(toml_version Cargo.toml)"
 if [ -z "$version" ]; then
     echo "Failed to read package version from Cargo.toml" >&2
     exit 1
 fi
 
-locked_version="$(lock_version)"
-if [ "$locked_version" != "$version" ]; then
-    echo "Cargo.lock version ($locked_version) does not match Cargo.toml version ($version)." >&2
-    exit 1
-fi
+require_same "Cargo.lock" "$(package_lock_version Cargo.lock ccstats)" "$version"
+require_same "desktop/src-tauri/Cargo.toml" "$(toml_version desktop/src-tauri/Cargo.toml)" "$version"
+require_same "desktop/src-tauri/Cargo.lock" "$(package_lock_version desktop/src-tauri/Cargo.lock ccstats-desktop)" "$version"
+require_same "desktop/src-tauri/tauri.conf.json" "$(json_top_version desktop/src-tauri/tauri.conf.json)" "$version"
+require_same "desktop/package.json" "$(json_top_version desktop/package.json)" "$version"
+require_same "desktop/package-lock.json" "$(json_top_version desktop/package-lock.json)" "$version"
 
 expected_tag="v$version"
 actual_tag="${GITHUB_REF_NAME:-}"

--- a/scripts/stage-desktop-artifacts.py
+++ b/scripts/stage-desktop-artifacts.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Copy the Tauri installer to a stable GitHub Release name and write a SHA-256 sidecar."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+import tempfile
+from pathlib import Path
+
+INSTALLER_SUFFIXES = {".dmg", ".msi", ".appimage"}
+
+
+def canonical_suffix(path: Path) -> str:
+    lowered = path.suffix.lower()
+    if lowered == ".appimage":
+        return ".AppImage"
+    if lowered == ".msi":
+        return ".msi"
+    if lowered == ".dmg":
+        return ".dmg"
+    raise ValueError(f"unsupported installer suffix: {path}")
+
+
+def find_installers(search_root: Path) -> list[Path]:
+    found = [
+        path
+        for path in search_root.rglob("*")
+        if path.is_file() and path.suffix.lower() in INSTALLER_SUFFIXES
+    ]
+    return sorted(found)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def stage(search_root: Path, output_dir: Path, target: str) -> Path:
+    installers = find_installers(search_root)
+    if len(installers) != 1:
+        names = ", ".join(str(path) for path in installers) or "(none)"
+        raise SystemExit(
+            f"expected exactly one installer under {search_root}, found: {names}"
+        )
+    source = installers[0]
+    output_dir.mkdir(parents=True, exist_ok=True)
+    destination = output_dir / f"ccstats-desktop-{target}{canonical_suffix(source)}"
+    destination.write_bytes(source.read_bytes())
+    sidecar = output_dir / f"{destination.name}.sha256"
+    sidecar.write_text(
+        f"{sha256_file(destination)}  {destination.name}\n", encoding="ascii"
+    )
+    print(destination)
+    print(sidecar)
+    return destination
+
+
+def self_test() -> None:
+    cases = [
+        ("ccstats_0.5.1_aarch64.dmg", "aarch64-apple-darwin", ".dmg"),
+        ("ccstats_0.5.1_x64_en-US.msi", "x86_64-pc-windows-msvc", ".msi"),
+        ("ccstats_0.5.1_amd64.AppImage", "x86_64-unknown-linux-gnu", ".AppImage"),
+    ]
+    for filename, target, suffix in cases:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            bundle = root / "bundle"
+            bundle.mkdir()
+            (bundle / filename).write_bytes(filename.encode("utf-8"))
+            staged = stage(bundle, root / "staged", target)
+            expected = root / "staged" / f"ccstats-desktop-{target}{suffix}"
+            if staged != expected:
+                raise SystemExit(f"staged path {staged} != {expected}")
+            sidecar = expected.with_name(expected.name + ".sha256")
+            digest = sha256_file(expected)
+            expected_sidecar = f"{digest}  {expected.name}\n"
+            if sidecar.read_text(encoding="ascii") != expected_sidecar:
+                raise SystemExit(f"checksum mismatch for {target}")
+    print("stage-desktop-artifacts self-test passed")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--search-root", type=Path)
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--target")
+    args = parser.parse_args()
+    if args.self_test:
+        self_test()
+        return 0
+    if args.search_root is None or args.output_dir is None or args.target is None:
+        parser.error("--search-root, --output-dir, and --target are required")
+    stage(args.search_root, args.output_dir, args.target)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/public_readiness.rs
+++ b/tests/public_readiness.rs
@@ -20,8 +20,8 @@ fn crate_publish_waits_for_every_platform_build() {
         .expect("homebrew job")
         .1;
 
-    assert!(publish.contains("needs: [preflight, build]"));
-    assert!(release.contains("needs: [build, publish]"));
+    assert!(publish.contains("needs: [preflight, build, desktop]"));
+    assert!(release.contains("needs: [build, desktop, publish]"));
     assert!(homebrew.contains("needs: release"));
 }
 


### PR DESCRIPTION
## Summary
- Extend the existing `v*` release workflow so one tag builds CLI archives plus macOS DMGs, a Windows MSI, and Linux AppImages, each with a SHA-256 sidecar.
- Require Developer ID signing and notarization for macOS and Authenticode signing for Windows. Missing credentials fail the release instead of silently publishing unsigned installers.
- Keep signing secrets scoped to their OS-specific build steps, verify the macOS notarization staple and Gatekeeper assessment, and require a valid MSI Authenticode signature.
- Align desktop versions with the CLI and reject version drift in `scripts/check-release.sh`.

Closes #154.

## Verification
- `scripts/check-release.sh`
- `python3 scripts/stage-desktop-artifacts.py --self-test`
- workflow YAML and Tauri JSON parse checks
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (686 library tests plus all integration tests)
- clean local `npm ci` followed by `npm run tauri -- build --bundles dmg`

## Operations prerequisite
The required Apple and Windows certificate secrets must be configured before the next `v*` tag. The workflow intentionally blocks release if they are absent.