### PR TITLE
fix(release): import Apple signing certificate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,20 +196,39 @@ jobs:
           done
 
           original_keychain="$(security default-keychain -d user | tr -d '"')"
+          original_keychains=()
+          while IFS= read -r existing_keychain; do
+            if [ -n "$existing_keychain" ]; then
+              original_keychains+=("$existing_keychain")
+            fi
+          done < <(
+            security list-keychains -d user \
+              | sed -E 's/^[[:space:]]*"//; s/"[[:space:]]*$//'
+          )
           keychain_path="$RUNNER_TEMP/ccstats-signing.keychain-db"
           certificate_path="$RUNNER_TEMP/ccstats-developer-id.p12"
           keychain_password="$(openssl rand -hex 32)"
 
           cleanup_signing() {
+            status=$?
             rm -f "$certificate_path"
-            security default-keychain -d user -s "$original_keychain" || true
-            security delete-keychain "$keychain_path" 2>/dev/null || true
+            if ! security default-keychain -d user -s "$original_keychain"; then
+              echo "::warning::Failed to restore the default macOS keychain"
+            fi
+            if ! security list-keychains -d user -s "${original_keychains[@]}"; then
+              echo "::warning::Failed to restore the macOS keychain search list"
+            fi
+            if ! security delete-keychain "$keychain_path"; then
+              echo "::warning::Failed to delete the temporary macOS signing keychain"
+            fi
+            return "$status"
           }
           trap cleanup_signing EXIT
 
           printf '%s' "$APPLE_CERTIFICATE" | base64 --decode > "$certificate_path"
           security create-keychain -p "$keychain_password" "$keychain_path"
           security default-keychain -d user -s "$keychain_path"
+          security list-keychains -d user -s "$keychain_path" "${original_keychains[@]}"
           security unlock-keychain -p "$keychain_password" "$keychain_path"
           security set-keychain-settings -lut 21600 "$keychain_path"
           security import "$certificate_path" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,6 +194,42 @@ jobs:
               exit 1
             fi
           done
+
+          original_keychain="$(security default-keychain -d user | tr -d '"')"
+          keychain_path="$RUNNER_TEMP/ccstats-signing.keychain-db"
+          certificate_path="$RUNNER_TEMP/ccstats-developer-id.p12"
+          keychain_password="$(openssl rand -hex 32)"
+
+          cleanup_signing() {
+            rm -f "$certificate_path"
+            security default-keychain -d user -s "$original_keychain" || true
+            security delete-keychain "$keychain_path" 2>/dev/null || true
+          }
+          trap cleanup_signing EXIT
+
+          printf '%s' "$APPLE_CERTIFICATE" | base64 --decode > "$certificate_path"
+          security create-keychain -p "$keychain_password" "$keychain_path"
+          security default-keychain -d user -s "$keychain_path"
+          security unlock-keychain -p "$keychain_password" "$keychain_path"
+          security set-keychain-settings -lut 21600 "$keychain_path"
+          security import "$certificate_path" \
+            -k "$keychain_path" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s \
+            -k "$keychain_password" \
+            "$keychain_path"
+
+          if ! security find-identity -v -p codesigning "$keychain_path" \
+            | grep -F -- "$APPLE_SIGNING_IDENTITY" >/dev/null; then
+            echo "::error::APPLE_SIGNING_IDENTITY was not found in the imported certificate"
+            exit 1
+          fi
+
+          rm -f "$certificate_path"
+          unset APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD keychain_password
           npm run tauri -- build ${{ matrix.args }}
           dmg_path="$(find src-tauri/target -type f -name '*.dmg' -print -quit)"
           if [ -z "$dmg_path" ]; then


### PR DESCRIPTION
## Summary

- create an ephemeral macOS keychain for the Developer ID certificate
- verify that the configured signing identity is available before building
- remove certificate material and restore the runner keychain after the build

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`
- `env -u GITHUB_REF_NAME scripts/check-release.sh`
- `python3 scripts/stage-desktop-artifacts.py --self-test`
- `cargo test --test public_readiness`
- `git diff --check`

Refs #154