### PR TITLE
fix(release): allow unsigned desktop installers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,12 +196,13 @@ jobs:
           done
 
           if [ "$apple_signing_count" -eq 0 ]; then
-            echo "::warning::Apple signing credentials are not configured; publishing an unsigned macOS installer."
+            echo "::warning::Apple signing credentials are not configured; publishing an ad-hoc-signed macOS installer."
             unset APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_SIGNING_IDENTITY APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID
+            export APPLE_SIGNING_IDENTITY=-
             npm run tauri -- build ${{ matrix.args }}
             dmg_path="$(find src-tauri/target -type f -name '*.dmg' -print -quit)"
             if [ -z "$dmg_path" ]; then
-              echo "::error::Unsigned macOS build did not produce a DMG."
+              echo "::error::Ad-hoc-signed macOS build did not produce a DMG."
               exit 1
             fi
             exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,7 +177,7 @@ jobs:
         working-directory: desktop
         run: npm run tauri -- build ${{ matrix.args }}
 
-      - name: Build signed and notarized macOS installer
+      - name: Build macOS installer
         if: runner.os == 'macOS'
         working-directory: desktop
         env:
@@ -188,12 +188,29 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
+          apple_signing_count=0
           for name in APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_SIGNING_IDENTITY APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID; do
-            if [ -z "$(printenv "$name")" ]; then
-              echo "::error::$name must be configured for signed macOS releases"
-              exit 1
+            if [ -n "$(printenv "$name")" ]; then
+              apple_signing_count=$((apple_signing_count + 1))
             fi
           done
+
+          if [ "$apple_signing_count" -eq 0 ]; then
+            echo "::warning::Apple signing credentials are not configured; publishing an unsigned macOS installer."
+            unset APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_SIGNING_IDENTITY APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID
+            npm run tauri -- build ${{ matrix.args }}
+            dmg_path="$(find src-tauri/target -type f -name '*.dmg' -print -quit)"
+            if [ -z "$dmg_path" ]; then
+              echo "::error::Unsigned macOS build did not produce a DMG."
+              exit 1
+            fi
+            exit 0
+          fi
+
+          if [ "$apple_signing_count" -ne 6 ]; then
+            echo "::error::Configure all six Apple signing secrets or leave all of them unset."
+            exit 1
+          fi
 
           original_keychain="$(security default-keychain -d user | tr -d '"')"
           original_keychains=()
@@ -258,7 +275,7 @@ jobs:
           xcrun stapler validate "$dmg_path"
           spctl --assess --type open --context context:primary-signature --verbose=2 "$dmg_path"
 
-      - name: Build signed Windows installer
+      - name: Build Windows installer
         if: runner.os == 'Windows'
         working-directory: desktop
         shell: pwsh
@@ -266,11 +283,24 @@ jobs:
           WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
           WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
         run: |
-          if ([string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE)) {
-            throw "WINDOWS_CERTIFICATE must be configured for signed Windows releases"
+          $hasCertificate = -not [string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE)
+          $hasPassword = -not [string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE_PASSWORD)
+          if ($hasCertificate -xor $hasPassword) {
+            throw "Configure both Windows signing secrets or leave both of them unset."
           }
-          if ([string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE_PASSWORD)) {
-            throw "WINDOWS_CERTIFICATE_PASSWORD must be configured for signed Windows releases"
+
+          if (-not $hasCertificate) {
+            Write-Output "::warning::Windows signing credentials are not configured; publishing an unsigned Windows installer."
+            Remove-Item Env:WINDOWS_CERTIFICATE, Env:WINDOWS_CERTIFICATE_PASSWORD
+            npm run tauri -- build ${{ matrix.args }}
+            if ($LASTEXITCODE -ne 0) {
+              throw "Tauri Windows build failed with exit code $LASTEXITCODE"
+            }
+            $installers = @(Get-ChildItem src-tauri/target -Recurse -Filter *.msi)
+            if ($installers.Count -ne 1) {
+              throw "Expected exactly one unsigned Windows MSI, found $($installers.Count)."
+            }
+            exit 0
           }
 
           $certificatePath = Join-Path $env:RUNNER_TEMP "ccstats-code-signing.pfx"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,40 +4,34 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-09-03
+
 ### Added
-- Desktop DMG, MSI, and AppImage installers on the existing `v*` GitHub Release workflow.
+- Desktop DMG, MSI, and AppImage installers on the existing `v*` GitHub Release workflow. macOS and Windows packages are published unsigned when signing credentials are unavailable.
 - `--source-breakdown` for `--source all` (per-source subtotals + combined total). Default combined output unchanged. Monthly `--monthly-budget --csv` keeps budget columns.
 - Expose `cache_creation_1h_tokens` in JSON, CSV, and SDK `TokenBreakdown`. `cache_creation_tokens` remains the inclusive cache-creation total; the 1-hour figure is a billed subset, not a sixth token bucket.
-
-### Changed
-- `blocks` uses activity-driven 5-hour estimated session windows (ccusage-style), not clock-aligned 00/05/10/15/20 buckets. Not an official billing reset.
-- Rewrite `ARCHITECTURE.md` against the source inventory and current runtime.
-- Register sources and `UsageSource` from one inventory so adding a source is a single table edit.
-- `--source all` default token totals no longer include estimated-proxy rows (for example Grok context snapshots). Cost remains real-only. Estimated-proxy token counts are omitted from those default totals; they are still priced separately as `estimated_cost` when present.
-
-### Fixed
-- Cline counts a session once when canonical `*.messages.json` and legacy `ui_messages.json` share an ID; legacy-only tasks still count.
-- Gemini session JSON last-writes on message id like the JSONL path.
-- Gemini/Google models now load from LiteLLM / fallback instead of N/A.
-
-### Documentation
-- Distinguish CLI `weekly`/`monthly` grouping of filtered history from SDK `UsageRange::ThisWeek`/`ThisMonth` current-period date ranges.
-
-## [0.5.1] - 2026-08-31
-
-### Added
 - Expose provider-authoritative Codex weekly quota reports through the Rust SDK with typed data and errors.
 - Expand local usage support from 5 to 29 sources across nine provider batches: Gemini CLI, Amp, Qwen Code, Cline, Roo Code, and Kilo Code; OpenCode, MiMo Code, and Kilo CLI; Pi, Senpi, and Kimchi; Gajae Code, Prime Agent, and Oh My Pi; GitHub Copilot CLI and Goose; OpenClaw, Xum, and Hermes Agent; Reasonix and Vercel Fx; Unsloth Studio; and DeepSeek Harness.
 - Add `ccstats doctor` for read-only, machine-readable diagnostics across all 29 registered sources.
 - Document privacy boundaries, network access, and the release process.
 
 ### Changed
+- `blocks` uses activity-driven 5-hour estimated session windows (ccusage-style), not clock-aligned 00/05/10/15/20 buckets. Not an official billing reset.
+- Rewrite `ARCHITECTURE.md` against the source inventory and current runtime.
+- Register sources and `UsageSource` from one inventory so adding a source is a single table edit.
+- `--source all` default token totals no longer include estimated-proxy rows (for example Grok context snapshots). Cost remains real-only. Estimated-proxy token counts are omitted from those default totals; they are still priced separately as `estimated_cost` when present.
 - Calculate Grok 4.5 and 4.6 USD cost from per-inference `unified.jsonl` token records, including prompt-cache rates and the 200k-token whole-request pricing tier, instead of using `turn_completed.costUsdTicks` as the Grok Build weekly-allowance value.
 - Improve the README first-run path, positioning, installation maintenance, and package metadata.
 
 ### Fixed
+- Cline counts a session once when canonical `*.messages.json` and legacy `ui_messages.json` share an ID; legacy-only tasks still count.
+- Gemini session JSON last-writes on message id like the JSONL path.
+- Gemini/Google models now load from LiteLLM / fallback instead of N/A.
 - Preserve Grok inference records in an atomic ccstats ledger so upstream head trimming does not remove usage that ccstats has already observed.
 - Publish crates.io through short-lived OIDC credentials before creating GitHub Releases or updating Homebrew.
+
+### Documentation
+- Distinguish CLI `weekly`/`monthly` grouping of filtered history from SDK `UsageRange::ThisWeek`/`ThisMonth` current-period date ranges.
 
 ## [0.5.0] - 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ## [0.5.1] - 2026-09-03
 
 ### Added
-- Desktop DMG, MSI, and AppImage installers on the existing `v*` GitHub Release workflow. macOS and Windows packages are published unsigned when signing credentials are unavailable.
+- Desktop DMG, MSI, and AppImage installers on the existing `v*` GitHub Release workflow. Without certificates, macOS packages use an ad-hoc signature and Windows packages are unsigned.
 - `--source-breakdown` for `--source all` (per-source subtotals + combined total). Default combined output unchanged. Monthly `--monthly-budget --csv` keeps budget columns.
 - Expose `cache_creation_1h_tokens` in JSON, CSV, and SDK `TokenBreakdown`. `cache_creation_tokens` remains the inclusive cache-creation total; the 1-hour figure is a billed subset, not a sixth token bucket.
 - Expose provider-authoritative Codex weekly quota reports through the Rust SDK with typed data and errors.

--- a/README.md
+++ b/README.md
@@ -177,6 +177,11 @@ Download installers and SHA-256 checksums from [GitHub Releases](https://github.
 - Linux x64: `ccstats-desktop-x86_64-unknown-linux-gnu.AppImage`
 - Linux ARM64: `ccstats-desktop-aarch64-unknown-linux-gnu.AppImage`
 
+macOS and Windows installers may be unsigned when release signing credentials
+are unavailable. Gatekeeper or SmartScreen may warn because publisher identity
+cannot be verified. Check the matching `.sha256` file before choosing an
+operating-system override.
+
 Make an AppImage executable before launching it:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -177,10 +177,10 @@ Download installers and SHA-256 checksums from [GitHub Releases](https://github.
 - Linux x64: `ccstats-desktop-x86_64-unknown-linux-gnu.AppImage`
 - Linux ARM64: `ccstats-desktop-aarch64-unknown-linux-gnu.AppImage`
 
-macOS and Windows installers may be unsigned when release signing credentials
-are unavailable. Gatekeeper or SmartScreen may warn because publisher identity
-cannot be verified. Check the matching `.sha256` file before choosing an
-operating-system override.
+Without release certificates, macOS installers use an ad-hoc signature and
+Windows installers are unsigned. Gatekeeper or SmartScreen may warn because
+publisher identity cannot be verified. Check the matching `.sha256` file
+before choosing an operating-system override.
 
 Make an AppImage executable before launching it:
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -21,8 +21,9 @@ Each installer has a matching `.sha256` sidecar. When a complete platform
 credential set is configured, macOS apps use a Developer ID certificate and
 notarization, while Windows MSIs use an Authenticode certificate and trusted
 timestamp. When all credentials for a platform are absent, the workflow emits
-a warning and publishes its installer unsigned. A partial credential set fails
-the release instead of silently falling back.
+a warning, publishes macOS with Tauri's ad-hoc identity `-`, and publishes
+Windows unsigned. A partial credential set fails the release instead of
+silently falling back.
 
 Optionally configure these GitHub Actions secrets before pushing a release tag:
 
@@ -39,9 +40,10 @@ Rotate a certificate by replacing its certificate and password secrets before
 the old certificate expires, then verify the next release with `codesign` and
 `Get-AuthenticodeSignature`. Revoke the old certificate after verification.
 Certificate contents and passwords must never be committed or printed in logs.
-Unsigned macOS and Windows installers do not provide publisher-identity
-verification and may trigger Gatekeeper or SmartScreen. Verify the matching
-`.sha256` file before choosing an operating-system override.
+Ad-hoc-signed macOS and unsigned Windows installers do not provide
+publisher-identity verification and may trigger Gatekeeper or SmartScreen.
+Verify the matching `.sha256` file before choosing an operating-system
+override.
 
 Contributors can build unsigned packages locally without release credentials:
 
@@ -95,9 +97,9 @@ The existing `HOMEBREW_TAP_TOKEN` secret must retain permission to update
 4. Create and push the matching tag, for example `v0.5.1` for version `0.5.1`.
 5. Confirm every job in the Release workflow succeeds. For signed builds, the
    workflow validates the macOS notarization staple and Gatekeeper assessment
-   and requires a valid Windows Authenticode signature. For unsigned builds,
-   confirm the workflow emitted the expected warning for each unsigned
-   platform.
+   and requires a valid Windows Authenticode signature. For certificate-free
+   builds, confirm the workflow emitted the expected ad-hoc macOS and unsigned
+   Windows warnings.
 
 ## Public verification
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -17,12 +17,14 @@ GitHub Release:
 - Linux: `ccstats-desktop-x86_64-unknown-linux-gnu.AppImage` and
   `ccstats-desktop-aarch64-unknown-linux-gnu.AppImage`
 
-Each installer has a matching `.sha256` sidecar. macOS apps use a Developer ID
-certificate and are notarized before the DMG is created. Windows MSIs use an
-Authenticode certificate and a trusted timestamp. The release fails instead
-of publishing unsigned macOS or Windows installers when credentials are absent.
+Each installer has a matching `.sha256` sidecar. When a complete platform
+credential set is configured, macOS apps use a Developer ID certificate and
+notarization, while Windows MSIs use an Authenticode certificate and trusted
+timestamp. When all credentials for a platform are absent, the workflow emits
+a warning and publishes its installer unsigned. A partial credential set fails
+the release instead of silently falling back.
 
-Configure these GitHub Actions secrets before pushing a release tag:
+Optionally configure these GitHub Actions secrets before pushing a release tag:
 
 - `APPLE_CERTIFICATE`: base64-encoded Developer ID Application `.p12`
 - `APPLE_CERTIFICATE_PASSWORD`: password for that `.p12`
@@ -37,6 +39,9 @@ Rotate a certificate by replacing its certificate and password secrets before
 the old certificate expires, then verify the next release with `codesign` and
 `Get-AuthenticodeSignature`. Revoke the old certificate after verification.
 Certificate contents and passwords must never be committed or printed in logs.
+Unsigned macOS and Windows installers do not provide publisher-identity
+verification and may trigger Gatekeeper or SmartScreen. Verify the matching
+`.sha256` file before choosing an operating-system override.
 
 Contributors can build unsigned packages locally without release credentials:
 
@@ -88,9 +93,11 @@ The existing `HOMEBREW_TAP_TOKEN` secret must retain permission to update
    ```
 
 4. Create and push the matching tag, for example `v0.5.1` for version `0.5.1`.
-5. Confirm every job in the Release workflow succeeds. The workflow validates
-   the macOS notarization staple and Gatekeeper assessment, and rejects a
-   Windows MSI unless PowerShell reports a valid Authenticode signature.
+5. Confirm every job in the Release workflow succeeds. For signed builds, the
+   workflow validates the macOS notarization staple and Gatekeeper assessment
+   and requires a valid Windows Authenticode signature. For unsigned builds,
+   confirm the workflow emitted the expected warning for each unsigned
+   platform.
 
 ## Public verification
 


### PR DESCRIPTION
## Summary

- publish certificate-free macOS and Windows installers when platform signing credentials are absent
- use Tauri ad-hoc signing for macOS, retain signed/notarized builds for complete credentials, and reject partial configuration
- document publisher-identity warnings and finalize the v0.5.1 changelog

## Verification

- built an Apple Silicon DMG locally without a certificate and verified the bundled app has a valid ad-hoc signature
- staged the DMG under the stable release filename and verified its SHA-256 sidecar
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features`
- `cargo deny check`
- `cargo publish --dry-run --locked`
- `GITHUB_REF_NAME=v0.5.1 scripts/check-release.sh`
- `python3 scripts/stage-desktop-artifacts.py --self-test`

Refs #154