### PR TITLE
fix(release): include Windows desktop icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.5.1] - 2026-09-03
+## [0.5.2] - 2026-09-03
 
 ### Added
 - Desktop DMG, MSI, and AppImage installers on the existing `v*` GitHub Release workflow. Without certificates, macOS packages use an ad-hoc signature and Windows packages are unsigned.
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - Improve the README first-run path, positioning, installation maintenance, and package metadata.
 
 ### Fixed
+- Include the Windows ICO resource required to build the desktop MSI.
 - Cline counts a session once when canonical `*.messages.json` and legacy `ui_messages.json` share an ID; legacy-only tasks still count.
 - Gemini session JSON last-writes on message id like the JSONL path.
 - Gemini/Google models now load from LiteLLM / fallback instead of N/A.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "ccstats"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "base64 0.23.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccstats"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Fast, local-first token and cost analytics for AI coding agents"

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccstats-desktop",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccstats-desktop",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "@fontsource/ibm-plex-mono": "5.3.0",
         "@fontsource/manrope": "5.3.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ccstats-desktop",
   "private": true,
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "ccstats"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "base64 0.23.1",
  "chrono",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "ccstats-desktop"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "ccstats",
  "chrono",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccstats-desktop"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"
@@ -17,7 +17,7 @@ native-e2e = ["dep:tauri-plugin-wdio-webdriver"]
 tauri-build = { version = "2.6.3", features = [] }
 
 [dependencies]
-ccstats = { path = "../..", version = "0.5.1" }
+ccstats = { path = "../..", version = "0.5.2" }
 chrono = "0.4.43"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ccstats",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "identifier": "io.ccstats.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -31,6 +31,7 @@
     "category": "DeveloperTool",
     "shortDescription": "Local AI coding usage analytics",
     "icon": [
+      "../../docs/branding/final/favicon.ico",
       "../../docs/branding/final/icon-32.png",
       "../../docs/branding/final/icon-128.png",
       "../../docs/branding/final/icon-256.png",

--- a/tests/public_readiness.rs
+++ b/tests/public_readiness.rs
@@ -54,11 +54,11 @@ fn public_docs_describe_the_full_registry_without_exact_setup_promises() {
 fn changelog_names_every_source_added_across_the_nine_provider_batches() {
     let changelog = fs::read_to_string("CHANGELOG.md").expect("changelog");
     let release = changelog
-        .split_once("## [0.5.1]")
-        .expect("0.5.1 release")
+        .split_once("## [0.5.2]")
+        .expect("0.5.2 release")
         .1
         .split_once("## [0.5.0]")
-        .expect("0.5.0 release follows 0.5.1")
+        .expect("0.5.0 release follows 0.5.2")
         .0;
 
     assert!(release.contains("5 to 29 sources across nine provider batches"));
@@ -73,7 +73,7 @@ fn changelog_names_every_source_added_across_the_nine_provider_batches() {
         "Unsloth Studio",
         "DeepSeek Harness",
     ] {
-        assert!(release.contains(batch), "0.5.1 does not name batch {batch}");
+        assert!(release.contains(batch), "0.5.2 does not name batch {batch}");
     }
 }
 


### PR DESCRIPTION
## Summary

- add the existing multi-size ICO asset to the Tauri bundle icon list so Windows resource generation succeeds
- advance release metadata to 0.5.2 because the pushed v0.5.1 tag is immutable and its release workflow failed before publishing any public artifacts
- update release notes and readiness coverage for v0.5.2

## Verification

- `GITHUB_REF_NAME=v0.5.2 scripts/check-release.sh`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features`
- `cargo deny check`
- `cargo publish --dry-run --locked --allow-dirty`
- `npm ci && npm run build`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml`
- built and mounted the aarch64 DMG with `APPLE_SIGNING_IDENTITY=-`; `codesign --verify --deep --strict` passed and reported `Signature=adhoc`

Failed release run being repaired: https://github.com/majiayu000/ccstats/actions/runs/33665952944