### PR TITLE
fix(release): write portable checksums

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,8 @@ jobs:
           cd target/${{ matrix.target }}/release
           7z a ../../../ccstats-${{ matrix.target }}.zip ccstats.exe
           cd ../../..
-          (Get-FileHash ccstats-${{ matrix.target }}.zip -Algorithm SHA256).Hash.ToLower() + "  ccstats-${{ matrix.target }}.zip" | Out-File -Encoding ascii ccstats-${{ matrix.target }}.zip.sha256
+          $checksum = (Get-FileHash ccstats-${{ matrix.target }}.zip -Algorithm SHA256).Hash.ToLower() + "  ccstats-${{ matrix.target }}.zip`n"
+          [IO.File]::WriteAllText((Join-Path $PWD "ccstats-${{ matrix.target }}.zip.sha256"), $checksum, [Text.Encoding]::ASCII)
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/scripts/stage-desktop-artifacts.py
+++ b/scripts/stage-desktop-artifacts.py
@@ -52,8 +52,8 @@ def stage(search_root: Path, output_dir: Path, target: str) -> Path:
     destination = output_dir / f"ccstats-desktop-{target}{canonical_suffix(source)}"
     destination.write_bytes(source.read_bytes())
     sidecar = output_dir / f"{destination.name}.sha256"
-    sidecar.write_text(
-        f"{sha256_file(destination)}  {destination.name}\n", encoding="ascii"
+    sidecar.write_bytes(
+        f"{sha256_file(destination)}  {destination.name}\n".encode("ascii")
     )
     print(destination)
     print(sidecar)
@@ -78,8 +78,8 @@ def self_test() -> None:
                 raise SystemExit(f"staged path {staged} != {expected}")
             sidecar = expected.with_name(expected.name + ".sha256")
             digest = sha256_file(expected)
-            expected_sidecar = f"{digest}  {expected.name}\n"
-            if sidecar.read_text(encoding="ascii") != expected_sidecar:
+            expected_sidecar = f"{digest}  {expected.name}\n".encode("ascii")
+            if sidecar.read_bytes() != expected_sidecar:
                 raise SystemExit(f"checksum mismatch for {target}")
     print("stage-desktop-artifacts self-test passed")
 


### PR DESCRIPTION
## Summary
- write Windows CLI checksum sidecars with an explicit LF
- write desktop checksum sidecars as ASCII bytes
- assert exact sidecar bytes in the existing staging self-test

## Verification
- `python3 scripts/stage-desktop-artifacts.py --self-test`
- parsed `.github/workflows/release.yml` with PyYAML
- `cargo test --test public_readiness`
- `git diff --check`

Found while independently verifying the published v0.5.2 assets; the two Windows-generated sidecars otherwise contained correct hashes.