### PR TITLE
docs: first-run UX specs for detected sources, identity, conclusion, login, and limits

### DIFF
--- a/specs/first-run-ux/F1-auto-detect/product.md
+++ b/specs/first-run-ux/F1-auto-detect/product.md
@@ -1,0 +1,58 @@
+# Product Spec — F1 Auto-detect default source
+
+## Linked Issue
+
+https://github.com/majiayu000/ccstats/issues/164
+
+## 用户问题
+
+无参数或未传 `--source` 时，`resolve_source_name` 固定返回 `"claude"`。本机只有 Codex / Grok / Cursor 的用户第一次运行得到空表或「没有 Claude 数据」，会认为产品坏了。README 已经让人先跑 `doctor` 再 `daily --source all`，但默认命令与文档不一致。
+
+## 目标
+
+- 未显式选源时，使用本机 **已检测或已配置** 的源。
+- 零就绪源时，自动展示 doctor，并给出下一步。
+- 单源就绪时直接出该源报告（不必写 `--source all`）。
+- 多源就绪时走现有 `--source all` 合计。
+- 显式 `--source`、源子命令、config `source` 行为不变。
+
+## 非目标
+
+- 不改变 SDK 缺省；SDK 调用方必须继续传 `UsageSource`。
+- 不改变 `--source all` 的会计规则（real-only token、estimated-proxy 处理）。
+- 不在本 PR 改表头结论行、login、limits、README 大改（只允许改与新默认相关的一两句 Quick Start）。
+- 不扫描或上传日志内容；检测继续只用现有只读 `diagnose()`。
+
+## Behavior Invariants
+
+1. 选择顺序：CLI `--source` > 源子命令 hint > config `source` > 自动检测。
+2. `doctor` / `sources` 命令本身不走自动检测（它们列出全部注册源）。
+3. 自动检测的就绪集合 = `diagnose().status` ∈ {Detected, Configured}。
+4. 就绪 0 个：stdout 打印与 `ccstats doctor` 相同的表（或 JSON/CSV 等价物），文案说明「没有检测到用量数据」，退出 0。
+5. 就绪 1 个：`dispatch_command` 使用该源名。
+6. 就绪 ≥ 2 个：源名为 `all`，走 `handle_all_sources_command`。
+7. `--source-breakdown` 仍只在最终源名为 `all` 时合法。
+8. 现有 `ccstats daily --source claude` 与 `ccstats codex daily` 金测试必须继续通过。
+9. 对未就绪源，自动检测不得去 parse 其日志、不得打 Cursor API。
+
+## 验收标准
+
+- [ ] 空 HOME、无凭证：`ccstats` / `ccstats daily` 输出 doctor 诊断，不出现 Claude 空用量表。
+- [ ] 只有 Codex fixture：无 `--source` 的 `daily`/`today` 产出 Codex 报告。
+- [ ] Claude + Codex 同时就绪：无 `--source` 的 `daily` 走 all-sources 合计。
+- [ ] `--source claude` 在只有 Codex 数据时仍只查 Claude（可为空），不改道。
+- [ ] config `source = "codex"` 在多源机器上仍只出 Codex。
+- [ ] `ccstats doctor` 输出与今日一致（不因 F1 改变诊断语义）。
+- [ ] JSON/CSV 空检测不把 doctor 行混进用量 schema；用量命令在 0 源时输出 doctor 的 json/csv 或明确的空状态对象（测试钉死一种）。
+
+## 边界情况
+
+- 仅 Cursor `Configured`（有 token、doctor 未联系 API）：算就绪，默认会打 Cursor API（与今天显式 `--source cursor` 相同）。
+- `CURSOR_USAGE_FILE` 指向存在的文件：Detected，算就绪。
+- statusline 无源：自动检测；0 源时 statusline 应保持安静（单行空/占位），不要把 29 行 doctor 打进 prompt。
+- `--source all` 显式传入：即使只有 1 个就绪源，仍走 all 路径（与今天一致）。
+- 源子命令与 `--source` 冲突：保持现有错误退出。
+
+## 发布说明
+
+Breaking 默认：无参数 CLI 不再假设 Claude。钉死源的用户应设 `--source` 或 config `source`。

--- a/specs/first-run-ux/F1-auto-detect/tech.md
+++ b/specs/first-run-ux/F1-auto-detect/tech.md
@@ -1,0 +1,91 @@
+# Tech Spec — F1 Auto-detect default source
+
+## Linked Issue
+
+https://github.com/majiayu000/ccstats/issues/164
+
+## Product Spec
+
+`specs/first-run-ux/F1-auto-detect/product.md`
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Source resolution | `src/lib.rs` `resolve_source_name` | `(None, None) => "claude"` | Primary change. |
+| Diagnostics | `src/source/mod.rs` `Source::diagnose`, `DiagnosticStatus` | Detected / Configured / Missing, no network | Ready-set definition. |
+| Catalog | `src/catalog.rs` `diagnose_usage_sources` | SDK projection of the same diagnose() | Reuse; do not fork a second detector. |
+| Dispatch | `src/lib.rs` `dispatch_command` | `all` → `handle_all_sources_command` | Multi-ready path already exists. |
+| Doctor | `src/doctor_cmd.rs` | Prints all 29 rows; empty hint to rerun doctor --json | Empty default should call this renderer, not duplicate strings. |
+| Statusline | `src/output/statusline.rs`, `SourceCommand::is_statusline` | Quiet hook output | 0-ready must not dump doctor table. |
+| Tests | `tests/cli_doctor.rs`, `tests/cli_codex_source_routing.rs`, `tests/common/mod.rs` | Isolated HOME + env scrub | New fixtures for 0/1/N ready. |
+
+## 设计方案
+
+1. Add `fn ready_source_names() -> Vec<&'static str>` (or crate-visible helper next to registry) that maps `all_sources()` through `diagnose()` and keeps Detected + Configured, preserving registry order.
+2. Change `resolve_source_name` so the `(None, None)` arm:
+   - if command is Doctor or Sources: keep returning a dummy (today `"claude"`) because those commands ignore it;
+   - else if `ready` is empty: return a new sentinel **or** handle before dispatch.
+3. Prefer an explicit empty path in `run_cli` after resolve:
+
+   ```text
+   if no explicit source and ready.is_empty() && command is a usage view:
+     if statusline: print quiet empty statusline; return
+     else: handle_doctor(ctx); return
+   ```
+
+   Do not invent a fake source named `"none"`.
+4. If ready.len() == 1, resolve to that name. If len() >= 2, resolve to `all` (`consts::ALL_SOURCES`).
+5. Explicit `--source` / hint / config remain as today. Config merge already happens before resolve via `cli.with_config`.
+6. Do not parse files during detect. `diagnose()` for local sources uses `find_files().len()`; Cursor uses env/file existence only.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation | Verification |
+| --- | --- | --- |
+| P1 priority | resolve order in `resolve_source_name` + run_cli empty branch | routing tests with --source, `ccstats codex`, config.toml |
+| P3 ready set | helper over diagnose() | unit test with temp HOME: only codex files → `["codex"]` |
+| P4 zero ready | run_cli → doctor | `tests/cli_doctor.rs` style empty HOME: `ccstats daily` contains "Source diagnostics" and setup hints; no period table title for Claude |
+| P5 one ready | resolve to that name | Codex-only fixture, `ccstats today` matches `ccstats today --source codex` on stdout tokens |
+| P6 many ready | resolve `all` | Claude+Codex fixtures, combined daily |
+| P7 breakdown | existing validate_source_breakdown | still errors without all; auto-detect two sources allows --source-breakdown |
+| statusline empty | quiet | `ccstats statusline` on empty HOME exits 0, stdout is a single short line, no 29-row dump |
+
+## 数据流
+
+```text
+parse_command → load config → resolve_source_name
+  explicit? → that name
+  else ready_source_names()
+    0 → doctor (or quiet statusline)
+    1 → dispatch that source
+    N → dispatch all
+```
+
+## 备选方案
+
+- Always default to `--source all` even with 0 or 1 sources: rejected. 0 源会走进 all-sources 空表；1 源不必付 all 的合并语义（部分命令 all 不支持）。
+- Default to first detected source only, never all: rejected. 多工具用户看不到总账，回到「以为没统计到」。
+- Change SDK default similarly: rejected. 嵌入方需要稳定、显式的源。
+
+## 风险
+
+- **Breaking default** for scripts that assumed Claude. Mitigate: changelog + config `source`. Project already declares no compatibility shims.
+- **Cursor Configured** may trigger API on first `ccstats`. Same as explicit cursor today; doctor already labels Configured as credentials-present not fetched.
+- **Performance**: 29× `find_files()`/`diagnose()` on every invocation. Doctor already does this; keep it. Do not parse JSONL at detect time.
+- **statusline**: noisy doctor would break prompts; dedicated quiet empty path is mandatory.
+
+## 测试计划
+
+- [ ] Unit tests for ready-set helper (0 / 1 / N).
+- [ ] CLI: empty HOME `daily`, `today`, default no-subcommand.
+- [ ] CLI: Codex-only auto daily equals `--source codex`.
+- [ ] CLI: Claude+Codex auto daily uses all-sources path (combined label or source-breakdown).
+- [ ] CLI: `--source claude` override with Codex-only data.
+- [ ] CLI: empty statusline quiet.
+- [ ] Existing doctor, codex routing, public_readiness tests.
+- [ ] `cargo test`
+
+## 回滚方案
+
+Restore `(None, None) => "claude"` and delete the ready helper. Doctor command remains.

--- a/specs/first-run-ux/F2-identity/product.md
+++ b/specs/first-run-ux/F2-identity/product.md
@@ -1,0 +1,42 @@
+# Product Spec — F2 Public identity and first-run docs
+
+## Linked Issue
+
+https://github.com/majiayu000/ccstats/issues/165
+
+## 用户问题
+
+GitHub 仓库 description 仍是 “Fast CLI for Claude Code and OpenAI Codex”。homepage 指向 crates.io。README 把桌面从源码编译、29 源百科、Grok 成本论文放在新用户第一屏。访客无法在 30 秒内回答：这是什么、怎么装、敲哪条命令。
+
+## 目标
+
+- GitHub description、topics、homepage 与 v0.5.2+ 产品一致。
+- README 第一屏只保留：一句话定位、一条安装、一条默认命令、doctor 说明、桌面下载链接（不是编译指南）。
+- 对外主打 Core 源：Claude、Codex、Cursor、Gemini、Grok、Kimi、OpenCode。其余源留在完整源表，不进第一屏。
+- 文档中的默认命令与 F1 对齐：无参数即本机已检测源；没有数据则 doctor。
+
+## 非目标
+
+- 不新建独立营销站（本轮 homepage 改为 GitHub repo 即可，不要 crates.io）。
+- 不改 CLI 行为（若 F1 尚未合并，README 仍写目标语义，并在 PR 中注明依赖；合并顺序：F1 先于或同批于 F2）。
+- 不把 ARCHITECTURE / PRIVACY / 源表删掉，只下沉到后部链接。
+- 不在本 PR 改桌面 UI。
+
+## Behavior Invariants
+
+1. README 开头 30 秒路径不超过：brew 安装、`ccstats`（或 `ccstats doctor` 若需强调只读检测）、一句话解释自动检测。
+2. 「Desktop application development」整节移到文档后部或 `desktop/README` / `docs/RELEASING.md` 链接，不得出现在 Highlights 之前。
+3. GitHub description 必须提到 local-first、多 coding agent、CLI（可提 desktop，不要只写双源）。
+4. topics 增加实际可搜词：至少 `cursor`、`codex`；去掉会误导成「只有 chatgpt」的过时观感不是强制删 `chatgpt`，但 description 不得再写「仅 Claude 和 Codex」。
+5. 完整 29 源表仍在 README 后部，标题明确是完整注册表。
+
+## 验收标准
+
+- [ ] `gh repo view majiayu000/ccstats --json description,homepageUrl,repositoryTopics` 与本 spec 一致（description/homepage/topics 由维护者在合并时或 PR 里用 `gh repo edit` 更新）。
+- [ ] README 在第一个 `## Installation` 之前不出现 `npm run tauri`、Rust 桌面前置、SDK 长示例。
+- [ ] Quick Start 不再默认只展示 Claude 命令作为唯一入口。
+- [ ] Core 源表（≤8 行）出现在完整源表之前。
+
+## 发布说明
+
+文档与商店元数据同步；无运行时变化。

--- a/specs/first-run-ux/F2-identity/tech.md
+++ b/specs/first-run-ux/F2-identity/tech.md
@@ -1,0 +1,66 @@
+# Tech Spec — F2 Public identity and first-run docs
+
+## Linked Issue
+
+https://github.com/majiayu000/ccstats/issues/165
+
+## Product Spec
+
+`specs/first-run-ux/F2-identity/product.md`
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| README | `README.md` on origin/main | 30s start is doctor + daily --source all; then long desktop build; then SDK | Reorder, do not rewrite accounting docs. |
+| Crate metadata | `Cargo.toml` description | "Fast, local-first token and cost analytics for AI coding agents" | Already closer to target; GitHub description is stale. |
+| Branding | `docs/branding/` | Card image | Keep the card near the top. |
+| Tests | `tests/public_readiness.rs` | Asserts doctor copy exists in source | Do not break; add README assertion only if the file already checks README. |
+
+## 设计方案
+
+1. Rewrite README sections **above Installation**:
+   - One-paragraph product sentence (CLI + local-first + coding agents; desktop is a sentence, not a tutorial).
+   - 30-second start: `brew install majiayu000/tap/ccstats` then `ccstats`.
+   - One line: no args uses detected sources; none → doctor.
+   - Core source table (7 rows) with start commands using `--source` canonical form; keep `ccstats codex today` as an alias example in a footnote or second column.
+2. Move "Desktop application development" below Installation or to `docs/RELEASING.md` / `desktop/README.md`. Keep download links for DMG/MSI/AppImage in Installation.
+3. Move Rust SDK examples below Usage or keep a short pointer to docs.rs.
+4. After merge (or in PR body checklist): 
+
+   ```bash
+   gh repo edit majiayu000/ccstats \
+     --description "Local-first CLI (and desktop) for token and cost analytics across AI coding agents" \
+     --homepage "https://github.com/majiayu000/ccstats" \
+     --add-topic cursor --add-topic grok --add-topic desktop
+   ```
+
+5. Do not change `src/**`.
+
+## Product-to-Test Mapping
+
+| Product invariant | Verification |
+| --- | --- |
+| First screen has no tauri dev | grep README from start through `## Installation` |
+| Core table before full registry | heading order |
+| GitHub identity | manual `gh repo view` on merge |
+
+## 备选方案
+
+- Point homepage at crates.io: rejected; crates.io 不是产品首页。
+- Write a new GitHub Pages site this PR: rejected as out of scope.
+
+## 风险
+
+- F1 未合并时 README 写「无参数自动检测」会与已发布二进制不一致。缓解：F2 以 F1 为 base，或 F2 明确 “as of this PR / vNext”。
+- topics 过多被 GitHub 截断：只加缺失的高价值词。
+
+## 测试计划
+
+- [ ] 人工阅读 README 第一屏。
+- [ ] 不运行 `cargo test` 需求除非 public_readiness 读 README。
+- [ ] 合并后 `gh repo view` 检查 description。
+
+## 回滚方案
+
+Revert README；`gh repo edit` 改回旧 description。

--- a/specs/first-run-ux/F3-conclusion/product.md
+++ b/specs/first-run-ux/F3-conclusion/product.md
@@ -1,0 +1,55 @@
+# Product Spec — F3 Human conclusion line
+
+## Linked Issue
+
+https://github.com/majiayu000/ccstats/issues/166
+
+## 用户问题
+
+默认成功输出是日期 × token 桶 × 费用的宽表。用户要带走的是：「今天大概花了多少、比平时快还是慢、这个数完不完整」。桌面设计文档已经要求 glance 结论；CLI 默认路径没有。
+
+## 目标
+
+在 **table** 模式的 `daily` / `today` / `weekly` / `monthly`（含 `--source all`）打印表 **之前** 输出一行结论，使用已有合计，不新算一套账。
+
+结论必须能口头复述，并标明费用是完整、下限，还是未知。
+
+## 非目标
+
+- 不改变 JSON/CSV schema（机器输出不加散文行；如需字段，另开 issue）。
+- 不加 LLM、不加「建议你换模型」类优化建议（那是 why/optimize，非本 PR）。
+- 不在 `session` / `project` / `blocks` / `tools` / `top` / `statusline` / `quota` 上加结论行。
+- 不把 `null` 费用格式化成 `$0.00`。
+
+## Behavior Invariants
+
+1. 仅 `OutputFormat::Table` 且命令为 Daily / Today / Weekly / Monthly。
+2. `--compact` 时结论行仍在，但更短（费用 + 完整/下限/未知，可省略 7 日对比）。
+3. `--no-cost` 时结论谈 token 总量，不编造美元。
+4. 费用状态：
+   - 所有计入成本的模型均为 recorded/live/fresh 且 coverage 完整 → 用精确金额，无「下限」字样。
+   - 存在未定价或 coverage 标明 lower bound → `≥ $X` 或 “at least $X (floor)”。
+   - 完全无费用（strict 全 N/A 或 show_cost false）→ 只报 token，写 `cost unknown` 或省略美元。
+5. 多日 `daily`：结论用过滤窗口内合计，不假装是「今天」。
+6. `today`：若能算 7 日日均（同源、本地时区、不含今天或含今天须在测试里钉死），给一句快/慢/持平；数据不足则不加对比，不得编造。
+7. `--source all`：结论针对合计；不在结论里点名 29 个源。可用 `(N sources)`。
+8. stderr 仍可有 pricing 警告；结论在 stdout，位于标题/表之前。
+9. 语言：英文（与现有 CLI 表头一致），短句，不用营销词。
+
+## 验收标准
+
+- [ ] `ccstats today --source claude` 在表前有一行含 token 或 cost。
+- [ ] 无法定价的 fixture 不出现 `$0.00` 充当真实花费。
+- [ ] `--json` / `--csv` stdout 仍是纯结构化数据（第一字符 `{` 或 header 行）。
+- [ ] `--compact` 仍有结论行。
+- [ ] 现有 table 列与合计数字不变。
+
+## 边界情况
+
+- 空结果（有源但无记录）：不要结论装成 $0；沿用现有 no-data hint。
+- 0 源走 doctor（F1）：无结论行。
+- 货币转换：结论使用与表相同的 currency 格式化。
+
+## 发布说明
+
+Table 模式 period 报告增加一行人类可读摘要；数字与表一致。

--- a/specs/first-run-ux/F3-conclusion/tech.md
+++ b/specs/first-run-ux/F3-conclusion/tech.md
@@ -1,0 +1,58 @@
+# Tech Spec — F3 Human conclusion line
+
+## Linked Issue
+
+https://github.com/majiayu000/ccstats/issues/166
+
+## Product Spec
+
+`specs/first-run-ux/F3-conclusion/product.md`
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Period tables | `src/output/table.rs`, `src/app/period_table.rs` | Renders period table then summary line (record counts) | Insert conclusion before table. |
+| Cost display | `CostDisplayMode`, `api_equivalent_cost_coverage`, `model_cost_kind` | Floor vs exact already exist for desktop/SDK | Reuse; do not invent a third cost theory. |
+| Number format | `NumberFormat`, currency converter | Table already formats cost | Conclusion must call the same helpers. |
+| Tests | `src/output/table_tests.rs`, CLI integration | Snapshot-ish stdout | Pin the line; pin json unchanged. |
+
+## 设计方案
+
+1. Add `print_period_conclusion(...)` in `output/table.rs` (or `output/conclusion.rs` if table.rs is already large) taking aggregated `Stats`/day map, cost mode, coverage, compact flag.
+2. Call it from the single period-table path used by daily/today/weekly/monthly (including all-sources). Do not scatter prints in every source handler.
+3. Cost sentence construction:
+   - Sum display cost with existing `sum_display_model_costs` / coverage flags already computed for the table footer.
+   - If `cost_is_lower_bound` or mixed unknown models: prefix `≥ ` using the same rule as desktop `displayedCost`.
+4. Pace sentence for `today` only: compare today's display cost (or tokens if no cost) to mean of previous up-to-7 complete local days in the already-loaded `day_stats` if those days exist. If fewer than 3 prior days, skip pace.
+5. Keep the existing trailing summary line (record counts / elapsed). Conclusion is extra, not a replacement.
+
+## Product-to-Test Mapping
+
+| Invariant | Test |
+| --- | --- |
+| Table-only | CLI today json has no conclusion prose in stdout |
+| Floor | fixture with unpriced model → stdout contains `≥` or `floor` and not `$0.00` as the headline |
+| Compact | `--compact today` still matches `^` conclusion then table |
+| Numbers match | parse cost from conclusion and footer; equal within formatting |
+
+## 备选方案
+
+- Put conclusion after the table: rejected；用户先看到表就会忽略结论。
+- Add JSON `headline` field now: rejected as schema change；需要的话单独 issue。
+
+## 风险
+
+- 双计费用：必须复用表的合计函数。
+- 7 日均值在时区边界出错：只用已经按 CLI timezone bucket 过的 `date_str` 键。
+- 颜色：结论可用与 summary line 相同的 color 开关，不要新调色盘。
+
+## 测试计划
+
+- [ ] Unit tests for conclusion string builder (exact / floor / no-cost / insufficient pace data).
+- [ ] CLI today table contains conclusion; json does not.
+- [ ] `cargo test`
+
+## 回滚方案
+
+Remove the print call and builder. Tables unchanged.

--- a/specs/first-run-ux/F3-conclusion/tech.md
+++ b/specs/first-run-ux/F3-conclusion/tech.md
@@ -24,7 +24,7 @@ https://github.com/majiayu000/ccstats/issues/166
 3. Cost sentence construction:
    - Sum display cost with existing `sum_display_model_costs` / coverage flags already computed for the table footer.
    - If `cost_is_lower_bound` or mixed unknown models: prefix `≥ ` using the same rule as desktop `displayedCost`.
-4. Pace sentence for `today` only: compare today's display cost (or tokens if no cost) to mean of previous up-to-7 complete local days in the already-loaded `day_stats` if those days exist. If fewer than 3 prior days, skip pace.
+4. For non-compact table-mode `today`, load today plus the previous seven local calendar days through the existing aggregation path. Keep the displayed table, totals, and quality metadata restricted to today; pass prior days only to the comparison. JSON/CSV keep their original query range. Compare against at least three prior days with complete data and known costs (or tokens with `--no-cost`); otherwise omit the comparison. Do not substitute older active dates for missing days in this seven-day window.
 5. Keep the existing trailing summary line (record counts / elapsed). Conclusion is extra, not a replacement.
 
 ## Product-to-Test Mapping

--- a/specs/first-run-ux/F4-cursor-login/product.md
+++ b/specs/first-run-ux/F4-cursor-login/product.md
@@ -1,0 +1,62 @@
+# Product Spec — F4 `ccstats login cursor`
+
+## Linked Issue
+
+https://github.com/majiayu000/ccstats/issues/167
+
+## 用户问题
+
+Cursor 用量来自官方 API，必须提供 `CURSOR_API_KEY` 或 `CURSOR_SESSION_TOKEN`。今天唯一路径是读 README、打开 dashboard、从 cookie 抠 `WorkosCursorSessionToken`、export 环境变量。cookie 过期后失败信息不够行动化。产品选择不偷读本地 SQLite，这是对的，但缺少引导式授权。
+
+## 目标
+
+增加 `ccstats login cursor`：
+
+- 说明两种凭证（企业 API key vs 个人 session cookie）的区别。
+- 打开（或打印）已文档化的 dashboard / API 页面 URL。
+- 接受粘贴的 token（交互 stdin 或 flag），写入 **本地配置文件**，权限仅当前用户可读。
+- 之后 `doctor` 将 Cursor 标为 Configured，无需再 export（环境变量仍优先，便于 CI）。
+- 明确：ccstats 不会代用户登录 Cursor，也不会把 cookie 传到第三方。
+
+## 非目标
+
+- 不实现 OAuth 服务器、不拦截浏览器 cookie、不读取 `state.vscdb`。
+- 不做 `login claude` / `login codex`（那些是本地文件源）。
+- 不在本 PR 改默认源检测（F1）或结论行（F3）。
+- 不把 token 写入 README 示例或 debug stdout。
+
+## Behavior Invariants
+
+1. 命令：`ccstats login cursor`。
+   - `--api-key <value>` 非交互写入 API key。
+   - `--session-token <value>` 非交互写入 session token。
+   - 两者同时提供：报错退出 1（一次只存一种）。
+   - 皆无且 stdin 是 TTY：打印说明 + URL，提示选择 1/2，隐藏回显读入一行。
+   - 皆无且 stdin 非 TTY：报错，要求 flag（测试走这条）。
+2. 存储路径：与 config 搜索同根的 credentials 文件，例如 `~/.config/ccstats/credentials.toml`（若本次运行已有权威 config 目录，用同一目录）。不把 secret 写进 `config.toml`。
+3. 文件权限：Unix 0600；写时先写 temp 再 rename。
+4. 读取顺序：环境变量 `CURSOR_API_KEY` / `CURSOR_SESSION_TOKEN` > credentials 文件 > 无。`CURSOR_USAGE_FILE` 仍独立。
+5. `ccstats login cursor --check`：不打印 secret，只打印是否已配置以及来源（env vs file）。
+6. `ccstats login cursor --clear`：删除文件中的 Cursor 字段或整个 credentials 文件（若已空）。
+7. doctor / diagnose：文件里有非空凭证时与 env 一样视为 Configured；detail 不得包含 token 内容或文件绝对路径中的 token。
+8. `--debug`、错误信息、JSON doctor 不得出现 token 值。
+9. 打开浏览器：能开则开文档中的 URL（API key → cursor.com/dashboard/api，session → cursor.com/dashboard/usage）；失败则打印 URL，不视为命令失败。
+
+## 验收标准
+
+- [ ] 非交互 `--session-token` 写入后，去掉 env，`doctor --json` 中 cursor status 为 `configured`。
+- [ ] 同一 doctor JSON 字符串不包含该 token。
+- [ ] env 已设置时覆盖文件，`--check` 报告 `env`。
+- [ ] `--api-key` 与 `--session-token` 同时给出 → exit 1。
+- [ ] `--clear` 后 doctor 回到 missing（无 env 时）。
+- [ ] 现有 `CURSOR_USAGE_FILE` 测试不受影响。
+
+## 边界情况
+
+- Windows：尽力设置 ACL；若做不到，仍写入并在 stderr 警告权限。
+- 空 token / 只有空白：拒绝保存。
+- 只读 HOME：明确 IO 错误，exit 1。
+
+## 发布说明
+
+新增 Cursor 登录向导；凭证只留在本机 ccstats credentials 文件。仍不读取 Cursor SQLite。

--- a/specs/first-run-ux/F4-cursor-login/tech.md
+++ b/specs/first-run-ux/F4-cursor-login/tech.md
@@ -1,0 +1,69 @@
+# Tech Spec — F4 `ccstats login cursor`
+
+## Linked Issue
+
+https://github.com/majiayu000/ccstats/issues/167
+
+## Product Spec
+
+`specs/first-run-ux/F4-cursor-login/product.md`
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| CLI commands | `src/cli/commands.rs` | Doctor, Sources, views, Codex/Grok/Kimi subcommands | Add `Login`. |
+| Cursor client | `src/source/cursor/client.rs` | Reads `CURSOR_API_KEY` / `CURSOR_SESSION_TOKEN` env only | Insert file fallback after env. |
+| Cursor diagnose | `src/source/cursor/config.rs` | `has_api_credentials()` | Must include file. |
+| Config paths | `src/config.rs` | config.toml search order | Credentials sit beside the winning config dir **or** XDG config `ccstats/` — pick one and test it. |
+| Doctor tests | `tests/cli_doctor.rs` | Asserts no credential leakage | Extend. |
+
+## 设计方案
+
+1. New module `src/credentials.rs` (or `src/login.rs`):
+   - `struct CursorCredentials { api_key: Option<String>, session_token: Option<String> }`
+   - TOML file `credentials.toml` with section `[cursor]` keys `api_key`, `session_token` (only one should be Some).
+   - Path: `dirs::config_dir()/ccstats/credentials.toml` plus `~/.config/ccstats/credentials.toml` fallback, **independent** of which `config.toml` won. Document this. Do not store secrets in the first-found config.toml (that file is user-edited and logged as "Loaded config from …").
+2. `has_api_credentials()` checks env then file.
+3. Client HTTP still uses the resolved secret in memory; never logs it.
+4. CLI:
+
+   ```text
+   ccstats login cursor [--api-key] [--session-token] [--check] [--clear] [--no-browser]
+   ```
+
+   Nested: `Commands::Login { target: LoginTarget::Cursor, ... }` so we do not invent `ccstats cursor` 源子命令（与「不再为新源加子命令」一致）。
+5. Browser: `open` crate is extra dependency — prefer `std::process::Command` with `open` / `xdg-open` / `cmd /c start` and ignore failure. Or print URL only if adding a dep is undesirable; **prefer zero new deps**.
+6. `login` is metadata-only: skip pricing load like doctor/sources.
+
+## Product-to-Test Mapping
+
+| Invariant | Test |
+| --- | --- |
+| File write | temp HOME, login --session-token, file mode 0600 on unix |
+| Doctor configured | after login, doctor json status configured, token not in stdout/stderr |
+| Env precedence | file + env, --check says env |
+| Mutual exclusion | both flags → exit 1 |
+| Clear | --clear then missing |
+| Non-TTY | no flags → exit 1 |
+
+## 备选方案
+
+- Store in config.toml: rejected because load logs path and users copy config.
+- Read macOS Keychain: nice later, out of scope.
+- `ccstats cursor login` subcommand: rejected to avoid a fourth source grammar.
+
+## 风险
+
+- Cookie in a file is still a secret. chmod 0600 + never print. Mention in PRIVACY.md one short bullet.
+- Path vs CLAUDE_CONFIG_DIR confusion: credentials are ccstats's, not Cursor's app dir.
+
+## 测试计划
+
+- [ ] CLI login tests with temp HOME (see `tests/common/mod.rs`; add `XDG_CONFIG_HOME` / `HOME`).
+- [ ] Doctor leakage test extended.
+- [ ] `cargo test`
+
+## 回滚方案
+
+Remove Login command and file fallback; env-only Cursor remains.

--- a/specs/first-run-ux/F5-limits/product.md
+++ b/specs/first-run-ux/F5-limits/product.md
@@ -1,0 +1,56 @@
+# Product Spec — F5 `ccstats limits`
+
+## Linked Issue
+
+https://github.com/majiayu000/ccstats/issues/168
+
+## 用户问题
+
+订阅用户的 P0 问题是「会不会超额度」，不是 LiteLLM 美元。今天 `ccstats quota` 只服务 Codex，却是顶层命令，看起来像通用额度。Claude 只有 `blocks`（活动推断的 5 小时窗，文档已写明不是官方 reset）。没有一条命令同时回答「Codex 这周」和「Claude 这个窗口」。
+
+## 目标
+
+- 新增 `ccstats limits`：在一条命令里展示本机 **能诚实给出** 的额度/窗口。
+- Codex：复用现有 weekly quota 报告（官方本地 snapshot）。
+- Claude：复用现有 activity-driven `blocks` 的 **当前活动窗**（若有），标明 estimated、not official billing reset。
+- `ccstats quota` 保留，行为不变，帮助文本标明它是 Codex 专用别名。
+- 未检测到的源整段省略，不要伪造余量。
+
+## 非目标
+
+- 不接入 Anthropic 官方 5h/7d 余量 API（那是后续；本轮只用本地已有信号）。
+- 不做 Cursor 计划余量（Cursor 源没有可靠本地 quota；禁止猜）。
+- 不改 blocks 窗口算法。
+- 不在本 PR 做菜单栏。
+
+## Behavior Invariants
+
+1. `ccstats limits` 忽略 `--source` 对「只跑一个源」的强制，**除非** `--source` 是 `codex` 或 `claude`（或 all/省略）。
+   - 省略 / `all`：输出所有能产生的段。
+   - `--source codex`：只 Codex 段。
+   - `--source claude`：只 Claude 段。
+   - `--source cursor` 或其他：exit 1，说明 limits 只支持 claude、codex、all。
+2. Codex 段：与 `ccstats quota` 相同的表/JSON 字段；失败时该段显示错误原因，不阻断 Claude 段。
+3. Claude 段：若无活动 block，写 `No active estimated 5-hour window`，不要 0% 假装有额度。
+4. 每个 Claude 窗口必须有一句：`Estimated from local logs; not an official Anthropic billing reset.`
+5. JSON：`{ "codex": {...}|null, "claude_blocks": {...}|null, "notes": [...] }` 或等价可版本化结构；null 表示源未就绪或不可用，不是零额度。
+6. CSV：稳定列，缺失段留空，不写 0。
+7. Table：两段标题 `Codex weekly quota` / `Claude estimated session window`。
+8. `ccstats quota --help` 写明 Codex-only；`limits --help` 写明组合视图。
+
+## 验收标准
+
+- [ ] 只有 Codex fixture：`limits` 含 Codex 数字，Claude 段为无窗口或不输出空进度条。
+- [ ] 只有 Claude 活动 fixture：`limits` 含 estimated 声明；无 Codex 时 Codex 段为不可用而不是 0%。
+- [ ] `ccstats quota` stdout 与改前测试一致。
+- [ ] `--source cursor` 的 limits 非 0 成功码。
+- [ ] JSON 不含把 missing 写成 used_pct=0。
+
+## 边界情况
+
+- 两源都 missing：table 解释跑 doctor；exit 0。
+- `--json` 与 jq 过滤继续可用。
+
+## 发布说明
+
+新增 `limits` 组合额度视图。`quota` 仍为 Codex 周额度。Claude 窗口仍是本地估算。

--- a/specs/first-run-ux/F5-limits/tech.md
+++ b/specs/first-run-ux/F5-limits/tech.md
@@ -1,0 +1,59 @@
+# Tech Spec — F5 `ccstats limits`
+
+## Linked Issue
+
+https://github.com/majiayu000/ccstats/issues/168
+
+## Product Spec
+
+`specs/first-run-ux/F5-limits/product.md`
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Quota command | `src/quota_cmd.rs`, `src/output/quota.rs`, `src/cli/commands.rs` Quota | Top-level, hard-hints Codex | Reuse handlers; do not copy pricing math. |
+| Blocks | `src/output/blocks.rs`, aggregator billing windows | Activity-driven 5h windows | Extract "active window" selection. |
+| Parse/dispatch | `parse_command`, `SourceCommand::Quota` | quota implies source_hint codex | `Limits` must **not** set source_hint to claude. |
+| Capabilities | `has_billing_blocks` | Claude true, others false | Gate Claude section. |
+
+## 设计方案
+
+1. Add `Commands::Limits` and `SourceCommand::Limits`. `parse_command` does not set a source hint.
+2. `limits` is metadata-ish but Codex quota and Claude blocks need their loaders. Skip unused sources.
+3. New `src/limits_cmd.rs`:
+   - Determine requested sections from `--source` (none/all → both attempts; claude/codex → one).
+   - Codex: call the same `load_weekly_quota` as quota_cmd; on error capture string.
+   - Claude: load Claude entries with existing pipeline, aggregate blocks, pick the window that contains `now` or the latest active window used by today's `blocks` output.
+4. Rendering functions in `output/limits.rs` wrapping existing quota table + a compact single-block summary (tokens, time remaining if already computed, estimated disclaimer).
+5. Keep `handle_quota` untouched besides help text on the Quota variant.
+6. Pricing: Codex value estimate follows quota_cmd (`show_cost`). Claude block cost uses existing block pricing if table already shows it; do not add a new estimator.
+
+## Product-to-Test Mapping
+
+| Invariant | Test |
+| --- | --- |
+| quota unchanged | existing `tests/cli_codex_quota.rs` |
+| limits codex-only | temp HOME with quota snapshot + no claude |
+| limits claude-only | blocks fixture, json `codex: null` |
+| bad source | `--source cursor` exit 1 |
+| disclaimer | table contains `not an official` |
+
+## 备选方案
+
+- Make `quota` generic and overload it: rejected；破坏现有 Codex 脚本。
+- Fetch Anthropic rate-limit headers: rejected this round（凭证与网络边界不同）。
+
+## 风险
+
+- Blocks 全历史加载可能比 quota 慢：只 load Claude source，日期过滤 today±1 天若现有 API 允许；否则沿用 blocks 命令同一加载。
+- F1 auto-detect 若先合并：`limits` 仍按本 spec 的 --source 规则，不要把 limits 默认成 all-usage 表。
+
+## 测试计划
+
+- [ ] Extend quota tests; add `tests/cli_limits.rs`.
+- [ ] `cargo test`
+
+## 回滚方案
+
+Remove Limits command and output module. quota/blocks remain.

--- a/specs/first-run-ux/README.md
+++ b/specs/first-run-ux/README.md
@@ -1,0 +1,23 @@
+# First-run UX specs
+
+Parent product spec: [`product.md`](product.md)
+
+This pack is the implementation contract for the first-run and decision-surface work. Each feature is a separate GitHub issue and PR.
+
+| Feature | Specs | Suggested PR base | Parallel? |
+| --- | --- | --- | --- |
+| F1 Auto-detect default source | #164 [F1-auto-detect/](F1-auto-detect/product.md) | `origin/main` | Yes |
+| F2 README + GitHub identity | #165 [F2-identity/](F2-identity/product.md) | after #164 for the default-command sentence | Docs-only |
+| F3 Conclusion line | #166 [F3-conclusion/](F3-conclusion/product.md) | `origin/main` | Yes |
+| F4 `login cursor` | #167 [F4-cursor-login/](F4-cursor-login/product.md) | `origin/main` | Yes |
+| F5 `limits` | #168 [F5-limits/](F5-limits/product.md) | `origin/main` | Yes; do not edit F4 files |
+
+## Command grammar (this wave)
+
+Canonical form: `ccstats <view> [--source <name>]`.
+
+Keep `ccstats codex|grok|kimi` as aliases. Do **not** add `ccstats cursor` or other new source subcommands. F4 uses `ccstats login cursor`.
+
+## Out of scope
+
+Menu bar, desktop IA collapse, long-tail sources, Tokscale-style leaderboards, `ccstats why`.

--- a/specs/first-run-ux/README.md
+++ b/specs/first-run-ux/README.md
@@ -10,7 +10,7 @@ This pack is the implementation contract for the first-run and decision-surface 
 | F2 README + GitHub identity | #165 [F2-identity/](F2-identity/product.md) | after #164 for the default-command sentence | Docs-only |
 | F3 Conclusion line | #166 [F3-conclusion/](F3-conclusion/product.md) | `origin/main` | Yes |
 | F4 `login cursor` | #167 [F4-cursor-login/](F4-cursor-login/product.md) | `origin/main` | Yes |
-| F5 `limits` | #168 [F5-limits/](F5-limits/product.md) | `origin/main` | Yes; do not edit F4 files |
+| F5 `limits` | #168 [F5-limits/](F5-limits/product.md) | #172 login branch, then retarget to `main` after #172 merges | Requires F1/F4 integration checks |
 
 ## Command grammar (this wave)
 

--- a/specs/first-run-ux/product.md
+++ b/specs/first-run-ux/product.md
@@ -1,0 +1,67 @@
+# Product Spec — First-run UX and decision surface
+
+## Linked Issue
+
+https://github.com/majiayu000/ccstats/issues/163
+
+Child issues: #164 F1, #165 F2, #166 F3, #167 F4, #168 F5.
+
+## 用户问题
+
+ccstats 在 v0.5.2 已经是 29 源本地账本 + CLI + SDK + 桌面，但第一次运行仍默认 Claude。没有 Claude 日志的用户看到空表；Cursor / Codex 用户必须先读 README。默认输出是宽表，没有一句能带走的结论。Cursor 授权要手贴 cookie。额度散落在 `quota`（只属于 Codex）和 `blocks`（Claude 语义）里。
+
+竞品（ccusage、CodeBurn、Tokscale、CodexBar、Claude-Code-Usage-Monitor）把「本机有什么就出什么」和「还剩多少额度」做成了默认路径。ccstats 的会计正确性没有进入这 30 秒。
+
+## 目标
+
+让新用户在不读文档的情况下完成：
+
+1. 第一次运行看到 **自己机器上已有的源**，而不是一张 Claude 空表。
+2. 没有任何源时看到 **可执行的安装/授权提示**（doctor），而不是空结果。
+3. 默认表输出带一句 **人话结论**（今天多少、是否完整/下限/未知）。
+4. Cursor 用户用一条命令完成凭证写入，不必去文档里找 cookie 名。
+5. 订阅用户用一条命令看到 **Codex 周额度 + Claude 估算窗口**，措辞不把估算当成官方账单。
+6. GitHub / README 第一屏与真实产品一致（不再写「只支持 Claude 和 Codex」）。
+
+## 非目标
+
+- 不删除 `ccstats codex` / `ccstats grok` / `ccstats kimi` 别名（保留，不再为新源增加对称子命令）。
+- 不把 SDK `summarize_cost` 的缺省源改成 auto-detect（SDK 必须显式传 `UsageSource`）。
+- 不在本轮做菜单栏、桌面信息架构收缩、长尾第 30 个源、排行榜/社交。
+- 不把估算额度伪装成官方 Anthropic / Cursor 账单余量。
+- 不在未签名桌面安装包上投入获客主路径。
+
+## 功能拆分
+
+| ID | 功能 | 用户可感知结果 | 依赖 |
+| --- | --- | --- | --- |
+| F1 | 默认使用已检测源；空数据走 doctor | `ccstats` / `ccstats daily` 无 `--source` 时不再默认 Claude | 无 |
+| F2 | README 第一屏 + GitHub 仓库身份 | 访客 30 秒内知道装什么、跑什么、产品是什么 | F1 的命令语义（文档可并行起草，合并前对齐） |
+| F3 | 默认表输出结论行 | 表上方一句人话 + floor/unknown 标记 | 无（可与 F1 并行；F1 之后 all-source 结论更有价值） |
+| F4 | `ccstats login cursor` | 向导写入凭证，doctor 显示 Configured | 无 |
+| F5 | `ccstats limits` | Codex quota + Claude blocks 同屏；`quota` 保留为别名 | 无 |
+
+每个功能单独 issue + PR。实现不得把两个功能塞进同一个 PR，除非后者只改前者引入的文档口误。
+
+## 全局不变量
+
+1. CLI `--source`、源子命令 hint（`codex`/`grok`/`kimi`）、config `source` 的优先级高于自动检测。
+2. 自动检测只把 `diagnose()` 为 `Detected` 或 `Configured` 的源当作就绪。`Missing` 不进入默认合计。
+3. 就绪源为 0 → 打印 doctor 表（与 `ccstats doctor` 相同内容），进程退出码 0（这是引导，不是故障）。JSON/CSV 模式下空检测输出 doctor 的结构化结果，不假装有用量。
+4. 就绪源为 1 → 该源，行为与今天 `--source <name>` 相同。
+5. 就绪源 ≥ 2 → 与今天 `--source all` 相同（含 real-only token 合计、`--source-breakdown` 规则）。
+6. `statusline` 若未指定源，也走自动检测，以便 hook 显示本机真实用量；config 里可钉死 `source`。
+7. 未知、下限、估算窗口必须保持可见；禁止把 `null` 显示成 `$0.00`。
+8. 不新增网络端点，除非 F4 只打开用户本机浏览器到已文档化的 Cursor dashboard URL（不代发 cookie）。
+
+## 成功标准（90 天产品，本轮交付切片）
+
+- [ ] 新机器只敲 `ccstats`，若本机有 Codex 或 Claude 日志，不必读文档即可看到自己的数。
+- [ ] 没有数据时，输出是 doctor 提示，不是空 Claude 表。
+- [ ] Cursor 用户可用 `ccstats login cursor` 完成授权（非交互 flag 也必须可用，便于测试）。
+- [ ] `ccstats limits` 能同时回答 Codex 周额度和 Claude 估算窗口，并标明估算 vs 官方。
+- [ ] GitHub description、README 首屏、默认命令说的是同一件事。
+
+## 发布说明方向
+
+这是一次面向采用的默认路径修复，不是新数据源。changelog 应强调：无参数 CLI 现在汇总本机已检测源；空库进入 doctor；Cursor 增加 login；新增 limits 视图。


### PR DESCRIPTION
## Summary
- Adds `specs/first-run-ux/` as the implementation contract for the first-run UX work.
- Parent issue #163. Child issues: #164 #165 #166 #167 #168.

## What
Product + tech specs only. No runtime changes.

## Why
Default CLI still assumes Claude, GitHub identity is stale, table output has no human conclusion, Cursor auth is copy-paste, and `quota` looks generic but is Codex-only.

## Test plan
- [x] Specs review against #163 acceptance
- [ ] Child PRs implement one feature each


Made with [Cursor](https://cursor.com)