### PR TITLE
feat: default CLI source to detected providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Default CLI usage commands auto-detect ready sources instead of assuming Claude. Zero ready sources print the same output as `ccstats doctor` (statusline stays a quiet empty line); one ready source uses that provider; two or more use the existing `--source all` path. Explicit `--source`, source subcommands, and config `source` still win. The Rust SDK still defaults to Claude.
+
 ## [0.5.2] - 2026-09-03
 
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,10 @@ use config::Config;
 use core::DateFilter;
 use output::NumberFormat;
 use pricing::{CurrencyConverter, PricingDb};
-use source::{ALL_SOURCES, CodexScope, CodexSource, get_source, source_choices, suggest_source};
+use source::{
+    ALL_SOURCES, CodexScope, CodexSource, auto_detected_source_name, get_source,
+    ready_source_names, source_choices, suggest_source,
+};
 use utils::{Timezone, parse_date};
 
 enum TimezoneSource {
@@ -203,16 +206,18 @@ fn resolve_source_name<'a>(
     source_hint: Option<&'static str>,
     source_override: Option<&'a str>,
     source_cmd: SourceCommand,
-) -> &'a str {
+) -> Option<&'a str> {
     if matches!(source_cmd, SourceCommand::Doctor | SourceCommand::Sources) {
-        return "claude";
+        return Some("claude");
     }
 
     match (source_hint, source_override) {
-        (Some(hint), Some(override_name)) => resolve_overridden_command_source(hint, override_name),
-        (Some(hint), None) => hint,
-        (None, Some(name)) => name,
-        (None, None) => "claude",
+        (Some(hint), Some(override_name)) => {
+            Some(resolve_overridden_command_source(hint, override_name))
+        }
+        (Some(hint), None) => Some(hint),
+        (None, Some(name)) => Some(name),
+        (None, None) => auto_detected_source_name(&ready_source_names()),
     }
 }
 
@@ -362,33 +367,42 @@ pub fn run_cli() {
     let budget_as_of = until.map_or(today, |end| end.min(today));
     let filter = build_date_filter(source_cmd, today, since, until);
     let show_cost = cli.show_cost();
-    let metadata_only = matches!(source_cmd, SourceCommand::Doctor | SourceCommand::Sources);
-    let needs_pricing = !metadata_only && (is_statusline || show_cost);
-    let pricing_db = load_pricing_db(&cli, needs_pricing, is_statusline);
     let source_name = resolve_source_name(
         parsed_command.source_hint,
         cli.source.as_deref(),
         source_cmd,
     );
-    validate_source_breakdown(&cli, source_name, source_cmd);
-    validate_codex_scope(cli.codex_scope, source_name);
-    let needs_currency = source_cmd != SourceCommand::Quota && needs_pricing;
+    if source_name.is_none() && is_statusline {
+        println!();
+        return;
+    }
+
+    let metadata_only = matches!(source_cmd, SourceCommand::Doctor | SourceCommand::Sources)
+        || source_name.is_none();
+    let needs_pricing = !metadata_only && (is_statusline || show_cost);
+    let pricing_db = load_pricing_db(&cli, needs_pricing, is_statusline);
+    if let Some(source_name) = source_name {
+        validate_source_breakdown(&cli, source_name, source_cmd);
+        validate_codex_scope(cli.codex_scope, source_name);
+    }
+    let needs_currency =
+        source_name.is_some() && source_cmd != SourceCommand::Quota && needs_pricing;
     let currency_converter = load_currency_converter(&cli, needs_currency, is_statusline);
 
-    dispatch_command(
-        source_name,
-        source_cmd,
-        &CommandContext {
-            filter: &filter,
-            cli: &cli,
-            pricing_db: &pricing_db,
-            timezone,
-            number_format,
-            jq_filter,
-            currency: currency_converter.as_ref(),
-            budget_as_of,
-        },
-    );
+    let context = CommandContext {
+        filter: &filter,
+        cli: &cli,
+        pricing_db: &pricing_db,
+        timezone,
+        number_format,
+        jq_filter,
+        currency: currency_converter.as_ref(),
+        budget_as_of,
+    };
+    match source_name {
+        Some(source_name) => dispatch_command(source_name, source_cmd, &context),
+        None => crate::doctor_cmd::handle_doctor(&context),
+    }
 
     if cli.debug && needs_pricing {
         for diagnostic in pricing_db.pricing_diagnostics() {

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -465,6 +465,10 @@ impl DiagnosticStatus {
             Self::Missing => "missing",
         }
     }
+
+    pub(crate) fn is_ready(self) -> bool {
+        matches!(self, Self::Detected | Self::Configured)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -621,7 +625,10 @@ pub(crate) use grok::{
 pub use inventory::UsageSource;
 
 // Re-export registry functions
-pub(crate) use registry::{ALL_SOURCES, all_sources, get_source, source_choices, suggest_source};
+pub(crate) use registry::{
+    ALL_SOURCES, all_sources, auto_detected_source_name, get_source, ready_source_names,
+    source_choices, suggest_source,
+};
 
 pub(crate) fn all_capabilities() -> Capabilities {
     Capabilities::combine(all_sources())

--- a/src/source/registry.rs
+++ b/src/source/registry.rs
@@ -18,6 +18,25 @@ pub(crate) fn all_sources() -> impl Iterator<Item = &'static dyn Source> {
     SOURCES.iter().map(std::convert::AsRef::as_ref)
 }
 
+/// Ready sources: `diagnose()` is Detected or Configured, in registry order.
+///
+/// This inspects local files and credentials only. It does not parse logs or
+/// contact remote APIs.
+pub(crate) fn ready_source_names() -> Vec<&'static str> {
+    all_sources()
+        .filter(|source| source.diagnose().status.is_ready())
+        .map(Source::name)
+        .collect()
+}
+
+pub(crate) fn auto_detected_source_name(ready: &[&'static str]) -> Option<&'static str> {
+    match ready {
+        [] => None,
+        [name] => Some(*name),
+        _ => Some(ALL_SOURCES),
+    }
+}
+
 /// Get a source by name or alias
 pub(crate) fn get_source(name: &str) -> Option<&'static dyn Source> {
     let name_lower = name.to_lowercase();
@@ -108,6 +127,7 @@ fn edit_distance(a: &str, b: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::source::DiagnosticStatus;
 
     #[test]
     fn test_get_source_by_name() {
@@ -308,5 +328,26 @@ mod tests {
     #[test]
     fn test_suggest_source_none_for_distant_input() {
         assert_eq!(suggest_source("totally-unknown"), None);
+    }
+
+    #[test]
+    fn auto_detected_source_name_maps_ready_counts() {
+        assert_eq!(auto_detected_source_name(&[]), None);
+        assert_eq!(auto_detected_source_name(&["codex"]), Some("codex"));
+        assert_eq!(
+            auto_detected_source_name(&["claude", "codex"]),
+            Some(ALL_SOURCES)
+        );
+        assert_eq!(
+            auto_detected_source_name(&["claude", "codex", "cursor"]),
+            Some(ALL_SOURCES)
+        );
+    }
+
+    #[test]
+    fn diagnostic_status_ready_is_detected_or_configured() {
+        assert!(DiagnosticStatus::Detected.is_ready());
+        assert!(DiagnosticStatus::Configured.is_ready());
+        assert!(!DiagnosticStatus::Missing.is_ready());
     }
 }

--- a/tests/cli_auto_detect.rs
+++ b/tests/cli_auto_detect.rs
@@ -1,0 +1,356 @@
+mod common;
+
+use chrono::Utc;
+use common::{run_ccstats, unique_temp_dir, write_file};
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+
+fn write_codex_session(codex_home: &Path, timestamp: &str, input: i64) {
+    write_file(
+        &codex_home.join("sessions").join("session.jsonl"),
+        &format!(
+            r#"{{"timestamp":"{timestamp}","type":"event_msg","payload":{{"type":"token_count","info":{{"total_token_usage":{{"input_tokens":{input},"cached_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":0,"total_tokens":{total}}},"last_token_usage":{{"input_tokens":{input},"cached_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":0,"total_tokens":{total}}},"model":"gpt-5"}}}}}}
+"#,
+            total = input + 5
+        ),
+    );
+}
+
+fn write_claude_session(root: &Path, timestamp: &str) {
+    write_file(
+        &root.join(".claude/projects/myapp/claude-session.jsonl"),
+        &format!(
+            r#"{{"timestamp":"{timestamp}","message":{{"id":"msg_1","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}}}}
+"#
+        ),
+    );
+}
+
+fn json_total_tokens(stdout: &[u8]) -> i64 {
+    let json: Value = serde_json::from_slice(stdout).expect("json");
+    json.as_array().expect("array output")[0]["total_tokens"]
+        .as_i64()
+        .expect("total_tokens")
+}
+
+fn assert_doctor_diagnostics(stdout: &[u8]) {
+    let output = String::from_utf8_lossy(stdout);
+    assert!(
+        output.contains("Source diagnostics"),
+        "expected doctor table, got: {output}"
+    );
+    assert!(
+        output.contains("No source data detected"),
+        "expected empty-source hint, got: {output}"
+    );
+    assert!(
+        !output.contains("Token Usage"),
+        "Claude period table leaked into empty auto-detect: {output}"
+    );
+    assert!(
+        !output.contains("No Claude Code usage data found"),
+        "default Claude empty table leaked: {output}"
+    );
+}
+
+#[test]
+fn empty_home_daily_prints_doctor_not_claude_table() {
+    let root = unique_temp_dir("auto-detect-empty-daily");
+    let (ok, stdout, stderr) = run_ccstats(&["daily", "-O", "--no-cost"], &[("HOME", &root)]);
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    assert_doctor_diagnostics(&stdout);
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn empty_home_default_command_prints_doctor_not_claude_table() {
+    let root = unique_temp_dir("auto-detect-empty-default");
+    let (ok, stdout, stderr) = run_ccstats(&["-O", "--no-cost"], &[("HOME", &root)]);
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    assert_doctor_diagnostics(&stdout);
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn empty_home_daily_json_uses_doctor_schema() {
+    let root = unique_temp_dir("auto-detect-empty-json");
+    let (ok, stdout, stderr) = run_ccstats(&["daily", "-j", "-O", "--no-cost"], &[("HOME", &root)]);
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let json: Value = serde_json::from_slice(&stdout).expect("doctor json");
+    let rows = json.as_array().expect("doctor array");
+    assert!(rows.iter().any(|row| row["name"] == "claude"));
+    assert!(rows.iter().any(|row| row["name"] == "codex"));
+    for row in rows {
+        assert!(
+            row.get("status").is_some(),
+            "doctor row missing status: {row}"
+        );
+        assert!(
+            row.get("setup").is_some(),
+            "doctor row missing setup: {row}"
+        );
+        assert!(
+            row.get("date").is_none(),
+            "usage schema mixed into doctor json: {row}"
+        );
+        assert!(
+            row.get("total_tokens").is_none(),
+            "usage totals mixed into doctor json: {row}"
+        );
+    }
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn empty_home_statusline_is_quiet_single_line() {
+    let root = unique_temp_dir("auto-detect-empty-statusline");
+    let (ok, stdout, stderr) = run_ccstats(&["statusline"], &[("HOME", &root)]);
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let output = String::from_utf8(stdout).expect("utf8 stdout");
+    assert!(
+        !output.contains("Source diagnostics"),
+        "statusline dumped doctor: {output}"
+    );
+    let lines: Vec<&str> = output.lines().collect();
+    assert_eq!(
+        lines.len(),
+        1,
+        "expected a single quiet line, got: {output:?}"
+    );
+    assert!(
+        lines[0].len() < 80,
+        "statusline line should stay short: {output:?}"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn codex_only_today_matches_explicit_codex_source() {
+    let root = unique_temp_dir("auto-detect-codex-only");
+    let codex_home = root.join("codex-home");
+    let timestamp = Utc::now().format("%Y-%m-%dT12:00:00Z").to_string();
+    write_codex_session(&codex_home, &timestamp, 10);
+
+    let args_auto = ["today", "-j", "-O", "--no-cost", "--timezone", "UTC"];
+    let args_explicit = [
+        "today",
+        "--source",
+        "codex",
+        "-j",
+        "-O",
+        "--no-cost",
+        "--timezone",
+        "UTC",
+    ];
+    let envs = [
+        ("HOME", root.as_path()),
+        ("CODEX_HOME", codex_home.as_path()),
+    ];
+
+    let (ok, auto_stdout, stderr) = run_ccstats(&args_auto, &envs);
+    assert!(ok, "auto stderr: {}", String::from_utf8_lossy(&stderr));
+    let (ok, explicit_stdout, stderr) = run_ccstats(&args_explicit, &envs);
+    assert!(ok, "explicit stderr: {}", String::from_utf8_lossy(&stderr));
+
+    assert_eq!(
+        json_total_tokens(&auto_stdout),
+        json_total_tokens(&explicit_stdout)
+    );
+    assert_eq!(json_total_tokens(&auto_stdout), 15);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn claude_and_codex_daily_uses_all_sources_path() {
+    let root = unique_temp_dir("auto-detect-claude-codex");
+    let codex_home = root.join("codex-home");
+    write_claude_session(&root, "2026-02-06T10:00:00Z");
+    write_codex_session(&codex_home, "2026-02-06T11:00:00Z", 10);
+
+    let period_args = [
+        "-j",
+        "-O",
+        "--no-cost",
+        "--timezone",
+        "UTC",
+        "--since",
+        "2026-02-06",
+        "--until",
+        "2026-02-06",
+    ];
+    let envs = [
+        ("HOME", root.as_path()),
+        ("CODEX_HOME", codex_home.as_path()),
+    ];
+
+    let mut auto_args = vec!["daily"];
+    auto_args.extend_from_slice(&period_args);
+    let (ok, auto_stdout, stderr) = run_ccstats(&auto_args, &envs);
+    assert!(ok, "auto stderr: {}", String::from_utf8_lossy(&stderr));
+
+    let mut all_args = vec!["daily", "--source", "all"];
+    all_args.extend_from_slice(&period_args);
+    let (ok, all_stdout, stderr) = run_ccstats(&all_args, &envs);
+    assert!(ok, "all stderr: {}", String::from_utf8_lossy(&stderr));
+
+    assert_eq!(
+        json_total_tokens(&auto_stdout),
+        json_total_tokens(&all_stdout)
+    );
+    assert_eq!(json_total_tokens(&auto_stdout), 165);
+
+    let mut breakdown_args = vec!["daily", "--source-breakdown"];
+    breakdown_args.extend_from_slice(&period_args);
+    let (ok, breakdown_stdout, stderr) = run_ccstats(&breakdown_args, &envs);
+    assert!(
+        ok,
+        "auto-detect two sources should allow --source-breakdown: {}",
+        String::from_utf8_lossy(&stderr)
+    );
+    let json: Value = serde_json::from_slice(&breakdown_stdout).expect("breakdown json");
+    assert!(json.is_object(), "all-sources breakdown wraps an object");
+    let names: Vec<&str> = json["sources"]
+        .as_array()
+        .expect("sources")
+        .iter()
+        .filter_map(|entry| entry["source"].as_str())
+        .collect();
+    assert_eq!(names, vec!["claude", "codex"]);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn explicit_claude_source_does_not_switch_to_codex() {
+    let root = unique_temp_dir("auto-detect-claude-override");
+    let codex_home = root.join("codex-home");
+    write_codex_session(&codex_home, "2026-02-06T11:00:00Z", 10);
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "--source",
+            "claude",
+            "-j",
+            "-O",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("HOME", &root), ("CODEX_HOME", &codex_home)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let output = String::from_utf8_lossy(&stdout);
+    assert!(
+        output.contains("No Claude Code usage data found"),
+        "expected Claude empty hint, got: {output}"
+    );
+    assert!(
+        !output.contains("\"total_tokens\":15"),
+        "explicit Claude switched to Codex: {output}"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn config_source_pins_codex_on_a_multi_source_machine() {
+    let root = unique_temp_dir("auto-detect-config-source");
+    let codex_home = root.join("codex-home");
+    write_claude_session(&root, "2026-02-06T10:00:00Z");
+    write_codex_session(&codex_home, "2026-02-06T11:00:00Z", 10);
+    write_file(
+        &root.join(".config/ccstats/config.toml"),
+        "source = \"codex\"\n",
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "-j",
+            "-O",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("HOME", &root), ("CODEX_HOME", &codex_home)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    assert_eq!(json_total_tokens(&stdout), 15);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn explicit_source_all_uses_all_path_with_one_ready_source() {
+    let root = unique_temp_dir("auto-detect-explicit-all");
+    let codex_home = root.join("codex-home");
+    write_codex_session(&codex_home, "2026-02-06T11:00:00Z", 10);
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "--source",
+            "all",
+            "--source-breakdown",
+            "-j",
+            "-O",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("HOME", &root), ("CODEX_HOME", &codex_home)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let json: Value = serde_json::from_slice(&stdout).expect("breakdown json");
+    assert!(json.is_object());
+    let names: Vec<&str> = json["sources"]
+        .as_array()
+        .expect("sources")
+        .iter()
+        .filter_map(|entry| entry["source"].as_str())
+        .collect();
+    assert_eq!(names, vec!["codex"]);
+
+    let (ok, _stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "--source-breakdown",
+            "-j",
+            "-O",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("HOME", &root), ("CODEX_HOME", &codex_home)],
+    );
+    assert!(
+        !ok,
+        "one ready source must not auto-select all for --source-breakdown"
+    );
+    assert!(
+        String::from_utf8_lossy(&stderr).contains("--source-breakdown requires --source all"),
+        "stderr: {}",
+        String::from_utf8_lossy(&stderr)
+    );
+
+    let _ = fs::remove_dir_all(root);
+}

--- a/tests/cli_claude.rs
+++ b/tests/cli_claude.rs
@@ -420,6 +420,8 @@ fn claude_daily_json_missing_claude_config_dir_returns_no_data() {
     let (ok, stdout, stderr) = run_ccstats(
         &[
             "daily",
+            "--source",
+            "claude",
             "-j",
             "-O",
             "--no-cost",


### PR DESCRIPTION
## What

Unspecified CLI `--source` now uses locally ready providers instead of hardcoding Claude.

## Why

First-run users who only have Codex, Cursor, or another provider were getting an empty Claude table and thought the product was broken. Doctor already knew which sources were present; the default command did not.

Fixes #164

## Changes

- Ready sources are `diagnose()` status Detected or Configured, in registry order. Detection still does not parse logs or call the Cursor API.
- Priority is unchanged: CLI `--source` > source subcommand hint > config `source` > auto-detect.
- Zero ready sources: usage commands print the same table/json/csv as `ccstats doctor` and exit 0. `statusline` prints one quiet empty line.
- One ready source uses that provider. Two or more use the existing `--source all` path. Explicit `--source all` still uses all even if only one source is ready.
- `doctor`/`sources` still ignore auto-detect. SDK `summarize_cost` still defaults to Claude.

## Test plan

- [ ] `cargo test --test cli_auto_detect --test cli_doctor --test cli_codex_source_routing`
- [ ] Empty HOME: `ccstats daily` and default no-subcommand print doctor diagnostics, not a Claude period table
- [ ] Empty HOME `ccstats daily -j` is doctor schema (status/setup), not usage `total_tokens`
- [ ] Codex-only fixture: `today` without `--source` matches `today --source codex` on token totals (`-j -O --no-cost`)
- [ ] Claude+Codex fixtures: no `--source` `daily` matches `--source all` and allows `--source-breakdown`
- [ ] `--source claude` with Codex-only data stays on Claude
- [ ] config `source = "codex"` on a multi-source machine stays on Codex
- [ ] `--source all` with one ready source still uses the all-sources path
- [ ] Empty HOME `statusline` exits 0 with a short single line and no `Source diagnostics`
- [ ] Existing `ccstats doctor` output is unchanged