### PR TITLE
feat: add a human conclusion line to period tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Print a one-line human conclusion before table-mode daily, today, weekly, and monthly reports. The amounts reuse the table footer; JSON and CSV stdout stay structured.
+
 ## [0.5.2] - 2026-09-03
 
 ### Added

--- a/src/app.rs
+++ b/src/app.rs
@@ -425,8 +425,9 @@ fn render_period_result(
     codex_scope: Option<CodexScope>,
     grok_reports: Option<&HashMap<String, GrokCostReport>>,
     ctx: &CommandContext<'_>,
-    cost_mode: CostDisplayMode,
+    flags: period_table::PeriodTableFlags,
 ) {
+    let cost_mode = flags.cost_mode;
     let cost_coverage = CostCoverage::from_stats(result.day_stats.values().map(|day| &day.stats));
     let visible_grok_reports = ctx.cli.show_cost().then_some(grok_reports).flatten();
     let selected_grok_report = cost_coverage::selected_grok_report(visible_grok_reports);
@@ -511,7 +512,7 @@ fn render_period_result(
             codex_scope,
             visible_grok_reports,
             ctx,
-            cost_mode,
+            flags,
         ),
     }
 }
@@ -550,10 +551,14 @@ fn handle_period(
         codex_scope_for_source(source, ctx),
         grok_reports.as_ref(),
         ctx,
-        grok_reports
-            .as_ref()
-            .filter(|reports| !reports.is_empty())
-            .map_or(CostDisplayMode::Total, |_| CostDisplayMode::RealOnly),
+        period_table::PeriodTableFlags {
+            cost_mode: grok_reports
+                .as_ref()
+                .filter(|reports| !reports.is_empty())
+                .map_or(CostDisplayMode::Total, |_| CostDisplayMode::RealOnly),
+            is_today: command == SourceCommand::Today,
+            source_count: None,
+        },
     );
 }
 
@@ -621,9 +626,9 @@ pub(crate) fn handle_source_command(
     handle_period(source, command, &caps, ctx);
 }
 
-fn load_all_daily(ctx: &CommandContext<'_>, quiet: bool) -> (LoadResult, Capabilities) {
+fn load_all_daily(ctx: &CommandContext<'_>, quiet: bool) -> (LoadResult, Capabilities, usize) {
     let loaded = source_breakdown::load_all_sources(ctx, quiet, false);
-    (loaded.combined, loaded.caps)
+    (loaded.combined, loaded.caps, loaded.contributing_sources)
 }
 
 fn handle_all_period(command: SourceCommand, ctx: &CommandContext<'_>) {
@@ -633,13 +638,14 @@ fn handle_all_period(command: SourceCommand, ctx: &CommandContext<'_>) {
         SourceCommand::Monthly => Period::Month,
         _ => return,
     };
+    let is_today = command == SourceCommand::Today;
 
     if ctx.cli.source_breakdown {
-        source_breakdown::render(period, ctx);
+        source_breakdown::render(period, is_today, ctx);
         return;
     }
 
-    let (result, caps) = load_all_daily(ctx, false);
+    let (result, caps, contributing_sources) = load_all_daily(ctx, false);
     if result.day_stats.is_empty() && !should_render_empty_structured_result(&result, ctx) {
         print_no_data_hint("All Sources", "usage");
         return;
@@ -651,7 +657,11 @@ fn handle_all_period(command: SourceCommand, ctx: &CommandContext<'_>) {
         None,
         None,
         ctx,
-        CostDisplayMode::Total,
+        period_table::PeriodTableFlags {
+            cost_mode: CostDisplayMode::Total,
+            is_today,
+            source_count: (contributing_sources > 1).then_some(contributing_sources),
+        },
     );
 }
 
@@ -665,7 +675,7 @@ pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandCo
             std::process::exit(1);
         }
         SourceCommand::Statusline => {
-            let (result, caps) = load_all_daily(ctx, true);
+            let (result, caps, _) = load_all_daily(ctx, true);
             if ctx.cli.json {
                 let json = print_statusline_json_with_quality(
                     &result.day_stats,
@@ -708,7 +718,7 @@ pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandCo
                 );
                 return;
             }
-            let (result, caps) = load_all_daily(ctx, false);
+            let (result, caps, _) = load_all_daily(ctx, false);
             let rows = rank_by_model_with_cost_mode(
                 &result.day_stats,
                 ctx.pricing_db,

--- a/src/app.rs
+++ b/src/app.rs
@@ -558,6 +558,7 @@ fn handle_period(
                 .map_or(CostDisplayMode::Total, |_| CostDisplayMode::RealOnly),
             is_today: command == SourceCommand::Today,
             source_count: None,
+            source_name: Some(source.name()),
         },
     );
 }
@@ -661,6 +662,7 @@ fn handle_all_period(command: SourceCommand, ctx: &CommandContext<'_>) {
             cost_mode: CostDisplayMode::Total,
             is_today,
             source_count: (contributing_sources > 1).then_some(contributing_sources),
+            source_name: None,
         },
     );
 }

--- a/src/app/period_table.rs
+++ b/src/app/period_table.rs
@@ -10,6 +10,13 @@ use crate::source::{Capabilities, CodexScope, GrokCostReport};
 
 use super::{CommandContext, cost_coverage};
 
+#[derive(Clone, Copy)]
+pub(super) struct PeriodTableFlags {
+    pub(super) cost_mode: CostDisplayMode,
+    pub(super) is_today: bool,
+    pub(super) source_count: Option<usize>,
+}
+
 pub(super) fn render(
     result: &LoadResult,
     period: Period,
@@ -17,7 +24,7 @@ pub(super) fn render(
     codex_scope: Option<CodexScope>,
     grok_reports: Option<&HashMap<String, GrokCostReport>>,
     ctx: &CommandContext<'_>,
-    cost_mode: CostDisplayMode,
+    flags: PeriodTableFlags,
 ) {
     if let Some(scope) = codex_scope {
         println!("\n  Codex scope: {}", scope.as_str());
@@ -46,7 +53,7 @@ pub(super) fn render(
             show_cache_creation: caps.has_cache_creation,
             supports_cache_read: caps.has_cache_read,
             currency: ctx.currency,
-            cost_mode,
+            cost_mode: flags.cost_mode,
             cost_label: if selected_grok_report.is_some() {
                 "Grok Reported"
             } else {
@@ -68,6 +75,8 @@ pub(super) fn render(
             pricing_note_override: selected_grok_report.map(|_| {
                 "Grok Reported comes from costUsdTicks; API Eq. Price uses xAI public rates. ~ is estimated, ranges mark unknown request boundaries, and ≥ marks partial Grok coverage."
             }),
+            is_today: flags.is_today,
+            source_count: flags.source_count,
         },
     );
     if ctx.cli.show_cost() {
@@ -83,7 +92,7 @@ pub(super) fn render(
             budget,
             ctx.budget_as_of,
             ctx.currency,
-            cost_mode,
+            flags.cost_mode,
         );
         print_monthly_budget_table(&reports, ctx.cli.use_color(), ctx.currency);
     }

--- a/src/app/period_table.rs
+++ b/src/app/period_table.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::core::LoadResult;
+use crate::core::{DateFilter, DayStats, LoadResult};
 use crate::output::{
     Period, PeriodSummaryFooter, TokenTableOptions, monthly_budget_reports,
     print_monthly_budget_table, print_period_table,
@@ -9,12 +9,14 @@ use crate::pricing::CostDisplayMode;
 use crate::source::{Capabilities, CodexScope, GrokCostReport};
 
 use super::{CommandContext, cost_coverage};
+use crate::source::{CodexSource, get_source, load_daily};
 
 #[derive(Clone, Copy)]
 pub(super) struct PeriodTableFlags {
     pub(super) cost_mode: CostDisplayMode,
     pub(super) is_today: bool,
     pub(super) source_count: Option<usize>,
+    pub(super) source_name: Option<&'static str>,
 }
 
 pub(super) fn render(
@@ -30,6 +32,11 @@ pub(super) fn render(
         println!("\n  Codex scope: {}", scope.as_str());
     }
 
+    let history = if flags.is_today && !ctx.cli.compact && result.parse_errors == 0 {
+        prior_days(flags.source_name, ctx)
+    } else {
+        HashMap::new()
+    };
     let selected_grok_report = cost_coverage::selected_grok_report(grok_reports);
     let grok_cost_displays = grok_reports
         .map(|reports| cost_coverage::table_cost_displays(reports, period, ctx.currency));
@@ -75,6 +82,7 @@ pub(super) fn render(
             pricing_note_override: selected_grok_report.map(|_| {
                 "Grok Reported comes from costUsdTicks; API Eq. Price uses xAI public rates. ~ is estimated, ranges mark unknown request boundaries, and ≥ marks partial Grok coverage."
             }),
+            comparison_days: Some(&history),
             is_today: flags.is_today,
             source_count: flags.source_count,
         },
@@ -95,5 +103,43 @@ pub(super) fn render(
             flags.cost_mode,
         );
         print_monthly_budget_table(&reports, ctx.cli.use_color(), ctx.currency);
+    }
+}
+
+fn prior_days(source_name: Option<&str>, ctx: &CommandContext<'_>) -> HashMap<String, DayStats> {
+    let today = ctx
+        .timezone
+        .to_fixed_offset(chrono::Utc::now())
+        .date_naive();
+    let filter = DateFilter::new(
+        today.checked_sub_signed(chrono::Duration::days(7)),
+        today.pred_opt(),
+    );
+    let result = match source_name {
+        Some("codex") => load_daily(
+            &CodexSource::with_scope(ctx.cli.codex_scope),
+            &filter,
+            ctx.timezone,
+            true,
+            ctx.cli.debug,
+        ),
+        Some(name) => {
+            let Some(source) = get_source(name) else {
+                return HashMap::new();
+            };
+            load_daily(source, &filter, ctx.timezone, true, ctx.cli.debug)
+        }
+        None => {
+            let prior_ctx = CommandContext {
+                filter: &filter,
+                ..*ctx
+            };
+            super::source_breakdown::load_all_sources(&prior_ctx, true, false).combined
+        }
+    };
+    if result.parse_errors > 0 {
+        HashMap::new()
+    } else {
+        result.day_stats
     }
 }

--- a/src/app/source_breakdown.rs
+++ b/src/app/source_breakdown.rs
@@ -27,6 +27,7 @@ pub(super) struct SourceSection {
 pub(super) struct AllSourceLoad {
     pub(super) combined: LoadResult,
     pub(super) caps: Capabilities,
+    pub(super) contributing_sources: usize,
     sections: Vec<SourceSection>,
 }
 
@@ -39,9 +40,13 @@ pub(super) fn load_all_sources(
     let mut combined = LoadResult::default();
     let caps = all_capabilities();
     let mut sections = Vec::new();
+    let mut contributing_sources = 0;
 
     for source in all_sources() {
         let mut result = load_daily(source, ctx.filter, ctx.timezone, quiet, ctx.cli.debug);
+        if !result.day_stats.is_empty() {
+            contributing_sources += 1;
+        }
         if keep_sections {
             apply_real_token_totals_for_all_source(&mut result.day_stats);
         }
@@ -73,11 +78,12 @@ pub(super) fn load_all_sources(
     AllSourceLoad {
         combined,
         caps,
+        contributing_sources,
         sections,
     }
 }
 
-pub(super) fn render(period: Period, ctx: &CommandContext<'_>) {
+pub(super) fn render(period: Period, is_today: bool, ctx: &CommandContext<'_>) {
     let loaded = load_all_sources(ctx, false, true);
     if loaded.combined.day_stats.is_empty()
         && !should_render_empty_structured_result(&loaded.combined, ctx)
@@ -89,7 +95,7 @@ pub(super) fn render(period: Period, ctx: &CommandContext<'_>) {
     match ctx.cli.output_format() {
         OutputFormat::Csv => render_csv(&loaded, period, ctx),
         OutputFormat::Json => render_json(&loaded, period, ctx),
-        OutputFormat::Table => render_table(&loaded, period, ctx),
+        OutputFormat::Table => render_table(&loaded, period, is_today, ctx),
     }
 }
 
@@ -248,7 +254,12 @@ fn render_csv(loaded: &AllSourceLoad, period: Period, ctx: &CommandContext<'_>) 
     print!("{csv}");
 }
 
-fn table_options<'a>(caps: &Capabilities, ctx: &'a CommandContext<'a>) -> TokenTableOptions<'a> {
+fn table_options<'a>(
+    caps: &Capabilities,
+    ctx: &'a CommandContext<'a>,
+    is_today: bool,
+    source_count: Option<usize>,
+) -> TokenTableOptions<'a> {
     TokenTableOptions {
         order: ctx.cli.sort_order(),
         use_color: ctx.cli.use_color(),
@@ -267,6 +278,8 @@ fn table_options<'a>(caps: &Capabilities, ctx: &'a CommandContext<'a>) -> TokenT
         secondary_cost_display_overrides: None,
         secondary_total_cost_display_override: None,
         pricing_note_override: None,
+        is_today,
+        source_count,
     }
 }
 
@@ -276,6 +289,7 @@ fn print_section_table(
     caps: &Capabilities,
     ctx: &CommandContext<'_>,
     heading: &str,
+    is_today: bool,
 ) {
     println!("\n  {heading}");
     print_period_table(
@@ -288,11 +302,11 @@ fn print_section_table(
             elapsed_ms: Some(result.elapsed_ms),
         },
         ctx.pricing_db,
-        table_options(caps, ctx),
+        table_options(caps, ctx, is_today, None),
     );
 }
 
-fn render_table(loaded: &AllSourceLoad, period: Period, ctx: &CommandContext<'_>) {
+fn render_table(loaded: &AllSourceLoad, period: Period, is_today: bool, ctx: &CommandContext<'_>) {
     for section in &loaded.sections {
         print_section_table(
             &section.result,
@@ -300,6 +314,7 @@ fn render_table(loaded: &AllSourceLoad, period: Period, ctx: &CommandContext<'_>
             &loaded.caps,
             ctx,
             section.display_name,
+            is_today,
         );
     }
     println!("\n  All Sources");
@@ -310,6 +325,10 @@ fn render_table(loaded: &AllSourceLoad, period: Period, ctx: &CommandContext<'_>
         None,
         None,
         ctx,
-        CostDisplayMode::Total,
+        period_table::PeriodTableFlags {
+            cost_mode: CostDisplayMode::Total,
+            is_today,
+            source_count: (loaded.contributing_sources > 1).then_some(loaded.contributing_sources),
+        },
     );
 }

--- a/src/app/source_breakdown.rs
+++ b/src/app/source_breakdown.rs
@@ -279,6 +279,7 @@ fn table_options<'a>(
         secondary_total_cost_display_override: None,
         pricing_note_override: None,
         is_today,
+        comparison_days: None,
         source_count,
     }
 }
@@ -329,6 +330,7 @@ fn render_table(loaded: &AllSourceLoad, period: Period, is_today: bool, ctx: &Co
             cost_mode: CostDisplayMode::Total,
             is_today,
             source_count: (loaded.contributing_sources > 1).then_some(loaded.contributing_sources),
+            source_name: None,
         },
     );
 }

--- a/src/output/conclusion.rs
+++ b/src/output/conclusion.rs
@@ -1,0 +1,407 @@
+//! One-line human conclusion for table-mode period reports.
+
+use std::cmp::Reverse;
+use std::collections::HashMap;
+
+use chrono::NaiveDate;
+
+use crate::consts::DATE_FORMAT;
+use crate::core::{DayStats, Stats};
+use crate::output::format::{NumberFormat, format_compact, format_cost, format_number};
+use crate::pricing::{
+    CostDisplayMode, CurrencyConverter, PricingDb, calculate_display_cost, sum_display_model_costs,
+};
+use crate::source::CostCoverage;
+
+const PACE_PRIOR_MIN: usize = 3;
+const PACE_PRIOR_MAX: usize = 7;
+const PACE_EVEN_RATIO: f64 = 0.05;
+
+pub(super) struct PeriodConclusionInput<'a> {
+    pub(super) day_stats: &'a HashMap<String, DayStats>,
+    pub(super) displayed: &'a HashMap<String, DayStats>,
+    pub(super) is_today: bool,
+    pub(super) source_count: Option<usize>,
+    pub(super) compact: bool,
+    pub(super) show_cost: bool,
+    pub(super) number_format: NumberFormat,
+    pub(super) currency: Option<&'a CurrencyConverter>,
+    pub(super) cost_mode: CostDisplayMode,
+    pub(super) pricing_db: &'a PricingDb,
+    pub(super) footer_cost: f64,
+    pub(super) footer_cost_text: &'a str,
+}
+
+pub(super) fn period_conclusion_line(input: &PeriodConclusionInput<'_>) -> Option<String> {
+    if input.displayed.is_empty() {
+        return None;
+    }
+
+    let mut total_stats = Stats::default();
+    for data in input.displayed.values() {
+        total_stats.add(&data.stats);
+    }
+
+    let label = if input.is_today {
+        "Today"
+    } else {
+        "This period"
+    };
+    let sources = match input.source_count {
+        Some(count) if count >= 2 => format!(" ({count} sources)"),
+        _ => String::new(),
+    };
+    let token_text = if input.compact {
+        format_compact(total_stats.total_tokens(), input.number_format)
+    } else {
+        format_number(total_stats.total_tokens(), input.number_format)
+    };
+
+    let mut line = format!("{label}{sources}: {token_text} tokens");
+    if let Some(cost_clause) = cost_clause(input) {
+        line.push_str(&cost_clause);
+    }
+    if !input.compact
+        && let Some(pace) = pace_clause(input)
+    {
+        line.push_str(&pace);
+    }
+    line.push('.');
+    Some(line)
+}
+
+fn cost_clause(input: &PeriodConclusionInput<'_>) -> Option<String> {
+    if !input.show_cost {
+        return None;
+    }
+
+    let amount = input.footer_cost_text.trim();
+    let unknown =
+        input.footer_cost.is_nan() || amount.is_empty() || amount.eq_ignore_ascii_case("N/A");
+    if unknown {
+        return Some(", cost unknown".to_string());
+    }
+
+    if is_floor(input) {
+        Some(format!(", {} (floor)", floor_amount(amount)))
+    } else {
+        Some(format!(", {amount}"))
+    }
+}
+
+fn is_floor(input: &PeriodConclusionInput<'_>) -> bool {
+    if input.footer_cost.is_nan() {
+        return false;
+    }
+    let coverage_floor = CostCoverage::from_stats(input.displayed.values().map(|day| &day.stats))
+        .is_some_and(CostCoverage::cost_is_lower_bound);
+    coverage_floor || has_unpriced_models(input) || input.footer_cost_text.contains('≥')
+}
+
+fn has_unpriced_models(input: &PeriodConclusionInput<'_>) -> bool {
+    input.displayed.values().any(|data| {
+        data.models.iter().any(|(model, stats)| {
+            calculate_display_cost(stats, model, input.pricing_db, input.cost_mode).is_nan()
+        })
+    })
+}
+
+fn floor_amount(amount: &str) -> String {
+    let trimmed = amount.trim();
+    if trimmed.starts_with('≥') {
+        if trimmed.starts_with("≥ ") {
+            trimmed.to_string()
+        } else {
+            trimmed.replacen('≥', "≥ ", 1)
+        }
+    } else {
+        format!("≥ {trimmed}")
+    }
+}
+
+fn pace_clause(input: &PeriodConclusionInput<'_>) -> Option<String> {
+    if !input.is_today {
+        return None;
+    }
+    let today_key = today_key(input.day_stats)?;
+    let prior = prior_complete_days(input.day_stats, today_key);
+    if prior.len() < PACE_PRIOR_MIN {
+        return None;
+    }
+
+    let today = input.day_stats.get(today_key)?;
+    let n = prior.len();
+    let compare_cost = input.show_cost
+        && today_metric_cost(today, input).is_finite()
+        && prior
+            .iter()
+            .all(|day| today_metric_cost(day, input).is_finite());
+
+    let (today_value, mean, mean_text) = if compare_cost {
+        let today_cost = today_metric_cost(today, input);
+        let mean = prior
+            .iter()
+            .map(|day| today_metric_cost(day, input))
+            .sum::<f64>()
+            / n as f64;
+        (today_cost, mean, format_cost(mean, input.currency))
+    } else {
+        let today_tokens = today.stats.total_tokens() as f64;
+        let mean = prior
+            .iter()
+            .map(|day| day.stats.total_tokens() as f64)
+            .sum::<f64>()
+            / n as f64;
+        let mean_tokens = mean.round() as i64;
+        let mean_text = if input.compact {
+            format_compact(mean_tokens, input.number_format)
+        } else {
+            format_number(mean_tokens, input.number_format)
+        };
+        (today_tokens, mean, format!("{mean_text} tokens"))
+    };
+
+    let relation = pace_relation(today_value, mean);
+    Some(format!(". {relation} the last {n}-day mean ({mean_text})"))
+}
+
+fn today_metric_cost(day: &DayStats, input: &PeriodConclusionInput<'_>) -> f64 {
+    sum_display_model_costs(&day.models, input.pricing_db, input.cost_mode)
+}
+
+fn today_key(day_stats: &HashMap<String, DayStats>) -> Option<&str> {
+    day_stats
+        .keys()
+        .filter(|key| NaiveDate::parse_from_str(key, DATE_FORMAT).is_ok())
+        .max()
+        .map(String::as_str)
+}
+
+fn prior_complete_days<'a>(
+    day_stats: &'a HashMap<String, DayStats>,
+    today: &str,
+) -> Vec<&'a DayStats> {
+    let Ok(today_date) = NaiveDate::parse_from_str(today, DATE_FORMAT) else {
+        return Vec::new();
+    };
+    let mut prior: Vec<_> = day_stats
+        .iter()
+        .filter_map(|(key, day)| {
+            let date = NaiveDate::parse_from_str(key, DATE_FORMAT).ok()?;
+            (date < today_date).then_some((date, day))
+        })
+        .collect();
+    prior.sort_by_key(|(date, _)| Reverse(*date));
+    prior.truncate(PACE_PRIOR_MAX);
+    prior.into_iter().map(|(_, day)| day).collect()
+}
+
+fn pace_relation(today: f64, mean: f64) -> &'static str {
+    if !today.is_finite() || !mean.is_finite() {
+        return "About even with";
+    }
+    if mean == 0.0 {
+        return if today == 0.0 {
+            "About even with"
+        } else {
+            "Faster than"
+        };
+    }
+    let delta = (today - mean).abs() / mean.abs();
+    if delta <= PACE_EVEN_RATIO {
+        "About even with"
+    } else if today > mean {
+        "Faster than"
+    } else {
+        "Slower than"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pricing::CostDisplayMode;
+
+    fn recorded(
+        input_tokens: i64,
+        output_tokens: i64,
+        cost: f64,
+        priced: i64,
+        coverage: i64,
+        model: &str,
+    ) -> DayStats {
+        let stats = Stats {
+            input_tokens,
+            output_tokens,
+            count: 1,
+            recorded_cost_usd: cost,
+            recorded_cost_entries: 1,
+            api_equivalent_priced_tokens: priced,
+            api_equivalent_coverage_tokens: coverage,
+            ..Default::default()
+        };
+        DayStats {
+            stats: stats.clone(),
+            models: HashMap::from([(model.to_string(), stats)]),
+        }
+    }
+
+    fn unpriced(input_tokens: i64, output_tokens: i64) -> Stats {
+        Stats {
+            input_tokens,
+            output_tokens,
+            count: 1,
+            api_equivalent_priced_tokens: 0,
+            api_equivalent_coverage_tokens: input_tokens + output_tokens,
+            ..Default::default()
+        }
+    }
+
+    fn line_for(
+        displayed: &HashMap<String, DayStats>,
+        extra_days: HashMap<String, DayStats>,
+        is_today: bool,
+        show_cost: bool,
+        compact: bool,
+        source_count: Option<usize>,
+    ) -> Option<String> {
+        let pricing_db = PricingDb::default();
+        let footer_cost = displayed.values().fold(0.0, |total, day| {
+            total + sum_display_model_costs(&day.models, &pricing_db, CostDisplayMode::Total)
+        });
+        let footer_cost_text = format_cost(footer_cost, None);
+        let mut day_stats = displayed.clone();
+        day_stats.extend(extra_days);
+        period_conclusion_line(&PeriodConclusionInput {
+            day_stats: &day_stats,
+            displayed,
+            is_today,
+            source_count,
+            compact,
+            show_cost,
+            number_format: NumberFormat::default(),
+            currency: None,
+            cost_mode: CostDisplayMode::Total,
+            pricing_db: &pricing_db,
+            footer_cost,
+            footer_cost_text: &footer_cost_text,
+        })
+    }
+
+    fn today_only(day: DayStats) -> HashMap<String, DayStats> {
+        HashMap::from([("2026-09-03".to_string(), day)])
+    }
+
+    #[test]
+    fn exact_cost_uses_plain_formatted_amount() {
+        let days = today_only(recorded(1_000, 500, 1.25, 1_500, 1_500, "claude-sonnet"));
+        let line = line_for(&days, HashMap::new(), true, true, false, None).expect("conclusion");
+        assert_eq!(line, "Today: 1,500 tokens, $1.25.");
+        assert!(!line.contains('≥'));
+        assert!(!line.contains("floor"));
+        assert!(!line.contains("$0.00"));
+    }
+
+    #[test]
+    fn floor_cost_prefixes_ge_and_mentions_floor() {
+        let mut mixed = recorded(1_000, 500, 2.00, 1_500, 1_610, "claude-sonnet");
+        let extra = unpriced(100, 10);
+        mixed.stats.add(&extra);
+        mixed.models.insert("mystery-model".to_string(), extra);
+        let displayed = today_only(mixed);
+        let line =
+            line_for(&displayed, HashMap::new(), true, true, false, None).expect("conclusion");
+        assert_eq!(line, "Today: 1,610 tokens, ≥ $2.00 (floor).");
+        assert!(!line.contains("$0.00"));
+    }
+
+    #[test]
+    fn no_cost_talks_tokens_only() {
+        let days = today_only(recorded(1_000, 500, 1.25, 1_500, 1_500, "claude-sonnet"));
+        let line = line_for(&days, HashMap::new(), true, false, false, None).expect("conclusion");
+        assert_eq!(line, "Today: 1,500 tokens.");
+        assert!(!line.contains('$'));
+        assert!(!line.contains("cost"));
+    }
+
+    fn prior_days() -> HashMap<String, DayStats> {
+        HashMap::from([
+            (
+                "2026-09-02".to_string(),
+                recorded(800, 400, 1.00, 1_200, 1_200, "claude-sonnet"),
+            ),
+            (
+                "2026-09-01".to_string(),
+                recorded(800, 400, 1.00, 1_200, 1_200, "claude-sonnet"),
+            ),
+        ])
+    }
+
+    #[test]
+    fn insufficient_pace_data_omits_comparison() {
+        let displayed = today_only(recorded(1_000, 500, 3.00, 1_500, 1_500, "claude-sonnet"));
+        let line = line_for(&displayed, prior_days(), true, true, false, None).expect("conclusion");
+        assert_eq!(line, "Today: 1,500 tokens, $3.00.");
+        assert!(!line.contains("mean"));
+        assert!(!line.contains("Faster"));
+        assert!(!line.contains("Slower"));
+    }
+
+    #[test]
+    fn unknown_cost_does_not_print_zero_dollars() {
+        let stats = unpriced(100, 50);
+        let day = DayStats {
+            stats: stats.clone(),
+            models: HashMap::from([("mystery-model".to_string(), stats)]),
+        };
+        let displayed = today_only(day);
+        let line =
+            line_for(&displayed, HashMap::new(), false, true, false, None).expect("conclusion");
+        assert_eq!(line, "This period: 150 tokens, cost unknown.");
+        assert!(!line.contains("$0.00"));
+        assert!(!line.contains("Today"));
+    }
+
+    #[test]
+    fn empty_window_has_no_conclusion() {
+        let empty = HashMap::new();
+        assert!(line_for(&empty, HashMap::new(), true, true, false, None).is_none());
+    }
+
+    #[test]
+    fn compact_omits_pace_even_with_prior_days() {
+        let mut extra = prior_days();
+        extra.insert(
+            "2026-08-31".to_string(),
+            recorded(800, 400, 1.00, 1_200, 1_200, "claude-sonnet"),
+        );
+        let displayed = today_only(recorded(1_000, 500, 3.00, 1_500, 1_500, "claude-sonnet"));
+        let line = line_for(&displayed, extra, true, true, true, None).expect("conclusion");
+        assert_eq!(line, "Today: 1.5K tokens, $3.00.");
+        assert!(!line.contains("mean"));
+    }
+
+    #[test]
+    fn pace_uses_prior_complete_days_when_available() {
+        let mut extra = prior_days();
+        extra.insert(
+            "2026-08-31".to_string(),
+            recorded(800, 400, 1.00, 1_200, 1_200, "claude-sonnet"),
+        );
+        let displayed = today_only(recorded(1_000, 500, 3.00, 1_500, 1_500, "claude-sonnet"));
+        let line = line_for(&displayed, extra, true, true, false, None).expect("conclusion");
+        assert_eq!(
+            line,
+            "Today: 1,500 tokens, $3.00. Faster than the last 3-day mean ($1.00)."
+        );
+    }
+
+    #[test]
+    fn source_all_mentions_count_not_names() {
+        let days = today_only(recorded(1_000, 500, 1.25, 1_500, 1_500, "claude-sonnet"));
+        let line =
+            line_for(&days, HashMap::new(), false, true, false, Some(29)).expect("conclusion");
+        assert_eq!(line, "This period (29 sources): 1,500 tokens, $1.25.");
+        assert!(!line.contains("claude"));
+    }
+}

--- a/src/output/conclusion.rs
+++ b/src/output/conclusion.rs
@@ -123,14 +123,28 @@ fn pace_clause(input: &PeriodConclusionInput<'_>) -> Option<String> {
     if !input.is_today {
         return None;
     }
-    let today_key = today_key(input.day_stats)?;
+    let today_key = today_key(input.displayed)?;
     let prior = prior_complete_days(input.day_stats, today_key);
     if prior.len() < PACE_PRIOR_MIN {
         return None;
     }
 
-    let today = input.day_stats.get(today_key)?;
+    let today = input.displayed.get(today_key)?;
     let n = prior.len();
+    if input.show_cost
+        && (is_floor(input)
+            || !today_metric_cost(today, input).is_finite()
+            || prior.iter().any(|day| {
+                CostCoverage::from_stats([&day.stats])
+                    .is_some_and(CostCoverage::cost_is_lower_bound)
+                    || day.models.iter().any(|(model, stats)| {
+                        !calculate_display_cost(stats, model, input.pricing_db, input.cost_mode)
+                            .is_finite()
+                    })
+            }))
+    {
+        return None;
+    }
     let compare_cost = input.show_cost
         && today_metric_cost(today, input).is_finite()
         && prior
@@ -188,7 +202,8 @@ fn prior_complete_days<'a>(
         .iter()
         .filter_map(|(key, day)| {
             let date = NaiveDate::parse_from_str(key, DATE_FORMAT).ok()?;
-            (date < today_date).then_some((date, day))
+            (date < today_date && today_date.signed_duration_since(date).num_days() <= 7)
+                .then_some((date, day))
         })
         .collect();
     prior.sort_by_key(|(date, _)| Reverse(*date));

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,5 +1,6 @@
 mod blocks;
 mod budget;
+mod conclusion;
 mod csv;
 mod endpoints;
 mod format;

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -34,6 +34,8 @@ pub(crate) struct TokenTableOptions<'a> {
     pub(crate) secondary_cost_display_overrides: Option<&'a HashMap<String, String>>,
     pub(crate) secondary_total_cost_display_override: Option<&'a str>,
     pub(crate) pricing_note_override: Option<&'a str>,
+    pub(crate) is_today: bool,
+    pub(crate) source_count: Option<usize>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -486,6 +488,34 @@ fn add_total_cost_cells(
     }
 }
 
+fn print_period_conclusion(
+    day_stats: &HashMap<String, DayStats>,
+    displayed: &HashMap<String, DayStats>,
+    pricing_db: &PricingDb,
+    options: &TokenTableOptions<'_>,
+    footer_cost: f64,
+) {
+    let footer_cost_text = total_cost_display(footer_cost, options);
+    if let Some(line) =
+        super::conclusion::period_conclusion_line(&super::conclusion::PeriodConclusionInput {
+            day_stats,
+            displayed,
+            is_today: options.is_today,
+            source_count: options.source_count,
+            compact: options.compact,
+            show_cost: options.show_cost,
+            number_format: options.number_format,
+            currency: options.currency,
+            cost_mode: options.cost_mode,
+            pricing_db,
+            footer_cost,
+            footer_cost_text: &footer_cost_text,
+        })
+    {
+        println!("\n  {line}");
+    }
+}
+
 pub(crate) fn print_period_table(
     day_stats: &HashMap<String, DayStats>,
     period: Period,
@@ -555,6 +585,7 @@ pub(crate) fn print_period_table(
         &options,
     );
 
+    print_period_conclusion(day_stats, stats_ref, pricing_db, &options, total_cost);
     println!("\n  {}\n", cfg.title);
     println!("{table}");
     if options.show_cost && has_estimated_proxy {

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -34,6 +34,7 @@ pub(crate) struct TokenTableOptions<'a> {
     pub(crate) secondary_cost_display_overrides: Option<&'a HashMap<String, String>>,
     pub(crate) secondary_total_cost_display_override: Option<&'a str>,
     pub(crate) pricing_note_override: Option<&'a str>,
+    pub(crate) comparison_days: Option<&'a HashMap<String, DayStats>>,
     pub(crate) is_today: bool,
     pub(crate) source_count: Option<usize>,
 }
@@ -498,7 +499,7 @@ fn print_period_conclusion(
     let footer_cost_text = total_cost_display(footer_cost, options);
     if let Some(line) =
         super::conclusion::period_conclusion_line(&super::conclusion::PeriodConclusionInput {
-            day_stats,
+            day_stats: options.comparison_days.unwrap_or(day_stats),
             displayed,
             is_today: options.is_today,
             source_count: options.source_count,

--- a/src/output/table_tests.rs
+++ b/src/output/table_tests.rs
@@ -23,6 +23,7 @@ fn default_opts() -> TokenTableOptions<'static> {
         secondary_cost_display_overrides: None,
         secondary_total_cost_display_override: None,
         pricing_note_override: None,
+        comparison_days: None,
         is_today: false,
         source_count: None,
     }

--- a/src/output/table_tests.rs
+++ b/src/output/table_tests.rs
@@ -23,6 +23,8 @@ fn default_opts() -> TokenTableOptions<'static> {
         secondary_cost_display_overrides: None,
         secondary_total_cost_display_override: None,
         pricing_note_override: None,
+        is_today: false,
+        source_count: None,
     }
 }
 

--- a/tests/cli_period_conclusion.rs
+++ b/tests/cli_period_conclusion.rs
@@ -1,0 +1,273 @@
+mod common;
+
+use chrono::Utc;
+use common::{run_ccstats, unique_temp_dir, write_file};
+use std::fs;
+
+fn write_today_claude(root: &std::path::Path, input_tokens: i64, output_tokens: i64) {
+    let today = Utc::now().format("%Y-%m-%dT12:00:00Z");
+    let path = root.join(".claude/projects/myproject/session-a.jsonl");
+    write_file(
+        &path,
+        &format!(
+            r#"{{"timestamp":"{today}","message":{{"id":"msg_1","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{{"input_tokens":{input_tokens},"output_tokens":{output_tokens}}}}}}}
+"#
+        ),
+    );
+}
+
+fn first_content_line(stdout: &str) -> &str {
+    stdout
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or("")
+}
+
+fn cost_in(text: &str) -> Option<String> {
+    let start = text.find('$')?;
+    let rest = &text[start..];
+    let mut end = 1;
+    let mut seen_dot = false;
+    for (i, c) in rest.char_indices().skip(1) {
+        if c.is_ascii_digit() || c == ',' {
+            end = i + c.len_utf8();
+        } else if c == '.' && !seen_dot {
+            seen_dot = true;
+            end = i + c.len_utf8();
+        } else {
+            break;
+        }
+    }
+    let token = rest[..end].to_string();
+    (token.len() > 1).then_some(token)
+}
+
+fn footer_cost(stdout: &str) -> Option<String> {
+    stdout
+        .lines()
+        .find(|line| line.contains("TOTAL"))
+        .and_then(cost_in)
+}
+
+#[test]
+fn today_table_prints_conclusion_before_table() {
+    let root = unique_temp_dir("period-conclusion-today");
+    write_today_claude(&root, 100_000, 20_000);
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &["today", "--source", "claude", "-O", "--timezone", "UTC"],
+        &[("HOME", &root)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let output = String::from_utf8(stdout).expect("utf8 stdout");
+
+    let conclusion = first_content_line(&output);
+    let title_at = output.find("Token Usage").expect("table title");
+    let conclusion_at = output.find(conclusion).expect("conclusion");
+    assert!(
+        conclusion_at < title_at,
+        "conclusion must precede the table:\n{output}"
+    );
+    assert!(conclusion.starts_with("Today:"), "conclusion: {conclusion}");
+    assert!(conclusion.contains("tokens"), "conclusion: {conclusion}");
+
+    let conclusion_cost = cost_in(conclusion).expect("cost in conclusion");
+    let table_cost = footer_cost(&output).expect("cost in TOTAL row");
+    assert_eq!(
+        conclusion_cost, table_cost,
+        "conclusion cost {conclusion_cost} must match TOTAL {table_cost}\n{output}"
+    );
+    assert!(
+        output.contains("usage records"),
+        "trailing summary must remain:\n{output}"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn today_json_stdout_is_pure_structured_data() {
+    let root = unique_temp_dir("period-conclusion-today-json");
+    write_today_claude(&root, 100_000, 20_000);
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "today",
+            "--source",
+            "claude",
+            "-j",
+            "-O",
+            "--timezone",
+            "UTC",
+        ],
+        &[("HOME", &root)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let output = String::from_utf8(stdout).expect("utf8 stdout");
+    let trimmed = output.trim_start();
+    assert!(
+        trimmed.starts_with('[') || trimmed.starts_with('{'),
+        "json must start with structured data: {output}"
+    );
+    assert!(
+        !output.contains("Today:"),
+        "json must not contain conclusion prose: {output}"
+    );
+    assert!(
+        !output.contains("This period:"),
+        "json must not contain conclusion prose: {output}"
+    );
+    assert!(
+        !output.contains("(floor)"),
+        "json must not contain conclusion prose: {output}"
+    );
+    serde_json::from_str::<serde_json::Value>(&output).expect("valid json");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn compact_today_still_prints_conclusion() {
+    let root = unique_temp_dir("period-conclusion-compact");
+    write_today_claude(&root, 100_000, 20_000);
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "today",
+            "--source",
+            "claude",
+            "--compact",
+            "-O",
+            "--timezone",
+            "UTC",
+        ],
+        &[("HOME", &root)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let output = String::from_utf8(stdout).expect("utf8 stdout");
+    let conclusion = first_content_line(&output);
+    assert!(
+        conclusion.starts_with("Today:"),
+        "compact conclusion: {conclusion}\n{output}"
+    );
+    assert!(
+        conclusion.contains("tokens"),
+        "compact conclusion: {conclusion}"
+    );
+    assert!(
+        !conclusion.contains("mean"),
+        "compact omits pace: {conclusion}"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn no_cost_today_omits_dollars() {
+    let root = unique_temp_dir("period-conclusion-no-cost");
+    write_today_claude(&root, 100_000, 20_000);
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "today",
+            "--source",
+            "claude",
+            "--no-cost",
+            "-O",
+            "--timezone",
+            "UTC",
+        ],
+        &[("HOME", &root)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let output = String::from_utf8(stdout).expect("utf8 stdout");
+    let conclusion = first_content_line(&output);
+    assert!(
+        conclusion.starts_with("Today:"),
+        "conclusion: {conclusion}\n{output}"
+    );
+    assert!(
+        !conclusion.contains('$'),
+        "no-cost conclusion must not invent dollars: {conclusion}"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn daily_table_does_not_say_today() {
+    let root = unique_temp_dir("period-conclusion-daily");
+    let path = root.join(".claude/projects/myproject/session-a.jsonl");
+    write_file(
+        &path,
+        r#"{"timestamp":"2026-02-06T12:00:00Z","message":{"id":"msg_1","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{"input_tokens":100000,"output_tokens":20000}}}
+"#,
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "--source",
+            "claude",
+            "-O",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("HOME", &root)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let output = String::from_utf8(stdout).expect("utf8 stdout");
+    let conclusion = first_content_line(&output);
+    assert!(
+        conclusion.starts_with("This period:"),
+        "daily conclusion: {conclusion}\n{output}"
+    );
+    assert!(!conclusion.contains("Today"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn unpriced_table_does_not_headline_zero_dollars() {
+    let root = unique_temp_dir("period-conclusion-unpriced");
+    let today = Utc::now().format("%Y-%m-%dT12:00:00Z");
+    let path = root.join(".claude/projects/myproject/session-a.jsonl");
+    write_file(
+        &path,
+        &format!(
+            r#"{{"timestamp":"{today}","message":{{"id":"msg_1","model":"mystery-model","stop_reason":"end_turn","usage":{{"input_tokens":100,"output_tokens":50}}}}}}
+"#
+        ),
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "today",
+            "--source",
+            "claude",
+            "-O",
+            "--strict-pricing",
+            "--timezone",
+            "UTC",
+        ],
+        &[("HOME", &root)],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let output = String::from_utf8(stdout).expect("utf8 stdout");
+    let conclusion = first_content_line(&output);
+    assert!(
+        conclusion.starts_with("Today:"),
+        "conclusion: {conclusion}\n{output}"
+    );
+    assert!(
+        !conclusion.contains("$0.00"),
+        "unpriced fixture must not headline $0.00: {conclusion}\n{output}"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}

--- a/tests/cli_period_conclusion.rs
+++ b/tests/cli_period_conclusion.rs
@@ -271,3 +271,89 @@ fn unpriced_table_does_not_headline_zero_dollars() {
 
     let _ = fs::remove_dir_all(root);
 }
+
+fn write_prior_days(root: &std::path::Path, offsets: &[i64]) {
+    for offset in offsets {
+        let timestamp = (Utc::now() - chrono::Duration::days(*offset)).format("%Y-%m-%dT12:00:00Z");
+        write_file(
+            &root.join(format!(".claude/projects/myproject/prior-{offset}.jsonl")),
+            &serde_json::json!({"timestamp":timestamp.to_string(),"message":{
+                "id":format!("prior-{offset}"),"model":"claude-3-5-sonnet-20241022",
+                "stop_reason":"end_turn","usage":{"input_tokens":100,"output_tokens":50}
+            }})
+            .to_string(),
+        );
+    }
+}
+
+#[test]
+fn real_today_command_compares_history_without_adding_it_to_totals() {
+    let root = unique_temp_dir("period-conclusion-history");
+    write_today_claude(&root, 1_000, 500);
+    write_prior_days(&root, &[1, 2, 3]);
+    for source in ["claude", "all"] {
+        let (ok, stdout, stderr) = run_ccstats(
+            &[
+                "today",
+                "--source",
+                source,
+                "--no-cost",
+                "-O",
+                "--timezone",
+                "UTC",
+            ],
+            &[("HOME", &root)],
+        );
+        assert!(ok, "{}", String::from_utf8_lossy(&stderr));
+        let output = String::from_utf8(stdout).unwrap();
+        assert!(
+            output.contains("Today: 1,500 tokens. Faster than the last 3-day mean (150 tokens)."),
+            "{output}"
+        );
+        assert!(
+            !output.contains("1,950"),
+            "history leaked into totals: {output}"
+        );
+        let (ok, stdout, stderr) = run_ccstats(
+            &[
+                "today",
+                "--source",
+                source,
+                "--no-cost",
+                "-j",
+                "-O",
+                "--timezone",
+                "UTC",
+            ],
+            &[("HOME", &root)],
+        );
+        assert!(ok, "{}", String::from_utf8_lossy(&stderr));
+        let json: serde_json::Value = serde_json::from_slice(&stdout).unwrap();
+        let rows = json.as_array().unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["total_tokens"], 1_500);
+    }
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn today_comparison_does_not_use_old_active_dates() {
+    let root = unique_temp_dir("period-conclusion-old-history");
+    write_today_claude(&root, 1_000, 500);
+    write_prior_days(&root, &[1, 2, 8, 9]);
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "today",
+            "--source",
+            "claude",
+            "--no-cost",
+            "-O",
+            "--timezone",
+            "UTC",
+        ],
+        &[("HOME", &root)],
+    );
+    assert!(ok, "{}", String::from_utf8_lossy(&stderr));
+    assert!(!String::from_utf8_lossy(&stdout).contains("mean"));
+    fs::remove_dir_all(root).unwrap();
+}


### PR DESCRIPTION
## What

Print one human-readable conclusion line on stdout before table-mode `daily` / `today` / `weekly` / `monthly` reports (including `--source all`).

## Why

Default table output is a wide token/cost grid. The line a person can take away is how much this window cost, whether that number is exact or a floor, and for `today` whether pace is above or below recent complete days.

## Test Plan

- [x] `cargo test --lib conclusion`
- [x] `cargo test --lib table`
- [x] `cargo test --test cli_period_conclusion`
- [x] `cargo test --lib`
- [ ] `cargo check` / CI

## Notes

- Table-only. JSON/CSV stdout stays structured.
- Amounts reuse `sum_display_model_costs` / the table footer (including Grok display overrides). Lower bound and mixed unknown use `≥` and `(floor)`. `--no-cost` talks tokens only.
- `today` adds a pace clause only when at least 3 prior complete local days are already in `day_stats`.
- Empty no-data hints are unchanged (no fake `$0.00` conclusion).
- Not added to session/project/blocks/tools/top/statusline/quota.

Fixes #166


Made with [Cursor](https://cursor.com)