### PR TITLE
feat: add ccstats limits for Codex quota and Claude windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always

--- a/src/app.rs
+++ b/src/app.rs
@@ -569,6 +569,7 @@ pub(crate) fn handle_source_command(
         SourceCommand::Doctor => return crate::doctor_cmd::handle_doctor(ctx),
         SourceCommand::Sources => return crate::sources_cmd::handle_sources(ctx),
         SourceCommand::Quota => return crate::quota_cmd::handle_quota(ctx),
+        SourceCommand::Limits => return crate::limits_cmd::handle_limits(ctx),
         SourceCommand::Session => return handle_session(source, ctx),
         SourceCommand::Project => {
             if !caps.has_projects {
@@ -664,6 +665,7 @@ pub(crate) fn handle_all_sources_command(command: SourceCommand, ctx: &CommandCo
             eprintln!("Error: quota analysis only supports the Codex source");
             std::process::exit(1);
         }
+        SourceCommand::Limits => return crate::limits_cmd::handle_limits(ctx),
         SourceCommand::Statusline => {
             let (result, caps) = load_all_daily(ctx, true);
             if ctx.cli.json {

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -25,8 +25,15 @@ pub(crate) enum Commands {
     Daily,
     /// Show weekly usage
     Weekly,
-    /// Estimate the current Codex weekly quota pace
+    /// Estimate the current Codex weekly quota pace (Codex-only)
     Quota,
+    /// Combined Codex weekly quota and Claude estimated session window
+    ///
+    /// Prints every honest local limit: Codex weekly quota snapshots and the
+    /// current Claude activity-driven 5-hour window. Omit `--source` or use
+    /// `--source all` for both; `--source codex` or `--source claude` for one
+    /// section. Other sources are not supported.
+    Limits,
     /// Show monthly usage
     Monthly,
     /// Show today's usage
@@ -108,7 +115,7 @@ pub(crate) enum CodexCommands {
     Daily,
     /// Show weekly Codex usage
     Weekly,
-    /// Estimate the current Codex weekly quota pace
+    /// Estimate the current Codex weekly quota pace (Codex-only)
     Quota,
     /// Show monthly Codex usage
     Monthly,
@@ -166,6 +173,7 @@ pub(crate) enum SourceCommand {
     Daily,
     Weekly,
     Quota,
+    Limits,
     Monthly,
     Today,
     Session,
@@ -196,6 +204,7 @@ impl SourceCommand {
             Self::Daily => "daily",
             Self::Weekly => "weekly",
             Self::Quota => "quota",
+            Self::Limits => "limits",
             Self::Monthly => "monthly",
             Self::Today => "today",
             Self::Session => "session",
@@ -225,6 +234,7 @@ impl From<&Commands> for SourceCommand {
             Commands::Daily => SourceCommand::Daily,
             Commands::Weekly => SourceCommand::Weekly,
             Commands::Quota => SourceCommand::Quota,
+            Commands::Limits => SourceCommand::Limits,
             Commands::Monthly => SourceCommand::Monthly,
             Commands::Today => SourceCommand::Today,
             Commands::Session => SourceCommand::Session,
@@ -355,6 +365,13 @@ mod tests {
         }));
         assert_eq!(nested.command, SourceCommand::Quota);
         assert_eq!(nested.source_hint, Some("codex"));
+    }
+
+    #[test]
+    fn parse_command_limits_has_no_source_hint() {
+        let parsed = parse_command(Some(&Commands::Limits));
+        assert_eq!(parsed.command, SourceCommand::Limits);
+        assert_eq!(parsed.source_hint, None);
     }
 
     #[test]

--- a/src/core/aggregator.rs
+++ b/src/core/aggregator.rs
@@ -228,9 +228,26 @@ fn into_block_stats(
     BlockStats {
         block_start: local_start.format("%Y-%m-%d %H:%M").to_string(),
         block_end: local_end.format("%H:%M").to_string(),
+        start_ms,
         stats,
         models,
     }
+}
+
+/// Pick the activity window that currently contains `now`.
+///
+/// Returns the block and remaining milliseconds until the 5-hour window ends.
+/// Expired historical windows are not treated as active; callers must not
+/// invent a 0% remaining quota when this returns `None`.
+pub(crate) fn select_active_block(
+    blocks: &[BlockStats],
+    now: DateTime<Utc>,
+) -> Option<(&BlockStats, i64)> {
+    let now_ms = now.timestamp_millis();
+    blocks.iter().find_map(|block| {
+        let end_ms = block.start_ms.saturating_add(SESSION_WINDOW_MS);
+        (now_ms >= block.start_ms && now_ms < end_ms).then_some((block, end_ms - now_ms))
+    })
 }
 
 /// Aggregate entries into activity-driven 5-hour estimated session windows.
@@ -807,6 +824,7 @@ mod tests {
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].block_start, "2025-01-01 02:00");
         assert_eq!(result[0].block_end, "07:00");
+        assert_eq!(result[0].start_ms, utc(2, 0).timestamp_millis());
         assert_eq!(result[0].stats.input_tokens, 300);
         assert_eq!(result[1].block_start, "2025-01-01 08:00");
         assert_eq!(result[1].block_end, "13:00");
@@ -879,5 +897,19 @@ mod tests {
         let result = aggregate_blocks(vec![entry_at(t1, 100)], timezone);
         assert_eq!(result[0].block_start, "2025-11-02 00:00");
         assert_eq!(result[0].block_end, "04:00");
+    }
+
+    #[test]
+    fn select_active_block_picks_window_containing_now() {
+        let t1 = utc(10, 55);
+        let t2 = utc(16, 10);
+        let blocks = aggregate_blocks(vec![entry_at(t1, 100), entry_at(t2, 200)], utc_tz());
+        let now = utc(11, 30);
+        let (active, remaining_ms) = select_active_block(&blocks, now).unwrap();
+        assert_eq!(active.block_start, "2025-01-01 10:00");
+        assert_eq!(remaining_ms, 3 * 60 * 60 * 1000 + 30 * 60 * 1000);
+        assert!(select_active_block(&blocks, utc(15, 30)).is_none());
+        let (later, _) = select_active_block(&blocks, utc(16, 30)).unwrap();
+        assert_eq!(later.block_start, "2025-01-01 16:00");
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -13,6 +13,7 @@ mod types;
 pub(crate) use aggregator::{
     aggregate_blocks, aggregate_by_endpoint, aggregate_daily, aggregate_projects,
     aggregate_sessions, aggregate_sessions_map, format_project_name, merge_day_stats,
+    select_active_block,
 };
 pub(crate) use dedup::{DedupAccumulator, source_wide_message_id};
 pub(crate) use tool_aggregator::aggregate_tools;

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -339,6 +339,8 @@ pub(crate) struct ProjectStats {
 pub(crate) struct BlockStats {
     pub(crate) block_start: String,
     pub(crate) block_end: String,
+    /// Floored UTC-hour start of this window, in Unix milliseconds.
+    pub(crate) start_ms: i64,
     pub(crate) stats: Stats,
     pub(crate) models: HashMap<String, Stats>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ mod credentials;
 mod doctor_cmd;
 mod endpoints_cmd;
 mod error;
+mod limits_cmd;
 mod login_cmd;
 mod output;
 mod pricing;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,6 +214,10 @@ fn resolve_source_name<'a>(
         return Some("claude");
     }
 
+    if source_cmd == SourceCommand::Limits {
+        return Some(source_override.unwrap_or(ALL_SOURCES));
+    }
+
     match (source_hint, source_override) {
         (Some(hint), Some(override_name)) => {
             Some(resolve_overridden_command_source(hint, override_name))

--- a/src/limits_cmd.rs
+++ b/src/limits_cmd.rs
@@ -1,0 +1,124 @@
+use crate::app::{CommandContext, print_json};
+use crate::core::select_active_block;
+use crate::output::{
+    BOTH_MISSING_HINT, CLAUDE_WINDOW_DISCLAIMER, ClaudeWindowView, LimitsTableOptions, LimitsView,
+    NO_ACTIVE_CLAUDE_WINDOW, OutputFormat, output_limits_csv, output_limits_json,
+    print_limits_table,
+};
+use crate::quota_cmd::load_quota;
+use crate::source::{ALL_SOURCES, get_source, load_blocks};
+use chrono::Utc;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LimitsScope {
+    All,
+    Codex,
+    Claude,
+}
+
+fn limits_scope(source: Option<&str>) -> Result<LimitsScope, String> {
+    let Some(name) = source else {
+        return Ok(LimitsScope::All);
+    };
+    if name.eq_ignore_ascii_case(ALL_SOURCES) {
+        return Ok(LimitsScope::All);
+    }
+    let Some(resolved) = get_source(name) else {
+        return Err(
+            "limits only supports --source claude, --source codex, or --source all".to_string(),
+        );
+    };
+    match resolved.name() {
+        "codex" => Ok(LimitsScope::Codex),
+        "claude" => Ok(LimitsScope::Claude),
+        other => Err(format!(
+            "limits does not support --source {other}; only claude, codex, or all"
+        )),
+    }
+}
+
+pub(crate) fn handle_limits(ctx: &CommandContext<'_>) {
+    let scope = match limits_scope(ctx.cli.source.as_deref()) {
+        Ok(scope) => scope,
+        Err(message) => {
+            eprintln!("Error: {message}");
+            std::process::exit(1);
+        }
+    };
+
+    let want_codex = matches!(scope, LimitsScope::All | LimitsScope::Codex);
+    let want_claude = matches!(scope, LimitsScope::All | LimitsScope::Claude);
+
+    let mut notes = Vec::new();
+    let mut loaded_quota = None;
+    let mut codex_error = None;
+
+    if want_codex {
+        match load_quota(ctx) {
+            Ok(loaded) => loaded_quota = Some(loaded),
+            Err(error) => {
+                let message = error.to_string();
+                notes.push(format!("Codex weekly quota unavailable: {message}"));
+                codex_error = Some(message);
+            }
+        }
+    }
+
+    let claude_blocks = want_claude.then(|| {
+        let Some(source) = get_source("claude") else {
+            return Vec::new();
+        };
+        load_blocks(source, ctx.filter, ctx.timezone, true)
+    });
+    let claude = claude_blocks
+        .as_deref()
+        .and_then(|blocks| select_active_block(blocks, Utc::now()))
+        .map(|(block, remaining_ms)| ClaudeWindowView {
+            block,
+            remaining_ms,
+        });
+
+    if want_claude {
+        if claude.is_none() {
+            notes.push(NO_ACTIVE_CLAUDE_WINDOW.to_string());
+        }
+        notes.push(CLAUDE_WINDOW_DISCLAIMER.to_string());
+    }
+
+    if want_codex && want_claude && loaded_quota.is_none() && claude.is_none() {
+        notes.push(BOTH_MISSING_HINT.replace('\n', " "));
+    }
+
+    let view = LimitsView {
+        want_codex,
+        want_claude,
+        codex: loaded_quota
+            .as_ref()
+            .map(|loaded| (&loaded.report, loaded.rendered())),
+        codex_error: codex_error.as_deref(),
+        claude,
+        notes: &notes,
+    };
+
+    match ctx.cli.output_format() {
+        OutputFormat::Json => print_json(
+            &output_limits_json(&view, ctx.pricing_db, ctx.cli.show_cost(), ctx.currency),
+            ctx.jq_filter,
+        ),
+        OutputFormat::Csv => print!(
+            "{}",
+            output_limits_csv(&view, ctx.pricing_db, ctx.cli.show_cost(), ctx.currency)
+        ),
+        OutputFormat::Table => print_limits_table(
+            &view,
+            ctx.pricing_db,
+            &LimitsTableOptions {
+                timezone: ctx.timezone,
+                number_format: ctx.number_format,
+                use_color: ctx.cli.use_color(),
+                show_cost: ctx.cli.show_cost(),
+                currency: ctx.currency,
+            },
+        ),
+    }
+}

--- a/src/output/blocks.rs
+++ b/src/output/blocks.rs
@@ -307,6 +307,7 @@ mod tests {
         BlockStats {
             block_start: start.to_string(),
             block_end: end.to_string(),
+            start_ms: 0,
             stats: Stats {
                 input_tokens: input,
                 output_tokens: output,
@@ -327,6 +328,7 @@ mod tests {
         BlockStats {
             block_start: start.to_string(),
             block_end: end.to_string(),
+            start_ms: 0,
             stats: Stats {
                 input_tokens: input,
                 output_tokens: output,
@@ -441,6 +443,7 @@ mod tests {
         let blocks = vec![BlockStats {
             block_start: "2026-02-12 10:00".to_string(),
             block_end: "2026-02-12 15:00".to_string(),
+            start_ms: 0,
             stats: Stats::default(),
             models,
         }];

--- a/src/output/csv_tests.rs
+++ b/src/output/csv_tests.rs
@@ -221,6 +221,7 @@ fn block_csv_structure() {
     let blocks = vec![BlockStats {
         block_start: "2025-01-01 00:00".to_string(),
         block_end: "2025-01-01 05:00".to_string(),
+        start_ms: 0,
         stats: Stats {
             input_tokens: 800,
             output_tokens: 300,

--- a/src/output/limits.rs
+++ b/src/output/limits.rs
@@ -1,0 +1,502 @@
+use std::fmt::Write as _;
+
+use comfy_table::Cell;
+use serde_json::{Value, json};
+
+use crate::core::BlockStats;
+use crate::output::format::{
+    NumberFormat, cost_json_value, create_styled_table, csv_escape, format_compact, format_cost,
+    header_cell, right_cell,
+};
+use crate::output::{QuotaValueEstimate, output_quota_json, print_quota_table};
+use crate::pricing::{CurrencyConverter, PricingDb, sum_model_costs};
+use crate::source::CodexWeeklyQuota;
+use crate::utils::Timezone;
+
+pub(crate) const CLAUDE_WINDOW_DISCLAIMER: &str =
+    "Estimated from local logs; not an official Anthropic billing reset.";
+
+pub(crate) const BOTH_MISSING_HINT: &str = "No Codex weekly quota or Claude estimated session window is available.\nRun `ccstats doctor` to check local source setup.";
+
+pub(crate) const NO_ACTIVE_CLAUDE_WINDOW: &str = "No active estimated 5-hour window";
+
+pub(crate) struct ClaudeWindowView<'a> {
+    pub block: &'a BlockStats,
+    pub remaining_ms: i64,
+}
+
+pub(crate) struct LimitsView<'a> {
+    pub want_codex: bool,
+    pub want_claude: bool,
+    pub codex: Option<(&'a CodexWeeklyQuota, QuotaValueEstimate<'a>)>,
+    pub codex_error: Option<&'a str>,
+    pub claude: Option<ClaudeWindowView<'a>>,
+    pub notes: &'a [String],
+}
+
+impl LimitsView<'_> {
+    fn both_missing(&self) -> bool {
+        self.want_codex && self.want_claude && self.codex.is_none() && self.claude.is_none()
+    }
+}
+
+fn remaining_minutes(remaining_ms: i64) -> i64 {
+    remaining_ms / 60_000
+}
+
+fn format_remaining(remaining_ms: i64) -> String {
+    let total_minutes = remaining_minutes(remaining_ms);
+    let hours = total_minutes / 60;
+    let minutes = total_minutes % 60;
+    if hours > 0 {
+        format!("{hours}h {minutes}m")
+    } else {
+        format!("{minutes}m")
+    }
+}
+
+fn claude_cost(block: &BlockStats, pricing_db: &PricingDb) -> f64 {
+    sum_model_costs(&block.models, pricing_db)
+}
+
+fn quota_json_value(report: &CodexWeeklyQuota, value_estimate: QuotaValueEstimate<'_>) -> Value {
+    serde_json::from_str(&output_quota_json(report, value_estimate)).unwrap_or(Value::Null)
+}
+
+fn claude_json_value(
+    window: &ClaudeWindowView<'_>,
+    pricing_db: &PricingDb,
+    show_cost: bool,
+    currency: Option<&CurrencyConverter>,
+) -> Value {
+    let mut obj = json!({
+        "block_start": window.block.block_start,
+        "block_end": window.block.block_end,
+        "input_tokens": window.block.stats.input_tokens,
+        "output_tokens": window.block.stats.output_tokens,
+        "cache_creation_tokens": window.block.stats.cache_creation,
+        "cache_read_tokens": window.block.stats.cache_read,
+        "total_tokens": window.block.stats.total_tokens(),
+        "remaining_minutes": remaining_minutes(window.remaining_ms),
+        "disclaimer": CLAUDE_WINDOW_DISCLAIMER,
+    });
+    if show_cost {
+        obj["cost"] = cost_json_value(claude_cost(window.block, pricing_db), currency);
+    }
+    obj
+}
+
+pub(crate) fn output_limits_json(
+    view: &LimitsView<'_>,
+    pricing_db: &PricingDb,
+    show_cost: bool,
+    currency: Option<&CurrencyConverter>,
+) -> String {
+    let codex = view.codex.map_or(Value::Null, |(report, estimate)| {
+        quota_json_value(report, estimate)
+    });
+    let claude_blocks = view.claude.as_ref().map_or(Value::Null, |window| {
+        claude_json_value(window, pricing_db, show_cost, currency)
+    });
+    json!({
+        "codex": codex,
+        "claude_blocks": claude_blocks,
+        "notes": view.notes,
+    })
+    .to_string()
+}
+
+const CSV_HEADER: &str = "section,source,window,window_minutes,used_pct,remaining_pct,projected_pct_at_reset,status,observed_at,resets_at,estimated_depletion_at,observed_cost_usd,estimated_weekly_value_usd,block_start,block_end,input_tokens,output_tokens,total_tokens,remaining_minutes,cost,disclaimer,error";
+
+fn csv_f64(value: Option<f64>, precision: usize) -> String {
+    value.map_or(String::new(), |v| format!("{v:.precision$}"))
+}
+
+fn csv_i64(value: Option<i64>) -> String {
+    value.map_or(String::new(), |v| v.to_string())
+}
+
+fn timestamp(value: chrono::DateTime<chrono::Utc>) -> String {
+    value.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+fn quota_value_columns(value_estimate: QuotaValueEstimate<'_>) -> (String, String) {
+    match value_estimate {
+        Some(Ok(estimate)) => (
+            format!("{:.6}", estimate.observed_cost_usd),
+            format!("{:.6}", estimate.estimated_weekly_value_usd),
+        ),
+        Some(Err(_)) | None => (String::new(), String::new()),
+    }
+}
+
+#[derive(Default)]
+struct LimitsCsvRow<'a> {
+    section: &'a str,
+    source: &'a str,
+    window: &'a str,
+    window_minutes: Option<i64>,
+    used_pct: Option<f64>,
+    remaining_pct: Option<f64>,
+    projected_pct: Option<f64>,
+    status: &'a str,
+    observed_at: &'a str,
+    resets_at: &'a str,
+    estimated_depletion_at: &'a str,
+    observed_cost: &'a str,
+    weekly_value: &'a str,
+    block_start: &'a str,
+    block_end: &'a str,
+    input_tokens: Option<i64>,
+    output_tokens: Option<i64>,
+    total_tokens: Option<i64>,
+    remaining_minutes: Option<i64>,
+    cost: &'a str,
+    disclaimer: &'a str,
+    error: &'a str,
+}
+
+impl LimitsCsvRow<'_> {
+    fn write_to(&self, out: &mut String) {
+        let _ = writeln!(
+            out,
+            "{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}",
+            self.section,
+            self.source,
+            self.window,
+            csv_i64(self.window_minutes),
+            csv_f64(self.used_pct, 2),
+            csv_f64(self.remaining_pct, 2),
+            csv_f64(self.projected_pct, 2),
+            self.status,
+            self.observed_at,
+            self.resets_at,
+            self.estimated_depletion_at,
+            self.observed_cost,
+            self.weekly_value,
+            csv_escape(self.block_start),
+            csv_escape(self.block_end),
+            csv_i64(self.input_tokens),
+            csv_i64(self.output_tokens),
+            csv_i64(self.total_tokens),
+            csv_i64(self.remaining_minutes),
+            self.cost,
+            csv_escape(self.disclaimer),
+            csv_escape(self.error),
+        );
+    }
+}
+
+pub(crate) fn output_limits_csv(
+    view: &LimitsView<'_>,
+    pricing_db: &PricingDb,
+    show_cost: bool,
+    currency: Option<&CurrencyConverter>,
+) -> String {
+    let mut out = format!("{CSV_HEADER}\n");
+    if view.want_codex {
+        if let Some((report, estimate)) = view.codex {
+            let depletion = report
+                .estimated_depletion_at
+                .map(timestamp)
+                .unwrap_or_default();
+            let observed_at = timestamp(report.observed_at);
+            let resets_at = timestamp(report.resets_at);
+            let (observed_cost, weekly_value) = quota_value_columns(estimate);
+            LimitsCsvRow {
+                section: "codex",
+                source: "codex",
+                window: "weekly",
+                window_minutes: Some(report.window_minutes),
+                used_pct: Some(report.used_pct),
+                remaining_pct: Some(report.remaining_pct),
+                projected_pct: Some(report.projected_pct_at_reset),
+                status: report.status.as_str(),
+                observed_at: &observed_at,
+                resets_at: &resets_at,
+                estimated_depletion_at: &depletion,
+                observed_cost: &observed_cost,
+                weekly_value: &weekly_value,
+                ..Default::default()
+            }
+            .write_to(&mut out);
+        } else {
+            LimitsCsvRow {
+                section: "codex",
+                source: "codex",
+                window: "weekly",
+                error: view.codex_error.unwrap_or_default(),
+                ..Default::default()
+            }
+            .write_to(&mut out);
+        }
+    }
+    if view.want_claude {
+        if let Some(window) = &view.claude {
+            let cost = if show_cost {
+                format_cost(claude_cost(window.block, pricing_db), currency)
+            } else {
+                String::new()
+            };
+            LimitsCsvRow {
+                section: "claude",
+                source: "claude",
+                window: "estimated_5h",
+                block_start: &window.block.block_start,
+                block_end: &window.block.block_end,
+                input_tokens: Some(window.block.stats.input_tokens),
+                output_tokens: Some(window.block.stats.output_tokens),
+                total_tokens: Some(window.block.stats.total_tokens()),
+                remaining_minutes: Some(remaining_minutes(window.remaining_ms)),
+                cost: &cost,
+                disclaimer: CLAUDE_WINDOW_DISCLAIMER,
+                ..Default::default()
+            }
+            .write_to(&mut out);
+        } else {
+            LimitsCsvRow {
+                section: "claude",
+                source: "claude",
+                window: "estimated_5h",
+                disclaimer: CLAUDE_WINDOW_DISCLAIMER,
+                error: NO_ACTIVE_CLAUDE_WINDOW,
+                ..Default::default()
+            }
+            .write_to(&mut out);
+        }
+    }
+    out
+}
+
+pub(crate) struct LimitsTableOptions<'a> {
+    pub timezone: Timezone,
+    pub number_format: NumberFormat,
+    pub use_color: bool,
+    pub show_cost: bool,
+    pub currency: Option<&'a CurrencyConverter>,
+}
+
+pub(crate) fn print_limits_table(
+    view: &LimitsView<'_>,
+    pricing_db: &PricingDb,
+    options: &LimitsTableOptions<'_>,
+) {
+    if view.both_missing() {
+        println!("{BOTH_MISSING_HINT}");
+        return;
+    }
+
+    if view.want_codex {
+        println!("Codex weekly quota");
+        if let Some((report, estimate)) = view.codex {
+            print_quota_table(
+                report,
+                estimate,
+                options.timezone,
+                options.number_format,
+                options.use_color,
+            );
+        } else {
+            println!(
+                "unavailable: {}",
+                view.codex_error
+                    .unwrap_or("Codex weekly quota is not available")
+            );
+        }
+        if view.want_claude {
+            println!();
+        }
+    }
+
+    if view.want_claude {
+        println!("Claude estimated session window");
+        if let Some(window) = &view.claude {
+            print_claude_window_table(window, pricing_db, options);
+        } else {
+            println!("{NO_ACTIVE_CLAUDE_WINDOW}");
+        }
+        println!("{CLAUDE_WINDOW_DISCLAIMER}");
+    }
+}
+
+fn print_claude_window_table(
+    window: &ClaudeWindowView<'_>,
+    pricing_db: &PricingDb,
+    options: &LimitsTableOptions<'_>,
+) {
+    let mut table = create_styled_table();
+    let mut header = vec![
+        header_cell("Window", options.use_color),
+        header_cell("Tokens", options.use_color),
+        header_cell("Remaining", options.use_color),
+    ];
+    if options.show_cost {
+        header.push(header_cell("Cost", options.use_color));
+    }
+    table.set_header(header);
+
+    let label = format!("{} - {}", window.block.block_start, window.block.block_end);
+    let mut row = vec![
+        Cell::new(label),
+        right_cell(
+            &format_compact(window.block.stats.total_tokens(), options.number_format),
+            None,
+            false,
+        ),
+        Cell::new(format_remaining(window.remaining_ms)),
+    ];
+    if options.show_cost {
+        row.push(right_cell(
+            &format_cost(claude_cost(window.block, pricing_db), options.currency),
+            None,
+            false,
+        ));
+    }
+    table.add_row(row);
+    println!("{table}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::source::CodexQuotaStatus;
+    use chrono::DateTime;
+    use std::collections::HashMap;
+
+    use crate::core::Stats;
+    use crate::sdk::CodexWeeklyValueEstimate;
+
+    fn report() -> CodexWeeklyQuota {
+        CodexWeeklyQuota {
+            observed_at: "2026-08-22T00:00:00Z".parse::<DateTime<_>>().unwrap(),
+            resets_at: "2026-08-28T00:00:00Z".parse::<DateTime<_>>().unwrap(),
+            estimated_depletion_at: Some("2026-08-25T00:00:00Z".parse::<DateTime<_>>().unwrap()),
+            window_minutes: 10_080,
+            used_pct: 25.0,
+            remaining_pct: 75.0,
+            projected_pct_at_reset: 175.0,
+            status: CodexQuotaStatus::LikelyExhausted,
+        }
+    }
+
+    fn estimate() -> CodexWeeklyValueEstimate {
+        CodexWeeklyValueEstimate {
+            observed_at: "2026-08-22T00:00:00Z".parse::<DateTime<_>>().unwrap(),
+            window_started_at: "2026-08-21T00:00:00Z".parse::<DateTime<_>>().unwrap(),
+            resets_at: "2026-08-28T00:00:00Z".parse::<DateTime<_>>().unwrap(),
+            used_pct: 25.0,
+            observed_cost_usd: 50.0,
+            estimated_weekly_value_usd: 200.0,
+            observed_tokens: 1_000_000,
+            estimated_weekly_tokens: 4_000_000.0,
+            valid_entries: 12,
+            dedup_skipped_entries: 2,
+        }
+    }
+
+    fn block() -> BlockStats {
+        BlockStats {
+            block_start: "2026-09-03 12:00".to_string(),
+            block_end: "17:00".to_string(),
+            start_ms: 1,
+            stats: Stats {
+                input_tokens: 100,
+                output_tokens: 50,
+                ..Default::default()
+            },
+            models: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn json_uses_null_for_missing_codex_without_zero_percent() {
+        let block = block();
+        let notes = vec![CLAUDE_WINDOW_DISCLAIMER.to_string()];
+        let view = LimitsView {
+            want_codex: true,
+            want_claude: true,
+            codex: None,
+            codex_error: Some("snapshot missing"),
+            claude: Some(ClaudeWindowView {
+                block: &block,
+                remaining_ms: 90 * 60 * 1000,
+            }),
+            notes: &notes,
+        };
+        let value: Value = serde_json::from_str(&output_limits_json(
+            &view,
+            &PricingDb::default(),
+            false,
+            None,
+        ))
+        .unwrap();
+        assert!(value["codex"].is_null());
+        assert!(value["codex"].get("used_pct").is_none());
+        assert_eq!(value["claude_blocks"]["total_tokens"], 150);
+        assert_eq!(value["claude_blocks"]["remaining_minutes"], 90);
+        assert!(
+            value["claude_blocks"]["disclaimer"]
+                .as_str()
+                .unwrap()
+                .contains("not an official")
+        );
+        assert!(
+            !value["claude_blocks"]
+                .as_object()
+                .unwrap()
+                .contains_key("used_pct")
+        );
+    }
+
+    #[test]
+    fn csv_leaves_missing_sections_blank_not_zero() {
+        let notes = Vec::<String>::new();
+        let view = LimitsView {
+            want_codex: true,
+            want_claude: true,
+            codex: None,
+            codex_error: Some("snapshot missing"),
+            claude: None,
+            notes: &notes,
+        };
+        let csv = output_limits_csv(&view, &PricingDb::default(), false, None);
+        let mut lines = csv.lines();
+        assert_eq!(lines.next(), Some(CSV_HEADER));
+        let codex = lines.next().unwrap();
+        assert!(codex.starts_with("codex,codex,weekly,"));
+        assert!(!codex.contains(",0.00,"));
+        assert!(codex.contains("snapshot missing"));
+        let claude = lines.next().unwrap();
+        assert!(claude.starts_with("claude,claude,estimated_5h,"));
+        assert!(!claude.contains(",0,") || claude.contains(NO_ACTIVE_CLAUDE_WINDOW));
+        let fields: Vec<_> = claude.split(',').collect();
+        // used_pct / remaining_pct / projected stay empty
+        assert_eq!(fields[4], "");
+        assert_eq!(fields[5], "");
+        assert_eq!(fields[6], "");
+    }
+
+    #[test]
+    fn json_includes_codex_quota_fields_when_present() {
+        let report = report();
+        let estimate = estimate();
+        let notes = Vec::<String>::new();
+        let view = LimitsView {
+            want_codex: true,
+            want_claude: false,
+            codex: Some((&report, Some(Ok(&estimate)))),
+            codex_error: None,
+            claude: None,
+            notes: &notes,
+        };
+        let value: Value = serde_json::from_str(&output_limits_json(
+            &view,
+            &PricingDb::default(),
+            true,
+            None,
+        ))
+        .unwrap();
+        assert_eq!(value["codex"]["used_pct"], 25.0);
+        assert!(value["claude_blocks"].is_null());
+    }
+}

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -4,6 +4,7 @@ mod csv;
 mod endpoints;
 mod format;
 mod json;
+mod limits;
 mod period;
 mod pricing_meta;
 mod project;
@@ -39,6 +40,10 @@ pub(crate) use csv::{
 pub(crate) use endpoints::{EndpointTableOptions, output_endpoint_json, print_endpoint_table};
 pub(crate) use format::{NumberFormat, csv_escape, format_cost};
 pub(crate) use json::output_period_json_with_quality;
+pub(crate) use limits::{
+    BOTH_MISSING_HINT, CLAUDE_WINDOW_DISCLAIMER, ClaudeWindowView, LimitsTableOptions, LimitsView,
+    NO_ACTIVE_CLAUDE_WINDOW, output_limits_csv, output_limits_json, print_limits_table,
+};
 pub(crate) use period::{Period, aggregate_day_stats_by_period, period_key};
 pub(crate) use project::{ProjectTableOptions, output_project_json, print_project_table};
 pub(crate) use quota::{

--- a/src/quota_cmd.rs
+++ b/src/quota_cmd.rs
@@ -2,31 +2,52 @@ use crate::app::{CommandContext, print_json};
 use crate::output::{
     OutputFormat, QuotaValueEstimate, output_quota_csv, output_quota_json, print_quota_table,
 };
-use crate::sdk::estimate_codex_weekly_value_with_pricing;
-use crate::source::load_weekly_quota;
+use crate::sdk::{
+    CodexWeeklyValueError, CodexWeeklyValueEstimate, estimate_codex_weekly_value_with_pricing,
+};
+use crate::source::{CodexQuotaError, CodexWeeklyQuota, load_weekly_quota};
+
+pub(crate) struct LoadedQuota {
+    pub report: CodexWeeklyQuota,
+    pub value_estimate: Option<Result<CodexWeeklyValueEstimate, CodexWeeklyValueError>>,
+}
+
+impl LoadedQuota {
+    pub(crate) fn rendered(&self) -> QuotaValueEstimate<'_> {
+        self.value_estimate.as_ref().map(Result::as_ref)
+    }
+}
+
+pub(crate) fn load_quota(ctx: &CommandContext<'_>) -> Result<LoadedQuota, CodexQuotaError> {
+    let report = load_weekly_quota()?;
+    let value_estimate = ctx
+        .cli
+        .show_cost()
+        .then(|| estimate_codex_weekly_value_with_pricing(&report, None, ctx.pricing_db));
+    Ok(LoadedQuota {
+        report,
+        value_estimate,
+    })
+}
 
 pub(crate) fn handle_quota(ctx: &CommandContext<'_>) {
-    let report = match load_weekly_quota() {
-        Ok(report) => report,
+    let loaded = match load_quota(ctx) {
+        Ok(loaded) => loaded,
         Err(error) => {
             eprintln!("Error: {error}");
             std::process::exit(1);
         }
     };
-    let value_estimate = ctx
-        .cli
-        .show_cost()
-        .then(|| estimate_codex_weekly_value_with_pricing(&report, None, ctx.pricing_db));
-    let rendered_estimate: QuotaValueEstimate<'_> = value_estimate.as_ref().map(Result::as_ref);
+    let rendered_estimate = loaded.rendered();
 
     match ctx.cli.output_format() {
         OutputFormat::Json => print_json(
-            &output_quota_json(&report, rendered_estimate),
+            &output_quota_json(&loaded.report, rendered_estimate),
             ctx.jq_filter,
         ),
-        OutputFormat::Csv => print!("{}", output_quota_csv(&report, rendered_estimate)),
+        OutputFormat::Csv => print!("{}", output_quota_csv(&loaded.report, rendered_estimate)),
         OutputFormat::Table => print_quota_table(
-            &report,
+            &loaded.report,
             rendered_estimate,
             ctx.timezone,
             ctx.number_format,

--- a/tests/cli_limits.rs
+++ b/tests/cli_limits.rs
@@ -294,3 +294,26 @@ fn quota_help_is_codex_only_and_limits_help_is_combined() {
 
     let _ = fs::remove_dir_all(home);
 }
+
+#[test]
+fn limits_empty_home_keeps_its_schema_and_ignores_unrelated_credentials() {
+    let home = unique_temp_dir("limits-empty-json");
+    for corrupt_cursor in [false, true] {
+        if corrupt_cursor {
+            write_file(
+                &home.join(".config/ccstats/credentials.toml"),
+                "[cursor]\napi_key = \"unterminated",
+            );
+        }
+        let (ok, stdout, stderr) = run_home(&home, &["limits", "--json", "--offline", "--no-cost"]);
+        assert!(ok, "{}", String::from_utf8_lossy(&stderr));
+        let value: Value = serde_json::from_slice(&stdout).unwrap();
+        assert!(
+            value.is_object(),
+            "limits must not dispatch doctor: {value}"
+        );
+        assert!(value.get("codex").unwrap().is_null());
+        assert!(value.get("claude_blocks").unwrap().is_null());
+    }
+    fs::remove_dir_all(home).unwrap();
+}

--- a/tests/cli_limits.rs
+++ b/tests/cli_limits.rs
@@ -1,0 +1,296 @@
+mod common;
+
+use std::fs;
+use std::path::Path;
+
+use chrono::{Duration, SecondsFormat, Timelike, Utc};
+use common::{run_ccstats, unique_temp_dir, write_file};
+use serde_json::{Value, json};
+
+fn quota_event(
+    observed_at: chrono::DateTime<Utc>,
+    used_pct: f64,
+    resets_at: chrono::DateTime<Utc>,
+    weekly_in_secondary: bool,
+) -> String {
+    let weekly = json!({
+        "used_percent": used_pct,
+        "window_minutes": 10_080,
+        "resets_at": resets_at.timestamp(),
+    });
+    let rate_limits = if weekly_in_secondary {
+        json!({
+            "primary": {
+                "used_percent": 10.0,
+                "window_minutes": 300,
+                "resets_at": (observed_at + Duration::hours(4)).timestamp(),
+            },
+            "secondary": weekly,
+        })
+    } else {
+        json!({"primary": weekly, "secondary": null})
+    };
+
+    format!(
+        "{}\n",
+        json!({
+            "timestamp": observed_at.to_rfc3339_opts(SecondsFormat::Secs, true),
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "total_token_usage": {
+                        "input_tokens": 1_000_000,
+                        "cached_input_tokens": 200_000,
+                        "output_tokens": 100_000,
+                        "reasoning_output_tokens": 50_000,
+                        "total_tokens": 1_100_000,
+                    },
+                    "last_token_usage": {
+                        "input_tokens": 1_000_000,
+                        "cached_input_tokens": 200_000,
+                        "output_tokens": 100_000,
+                        "reasoning_output_tokens": 50_000,
+                        "total_tokens": 1_100_000,
+                    },
+                    "model": "gpt-5",
+                },
+                "rate_limits": rate_limits,
+            },
+        })
+    )
+}
+
+fn write_codex_quota(home: &Path) {
+    let observed_at = Utc::now().with_nanosecond(0).unwrap();
+    let resets_at = observed_at + Duration::days(6);
+    write_file(
+        &home.join(".codex/sessions/newer.jsonl"),
+        &quota_event(observed_at, 25.0, resets_at, true),
+    );
+}
+
+fn write_active_claude_block(home: &Path) {
+    let timestamp = Utc::now()
+        .with_nanosecond(0)
+        .unwrap()
+        .to_rfc3339_opts(SecondsFormat::Secs, true);
+    write_file(
+        &home.join(".claude/projects/limits-app/session.jsonl"),
+        &format!(
+            r#"{{"timestamp":"{timestamp}","message":{{"id":"msg_limits_1","model":"claude-3-5-sonnet-20241022","stop_reason":"end_turn","usage":{{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}}}}
+"#
+        ),
+    );
+}
+
+fn run_home(home: &Path, args: &[&str]) -> (bool, Vec<u8>, Vec<u8>) {
+    run_ccstats(args, &[("HOME", home)])
+}
+
+#[test]
+fn limits_codex_only_home_shows_quota_without_fake_claude_percent() {
+    let home = unique_temp_dir("limits-codex-only");
+    write_codex_quota(&home);
+
+    let (ok, stdout, stderr) = run_home(
+        &home,
+        &["limits", "--offline", "--no-color", "--timezone", "UTC"],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let text = String::from_utf8_lossy(&stdout);
+    assert!(text.contains("Codex weekly quota"), "{text}");
+    assert!(text.contains("25.0%"), "{text}");
+    assert!(text.contains("Claude estimated session window"), "{text}");
+    assert!(text.contains("No active estimated 5-hour window"), "{text}");
+    assert!(text.contains("not an official"), "{text}");
+
+    let (json_ok, json_stdout, json_stderr) = run_home(&home, &["limits", "--json", "--offline"]);
+    assert!(json_ok, "stderr: {}", String::from_utf8_lossy(&json_stderr));
+    let value: Value = serde_json::from_slice(&json_stdout).unwrap();
+    assert_eq!(value["codex"]["used_pct"], 25.0);
+    assert!(value["claude_blocks"].is_null());
+
+    let _ = fs::remove_dir_all(home);
+}
+
+#[test]
+fn limits_claude_only_json_codex_is_null_and_table_has_disclaimer() {
+    let home = unique_temp_dir("limits-claude-only");
+    write_active_claude_block(&home);
+
+    let (ok, stdout, stderr) = run_home(
+        &home,
+        &[
+            "limits",
+            "--offline",
+            "--no-color",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+        ],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let text = String::from_utf8_lossy(&stdout);
+    assert!(text.contains("Claude estimated session window"), "{text}");
+    assert!(text.contains("not an official"), "{text}");
+    assert!(text.contains("Codex weekly quota"), "{text}");
+    assert!(text.contains("unavailable:"), "{text}");
+
+    let (json_ok, json_stdout, json_stderr) = run_home(
+        &home,
+        &[
+            "limits",
+            "--json",
+            "--offline",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+        ],
+    );
+    assert!(json_ok, "stderr: {}", String::from_utf8_lossy(&json_stderr));
+    let value: Value = serde_json::from_slice(&json_stdout).unwrap();
+    assert!(
+        value["codex"].is_null(),
+        "missing Codex must be null: {value}"
+    );
+    assert!(
+        value["codex"].get("used_pct").is_none(),
+        "missing Codex must not be used_pct=0: {value}"
+    );
+    assert_eq!(value["claude_blocks"]["total_tokens"], 150);
+    assert!(
+        value["claude_blocks"]["disclaimer"]
+            .as_str()
+            .unwrap()
+            .contains("not an official")
+    );
+    assert!(
+        !value["claude_blocks"]
+            .as_object()
+            .unwrap()
+            .contains_key("used_pct")
+    );
+
+    let _ = fs::remove_dir_all(home);
+}
+
+#[test]
+fn limits_rejects_cursor_source() {
+    let home = unique_temp_dir("limits-cursor-source");
+    let (ok, _stdout, stderr) = run_home(&home, &["limits", "--source", "cursor"]);
+    assert!(!ok);
+    let err = String::from_utf8_lossy(&stderr);
+    assert!(
+        err.contains("limits does not support --source cursor"),
+        "{err}"
+    );
+
+    let _ = fs::remove_dir_all(home);
+}
+
+#[test]
+fn limits_source_claude_omits_codex_attempt_as_null() {
+    let home = unique_temp_dir("limits-source-claude");
+    write_active_claude_block(&home);
+
+    let (ok, stdout, stderr) = run_home(
+        &home,
+        &[
+            "limits",
+            "--source",
+            "claude",
+            "--json",
+            "--offline",
+            "--no-cost",
+        ],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let value: Value = serde_json::from_slice(&stdout).unwrap();
+    assert!(value["codex"].is_null());
+    assert_eq!(value["claude_blocks"]["total_tokens"], 150);
+
+    let _ = fs::remove_dir_all(home);
+}
+
+#[test]
+fn limits_csv_blanks_missing_codex_instead_of_zero() {
+    let home = unique_temp_dir("limits-csv-missing-codex");
+    write_active_claude_block(&home);
+
+    let (ok, stdout, stderr) = run_home(
+        &home,
+        &[
+            "limits",
+            "--csv",
+            "--offline",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+        ],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let csv = String::from_utf8(stdout).unwrap();
+    let mut lines = csv.lines();
+    let header = lines.next().unwrap();
+    assert!(header.starts_with("section,source,window,"));
+    let codex = lines.next().unwrap();
+    let fields: Vec<_> = codex.split(',').collect();
+    assert_eq!(fields[0], "codex");
+    assert_eq!(
+        fields[4], "",
+        "used_pct must be blank when Codex is missing: {codex}"
+    );
+    assert_eq!(fields[5], "", "remaining_pct must be blank: {codex}");
+    assert_eq!(fields[6], "", "projected_pct must be blank: {codex}");
+
+    let _ = fs::remove_dir_all(home);
+}
+
+#[test]
+fn limits_both_missing_tells_user_to_run_doctor() {
+    let home = unique_temp_dir("limits-both-missing");
+    fs::create_dir_all(home.join(".empty")).unwrap();
+
+    let (ok, stdout, stderr) = run_home(&home, &["limits", "--no-color", "--offline"]);
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let text = String::from_utf8_lossy(&stdout);
+    assert!(text.contains("ccstats doctor"), "{text}");
+    assert!(!text.contains("0%"), "{text}");
+
+    let _ = fs::remove_dir_all(home);
+}
+
+#[test]
+fn quota_help_is_codex_only_and_limits_help_is_combined() {
+    let home = unique_temp_dir("limits-help");
+    let (quota_ok, quota_stdout, quota_stderr) = run_home(&home, &["quota", "--help"]);
+    assert!(
+        quota_ok,
+        "stderr: {}",
+        String::from_utf8_lossy(&quota_stderr)
+    );
+    let quota_help = String::from_utf8_lossy(&quota_stdout);
+    assert!(
+        quota_help.to_ascii_lowercase().contains("codex-only") || quota_help.contains("Codex-only"),
+        "{quota_help}"
+    );
+
+    let (limits_ok, limits_stdout, limits_stderr) = run_home(&home, &["limits", "--help"]);
+    assert!(
+        limits_ok,
+        "stderr: {}",
+        String::from_utf8_lossy(&limits_stderr)
+    );
+    let limits_help = String::from_utf8_lossy(&limits_stdout);
+    assert!(
+        limits_help.contains("claude") || limits_help.contains("Claude"),
+        "{limits_help}"
+    );
+    assert!(
+        limits_help.contains("codex") || limits_help.contains("Codex"),
+        "{limits_help}"
+    );
+
+    let _ = fs::remove_dir_all(home);
+}


### PR DESCRIPTION
Add `ccstats limits` for Codex weekly quota snapshots and Claude estimated activity windows. Missing sections remain null or blank, and Claude windows always state that they are not official Anthropic billing resets.

Fixes #168

This PR remains based on #172. Merge #172 after human credential review, then retarget this PR to main and verify the final diff and checks.

The limits command bypasses default source discovery so empty machines retain the limits schema, and unrelated malformed Cursor credentials do not block local Codex/Claude limits. Unsupported explicit sources fail. CI now checks PRs targeting stacked branches as well as main.

Validation: full local Rust suite (933 tests), Clippy and format. The 23 quota, limits, and login integration tests pass, including empty-home JSON, unavailable values, and unchanged quota behavior. GitHub checks run on this stacked branch.

P2 desktop follow-up: includes #172 fix `69b0954`, propagating source diagnostic errors before All Sources aggregation or machine snapshot persistence. Four new regression tests cover overview, live startup/refresh, and capture. Check, Coverage, Desktop, and Windows credentials CI all pass at `c4af5bb`. The owner approved SEC-11 review; the #172 correctness fix awaits re-review before the stack can merge.
