### PR TITLE
perf(codex): cache unchanged usage files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,4 +51,4 @@ lto = true
 codegen-units = 1
 strip = true
 panic = "abort"
-opt-level = "z"
+opt-level = 3

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -37,6 +37,12 @@ ccstats writes only operational data needed to make repeated reports reliable:
 
 - pricing cache under the platform cache directory and exchange-rate cache
   under `~/.cache/ccstats/`;
+- a Codex usage cache at `<platform cache>/ccstats/codex-usage-v1.sqlite3`
+  (with SQLite WAL/SHM sidecars). It stores file identities, event timestamps,
+  model names, deduplication keys, and token counts; it does not store conversation
+  text or fixed prices. Unchanged files reuse these facts across reports and
+  timezones. Changed files are reparsed, and removed source files stop contributing.
+  Deleting this cache and its sidecars while ccstats is stopped forces a rebuild;
 - a Grok inference ledger under the ccstats cache directory because Grok may
   trim its live log in place;
 - desktop machine snapshots under the app data directory. These snapshots

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -37,7 +37,7 @@ ccstats writes only operational data needed to make repeated reports reliable:
 
 - pricing cache under the platform cache directory and exchange-rate cache
   under `~/.cache/ccstats/`;
-- a Codex usage cache at `<platform cache>/ccstats/codex-usage-v1.sqlite3`
+- a Codex usage cache at `<platform cache>/ccstats/codex-usage-v2.sqlite3`
   (with SQLite WAL/SHM sidecars). It stores file identities, event timestamps,
   model names, deduplication keys, and token counts; it does not store conversation
   text or fixed prices. Unchanged files reuse these facts across reports and

--- a/src/core/aggregator.rs
+++ b/src/core/aggregator.rs
@@ -12,7 +12,7 @@ use crate::utils::Timezone;
 
 /// Aggregate entries by day (consumes entries to avoid cloning)
 pub(crate) fn aggregate_daily(entries: Vec<RawEntry>) -> HashMap<String, DayStats> {
-    let mut day_stats: HashMap<String, DayStats> = HashMap::with_capacity(entries.len());
+    let mut day_stats: HashMap<String, DayStats> = HashMap::new();
 
     for entry in entries {
         let stats = entry.to_stats();

--- a/src/core/dedup.rs
+++ b/src/core/dedup.rs
@@ -4,7 +4,7 @@
 //! We keep the entry with `stop_reason` (completed message) to get accurate token counts.
 
 use crate::core::types::RawEntry;
-use std::collections::HashMap;
+use std::collections::{HashMap, hash_map::Entry};
 
 const SOURCE_WIDE_DEDUP_PREFIX: &str = "source-wide:";
 
@@ -51,16 +51,18 @@ impl Deduplicatable for RawEntry {
 #[derive(Debug)]
 struct CandidateState<T: Deduplicatable> {
     /// Best completed entry seen so far (excluding `latest` when it is completed).
-    best_completed: Option<T>,
+    // Most entries never need a second candidate. Avoid reserving another full
+    // RawEntry in every hash bucket when that slot is empty.
+    best_completed: Option<Box<T>>,
     /// Latest entry by timestamp (fallback)
-    latest: T,
+    latest: Box<T>,
 }
 
 impl<T: Deduplicatable> CandidateState<T> {
     fn new(entry: T) -> Self {
         Self {
             best_completed: None,
-            latest: entry,
+            latest: Box::new(entry),
         }
     }
 
@@ -84,7 +86,7 @@ impl<T: Deduplicatable> CandidateState<T> {
             None => true,
         };
         if should_replace {
-            self.best_completed = Some(entry);
+            self.best_completed = Some(Box::new(entry));
         }
     }
 
@@ -93,10 +95,10 @@ impl<T: Deduplicatable> CandidateState<T> {
         if entry_ts > self.latest.timestamp_ms() {
             // Move completed latest into the completed slot before replacing it.
             if self.latest.has_stop_reason() {
-                let old_latest = std::mem::replace(&mut self.latest, entry);
+                let old_latest = std::mem::replace(&mut *self.latest, entry);
                 self.replace_best_completed_if_newer(old_latest);
             } else {
-                self.latest = entry;
+                *self.latest = entry;
             }
             return;
         }
@@ -112,9 +114,9 @@ impl<T: Deduplicatable> CandidateState<T> {
             latest,
         } = other;
         if let Some(entry) = best_completed {
-            self.update(entry);
+            self.update(*entry);
         }
-        self.update(latest);
+        self.update(*latest);
     }
 
     /// Get the best entry: completed if available, otherwise latest
@@ -124,9 +126,9 @@ impl<T: Deduplicatable> CandidateState<T> {
                 if !self.latest.has_stop_reason()
                     || best.timestamp_ms() > self.latest.timestamp_ms() =>
             {
-                best
+                *best
             }
-            _ => self.latest,
+            _ => *self.latest,
         }
     }
 }
@@ -161,10 +163,10 @@ impl<T: Deduplicatable> DedupAccumulator<T> {
                 entry.dedup_scope().unwrap_or_default().to_string(),
                 id.to_string(),
             );
-            match self.message_map.get_mut(&key) {
-                Some(state) => state.update(entry),
-                None => {
-                    self.message_map.insert(key, CandidateState::new(entry));
+            match self.message_map.entry(key) {
+                Entry::Occupied(mut state) => state.get_mut().update(entry),
+                Entry::Vacant(slot) => {
+                    slot.insert(CandidateState::new(entry));
                 }
             }
         } else if entry.has_stop_reason() {
@@ -186,10 +188,10 @@ impl<T: Deduplicatable> DedupAccumulator<T> {
         self.no_id_entries.extend(other.no_id_entries);
 
         for (key, state) in other.message_map {
-            match self.message_map.get_mut(&key) {
-                Some(existing) => existing.merge(state),
-                None => {
-                    self.message_map.insert(key, state);
+            match self.message_map.entry(key) {
+                Entry::Occupied(mut existing) => existing.get_mut().merge(state),
+                Entry::Vacant(slot) => {
+                    slot.insert(state);
                 }
             }
         }

--- a/src/pricing/cache.rs
+++ b/src/pricing/cache.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::fs::{self, File, OpenOptions};
-use std::io::{BufWriter, ErrorKind, Write};
+use std::io::{BufReader, BufWriter, ErrorKind, Write};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -163,9 +163,11 @@ pub(super) fn load_raw_cache_snapshot_from_paths(
             path: path.clone(),
             source,
         })?;
-        let data = serde_json::from_reader(file).map_err(|source| CacheReadError::Malformed {
-            path: path.clone(),
-            source,
+        let data = serde_json::from_reader(BufReader::new(file)).map_err(|source| {
+            CacheReadError::Malformed {
+                path: path.clone(),
+                source,
+            }
         })?;
         return Ok(Some(RawPricingCacheSnapshot {
             data,
@@ -209,9 +211,11 @@ pub(super) fn load_raw_cache_if_fresh_from_paths(
             path: path.clone(),
             source,
         })?;
-        let data = serde_json::from_reader(file).map_err(|source| CacheReadError::Malformed {
-            path: path.clone(),
-            source,
+        let data = serde_json::from_reader(BufReader::new(file)).map_err(|source| {
+            CacheReadError::Malformed {
+                path: path.clone(),
+                source,
+            }
         })?;
         return Ok(Some(RawPricingCacheSnapshot { data, metadata }));
     }

--- a/src/source/codex/cache.rs
+++ b/src/source/codex/cache.rs
@@ -1,0 +1,330 @@
+//! Reusable usage facts. Source JSONL files remain authoritative.
+
+use std::error::Error;
+use std::fs;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::time::Duration;
+
+use chrono::{DateTime, NaiveDate, Utc};
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::Deserialize;
+
+use crate::consts::{DATE_FORMAT, UNKNOWN};
+use crate::core::{CostKind, DateFilter, Endpoint, RawEntry};
+use crate::source::{ParseOutput, loader::DataLoader};
+use crate::utils::Timezone;
+
+use super::config::CodexScope;
+use super::parser::parse_codex_file_with_scope;
+
+type CacheResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+// Version the filename when the parser's usage semantics or stored fields change.
+const CACHE_FILE: &str = "codex-usage-v1.sqlite3";
+
+#[derive(Default)]
+pub(super) struct CodexCache {
+    connection: OnceLock<Result<Mutex<Connection>, String>>,
+    hits: AtomicUsize,
+    reported_error: AtomicBool,
+}
+
+// Timestamp, milliseconds, dedup identity, model, input, output, cache, reasoning.
+// Session paths and local dates are reconstructed, never serialized per event.
+#[derive(Deserialize)]
+struct StoredEntry(String, i64, Option<String>, String, i64, i64, i64, i64);
+
+impl StoredEntry {
+    fn expand(self, path: &Path, date: NaiveDate) -> RawEntry {
+        RawEntry {
+            timestamp: self.0,
+            timestamp_ms: self.1,
+            date_str: date.format(DATE_FORMAT).to_string(),
+            message_id: self.2,
+            session_key: path.display().to_string(),
+            session_id: path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or(UNKNOWN)
+                .to_string(),
+            project_path: String::new(),
+            model: self.3,
+            input_tokens: self.4,
+            output_tokens: self.5,
+            cache_creation: 0,
+            cache_creation_1h: 0,
+            cache_read: self.6,
+            reasoning_tokens: self.7,
+            stop_reason: Some("complete".to_string()),
+            cost_kind: CostKind::Real,
+            endpoint: Endpoint::Unknown,
+            call_count: 1,
+            reported_total_tokens: None,
+            recorded_cost_usd: None,
+            api_equivalent_priced_tokens: 0,
+            api_equivalent_coverage_tokens: 0,
+        }
+    }
+}
+
+fn open_cache(path: &Path) -> CacheResult<Connection> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let connection = Connection::open(path)?;
+    connection.busy_timeout(Duration::from_secs(5))?;
+    connection.execute_batch(
+        "PRAGMA journal_mode=WAL;
+         PRAGMA synchronous=NORMAL;
+         CREATE TABLE IF NOT EXISTS files (
+             path BLOB NOT NULL,
+             scope TEXT NOT NULL,
+             stamp TEXT NOT NULL,
+             first_ms INTEGER,
+             last_ms INTEGER,
+             payload BLOB NOT NULL,
+             PRIMARY KEY (path, scope)
+         ) WITHOUT ROWID;",
+    )?;
+    Ok(connection)
+}
+
+fn fingerprint(path: &Path) -> CacheResult<String> {
+    let metadata = fs::metadata(path)?;
+    let mut stamp = format!("{}:{:?}", metadata.len(), metadata.modified()?);
+    // Detect same-size rewrites with restored mtime, and atomic replacement.
+    #[cfg(unix)]
+    {
+        use std::fmt::Write;
+        use std::os::unix::fs::MetadataExt;
+        write!(
+            stamp,
+            ":{}:{}:{}:{}",
+            metadata.dev(),
+            metadata.ino(),
+            metadata.ctime(),
+            metadata.ctime_nsec()
+        )?;
+    }
+    #[cfg(not(unix))]
+    {
+        use std::fmt::Write;
+        write!(stamp, ":{:?}", metadata.created()?)?;
+    }
+    Ok(stamp)
+}
+
+fn overlaps(
+    first: Option<i64>,
+    last: Option<i64>,
+    filter: &DateFilter,
+    timezone: Timezone,
+) -> CacheResult<bool> {
+    let (Some(first), Some(last)) = (first, last) else {
+        return Ok(false);
+    };
+    if filter.has_timestamp_range() {
+        return Ok(filter.since_timestamp_ms.is_none_or(|since| last >= since)
+            && filter.until_timestamp_ms.is_none_or(|until| first <= until));
+    }
+    let first =
+        DateTime::<Utc>::from_timestamp_millis(first).ok_or("invalid first cached timestamp")?;
+    let last =
+        DateTime::<Utc>::from_timestamp_millis(last).ok_or("invalid last cached timestamp")?;
+    let first = timezone.to_fixed_offset(first).date_naive();
+    let last = timezone.to_fixed_offset(last).date_naive();
+    Ok(filter.since.is_none_or(|since| last >= since)
+        && filter.until.is_none_or(|until| first <= until))
+}
+
+impl CodexCache {
+    fn connection(&self) -> CacheResult<MutexGuard<'_, Connection>> {
+        let connection = self.connection.get_or_init(|| {
+            let result = dirs::cache_dir()
+                .ok_or_else(|| "cannot locate the platform cache directory".to_string())
+                .and_then(|root| {
+                    open_cache(&root.join("ccstats").join(CACHE_FILE)).map_err(|e| e.to_string())
+                });
+            result.map(Mutex::new)
+        });
+        let connection = connection.as_ref().map_err(Clone::clone)?;
+        connection.lock().map_err(|e| e.to_string().into())
+    }
+
+    pub(super) fn hits(&self) -> usize {
+        self.hits.load(Ordering::Relaxed)
+    }
+
+    fn report_error(&self, error: &dyn std::fmt::Display) {
+        if !self.reported_error.swap(true, Ordering::Relaxed) {
+            eprintln!("Error using Codex usage cache: {error}. Rebuilding usage from source logs.");
+        }
+    }
+
+    fn load(
+        &self,
+        path: &Path,
+        scope: CodexScope,
+        stamp: &str,
+        filter: &DateFilter,
+        timezone: Timezone,
+    ) -> CacheResult<Option<Vec<RawEntry>>> {
+        let key = std::path::absolute(path)?;
+        let payload: Vec<u8> = {
+            let connection = self.connection()?;
+            if filter.since.is_none() && filter.until.is_none() && !filter.has_timestamp_range() {
+                let payload = connection
+                    .prepare_cached(
+                        "SELECT payload FROM files WHERE path=?1 AND scope=?2 AND stamp=?3",
+                    )?
+                    .query_row(
+                        params![key.as_os_str().as_encoded_bytes(), scope.as_str(), stamp],
+                        |row| row.get(0),
+                    )
+                    .optional()?;
+                let Some(payload) = payload else {
+                    return Ok(None);
+                };
+                payload
+            } else {
+                let header = connection
+                    .prepare_cached(
+                        "SELECT stamp, first_ms, last_ms FROM files WHERE path=?1 AND scope=?2",
+                    )?
+                    .query_row(
+                        params![key.as_os_str().as_encoded_bytes(), scope.as_str()],
+                        |row| {
+                            Ok((
+                                row.get::<_, String>(0)?,
+                                row.get::<_, Option<i64>>(1)?,
+                                row.get::<_, Option<i64>>(2)?,
+                            ))
+                        },
+                    )
+                    .optional()?;
+                let Some((cached_stamp, first, last)) = header else {
+                    return Ok(None);
+                };
+                if cached_stamp != stamp {
+                    return Ok(None);
+                }
+                if !overlaps(first, last, filter, timezone)? {
+                    return Ok(Some(Vec::new()));
+                }
+                // Match the fingerprint again in SQL: another process may replace this row.
+                let payload = connection
+                    .prepare_cached(
+                        "SELECT payload FROM files WHERE path=?1 AND scope=?2 AND stamp=?3",
+                    )?
+                    .query_row(
+                        params![key.as_os_str().as_encoded_bytes(), scope.as_str(), stamp],
+                        |row| row.get(0),
+                    )
+                    .optional()?;
+                let Some(payload) = payload else {
+                    return Ok(None);
+                };
+                payload
+            }
+        };
+        let bytes = zstd::stream::decode_all(payload.as_slice())?;
+        let stored: Vec<StoredEntry> = serde_json::from_slice(&bytes)?;
+        let mut entries = Vec::new();
+        for entry in stored {
+            let timestamp = DateTime::<Utc>::from_timestamp_millis(entry.1)
+                .ok_or("invalid cached timestamp")?;
+            let date = timezone.to_fixed_offset(timestamp).date_naive();
+            let included = if filter.has_timestamp_range() {
+                filter.contains_entry_timestamp(&entry.0, entry.1)
+            } else {
+                filter.contains(date)
+            };
+            if included {
+                entries.push(entry.expand(path, date));
+            }
+        }
+        Ok(Some(entries))
+    }
+
+    fn save(
+        &self,
+        path: &Path,
+        scope: CodexScope,
+        stamp: &str,
+        entries: &[RawEntry],
+    ) -> CacheResult<()> {
+        let key = std::path::absolute(path)?;
+        let stored: Vec<_> = entries
+            .iter()
+            .map(|entry| {
+                (
+                    &entry.timestamp,
+                    entry.timestamp_ms,
+                    &entry.message_id,
+                    &entry.model,
+                    entry.input_tokens,
+                    entry.output_tokens,
+                    entry.cache_read,
+                    entry.reasoning_tokens,
+                )
+            })
+            .collect();
+        let bytes = serde_json::to_vec(&stored)?;
+        let payload = zstd::stream::encode_all(bytes.as_slice(), 1)?;
+        let first = entries.iter().map(|e| e.timestamp_ms).min();
+        let last = entries.iter().map(|e| e.timestamp_ms).max();
+        self.connection()?.prepare_cached(
+            "INSERT INTO files (path,scope,stamp,first_ms,last_ms,payload) VALUES (?1,?2,?3,?4,?5,?6)
+             ON CONFLICT(path,scope) DO UPDATE SET stamp=excluded.stamp, first_ms=excluded.first_ms,
+             last_ms=excluded.last_ms, payload=excluded.payload"
+        )?.execute(params![key.as_os_str().as_encoded_bytes(), scope.as_str(), stamp, first, last, payload])?;
+        Ok(())
+    }
+
+    pub(super) fn parse(
+        &self,
+        path: &Path,
+        scope: CodexScope,
+        filter: &DateFilter,
+        timezone: Timezone,
+        debug: bool,
+    ) -> ParseOutput {
+        let before = fingerprint(path);
+        match &before {
+            Ok(stamp) => match self.load(path, scope, stamp, filter, timezone) {
+                Ok(Some(entries)) => {
+                    self.hits.fetch_add(1, Ordering::Relaxed);
+                    return ParseOutput { entries, errors: 0 };
+                }
+                Ok(None) => {}
+                Err(error) => self.report_error(&error),
+            },
+            Err(error) => self.report_error(error),
+        }
+        let parsed = parse_codex_file_with_scope(path, timezone, debug, scope);
+        // Never cache malformed or unstable reads. A growing file is parsed again next time.
+        if parsed.errors == 0
+            && let Ok(before) = before
+        {
+            match fingerprint(path) {
+                Ok(after) if before == after => {
+                    if let Err(error) = self.save(path, scope, &before, &parsed.entries) {
+                        self.report_error(&error);
+                    }
+                }
+                Ok(_) => {}
+                Err(error) => self.report_error(&error),
+            }
+        }
+        ParseOutput {
+            entries: DataLoader::filter_entries(parsed.entries, filter, timezone),
+            errors: parsed.errors,
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "cache_tests.rs"]
+mod tests;

--- a/src/source/codex/cache.rs
+++ b/src/source/codex/cache.rs
@@ -22,7 +22,7 @@ use super::parser::parse_codex_file_with_scope;
 type CacheResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
 
 // Version the filename when the parser's usage semantics or stored fields change.
-const CACHE_FILE: &str = "codex-usage-v1.sqlite3";
+const CACHE_FILE: &str = "codex-usage-v2.sqlite3";
 
 #[derive(Default)]
 pub(super) struct CodexCache {
@@ -31,10 +31,11 @@ pub(super) struct CodexCache {
     reported_error: AtomicBool,
 }
 
-// Timestamp, milliseconds, dedup identity, model, input, output, cache, reasoning.
+// Timestamp, milliseconds, dedup identity, model, input, output, cache read,
+// reasoning, cache creation.
 // Session paths and local dates are reconstructed, never serialized per event.
 #[derive(Deserialize)]
-struct StoredEntry(String, i64, Option<String>, String, i64, i64, i64, i64);
+struct StoredEntry(String, i64, Option<String>, String, i64, i64, i64, i64, i64);
 
 impl StoredEntry {
     fn expand(self, path: &Path, date: NaiveDate) -> RawEntry {
@@ -53,7 +54,7 @@ impl StoredEntry {
             model: self.3,
             input_tokens: self.4,
             output_tokens: self.5,
-            cache_creation: 0,
+            cache_creation: self.8,
             cache_creation_1h: 0,
             cache_read: self.6,
             reasoning_tokens: self.7,
@@ -268,6 +269,7 @@ impl CodexCache {
                     entry.output_tokens,
                     entry.cache_read,
                     entry.reasoning_tokens,
+                    entry.cache_creation,
                 )
             })
             .collect();

--- a/src/source/codex/cache_tests.rs
+++ b/src/source/codex/cache_tests.rs
@@ -1,0 +1,272 @@
+use super::*;
+use crate::core::DedupAccumulator;
+use chrono::NaiveDate;
+use std::io::Write;
+
+fn cache(root: &Path) -> CodexCache {
+    let cache = CodexCache::default();
+    cache
+        .connection
+        .set(Ok(Mutex::new(open_cache(&root.join(CACHE_FILE)).unwrap())))
+        .unwrap();
+    cache
+}
+
+fn event(timestamp: &str, total: i64) -> String {
+    format!(
+        "{}\n",
+        serde_json::json!({
+            "type":"event_msg", "timestamp":timestamp,
+            "payload":{"type":"token_count", "info":{
+                "total_token_usage":{"input_tokens":total,"cached_input_tokens":0,"output_tokens":0,"total_tokens":total}
+            }}
+        })
+    )
+}
+
+fn session(path: &Path) {
+    fs::write(path, format!("{}\n{}\n{}{}",
+        serde_json::json!({"type":"session_meta","payload":{"id":"shared-session","source":"cli"}}),
+        serde_json::json!({"type":"turn_context","payload":{"model":"gpt-5"}}),
+        event("2026-09-01T23:30:00.123456Z", 10),
+        event("2026-09-02T00:30:00Z", 30),
+    )).unwrap();
+}
+
+fn utc() -> Timezone {
+    Timezone::Named(chrono_tz::UTC)
+}
+
+fn parse(cache: &CodexCache, path: &Path, filter: &DateFilter, tz: Timezone) -> ParseOutput {
+    cache.parse(path, CodexScope::All, filter, tz, false)
+}
+
+fn assert_equal(actual: &ParseOutput, expected: &ParseOutput) {
+    assert_eq!(actual.errors, expected.errors);
+    assert_eq!(
+        serde_json::to_value(&actual.entries).unwrap(),
+        serde_json::to_value(&expected.entries).unwrap()
+    );
+    assert_eq!(
+        actual
+            .entries
+            .iter()
+            .map(|e| &e.session_key)
+            .collect::<Vec<_>>(),
+        expected
+            .entries
+            .iter()
+            .map(|e| &e.session_key)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn warm_cache_preserves_all_fields_and_session_identity_across_reopening() {
+    let root = tempfile::tempdir().unwrap();
+    let path = root.path().join("session.jsonl");
+    session(&path);
+    let first = cache(root.path());
+    let expected = parse(&first, &path, &DateFilter::default(), utc());
+    assert_eq!(first.hits(), 0);
+    let second = cache(root.path());
+    assert_equal(
+        &parse(&second, &path, &DateFilter::default(), utc()),
+        &expected,
+    );
+    assert_eq!(second.hits(), 1);
+}
+
+#[test]
+fn cached_ranges_and_timezone_changes_match_uncached_filtering() {
+    let root = tempfile::tempdir().unwrap();
+    let path = root.path().join("old-session.jsonl");
+    session(&path);
+    let cache = cache(root.path());
+    parse(&cache, &path, &DateFilter::default(), utc());
+    let day = NaiveDate::from_ymd_opt(2026, 9, 2).unwrap();
+    let filters = [
+        DateFilter::new(Some(day), Some(day)),
+        DateFilter::new(Some(day.succ_opt().unwrap()), None),
+        DateFilter::default().with_exact_timestamp_range(
+            "2026-09-01T23:30:00.123457Z".parse().unwrap(),
+            "2026-09-02T00:30:00Z".parse().unwrap(),
+        ),
+    ];
+    for timezone in [
+        utc(),
+        Timezone::Named(chrono_tz::Asia::Shanghai),
+        Timezone::Named(chrono_tz::America::Los_Angeles),
+    ] {
+        for filter in &filters {
+            let raw = parse_codex_file_with_scope(&path, timezone, false, CodexScope::All);
+            let expected = ParseOutput {
+                entries: DataLoader::filter_entries(raw.entries, filter, timezone),
+                errors: raw.errors,
+            };
+            assert_equal(&parse(&cache, &path, filter, timezone), &expected);
+        }
+    }
+    assert_eq!(cache.hits(), 9);
+}
+
+#[test]
+fn date_filtered_first_run_keeps_history_in_the_cache() {
+    let root = tempfile::tempdir().unwrap();
+    let path = root.path().join("session.jsonl");
+    session(&path);
+    let cache = cache(root.path());
+    let date = NaiveDate::from_ymd_opt(2026, 9, 2).unwrap();
+    assert_eq!(
+        parse(&cache, &path, &DateFilter::new(Some(date), None), utc())
+            .entries
+            .len(),
+        1
+    );
+    assert_eq!(
+        parse(&cache, &path, &DateFilter::default(), utc())
+            .entries
+            .len(),
+        2
+    );
+    assert_eq!(cache.hits(), 1);
+}
+
+#[test]
+fn append_rewrite_and_delete_invalidate_cached_records() {
+    let root = tempfile::tempdir().unwrap();
+    let path = root.path().join("session.jsonl");
+    session(&path);
+    let cache = cache(root.path());
+    let filter = DateFilter::default();
+    parse(&cache, &path, &filter, utc());
+    fs::OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .unwrap()
+        .write_all(event("2026-09-03T00:00:00Z", 50).as_bytes())
+        .unwrap();
+    let appended = parse(&cache, &path, &filter, utc());
+    assert_eq!(
+        appended.entries.iter().map(|e| e.input_tokens).sum::<i64>(),
+        50
+    );
+    assert_eq!(appended.entries.len(), 3);
+    assert_eq!(cache.hits(), 0);
+    let old_time = fs::metadata(&path).unwrap().modified().unwrap();
+    let text = fs::read_to_string(&path).unwrap().replace("50", "60");
+    fs::write(&path, text).unwrap();
+    // Equal-length overwrite is detected even with restored mtime on Unix.
+    #[cfg(unix)]
+    fs::File::open(&path)
+        .unwrap()
+        .set_times(fs::FileTimes::new().set_modified(old_time))
+        .unwrap();
+    #[cfg(not(unix))]
+    let _ = old_time;
+    assert_eq!(
+        parse(&cache, &path, &filter, utc())
+            .entries
+            .iter()
+            .map(|e| e.input_tokens)
+            .sum::<i64>(),
+        60
+    );
+    fs::remove_file(&path).unwrap();
+    let deleted = parse(&cache, &path, &filter, utc());
+    assert!(deleted.entries.is_empty());
+    assert_eq!(deleted.errors, 1);
+}
+
+#[test]
+fn scope_cache_does_not_mix_origins() {
+    let root = tempfile::tempdir().unwrap();
+    let path = root.path().join("session.jsonl");
+    session(&path);
+    let cache = cache(root.path());
+    let filter = DateFilter::default();
+    for scope in [
+        CodexScope::All,
+        CodexScope::Interactive,
+        CodexScope::Exec,
+        CodexScope::Subagent,
+    ] {
+        let expected = parse_codex_file_with_scope(&path, utc(), false, scope);
+        assert_equal(&cache.parse(&path, scope, &filter, utc(), false), &expected);
+        assert_equal(&cache.parse(&path, scope, &filter, utc(), false), &expected);
+    }
+    assert_eq!(cache.hits(), 4);
+}
+
+#[test]
+fn malformed_source_is_not_cached_and_partial_tail_can_be_completed() {
+    let root = tempfile::tempdir().unwrap();
+    let path = root.path().join("session.jsonl");
+    session(&path);
+    let cache = cache(root.path());
+    let filter = DateFilter::default();
+    let line = event("2026-09-03T00:00:00Z", 60);
+    let split = line.len() / 2;
+    fs::OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .unwrap()
+        .write_all(&line.as_bytes()[..split])
+        .unwrap();
+    assert_eq!(parse(&cache, &path, &filter, utc()).errors, 1);
+    assert_eq!(parse(&cache, &path, &filter, utc()).errors, 1);
+    assert_eq!(cache.hits(), 0);
+    fs::OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .unwrap()
+        .write_all(&line.as_bytes()[split..])
+        .unwrap();
+    let completed = parse(&cache, &path, &filter, utc());
+    assert_eq!(completed.errors, 0);
+    assert_eq!(completed.entries.len(), 3);
+    assert_equal(&parse(&cache, &path, &filter, utc()), &completed);
+    assert_eq!(cache.hits(), 1);
+}
+
+#[test]
+fn corrupt_cache_is_rebuilt_from_source_without_losing_usage() {
+    let root = tempfile::tempdir().unwrap();
+    let path = root.path().join("session.jsonl");
+    session(&path);
+    let cache = cache(root.path());
+    let filter = DateFilter::default();
+    let expected = parse(&cache, &path, &filter, utc());
+    cache
+        .connection()
+        .unwrap()
+        .execute("UPDATE files SET payload = x'00'", [])
+        .unwrap();
+    assert_equal(&parse(&cache, &path, &filter, utc()), &expected);
+    assert!(cache.reported_error.load(Ordering::Relaxed));
+    assert_eq!(cache.hits(), 0);
+    assert_equal(&parse(&cache, &path, &filter, utc()), &expected);
+    assert_eq!(cache.hits(), 1);
+}
+
+#[test]
+fn copied_and_archived_files_keep_cross_file_deduplication() {
+    let root = tempfile::tempdir().unwrap();
+    let path = root.path().join("session.jsonl");
+    let copy = root.path().join("archived.jsonl");
+    session(&path);
+    fs::copy(&path, &copy).unwrap();
+    let cache = cache(root.path());
+    let filter = DateFilter::default();
+    for _ in 0..2 {
+        let mut all = DedupAccumulator::new();
+        for p in [&path, &copy] {
+            all.extend(parse(&cache, p, &filter, utc()).entries);
+        }
+        let (entries, skipped) = all.finalize();
+        // The initial event is file-scoped; subsequent events are source-wide.
+        assert_eq!(skipped, 1);
+        assert_eq!(entries.iter().map(|e| e.input_tokens).sum::<i64>(), 40);
+    }
+    assert_eq!(cache.hits(), 2);
+}

--- a/src/source/codex/cache_tests.rs
+++ b/src/source/codex/cache_tests.rs
@@ -78,6 +78,68 @@ fn warm_cache_preserves_all_fields_and_session_identity_across_reopening() {
 }
 
 #[test]
+fn cache_writes_and_long_context_classification_survive_reopening() {
+    let root = tempfile::tempdir().unwrap();
+    let path = root.path().join("writes.jsonl");
+    let mut lines = vec![
+        serde_json::json!({"type":"session_meta","payload":{"id":"writes","source":"cli"}}),
+        serde_json::json!({"type":"turn_context","payload":{"model":"gpt-5"}}),
+    ];
+    let mut total_input = 0;
+    let mut total_writes = 0;
+    for (index, input) in [272_000, 272_001, 100_000].into_iter().enumerate() {
+        total_input += input;
+        total_writes += 20_000;
+        lines.push(serde_json::json!({
+            "type":"event_msg", "timestamp":format!("2026-09-02T00:0{index}:00Z"),
+            "payload":{"type":"token_count", "info":{
+                "total_token_usage":{"input_tokens":total_input,
+                    "cache_write_input_tokens":total_writes,"output_tokens":0,
+                    "total_tokens":total_input}
+            }}
+        }));
+    }
+    fs::write(
+        &path,
+        lines
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n"),
+    )
+    .unwrap();
+    let expected = parse_codex_file_with_scope(&path, utc(), false, CodexScope::All);
+    assert_eq!(expected.errors, 0);
+    assert_eq!(expected.entries.len(), 3);
+    assert_eq!(
+        expected
+            .entries
+            .iter()
+            .map(|e| e.cache_creation)
+            .sum::<i64>(),
+        60_000
+    );
+    assert_eq!(expected.entries[0].to_stats().above_272k.cache_creation, 0);
+    assert_eq!(
+        expected.entries[1].to_stats().above_272k.cache_creation,
+        20_000
+    );
+    let cold = cache(root.path());
+    assert_equal(
+        &parse(&cold, &path, &DateFilter::default(), utc()),
+        &expected,
+    );
+    drop(cold);
+    let reopened = cache(root.path());
+    let warm = parse(&reopened, &path, &DateFilter::default(), utc());
+    assert_equal(&warm, &expected);
+    assert_eq!(reopened.hits(), 1);
+    for (actual, expected) in warm.entries.iter().zip(&expected.entries) {
+        assert_eq!(actual.to_stats().above_272k, expected.to_stats().above_272k);
+    }
+}
+
+#[test]
 fn cached_ranges_and_timezone_changes_match_uncached_filtering() {
     let root = tempfile::tempdir().unwrap();
     let path = root.path().join("old-session.jsonl");

--- a/src/source/codex/config.rs
+++ b/src/source/codex/config.rs
@@ -6,9 +6,11 @@ use std::path::{Path, PathBuf};
 
 use clap::ValueEnum;
 
+use crate::core::DateFilter;
 use crate::source::{Capabilities, ParseOutput, Source};
 use crate::utils::Timezone;
 
+use super::cache::CodexCache;
 use super::parser::{find_codex_files, parse_codex_file_with_scope};
 
 #[derive(Debug, Clone, Copy, Default, ValueEnum, PartialEq, Eq)]
@@ -47,6 +49,7 @@ impl CodexScope {
 /// Codex data source
 pub(crate) struct CodexSource {
     scope: CodexScope,
+    cache: CodexCache,
 }
 
 impl CodexSource {
@@ -55,7 +58,10 @@ impl CodexSource {
     }
 
     pub(crate) fn with_scope(scope: CodexScope) -> Self {
-        Self { scope }
+        Self {
+            scope,
+            cache: CodexCache::default(),
+        }
     }
 }
 
@@ -101,5 +107,19 @@ impl Source for CodexSource {
 
     fn parse_file(&self, path: &Path, timezone: Timezone, debug: bool) -> ParseOutput {
         parse_codex_file_with_scope(path, timezone, debug, self.scope)
+    }
+
+    fn parse_file_filtered(
+        &self,
+        path: &Path,
+        filter: &DateFilter,
+        timezone: Timezone,
+        debug: bool,
+    ) -> ParseOutput {
+        self.cache.parse(path, self.scope, filter, timezone, debug)
+    }
+
+    fn cached_file_count(&self) -> usize {
+        self.cache.hits()
     }
 }

--- a/src/source/codex/mod.rs
+++ b/src/source/codex/mod.rs
@@ -3,6 +3,7 @@
 //! Parses JSONL logs from ~/.codex/sessions/ directory.
 //! Codex log format uses cumulative token counts that need delta computation.
 
+mod cache;
 mod config;
 mod parser;
 mod quota;

--- a/src/source/codex/parser.rs
+++ b/src/source/codex/parser.rs
@@ -195,16 +195,6 @@ pub(super) fn find_codex_files() -> Vec<PathBuf> {
 // Parsing
 // ============================================================================
 
-fn estimate_entry_capacity(file: &File, approx_bytes_per_entry: u64) -> usize {
-    let estimate = file
-        .metadata()
-        .ok()
-        .map(|meta| meta.len() / approx_bytes_per_entry)
-        .and_then(|n| usize::try_from(n).ok())
-        .unwrap_or(0);
-    estimate.saturating_add(1)
-}
-
 fn non_empty_model(model: Option<&str>) -> Option<&str> {
     model.filter(|m| !m.trim().is_empty())
 }
@@ -341,8 +331,7 @@ fn parse_codex_file(
         Ok(file) => file,
         Err(output) => return output,
     };
-    let estimated_capacity = estimate_entry_capacity(&file, 260);
-    let mut state = CodexParseState::new(estimated_capacity, context.identity.session_key.clone());
+    let mut state = CodexParseState::new(0, context.identity.session_key.clone());
 
     parse_codex_reader(BufReader::new(file), &context, &mut state);
     state.finish()
@@ -382,7 +371,7 @@ fn parse_codex_reader<R: BufRead>(
                     );
                 }
                 state.parse_errors += 1;
-                continue;
+                break;
             }
         };
         if bytes_read == 0 {

--- a/src/source/loader.rs
+++ b/src/source/loader.rs
@@ -97,7 +97,7 @@ impl<'a> DataLoader<'a> {
         true
     }
 
-    fn filter_entries(
+    pub(super) fn filter_entries(
         entries: Vec<RawEntry>,
         filter: &DateFilter,
         timezone: Timezone,
@@ -191,13 +191,15 @@ impl<'a> DataLoader<'a> {
         }
 
         let file_count = files.len();
+        let cached_before = self.source.cached_file_count();
         let parse_start = Instant::now();
         let (result, parse_errors) = files
             .par_iter()
             .map(|path| {
-                let parsed = self.source.parse_file(path, timezone, self.debug);
-                let filtered = Self::filter_entries(parsed.entries, filter, timezone);
-                (per_file(filtered), parsed.errors)
+                let parsed = self
+                    .source
+                    .parse_file_filtered(path, filter, timezone, self.debug);
+                (per_file(parsed.entries), parsed.errors)
             })
             .reduce(
                 || (init(), 0usize),
@@ -208,7 +210,13 @@ impl<'a> DataLoader<'a> {
         let parse_ms = parse_start.elapsed().as_secs_f64() * 1000.0;
 
         if !self.quiet {
-            eprintln!("Parsed {file_count} files incrementally ({parse_ms:.2}ms)");
+            let cached = self
+                .source
+                .cached_file_count()
+                .saturating_sub(cached_before);
+            eprintln!(
+                "Processed {file_count} files ({cached} cached), filtered and merged ({parse_ms:.2}ms)"
+            );
             if parse_errors > 0 {
                 eprintln!("Warning: ignored {parse_errors} malformed records");
             }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -592,6 +592,25 @@ pub(crate) trait Source: Send + Sync {
     /// Parse a single file into raw entries and diagnostics.
     fn parse_file(&self, path: &Path, timezone: Timezone, debug: bool) -> ParseOutput;
 
+    /// Sources with a usage cache can apply the range before expanding cached records.
+    fn parse_file_filtered(
+        &self,
+        path: &Path,
+        filter: &DateFilter,
+        timezone: Timezone,
+        debug: bool,
+    ) -> ParseOutput {
+        let parsed = self.parse_file(path, timezone, debug);
+        ParseOutput {
+            entries: loader::DataLoader::filter_entries(parsed.entries, filter, timezone),
+            errors: parsed.errors,
+        }
+    }
+
+    fn cached_file_count(&self) -> usize {
+        0
+    }
+
     fn finalize_entries(&self, entries: Vec<RawEntry>) -> Vec<RawEntry> {
         entries
     }


### PR DESCRIPTION
## What

Repeated `ccstats codex` reports currently reparse every historical JSONL file. Reuse unchanged files through a versioned SQLite cache of compressed usage facts, then apply the existing cross-file deduplication. Cache actual event time ranges so date-filtered reports can skip unrelated cached records before expanding them. Preserve source fingerprints, scope separation, query-time timezone conversion, and current pricing.

Also reduce deduplication hash-bucket size and duplicate lookups, remove oversized record/date-map preallocation, buffer pricing-cache reads, and optimize release builds for execution speed. Processing logs now report cache hits. Document the local cache and its removal behavior.

## Why

On a local dataset of roughly 42,700 files / 27 GiB, a final full report completed in about 6 seconds with approximately 2 GiB peak RSS; previous full reports took roughly 12–18 seconds and about 5 GiB. Cached date-filtered runs reached roughly 1.2 seconds on the fixed snapshot. Pricing-cache reads fell from about 636 ms to 12–29 ms.

These are local observations, not performance guarantees. Directory scanning varied substantially, the first cache build still reads all history, and modified files are reparsed in full. The full-history two-second target is not met. One validation run timed out before producing phase logs; its cause remains unresolved, and subsequent snapshot and live-data runs completed normally.

## Test Plan

- [x] `cargo check --locked` passes on this branch
- [x] `cargo test --locked` passes: 891 tests
- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes for identical source files
- [x] `cargo build --release --locked` and the repository benchmark script pass
- [x] Eight new cache tests cover reopening, date/timezone filters, filtered-first-run history, append/rewrite/delete, scopes, malformed tails, corrupted cache recovery, and cross-file deduplication
- [x] Fixed-snapshot full-history and date-filtered usage JSON matches the unmodified 0.5.2 build; token/cost/provenance comparisons also pass, accounting for elapsed pricing-cache age
- [x] Installed release binary runs `ccstats codex` and `ccstats codex today` successfully
