### PR TITLE
fix(codex): price cache writes and long contexts

### DIFF
--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -5,9 +5,59 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Token subset from individual requests with more than 272K input tokens.
+/// Kept separate from display totals so aggregation never changes the price tier.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct LongContextTokens {
+    pub(crate) input_tokens: i64,
+    pub(crate) output_tokens: i64,
+    pub(crate) cache_creation: i64,
+    pub(crate) cache_creation_1h: i64,
+    pub(crate) cache_read: i64,
+    pub(crate) reasoning_tokens: i64,
+}
+
+impl LongContextTokens {
+    fn add(&mut self, other: &Self) {
+        self.input_tokens = self.input_tokens.saturating_add(other.input_tokens);
+        self.output_tokens = self.output_tokens.saturating_add(other.output_tokens);
+        self.cache_creation = self.cache_creation.saturating_add(other.cache_creation);
+        self.cache_creation_1h = self
+            .cache_creation_1h
+            .saturating_add(other.cache_creation_1h);
+        self.cache_read = self.cache_read.saturating_add(other.cache_read);
+        self.reasoning_tokens = self.reasoning_tokens.saturating_add(other.reasoning_tokens);
+    }
+
+    fn saturating_sub(self, other: &Self) -> Self {
+        Self {
+            input_tokens: self.input_tokens.saturating_sub(other.input_tokens).max(0),
+            output_tokens: self
+                .output_tokens
+                .saturating_sub(other.output_tokens)
+                .max(0),
+            cache_creation: self
+                .cache_creation
+                .saturating_sub(other.cache_creation)
+                .max(0),
+            cache_creation_1h: self
+                .cache_creation_1h
+                .saturating_sub(other.cache_creation_1h)
+                .max(0),
+            cache_read: self.cache_read.saturating_sub(other.cache_read).max(0),
+            reasoning_tokens: self
+                .reasoning_tokens
+                .saturating_sub(other.reasoning_tokens)
+                .max(0),
+        }
+    }
+}
+
 /// Token usage statistics
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub(crate) struct Stats {
+    #[serde(default)]
+    pub(crate) above_272k: LongContextTokens,
     pub(crate) input_tokens: i64,
     pub(crate) output_tokens: i64,
     pub(crate) cache_creation: i64,
@@ -46,6 +96,7 @@ pub(crate) struct Stats {
 
 impl Stats {
     pub(crate) fn add(&mut self, other: &Stats) {
+        self.above_272k.add(&other.above_272k);
         self.input_tokens = self.input_tokens.saturating_add(other.input_tokens);
         self.output_tokens = self.output_tokens.saturating_add(other.output_tokens);
         self.cache_creation = self.cache_creation.saturating_add(other.cache_creation);
@@ -107,6 +158,7 @@ impl Stats {
 
     pub(crate) fn cost_tokens(&self) -> CostTokens {
         CostTokens {
+            above_272k: self.above_272k,
             input_tokens: self.input_tokens,
             output_tokens: self.output_tokens,
             cache_creation: self.cache_creation,
@@ -136,6 +188,7 @@ impl Stats {
         self.cache_read = real.cache_read;
         self.reasoning_tokens = real.reasoning_tokens;
         self.count = real.count;
+        self.above_272k = real.above_272k;
         // Keep Total-mode recorded+priced cost real-only: priced_tokens still
         // includes estimated-proxy rows until they are dropped here.
         self.priced_tokens = self.priced_tokens.saturating_sub(&self.estimated_proxy);
@@ -219,6 +272,8 @@ impl Endpoint {
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct CostTokens {
+    #[serde(default)]
+    pub(crate) above_272k: LongContextTokens,
     pub(crate) input_tokens: i64,
     pub(crate) output_tokens: i64,
     pub(crate) cache_creation: i64,
@@ -240,6 +295,7 @@ impl CostTokens {
     }
 
     pub(crate) fn add(&mut self, other: &Self) {
+        self.above_272k.add(&other.above_272k);
         self.input_tokens = self.input_tokens.saturating_add(other.input_tokens);
         self.output_tokens = self.output_tokens.saturating_add(other.output_tokens);
         self.cache_creation = self.cache_creation.saturating_add(other.cache_creation);
@@ -253,6 +309,7 @@ impl CostTokens {
 
     pub(crate) fn saturating_sub(self, other: &Self) -> Self {
         Self {
+            above_272k: self.above_272k.saturating_sub(&other.above_272k),
             input_tokens: self.input_tokens.saturating_sub(other.input_tokens).max(0),
             output_tokens: self
                 .output_tokens
@@ -421,6 +478,7 @@ impl RawEntry {
             .saturating_add(self.cache_read)
             .saturating_add(self.reasoning_tokens);
         let mut stats = Stats {
+            above_272k: LongContextTokens::default(),
             input_tokens: self.input_tokens,
             output_tokens: self.output_tokens,
             cache_creation: self.cache_creation,
@@ -440,6 +498,21 @@ impl RawEntry {
             api_equivalent_coverage_tokens: self.api_equivalent_coverage_tokens.max(0),
             priced_tokens: CostTokens::default(),
         };
+        if self
+            .input_tokens
+            .saturating_add(self.cache_creation)
+            .saturating_add(self.cache_read)
+            > 272_000
+        {
+            stats.above_272k = LongContextTokens {
+                input_tokens: self.input_tokens,
+                output_tokens: self.output_tokens,
+                cache_creation: self.cache_creation,
+                cache_creation_1h: self.cache_creation_1h,
+                cache_read: self.cache_read,
+                reasoning_tokens: self.reasoning_tokens,
+            };
+        }
         if self.cost_kind == CostKind::EstimatedProxy {
             stats.estimated_proxy = stats.cost_tokens();
             stats.priced_tokens = stats.cost_tokens();
@@ -590,338 +663,5 @@ impl LoadResult {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use chrono::NaiveDate;
-
-    fn make_stats(input: i64, output: i64, cache_c: i64, cache_r: i64, reason: i64) -> Stats {
-        Stats {
-            input_tokens: input,
-            output_tokens: output,
-            cache_creation: cache_c,
-            cache_creation_1h: 0,
-            cache_read: cache_r,
-            reasoning_tokens: reason,
-            count: 1,
-            skipped_chunks: 0,
-            estimated_proxy: CostTokens::default(),
-            ..Default::default()
-        }
-    }
-
-    #[test]
-    fn cache_hit_rate_uses_all_input_side_tokens() {
-        let stats = make_stats(100, 50, 20, 80, 10);
-        assert_eq!(stats.cache_hit_rate(true), Some(40.0));
-    }
-
-    #[test]
-    fn cache_hit_rate_is_zero_when_supported_without_hits() {
-        let stats = make_stats(100, 50, 0, 0, 0);
-        assert_eq!(stats.cache_hit_rate(true), Some(0.0));
-    }
-
-    #[test]
-    fn cache_hit_rate_is_unavailable_without_input_or_source_support() {
-        assert_eq!(Stats::default().cache_hit_rate(true), None);
-        assert_eq!(make_stats(100, 0, 0, 50, 0).cache_hit_rate(false), None);
-    }
-
-    #[test]
-    fn cache_hit_rate_clamps_negative_components() {
-        let stats = make_stats(-100, 0, -20, 80, 0);
-        assert_eq!(stats.cache_hit_rate(true), Some(100.0));
-    }
-
-    // --- Stats ---
-
-    #[test]
-    fn stats_default_all_zero() {
-        let s = Stats::default();
-        assert_eq!(s.input_tokens, 0);
-        assert_eq!(s.output_tokens, 0);
-        assert_eq!(s.cache_creation, 0);
-        assert_eq!(s.cache_read, 0);
-        assert_eq!(s.reasoning_tokens, 0);
-        assert_eq!(s.count, 0);
-        assert_eq!(s.skipped_chunks, 0);
-    }
-
-    #[test]
-    fn stats_total_tokens_sums_five_fields() {
-        let s = make_stats(100, 200, 50, 30, 20);
-        assert_eq!(s.total_tokens(), 400); // 100+200+50+30+20
-    }
-
-    #[test]
-    fn stats_total_tokens_excludes_count_and_skipped() {
-        let s = Stats {
-            input_tokens: 10,
-            output_tokens: 5,
-            cache_creation: 0,
-            cache_creation_1h: 0,
-            cache_read: 0,
-            reasoning_tokens: 0,
-            count: 999,
-            skipped_chunks: 42,
-            estimated_proxy: CostTokens::default(),
-            ..Default::default()
-        };
-        assert_eq!(s.total_tokens(), 15);
-    }
-
-    #[test]
-    fn stats_total_tokens_zero_when_default() {
-        assert_eq!(Stats::default().total_tokens(), 0);
-    }
-
-    #[test]
-    fn stats_aggregation_saturates_at_i64_max() {
-        let mut total = Stats {
-            input_tokens: i64::MAX,
-            count: i64::MAX,
-            records: i64::MAX,
-            ..Default::default()
-        };
-        total.add(&Stats {
-            input_tokens: 1,
-            count: 1,
-            records: 1,
-            ..Default::default()
-        });
-
-        assert_eq!(total.input_tokens, i64::MAX);
-        assert_eq!(total.count, i64::MAX);
-        assert_eq!(total.records, i64::MAX);
-        assert_eq!(total.total_tokens(), i64::MAX);
-    }
-
-    #[test]
-    fn stats_add_accumulates_all_fields() {
-        let mut a = make_stats(10, 20, 5, 3, 1);
-        a.skipped_chunks = 2;
-        let b = Stats {
-            input_tokens: 100,
-            output_tokens: 200,
-            cache_creation: 50,
-            cache_creation_1h: 0,
-            cache_read: 30,
-            reasoning_tokens: 10,
-            count: 3,
-            skipped_chunks: 5,
-            estimated_proxy: CostTokens::default(),
-            ..Default::default()
-        };
-        a.add(&b);
-        assert_eq!(a.input_tokens, 110);
-        assert_eq!(a.output_tokens, 220);
-        assert_eq!(a.cache_creation, 55);
-        assert_eq!(a.cache_read, 33);
-        assert_eq!(a.reasoning_tokens, 11);
-        assert_eq!(a.count, 4);
-        assert_eq!(a.skipped_chunks, 7);
-    }
-
-    #[test]
-    fn stats_add_to_default() {
-        let mut a = Stats::default();
-        let b = make_stats(5, 10, 15, 20, 25);
-        a.add(&b);
-        assert_eq!(a.input_tokens, 5);
-        assert_eq!(a.output_tokens, 10);
-        assert_eq!(a.total_tokens(), 75);
-    }
-
-    // --- DayStats ---
-
-    #[test]
-    fn day_stats_add_single_model() {
-        let mut ds = DayStats::default();
-        let s = make_stats(100, 200, 0, 0, 0);
-        ds.add_stats("claude-3".into(), &s);
-        assert_eq!(ds.stats.input_tokens, 100);
-        assert_eq!(ds.stats.output_tokens, 200);
-        assert_eq!(ds.stats.count, 1);
-        assert_eq!(ds.models.len(), 1);
-        assert_eq!(ds.models["claude-3"].input_tokens, 100);
-    }
-
-    #[test]
-    fn day_stats_add_same_model_twice() {
-        let mut ds = DayStats::default();
-        ds.add_stats("gpt-4".into(), &make_stats(10, 20, 0, 0, 0));
-        ds.add_stats("gpt-4".into(), &make_stats(30, 40, 0, 0, 0));
-        assert_eq!(ds.stats.input_tokens, 40);
-        assert_eq!(ds.stats.output_tokens, 60);
-        assert_eq!(ds.stats.count, 2);
-        assert_eq!(ds.models.len(), 1);
-        assert_eq!(ds.models["gpt-4"].input_tokens, 40);
-    }
-
-    #[test]
-    fn day_stats_add_multiple_models() {
-        let mut ds = DayStats::default();
-        ds.add_stats("a".into(), &make_stats(10, 0, 0, 0, 0));
-        ds.add_stats("b".into(), &make_stats(20, 0, 0, 0, 0));
-        ds.add_stats("c".into(), &make_stats(30, 0, 0, 0, 0));
-        assert_eq!(ds.stats.input_tokens, 60);
-        assert_eq!(ds.models.len(), 3);
-    }
-
-    // --- RawEntry ---
-
-    #[test]
-    fn raw_entry_to_stats() {
-        let entry = RawEntry {
-            timestamp: String::new(),
-            timestamp_ms: 0,
-            date_str: String::new(),
-            message_id: None,
-            session_key: String::new(),
-            session_id: String::new(),
-            project_path: String::new(),
-            model: String::new(),
-            input_tokens: 100,
-            output_tokens: 200,
-            cache_creation: 50,
-            cache_creation_1h: 0,
-            cache_read: 30,
-            reasoning_tokens: 10,
-            stop_reason: None,
-            cost_kind: CostKind::Real,
-            endpoint: Endpoint::Unknown,
-            call_count: 1,
-            reported_total_tokens: None,
-            recorded_cost_usd: None,
-            api_equivalent_priced_tokens: 0,
-            api_equivalent_coverage_tokens: 0,
-        };
-        let s = entry.to_stats();
-        assert_eq!(s.input_tokens, 100);
-        assert_eq!(s.output_tokens, 200);
-        assert_eq!(s.cache_creation, 50);
-        assert_eq!(s.cache_read, 30);
-        assert_eq!(s.reasoning_tokens, 10);
-        assert_eq!(s.count, 1);
-        assert_eq!(s.records, 1);
-        assert_eq!(s.skipped_chunks, 0);
-        assert_eq!(s.recorded_cost_entries, 0);
-        assert_eq!(s.priced_tokens.input_tokens, 100);
-    }
-
-    #[test]
-    fn raw_entry_to_stats_uses_call_count_and_recorded_cost() {
-        let entry = RawEntry {
-            timestamp: String::new(),
-            timestamp_ms: 0,
-            date_str: String::new(),
-            message_id: None,
-            session_key: String::new(),
-            session_id: String::new(),
-            project_path: String::new(),
-            model: String::new(),
-            input_tokens: 10,
-            output_tokens: 2,
-            cache_creation: 0,
-            cache_creation_1h: 0,
-            cache_read: 0,
-            reasoning_tokens: 0,
-            stop_reason: None,
-            cost_kind: CostKind::Real,
-            endpoint: Endpoint::Unknown,
-            call_count: 5,
-            reported_total_tokens: None,
-            recorded_cost_usd: Some(1.25),
-            api_equivalent_priced_tokens: 0,
-            api_equivalent_coverage_tokens: 0,
-        };
-        let stats = entry.to_stats();
-        assert_eq!(stats.count, 5);
-        assert_eq!(stats.records, 1);
-        assert!((stats.recorded_cost_usd - 1.25).abs() < 1e-12);
-        assert_eq!(stats.recorded_cost_entries, 1);
-        assert!(!stats.priced_tokens.has_entries());
-    }
-
-    #[test]
-    fn raw_entry_preserves_independent_reported_total_without_repricing_the_delta() {
-        let entry = RawEntry {
-            timestamp: String::new(),
-            timestamp_ms: 0,
-            date_str: String::new(),
-            message_id: None,
-            session_key: String::new(),
-            session_id: String::new(),
-            project_path: String::new(),
-            model: "provider/model".to_string(),
-            input_tokens: 3,
-            output_tokens: 4,
-            cache_creation: 0,
-            cache_creation_1h: 0,
-            cache_read: 0,
-            reasoning_tokens: 0,
-            reported_total_tokens: Some(9),
-            stop_reason: Some("complete".to_string()),
-            cost_kind: CostKind::Real,
-            endpoint: Endpoint::Unknown,
-            call_count: 1,
-            recorded_cost_usd: None,
-            api_equivalent_priced_tokens: 0,
-            api_equivalent_coverage_tokens: 0,
-        };
-
-        let stats = entry.to_stats();
-        assert_eq!(stats.total_tokens(), 9);
-        assert_eq!(stats.input_tokens, 3);
-        assert_eq!(stats.output_tokens, 4);
-        assert_eq!(stats.priced_tokens.input_tokens, 3);
-        assert_eq!(stats.priced_tokens.output_tokens, 4);
-    }
-
-    // --- DateFilter ---
-
-    fn d(y: i32, m: u32, day: u32) -> NaiveDate {
-        NaiveDate::from_ymd_opt(y, m, day).unwrap()
-    }
-
-    #[test]
-    fn date_filter_no_bounds() {
-        let f = DateFilter::new(None, None);
-        assert!(f.contains(d(2020, 1, 1)));
-        assert!(f.contains(d(2099, 12, 31)));
-    }
-
-    #[test]
-    fn date_filter_since_only() {
-        let f = DateFilter::new(Some(d(2025, 6, 1)), None);
-        assert!(!f.contains(d(2025, 5, 31)));
-        assert!(f.contains(d(2025, 6, 1))); // inclusive
-        assert!(f.contains(d(2025, 6, 2)));
-    }
-
-    #[test]
-    fn date_filter_until_only() {
-        let f = DateFilter::new(None, Some(d(2025, 6, 30)));
-        assert!(f.contains(d(2025, 6, 29)));
-        assert!(f.contains(d(2025, 6, 30))); // inclusive
-        assert!(!f.contains(d(2025, 7, 1)));
-    }
-
-    #[test]
-    fn date_filter_both_bounds() {
-        let f = DateFilter::new(Some(d(2025, 3, 1)), Some(d(2025, 3, 31)));
-        assert!(!f.contains(d(2025, 2, 28)));
-        assert!(f.contains(d(2025, 3, 1)));
-        assert!(f.contains(d(2025, 3, 15)));
-        assert!(f.contains(d(2025, 3, 31)));
-        assert!(!f.contains(d(2025, 4, 1)));
-    }
-
-    #[test]
-    fn date_filter_single_day_range() {
-        let f = DateFilter::new(Some(d(2025, 1, 15)), Some(d(2025, 1, 15)));
-        assert!(!f.contains(d(2025, 1, 14)));
-        assert!(f.contains(d(2025, 1, 15)));
-        assert!(!f.contains(d(2025, 1, 16)));
-    }
-}
+#[path = "types_tests.rs"]
+mod tests;

--- a/src/core/types_tests.rs
+++ b/src/core/types_tests.rs
@@ -1,0 +1,333 @@
+use super::*;
+use chrono::NaiveDate;
+
+fn make_stats(input: i64, output: i64, cache_c: i64, cache_r: i64, reason: i64) -> Stats {
+    Stats {
+        input_tokens: input,
+        output_tokens: output,
+        cache_creation: cache_c,
+        cache_creation_1h: 0,
+        cache_read: cache_r,
+        reasoning_tokens: reason,
+        count: 1,
+        skipped_chunks: 0,
+        estimated_proxy: CostTokens::default(),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn cache_hit_rate_uses_all_input_side_tokens() {
+    let stats = make_stats(100, 50, 20, 80, 10);
+    assert_eq!(stats.cache_hit_rate(true), Some(40.0));
+}
+
+#[test]
+fn cache_hit_rate_is_zero_when_supported_without_hits() {
+    let stats = make_stats(100, 50, 0, 0, 0);
+    assert_eq!(stats.cache_hit_rate(true), Some(0.0));
+}
+
+#[test]
+fn cache_hit_rate_is_unavailable_without_input_or_source_support() {
+    assert_eq!(Stats::default().cache_hit_rate(true), None);
+    assert_eq!(make_stats(100, 0, 0, 50, 0).cache_hit_rate(false), None);
+}
+
+#[test]
+fn cache_hit_rate_clamps_negative_components() {
+    let stats = make_stats(-100, 0, -20, 80, 0);
+    assert_eq!(stats.cache_hit_rate(true), Some(100.0));
+}
+
+// --- Stats ---
+
+#[test]
+fn stats_default_all_zero() {
+    let s = Stats::default();
+    assert_eq!(s.input_tokens, 0);
+    assert_eq!(s.output_tokens, 0);
+    assert_eq!(s.cache_creation, 0);
+    assert_eq!(s.cache_read, 0);
+    assert_eq!(s.reasoning_tokens, 0);
+    assert_eq!(s.count, 0);
+    assert_eq!(s.skipped_chunks, 0);
+}
+
+#[test]
+fn stats_total_tokens_sums_five_fields() {
+    let s = make_stats(100, 200, 50, 30, 20);
+    assert_eq!(s.total_tokens(), 400); // 100+200+50+30+20
+}
+
+#[test]
+fn stats_total_tokens_excludes_count_and_skipped() {
+    let s = Stats {
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_creation: 0,
+        cache_creation_1h: 0,
+        cache_read: 0,
+        reasoning_tokens: 0,
+        count: 999,
+        skipped_chunks: 42,
+        estimated_proxy: CostTokens::default(),
+        ..Default::default()
+    };
+    assert_eq!(s.total_tokens(), 15);
+}
+
+#[test]
+fn stats_total_tokens_zero_when_default() {
+    assert_eq!(Stats::default().total_tokens(), 0);
+}
+
+#[test]
+fn stats_aggregation_saturates_at_i64_max() {
+    let mut total = Stats {
+        input_tokens: i64::MAX,
+        count: i64::MAX,
+        records: i64::MAX,
+        ..Default::default()
+    };
+    total.add(&Stats {
+        input_tokens: 1,
+        count: 1,
+        records: 1,
+        ..Default::default()
+    });
+
+    assert_eq!(total.input_tokens, i64::MAX);
+    assert_eq!(total.count, i64::MAX);
+    assert_eq!(total.records, i64::MAX);
+    assert_eq!(total.total_tokens(), i64::MAX);
+}
+
+#[test]
+fn stats_add_accumulates_all_fields() {
+    let mut a = make_stats(10, 20, 5, 3, 1);
+    a.skipped_chunks = 2;
+    let b = Stats {
+        input_tokens: 100,
+        output_tokens: 200,
+        cache_creation: 50,
+        cache_creation_1h: 0,
+        cache_read: 30,
+        reasoning_tokens: 10,
+        count: 3,
+        skipped_chunks: 5,
+        estimated_proxy: CostTokens::default(),
+        ..Default::default()
+    };
+    a.add(&b);
+    assert_eq!(a.input_tokens, 110);
+    assert_eq!(a.output_tokens, 220);
+    assert_eq!(a.cache_creation, 55);
+    assert_eq!(a.cache_read, 33);
+    assert_eq!(a.reasoning_tokens, 11);
+    assert_eq!(a.count, 4);
+    assert_eq!(a.skipped_chunks, 7);
+}
+
+#[test]
+fn stats_add_to_default() {
+    let mut a = Stats::default();
+    let b = make_stats(5, 10, 15, 20, 25);
+    a.add(&b);
+    assert_eq!(a.input_tokens, 5);
+    assert_eq!(a.output_tokens, 10);
+    assert_eq!(a.total_tokens(), 75);
+}
+
+// --- DayStats ---
+
+#[test]
+fn day_stats_add_single_model() {
+    let mut ds = DayStats::default();
+    let s = make_stats(100, 200, 0, 0, 0);
+    ds.add_stats("claude-3".into(), &s);
+    assert_eq!(ds.stats.input_tokens, 100);
+    assert_eq!(ds.stats.output_tokens, 200);
+    assert_eq!(ds.stats.count, 1);
+    assert_eq!(ds.models.len(), 1);
+    assert_eq!(ds.models["claude-3"].input_tokens, 100);
+}
+
+#[test]
+fn day_stats_add_same_model_twice() {
+    let mut ds = DayStats::default();
+    ds.add_stats("gpt-4".into(), &make_stats(10, 20, 0, 0, 0));
+    ds.add_stats("gpt-4".into(), &make_stats(30, 40, 0, 0, 0));
+    assert_eq!(ds.stats.input_tokens, 40);
+    assert_eq!(ds.stats.output_tokens, 60);
+    assert_eq!(ds.stats.count, 2);
+    assert_eq!(ds.models.len(), 1);
+    assert_eq!(ds.models["gpt-4"].input_tokens, 40);
+}
+
+#[test]
+fn day_stats_add_multiple_models() {
+    let mut ds = DayStats::default();
+    ds.add_stats("a".into(), &make_stats(10, 0, 0, 0, 0));
+    ds.add_stats("b".into(), &make_stats(20, 0, 0, 0, 0));
+    ds.add_stats("c".into(), &make_stats(30, 0, 0, 0, 0));
+    assert_eq!(ds.stats.input_tokens, 60);
+    assert_eq!(ds.models.len(), 3);
+}
+
+// --- RawEntry ---
+
+#[test]
+fn raw_entry_to_stats() {
+    let entry = RawEntry {
+        timestamp: String::new(),
+        timestamp_ms: 0,
+        date_str: String::new(),
+        message_id: None,
+        session_key: String::new(),
+        session_id: String::new(),
+        project_path: String::new(),
+        model: String::new(),
+        input_tokens: 100,
+        output_tokens: 200,
+        cache_creation: 50,
+        cache_creation_1h: 0,
+        cache_read: 30,
+        reasoning_tokens: 10,
+        stop_reason: None,
+        cost_kind: CostKind::Real,
+        endpoint: Endpoint::Unknown,
+        call_count: 1,
+        reported_total_tokens: None,
+        recorded_cost_usd: None,
+        api_equivalent_priced_tokens: 0,
+        api_equivalent_coverage_tokens: 0,
+    };
+    let s = entry.to_stats();
+    assert_eq!(s.input_tokens, 100);
+    assert_eq!(s.output_tokens, 200);
+    assert_eq!(s.cache_creation, 50);
+    assert_eq!(s.cache_read, 30);
+    assert_eq!(s.reasoning_tokens, 10);
+    assert_eq!(s.count, 1);
+    assert_eq!(s.records, 1);
+    assert_eq!(s.skipped_chunks, 0);
+    assert_eq!(s.recorded_cost_entries, 0);
+    assert_eq!(s.priced_tokens.input_tokens, 100);
+}
+
+#[test]
+fn raw_entry_to_stats_uses_call_count_and_recorded_cost() {
+    let entry = RawEntry {
+        timestamp: String::new(),
+        timestamp_ms: 0,
+        date_str: String::new(),
+        message_id: None,
+        session_key: String::new(),
+        session_id: String::new(),
+        project_path: String::new(),
+        model: String::new(),
+        input_tokens: 10,
+        output_tokens: 2,
+        cache_creation: 0,
+        cache_creation_1h: 0,
+        cache_read: 0,
+        reasoning_tokens: 0,
+        stop_reason: None,
+        cost_kind: CostKind::Real,
+        endpoint: Endpoint::Unknown,
+        call_count: 5,
+        reported_total_tokens: None,
+        recorded_cost_usd: Some(1.25),
+        api_equivalent_priced_tokens: 0,
+        api_equivalent_coverage_tokens: 0,
+    };
+    let stats = entry.to_stats();
+    assert_eq!(stats.count, 5);
+    assert_eq!(stats.records, 1);
+    assert!((stats.recorded_cost_usd - 1.25).abs() < 1e-12);
+    assert_eq!(stats.recorded_cost_entries, 1);
+    assert!(!stats.priced_tokens.has_entries());
+}
+
+#[test]
+fn raw_entry_preserves_independent_reported_total_without_repricing_the_delta() {
+    let entry = RawEntry {
+        timestamp: String::new(),
+        timestamp_ms: 0,
+        date_str: String::new(),
+        message_id: None,
+        session_key: String::new(),
+        session_id: String::new(),
+        project_path: String::new(),
+        model: "provider/model".to_string(),
+        input_tokens: 3,
+        output_tokens: 4,
+        cache_creation: 0,
+        cache_creation_1h: 0,
+        cache_read: 0,
+        reasoning_tokens: 0,
+        reported_total_tokens: Some(9),
+        stop_reason: Some("complete".to_string()),
+        cost_kind: CostKind::Real,
+        endpoint: Endpoint::Unknown,
+        call_count: 1,
+        recorded_cost_usd: None,
+        api_equivalent_priced_tokens: 0,
+        api_equivalent_coverage_tokens: 0,
+    };
+
+    let stats = entry.to_stats();
+    assert_eq!(stats.total_tokens(), 9);
+    assert_eq!(stats.input_tokens, 3);
+    assert_eq!(stats.output_tokens, 4);
+    assert_eq!(stats.priced_tokens.input_tokens, 3);
+    assert_eq!(stats.priced_tokens.output_tokens, 4);
+}
+
+// --- DateFilter ---
+
+fn d(y: i32, m: u32, day: u32) -> NaiveDate {
+    NaiveDate::from_ymd_opt(y, m, day).unwrap()
+}
+
+#[test]
+fn date_filter_no_bounds() {
+    let f = DateFilter::new(None, None);
+    assert!(f.contains(d(2020, 1, 1)));
+    assert!(f.contains(d(2099, 12, 31)));
+}
+
+#[test]
+fn date_filter_since_only() {
+    let f = DateFilter::new(Some(d(2025, 6, 1)), None);
+    assert!(!f.contains(d(2025, 5, 31)));
+    assert!(f.contains(d(2025, 6, 1))); // inclusive
+    assert!(f.contains(d(2025, 6, 2)));
+}
+
+#[test]
+fn date_filter_until_only() {
+    let f = DateFilter::new(None, Some(d(2025, 6, 30)));
+    assert!(f.contains(d(2025, 6, 29)));
+    assert!(f.contains(d(2025, 6, 30))); // inclusive
+    assert!(!f.contains(d(2025, 7, 1)));
+}
+
+#[test]
+fn date_filter_both_bounds() {
+    let f = DateFilter::new(Some(d(2025, 3, 1)), Some(d(2025, 3, 31)));
+    assert!(!f.contains(d(2025, 2, 28)));
+    assert!(f.contains(d(2025, 3, 1)));
+    assert!(f.contains(d(2025, 3, 15)));
+    assert!(f.contains(d(2025, 3, 31)));
+    assert!(!f.contains(d(2025, 4, 1)));
+}
+
+#[test]
+fn date_filter_single_day_range() {
+    let f = DateFilter::new(Some(d(2025, 1, 15)), Some(d(2025, 1, 15)));
+    assert!(!f.contains(d(2025, 1, 14)));
+    assert!(f.contains(d(2025, 1, 15)));
+    assert!(!f.contains(d(2025, 1, 16)));
+}

--- a/src/pricing/cost.rs
+++ b/src/pricing/cost.rs
@@ -19,12 +19,25 @@ fn calculate_token_cost(tokens: CostTokens, model: &str, pricing_db: &PricingDb)
         Some(pricing) => {
             let long_ttl_tokens = tokens.cache_creation_1h.min(tokens.cache_creation);
             let short_ttl_tokens = tokens.cache_creation - long_ttl_tokens;
-            tokens.input_tokens as f64 * pricing.input
+            let base_cost = tokens.input_tokens as f64 * pricing.input
                 + tokens.output_tokens as f64 * pricing.output
                 + tokens.reasoning_tokens as f64 * pricing.reasoning_output
                 + short_ttl_tokens as f64 * pricing.cache_create
                 + long_ttl_tokens as f64 * pricing.cache_create_1h
-                + tokens.cache_read as f64 * pricing.cache_read
+                + tokens.cache_read as f64 * pricing.cache_read;
+            // Only the token subset classified before aggregation receives the
+            // long-context rates. Recorded provider costs still bypass pricing.
+            let long = tokens.above_272k;
+            let adjustment = pricing.above_272k.as_ref().map_or(0.0, |rate| {
+                long.input_tokens as f64 * (rate.input - pricing.input)
+                    + long.output_tokens as f64 * (rate.output - pricing.output)
+                    + long.reasoning_tokens as f64 * (rate.output - pricing.reasoning_output)
+                    + long.cache_read as f64 * (rate.cache_read - pricing.cache_read)
+                    + (long.cache_creation - long.cache_creation_1h) as f64
+                        * (rate.cache_create - pricing.cache_create)
+                    + long.cache_creation_1h as f64 * (rate.cache_create - pricing.cache_create_1h)
+            });
+            base_cost + adjustment
         }
         None => f64::NAN,
     }
@@ -307,8 +320,88 @@ mod tests {
         db
     }
 
+    fn astra_pricing_db() -> PricingDb {
+        let data = HashMap::from([(
+            "gpt-6-astra".to_string(),
+            serde_json::json!({
+                "input_cost_per_token": 0.00001,
+                "output_cost_per_token": 0.00005,
+                "cache_read_input_token_cost": 1e-6,
+                "cache_creation_input_token_cost": 1.25e-5,
+                "input_cost_per_token_above_272k_tokens": 0.00002,
+                "output_cost_per_token_above_272k_tokens": 7.5e-5,
+                "cache_read_input_token_cost_above_272k_tokens": 2e-6,
+                "cache_creation_input_token_cost_above_272k_tokens": 2.5e-5,
+            }),
+        )]);
+        let mut models = super::super::resolver::parse_litellm_data(data);
+        pricing_db_with("gpt-6-astra", models.remove("gpt-6-astra").unwrap())
+    }
+
+    fn context_entry(input: i64) -> crate::core::RawEntry {
+        crate::core::RawEntry {
+            timestamp: String::new(),
+            timestamp_ms: 0,
+            date_str: String::new(),
+            message_id: None,
+            session_key: String::new(),
+            session_id: String::new(),
+            project_path: String::new(),
+            model: "gpt-6-astra".to_string(),
+            input_tokens: input,
+            cache_read: 190_000,
+            cache_creation: 10_000,
+            output_tokens: 600,
+            reasoning_tokens: 400,
+            call_count: 1,
+            cache_creation_1h: 0,
+            reported_total_tokens: None,
+            stop_reason: None,
+            cost_kind: CostKind::Real,
+            endpoint: crate::core::Endpoint::Unknown,
+            recorded_cost_usd: None,
+            api_equivalent_priced_tokens: 0,
+            api_equivalent_coverage_tokens: 0,
+        }
+    }
+
+    #[test]
+    fn long_context_prices_each_request_before_aggregation() {
+        let db = astra_pricing_db();
+        // Exactly 272K stays standard; 272K+1 changes the entire request tier,
+        // including cached input, cache writes and reasoning output.
+        let short = context_entry(72_000).to_stats();
+        let long = context_entry(72_001).to_stats();
+        assert!((calculate_cost(&short, "gpt-6-astra", &db) - 1.085).abs() < 1e-9);
+        assert!((calculate_cost(&long, "gpt-6-astra", &db) - 2.14502).abs() < 1e-9);
+        let mut combined = short.clone();
+        combined.add(&short);
+        // Total input is already >272K, but neither request crosses the boundary.
+        assert!((calculate_cost(&combined, "gpt-6-astra", &db) - 2.17).abs() < 1e-9);
+        combined.add(&long);
+        assert!((calculate_cost(&combined, "gpt-6-astra", &db) - 4.31502).abs() < 1e-9);
+        assert_eq!(combined.total_tokens(), 819_001);
+    }
+
+    #[test]
+    fn long_context_preserves_recorded_cost_and_proxy_filtering() {
+        let db = astra_pricing_db();
+        let mut recorded = context_entry(72_001);
+        recorded.recorded_cost_usd = Some(7.0);
+        let mut stats = recorded.to_stats();
+        stats.add(&context_entry(72_001).to_stats());
+        let mut proxy = context_entry(72_001);
+        proxy.cost_kind = CostKind::EstimatedProxy;
+        stats.add(&proxy.to_stats());
+        assert!((calculate_cost(&stats, "gpt-6-astra", &db) - 11.29004).abs() < 1e-9);
+        assert!((calculate_real_cost(&stats, "gpt-6-astra", &db) - 9.14502).abs() < 1e-9);
+        stats.retain_real_token_totals();
+        assert!((calculate_cost(&stats, "gpt-6-astra", &db) - 9.14502).abs() < 1e-9);
+    }
+
     fn fable_pricing() -> super::super::types::ModelPricing {
         super::super::types::ModelPricing {
+            above_272k: None,
             input: 1e-5,
             output: 5e-5,
             reasoning_output: 5e-5,

--- a/src/pricing/db.rs
+++ b/src/pricing/db.rs
@@ -392,6 +392,7 @@ mod tests {
         db.models.insert(
             "sonnet-4".to_string(),
             ModelPricing {
+                above_272k: None,
                 input: 3e-6,
                 output: 15e-6,
                 reasoning_output: 15e-6,
@@ -425,6 +426,7 @@ mod tests {
         db.models.insert(
             "sonnet-4".to_string(),
             ModelPricing {
+                above_272k: None,
                 input: 3e-6,
                 output: 15e-6,
                 reasoning_output: 15e-6,
@@ -497,6 +499,7 @@ mod tests {
         db.models.insert(
             "opus-4".to_string(),
             ModelPricing {
+                above_272k: None,
                 input: 15e-6,
                 output: 75e-6,
                 reasoning_output: 75e-6,

--- a/src/pricing/resolver/fallback.rs
+++ b/src/pricing/resolver/fallback.rs
@@ -2,17 +2,19 @@ use super::super::types::ModelPricing;
 
 fn openai_pricing(input: f64, output: f64, cache_read: f64) -> ModelPricing {
     ModelPricing {
+        above_272k: None,
         input,
         output,
         reasoning_output: output,
-        cache_create: 0.0,
-        cache_create_1h: 0.0,
+        cache_create: input * 1.25,
+        cache_create_1h: input * 1.25,
         cache_read,
     }
 }
 
 fn xai_pricing(input: f64, output: f64, cache_read: f64) -> ModelPricing {
     ModelPricing {
+        above_272k: None,
         input,
         output,
         reasoning_output: output,
@@ -24,6 +26,7 @@ fn xai_pricing(input: f64, output: f64, cache_read: f64) -> ModelPricing {
 
 fn moonshot_pricing(input: f64, output: f64, cache_read: f64) -> ModelPricing {
     ModelPricing {
+        above_272k: None,
         input,
         output,
         reasoning_output: output,
@@ -35,6 +38,7 @@ fn moonshot_pricing(input: f64, output: f64, cache_read: f64) -> ModelPricing {
 
 fn google_pricing(input: f64, output: f64, cache_read: f64) -> ModelPricing {
     ModelPricing {
+        above_272k: None,
         input,
         output,
         reasoning_output: output,
@@ -49,6 +53,7 @@ pub(crate) fn fallback_pricing(model: &str) -> Option<ModelPricing> {
     Some(
         if model_lower.contains("opus-4-5") || model_lower.contains("opus-4.5") {
             ModelPricing {
+                above_272k: None,
                 input: 5e-6,   // $5/M
                 output: 25e-6, // $25/M
                 reasoning_output: 25e-6,
@@ -58,6 +63,7 @@ pub(crate) fn fallback_pricing(model: &str) -> Option<ModelPricing> {
             }
         } else if model_lower.contains("opus") {
             ModelPricing {
+                above_272k: None,
                 input: 15e-6,
                 output: 75e-6,
                 reasoning_output: 75e-6,
@@ -67,6 +73,7 @@ pub(crate) fn fallback_pricing(model: &str) -> Option<ModelPricing> {
             }
         } else if model_lower.contains("sonnet") {
             ModelPricing {
+                above_272k: None,
                 input: 3e-6,
                 output: 15e-6,
                 reasoning_output: 15e-6,
@@ -76,6 +83,7 @@ pub(crate) fn fallback_pricing(model: &str) -> Option<ModelPricing> {
             }
         } else if model_lower.contains("haiku") {
             ModelPricing {
+                above_272k: None,
                 input: 0.8e-6,
                 output: 4e-6,
                 reasoning_output: 4e-6,

--- a/src/pricing/resolver/parse.rs
+++ b/src/pricing/resolver/parse.rs
@@ -37,6 +37,7 @@ pub(crate) fn parse_litellm_data(
             .unwrap_or(0.0);
 
         let pricing = ModelPricing {
+            above_272k: long_context_pricing(&value, output, cache_create),
             input,
             output,
             reasoning_output,
@@ -123,6 +124,32 @@ fn insert_google_aliases(
     } else {
         models.entry(bare.to_string()).or_insert(pricing.clone());
     }
+}
+
+fn long_context_pricing(
+    value: &serde_json::Value,
+    output: f64,
+    cache_create: f64,
+) -> Option<super::super::types::LongContextPricing> {
+    value
+        .get("input_cost_per_token_above_272k_tokens")
+        .and_then(serde_json::Value::as_f64)
+        .map(|long_input| super::super::types::LongContextPricing {
+            input: long_input,
+            output: value
+                .get("output_cost_per_token_above_272k_tokens")
+                .and_then(serde_json::Value::as_f64)
+                .unwrap_or(output),
+            cache_read: value
+                .get("cache_read_input_token_cost_above_272k_tokens")
+                .or_else(|| value.get("cache_read_input_token_cost"))
+                .and_then(serde_json::Value::as_f64)
+                .unwrap_or(0.0),
+            cache_create: value
+                .get("cache_creation_input_token_cost_above_272k_tokens")
+                .and_then(serde_json::Value::as_f64)
+                .unwrap_or(cache_create),
+        })
 }
 
 #[cfg(test)]

--- a/src/pricing/resolver/resolve.rs
+++ b/src/pricing/resolver/resolve.rs
@@ -299,7 +299,7 @@ fn strip_yyyy_mm_dd_suffix(key: &str) -> Option<&str> {
 }
 
 fn unique_pricing(
-    candidates: Vec<(String, String, [u64; 6], &ModelPricing)>,
+    candidates: Vec<(String, String, [u64; 11], &ModelPricing)>,
 ) -> Option<PricingMatch> {
     match resolve_unique_pricing(candidates) {
         PricingResolution::Resolved(pricing) => Some(pricing),
@@ -308,7 +308,7 @@ fn unique_pricing(
 }
 
 fn resolve_unique_pricing(
-    candidates: Vec<(String, String, [u64; 6], &ModelPricing)>,
+    candidates: Vec<(String, String, [u64; 11], &ModelPricing)>,
 ) -> PricingResolution {
     let mut unique = HashMap::new();
     for (canonical, matched_key, signature, pricing) in candidates {
@@ -339,7 +339,7 @@ fn resolve_unique_pricing(
     })
 }
 
-fn pricing_signature(pricing: &ModelPricing) -> [u64; 6] {
+fn pricing_signature(pricing: &ModelPricing) -> [u64; 11] {
     [
         pricing.input.to_bits(),
         pricing.output.to_bits(),
@@ -347,6 +347,20 @@ fn pricing_signature(pricing: &ModelPricing) -> [u64; 6] {
         pricing.cache_read.to_bits(),
         pricing.cache_create.to_bits(),
         pricing.cache_create_1h.to_bits(),
+        u64::from(pricing.above_272k.is_some()),
+        pricing.above_272k.as_ref().map_or(0, |p| p.input.to_bits()),
+        pricing
+            .above_272k
+            .as_ref()
+            .map_or(0, |p| p.output.to_bits()),
+        pricing
+            .above_272k
+            .as_ref()
+            .map_or(0, |p| p.cache_read.to_bits()),
+        pricing
+            .above_272k
+            .as_ref()
+            .map_or(0, |p| p.cache_create.to_bits()),
     ]
 }
 

--- a/src/pricing/types.rs
+++ b/src/pricing/types.rs
@@ -1,6 +1,7 @@
 /// Model pricing info (per token, not per million)
 #[derive(Debug, Clone, Default)]
 pub(super) struct ModelPricing {
+    pub(super) above_272k: Option<LongContextPricing>,
     pub(super) input: f64,
     pub(super) output: f64,
     pub(super) reasoning_output: f64,
@@ -9,6 +10,15 @@ pub(super) struct ModelPricing {
     /// Cache creation with 1-hour TTL (falls back to `cache_create` when the
     /// provider does not publish a separate 1h rate).
     pub(super) cache_create_1h: f64,
+}
+
+/// Standard API rates for a request whose input exceeds 272K tokens.
+#[derive(Debug, Clone)]
+pub(super) struct LongContextPricing {
+    pub(super) input: f64,
+    pub(super) output: f64,
+    pub(super) cache_read: f64,
+    pub(super) cache_create: f64,
 }
 
 /// Normalize version separators: some hosters spell version dots as `p`

--- a/src/source/codex/config.rs
+++ b/src/source/codex/config.rs
@@ -83,7 +83,7 @@ impl Source for CodexSource {
             has_projects: false,       // Codex doesn't track projects
             has_billing_blocks: false, // Different billing model
             has_reasoning_tokens: true,
-            has_cache_creation: false,
+            has_cache_creation: true,
             has_cache_read: true,
             needs_dedup: true,
             has_tool_calls: false,

--- a/src/source/codex/parser.rs
+++ b/src/source/codex/parser.rs
@@ -67,6 +67,7 @@ struct Metadata<'a> {
 struct TokenUsage {
     input_tokens: Option<i64>,
     cached_input_tokens: Option<i64>,
+    cache_write_input_tokens: Option<i64>,
     #[serde(alias = "cache_read_input_tokens")]
     alt_cache_read_input_tokens: Option<i64>,
     output_tokens: Option<i64>,
@@ -88,6 +89,11 @@ impl TokenUsage {
                 (self.input_tokens.unwrap_or(0) - prev.input_tokens.unwrap_or(0)).max(0),
             ),
             cached_input_tokens: Some((self.cached_input() - prev.cached_input()).max(0)),
+            cache_write_input_tokens: Some(
+                (self.cache_write_input_tokens.unwrap_or(0)
+                    - prev.cache_write_input_tokens.unwrap_or(0))
+                .max(0),
+            ),
             alt_cache_read_input_tokens: None,
             output_tokens: Some(
                 (self.output_tokens.unwrap_or(0) - prev.output_tokens.unwrap_or(0)).max(0),
@@ -107,6 +113,7 @@ impl TokenUsage {
     fn is_empty(&self) -> bool {
         self.input_tokens.unwrap_or(0) == 0
             && self.cached_input() == 0
+            && self.cache_write_input_tokens.unwrap_or(0) == 0
             && self.output_tokens.unwrap_or(0) == 0
             && self.reasoning_output_tokens.unwrap_or(0) == 0
     }
@@ -117,6 +124,7 @@ impl TokenUsage {
 struct UsageTotals {
     input_tokens: i64,
     cached_input_tokens: i64,
+    cache_write_input_tokens: i64,
     output_tokens: i64,
     reasoning_output_tokens: i64,
     total_tokens: i64,
@@ -127,6 +135,7 @@ impl UsageTotals {
         Self {
             input_tokens: usage.input_tokens.unwrap_or(0),
             cached_input_tokens: usage.cached_input(),
+            cache_write_input_tokens: usage.cache_write_input_tokens.unwrap_or(0),
             output_tokens: usage.output_tokens.unwrap_or(0),
             reasoning_output_tokens: usage.reasoning_output_tokens.unwrap_or(0),
             total_tokens: usage.total_tokens.unwrap_or(0),
@@ -137,6 +146,9 @@ impl UsageTotals {
         Self {
             input_tokens: (self.input_tokens - prev.input_tokens).max(0),
             cached_input_tokens: (self.cached_input_tokens - prev.cached_input_tokens).max(0),
+            cache_write_input_tokens: (self.cache_write_input_tokens
+                - prev.cache_write_input_tokens)
+                .max(0),
             output_tokens: (self.output_tokens - prev.output_tokens).max(0),
             reasoning_output_tokens: (self.reasoning_output_tokens - prev.reasoning_output_tokens)
                 .max(0),
@@ -151,6 +163,7 @@ impl UsageTotals {
     fn is_empty(self) -> bool {
         self.input_tokens == 0
             && self.cached_input_tokens == 0
+            && self.cache_write_input_tokens == 0
             && self.output_tokens == 0
             && self.reasoning_output_tokens == 0
     }
@@ -233,14 +246,16 @@ fn usage_message_id(
         CODEX_USAGE_MESSAGE_PREFIX
     };
     format!(
-        "{prefix}:{logical_session_key}:{model}:total={},{},{},{},{}:delta={},{},{},{},{}",
+        "{prefix}:{logical_session_key}:{model}:total={},{},{},{},{},{}:delta={},{},{},{},{},{}",
         total.input_tokens,
         total.cached_input_tokens,
+        total.cache_write_input_tokens,
         total.output_tokens,
         total.reasoning_output_tokens,
         total.total_tokens,
         delta.input_tokens,
         delta.cached_input_tokens,
+        delta.cache_write_input_tokens,
         delta.output_tokens,
         delta.reasoning_output_tokens,
         delta.total_tokens
@@ -471,6 +486,16 @@ fn process_event_message(
     let Some((total, delta)) = next_usage_delta(info, state) else {
         return;
     };
+    if delta.cache_write_input_tokens < 0
+        || delta.cached_input_tokens < 0
+        || delta
+            .cache_write_input_tokens
+            .saturating_add(delta.cached_input_tokens)
+            > delta.input_tokens
+    {
+        state.parse_errors += 1;
+        return;
+    }
     let Some(utc_dt) = parse_entry_timestamp(timestamp, line_no, context, state) else {
         return;
     };
@@ -631,7 +656,7 @@ fn push_codex_entry(
         model,
         input_tokens,
         output_tokens,
-        cache_creation: 0, // Codex doesn't have cache creation
+        cache_creation: delta.cache_write_input_tokens,
         cache_creation_1h: 0,
         cache_read,
         reasoning_tokens,
@@ -648,7 +673,8 @@ fn push_codex_entry(
 
 fn split_codex_usage(delta: UsageTotals) -> (i64, i64, i64, i64) {
     // Codex's input_tokens includes cached_input_tokens.
-    let input_tokens = (delta.input_tokens - delta.cached_input_tokens).max(0);
+    let input_tokens =
+        (delta.input_tokens - delta.cached_input_tokens - delta.cache_write_input_tokens).max(0);
 
     // OpenAI's output_tokens includes reasoning_output_tokens as a subset.
     // Separate them so total_tokens() and calculate_cost() don't double-count.

--- a/src/source/codex/parser_tests.rs
+++ b/src/source/codex/parser_tests.rs
@@ -1,5 +1,56 @@
 use super::*;
 
+fn parse_cache_write_usage(writes: i64) -> ParseOutput {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("usage.jsonl");
+    let usage = serde_json::json!({
+        "input_tokens": 1000, "cached_input_tokens": 600,
+        "cache_write_input_tokens": writes, "output_tokens": 50,
+        "reasoning_output_tokens": 20, "total_tokens": 1050,
+    });
+    let event = serde_json::json!({
+        "timestamp": "2026-09-05T00:51:00Z", "type": "event_msg",
+        "payload": {"type": "token_count", "model": "gpt-6-astra",
+            "info": {"total_token_usage": usage, "last_token_usage": usage}}
+    });
+    std::fs::write(&path, event.to_string()).unwrap();
+    parse_codex_file_for_quota(&path, Timezone::Named(chrono_tz::UTC))
+}
+
+#[test]
+fn cache_writes_are_separate_from_uncached_input() {
+    let result = parse_cache_write_usage(300);
+    assert_eq!(result.errors, 0);
+    let entry = &result.entries[0];
+    assert_eq!(entry.cache_creation, 300);
+    assert_eq!(entry.input_tokens, 100);
+    assert_eq!(entry.to_stats().total_tokens(), 1050);
+}
+
+#[test]
+fn invalid_cache_write_buckets_fail_instead_of_underpricing() {
+    for writes in [-1, 401] {
+        let result = parse_cache_write_usage(writes);
+        assert_eq!(result.errors, 1);
+        assert!(result.entries.is_empty());
+    }
+}
+
+#[test]
+fn cumulative_cache_writes_participate_in_deltas_and_deduplication() {
+    let first = UsageTotals {
+        input_tokens: 1000,
+        cache_write_input_tokens: 100,
+        ..UsageTotals::default()
+    };
+    let second = UsageTotals {
+        cache_write_input_tokens: 200,
+        ..first
+    };
+    assert!(!second.is_duplicate_of(&first));
+    assert_eq!(second.subtract(first).cache_write_input_tokens, 100);
+}
+
 #[test]
 fn discovery_includes_active_and_archived_sessions() {
     let temp = tempfile::tempdir().unwrap();
@@ -20,6 +71,7 @@ fn discovery_includes_active_and_archived_sessions() {
 #[test]
 fn test_subtract_normal() {
     let total = TokenUsage {
+        cache_write_input_tokens: None,
         input_tokens: Some(1000),
         cached_input_tokens: Some(200),
         alt_cache_read_input_tokens: None,
@@ -28,6 +80,7 @@ fn test_subtract_normal() {
         total_tokens: Some(1500),
     };
     let prev = TokenUsage {
+        cache_write_input_tokens: None,
         input_tokens: Some(400),
         cached_input_tokens: Some(100),
         alt_cache_read_input_tokens: None,
@@ -46,6 +99,7 @@ fn test_subtract_normal() {
 #[test]
 fn test_subtract_clamps_negative_to_zero() {
     let total = TokenUsage {
+        cache_write_input_tokens: None,
         input_tokens: Some(100),
         cached_input_tokens: Some(50),
         alt_cache_read_input_tokens: None,
@@ -54,6 +108,7 @@ fn test_subtract_clamps_negative_to_zero() {
         total_tokens: Some(110),
     };
     let prev = TokenUsage {
+        cache_write_input_tokens: None,
         input_tokens: Some(500),
         cached_input_tokens: Some(200),
         alt_cache_read_input_tokens: None,
@@ -85,6 +140,7 @@ fn test_subtract_none_fields_treated_as_zero() {
 #[test]
 fn test_usage_totals_duplicate_when_complete_vector_matches() {
     let prev = UsageTotals {
+        cache_write_input_tokens: 0,
         input_tokens: 100,
         cached_input_tokens: 20,
         output_tokens: 30,
@@ -92,6 +148,7 @@ fn test_usage_totals_duplicate_when_complete_vector_matches() {
         total_tokens: 0,
     };
     let total = UsageTotals {
+        cache_write_input_tokens: 0,
         input_tokens: 100,
         cached_input_tokens: 20,
         output_tokens: 30,
@@ -105,6 +162,7 @@ fn test_usage_totals_duplicate_when_complete_vector_matches() {
 #[test]
 fn test_usage_totals_not_duplicate_when_component_grows_with_zero_total() {
     let prev = UsageTotals {
+        cache_write_input_tokens: 0,
         input_tokens: 100,
         cached_input_tokens: 20,
         output_tokens: 30,
@@ -112,6 +170,7 @@ fn test_usage_totals_not_duplicate_when_component_grows_with_zero_total() {
         total_tokens: 0,
     };
     let total = UsageTotals {
+        cache_write_input_tokens: 0,
         input_tokens: 150,
         cached_input_tokens: 20,
         output_tokens: 30,

--- a/src/source/grok/cost_report.rs
+++ b/src/source/grok/cost_report.rs
@@ -524,6 +524,7 @@ fn entry_cost_tokens(entry: &RawEntry) -> CostTokens {
         cache_read: entry.cache_read,
         reasoning_tokens: 0,
         count: 0,
+        ..CostTokens::default()
     }
 }
 

--- a/src/source/registry.rs
+++ b/src/source/registry.rs
@@ -218,7 +218,7 @@ mod tests {
         let caps = source.capabilities();
         assert!(!caps.has_projects);
         assert!(!caps.has_billing_blocks);
-        assert!(!caps.has_cache_creation);
+        assert!(caps.has_cache_creation);
         assert!(caps.has_cache_read);
         assert!(caps.needs_dedup);
         assert!(caps.has_reasoning_tokens);

--- a/tests/catalog_integration.rs
+++ b/tests/catalog_integration.rs
@@ -28,7 +28,7 @@ fn catalog_projects_every_registered_usage_source() {
         .find(|source| source.name == "codex")
         .expect("Codex descriptor");
     assert!(!codex.has_projects);
-    assert!(!codex.has_cache_creation);
+    assert!(codex.has_cache_creation);
     assert!(codex.has_cache_read);
     assert!(codex.has_reasoning_tokens);
 }


### PR DESCRIPTION
## What

Fix Codex standard API-equivalent costs for cache writes and requests above the 272K input-token pricing boundary. Cache writes are now separated from ordinary input, included in cumulative deltas/deduplication, and advertised in source capabilities. Invalid overlapping cache buckets produce a parse error.

Preserve the token subset belonging to individual requests above 272K through aggregation and apply the published long-context rates, including cached input, cache writes, and reasoning output. Combining several short requests must not trigger long-context pricing. Recorded provider costs and real/proxy filtering retain their existing semantics.

## Why

The parser previously set cache creation to zero and the price resolver only loaded base token rates. Both could understate standard API-equivalent costs. This remains a standard-price estimate; it does not model Fast-mode premiums or purchased-credit billing.

The core types file exceeded the local file-size gate, so its existing tests were moved unchanged to `src/core/types_tests.rs`; their content was verified unchanged after whitespace normalization.

Pricing reference: https://developers.openai.com/api/docs/models/gpt-6-astra

## Test Plan

- [x] `cargo clippy --all-targets -- -D warnings` (includes crate checking)
- [x] `cargo fmt --check`
- [x] `cargo test` — 888 passed, 0 failed
- [x] Regression coverage: disjoint cache writes, malformed buckets, write-only cumulative changes, 272K/272K+1 boundary, mixed short/long requests, recorded costs, and proxy filtering
- [x] Read-only replay through the public SDK preserved the previously verified totals for the reported sample

No local session logs or pricing caches are included in this PR.
