### PR TITLE
chore(release): prepare ccstats 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-09-05
+
 ### Added
+- Add `ccstats limits` for Codex weekly quota snapshots and Claude estimated activity windows; unavailable data stays null.
 - Add `ccstats login cursor` to store a Cursor API key or session token in a local `credentials.toml`. Environment variables still take precedence. ccstats still does not read Cursor SQLite.
 - Print a one-line human conclusion before table-mode daily, today, weekly, and monthly reports. The amounts reuse the table footer; JSON and CSV stdout stay structured.
 ### Changed
 - Default CLI usage commands auto-detect ready sources instead of assuming Claude. Zero ready sources print the same output as `ccstats doctor` (statusline stays a quiet empty line); one ready source uses that provider; two or more use the existing `--source all` path. Explicit `--source`, source subcommands, and config `source` still win. The Rust SDK still defaults to Claude.
+
+### Fixed
+- Preserve Codex cache-write tokens and request-level long-context price tiers, including when reading cached usage.
+- Report malformed credentials as errors and hide interactive credential input on Unix and Windows.
+
+### Performance
+- Cache unchanged Codex usage files and filter stored date ranges before expanding records. Cache format v2 rebuilds usage from source logs and stores no conversation text.
 
 ## [0.5.2] - 2026-09-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "ccstats"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "base64 0.23.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccstats"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Fast, local-first token and cost analytics for AI coding agents"

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccstats-desktop",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccstats-desktop",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "dependencies": {
         "@fontsource/ibm-plex-mono": "5.3.0",
         "@fontsource/manrope": "5.3.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ccstats-desktop",
   "private": true,
-  "version": "0.5.2",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "ccstats"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "base64 0.23.1",
  "chrono",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "ccstats-desktop"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "ccstats",
  "chrono",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ native-e2e = ["dep:tauri-plugin-wdio-webdriver"]
 tauri-build = { version = "2.6.3", features = [] }
 
 [dependencies]
-ccstats = { path = "../..", version = "0.5.2" }
+ccstats = { path = "../..", version = "0.6.0" }
 chrono = "0.4.43"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccstats-desktop"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ccstats",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "identifier": "io.ccstats.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -12,7 +12,7 @@
   "app": {
     "windows": [
       {
-        "title": "ccstats · Local ledger",
+        "title": "ccstats \u00b7 Local ledger",
         "width": 1280,
         "height": 860,
         "minWidth": 980,

--- a/scripts/check-release.sh
+++ b/scripts/check-release.sh
@@ -53,6 +53,7 @@ fi
 
 require_same "Cargo.lock" "$(package_lock_version Cargo.lock ccstats)" "$version"
 require_same "desktop/src-tauri/Cargo.toml" "$(toml_version desktop/src-tauri/Cargo.toml)" "$version"
+require_same "desktop ccstats dependency" "$(sed -n 's/^ccstats = {.*version = "\([^"]*\)".*/\1/p' desktop/src-tauri/Cargo.toml)" "$version"
 require_same "desktop/src-tauri/Cargo.lock" "$(package_lock_version desktop/src-tauri/Cargo.lock ccstats-desktop)" "$version"
 require_same "desktop/src-tauri/tauri.conf.json" "$(json_top_version desktop/src-tauri/tauri.conf.json)" "$version"
 require_same "desktop/package.json" "$(json_top_version desktop/package.json)" "$version"


### PR DESCRIPTION
Prepare ccstats 0.6.0 with synchronized CLI, Tauri, npm, and lockfile versions, plus release notes for first-run UX and Codex accounting/cache fixes. The desktop core dependency constraint also advances to 0.6.0, and the existing release preflight now checks it.

This draft is stacked on #174 so its diff contains only release metadata. Merge #172 after the required human credential review, then #174, then retarget this PR to main. Do not publish a tag before those steps and final CI pass.

Validation on the combined candidate:
- Rust 1.88.0: 950 tests passed.
- `cargo +1.88.0 publish --dry-run --locked` passed; no crate was uploaded.
- `cargo +1.88.0 build --release --locked` passed.
- Release metadata and desktop artifact staging self-tests passed.
- Repository deterministic benchmark passed (3 measured iterations after 1 warmup). This is synthetic fixture evidence, not the previous 27 GiB dataset.

After publishing the new tag, verify OIDC authentication, crates.io publication, all CLI/desktop artifacts and SHA-256 sidecars, and the Homebrew update before closing #162. #154 remains open until Developer ID/notarization and Windows Authenticode acceptance succeeds. This PR does not add signing secrets or claim signed installers.

P2 desktop follow-up: includes #172 fix `69b0954`, propagating source diagnostic errors before All Sources aggregation or machine snapshot persistence. Four new regression tests cover overview, live startup/refresh, and capture. Check, Coverage, Desktop, and Windows credentials CI all pass at `0c18cac`. The owner approved SEC-11 review; the #172 correctness fix awaits re-review before the stack can merge.
