### PR TITLE
fix(codex): handle escaped working directory paths

### DIFF
--- a/src/source/codex/parser.rs
+++ b/src/source/codex/parser.rs
@@ -42,7 +42,9 @@ struct Payload<'a> {
     #[serde(rename = "type")]
     payload_type: Option<&'a str>,
     id: Option<&'a str>,
-    cwd: Option<&'a str>,
+    // Paths may contain JSON escapes (notably Windows backslashes), which
+    // cannot be deserialized into a borrowed string.
+    cwd: Option<String>,
     info: Option<TokenInfo<'a>>,
     model: Option<&'a str>,
     source: Option<serde_json::Value>,
@@ -446,7 +448,7 @@ fn update_session_metadata(payload: Option<&Payload<'_>>, state: &mut CodexParse
         state.session_id = Some(id.to_string());
     }
     if let Some(cwd) = payload
-        .and_then(|payload| payload.cwd)
+        .and_then(|payload| payload.cwd.as_deref())
         .filter(|cwd| !cwd.is_empty())
     {
         state.project_path = cwd.to_string();

--- a/src/source/codex/parser_tests.rs
+++ b/src/source/codex/parser_tests.rs
@@ -1,5 +1,53 @@
 use super::*;
 
+#[test]
+fn escaped_working_directories_preserve_session_and_model_metadata() {
+    for cwd in [
+        r"C:\Users\example\项目",
+        r"\\server\share\project",
+        "/work/project\"quoted\"",
+        "/work/project",
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("usage.jsonl");
+        let rows = [
+            serde_json::json!({"type": "session_meta", "payload": {
+                "id": "path-test-session", "source": "cli", "cwd": cwd
+            }}),
+            serde_json::json!({"type": "turn_context", "payload": {
+                "model": "gpt-6-astra", "cwd": cwd
+            }}),
+            serde_json::json!({
+                "timestamp": "2026-09-05T00:51:00Z", "type": "event_msg",
+                "payload": {"type": "token_count", "info": {
+                    "total_token_usage": {"input_tokens": 100, "output_tokens": 5}
+                }}
+            }),
+        ];
+        let lines = rows.map(|row| row.to_string()).join("\n");
+        // Exercise escaped Unicode as well as backslashes and quotes.
+        std::fs::write(&path, lines.replace("项目", r"\u9879\u76ee")).unwrap();
+
+        for result in [
+            parse_codex_file_for_quota(&path, Timezone::Named(chrono_tz::UTC)),
+            parse_codex_file_with_scope(
+                &path,
+                Timezone::Named(chrono_tz::UTC),
+                false,
+                CodexScope::Interactive,
+            ),
+        ] {
+            assert_eq!(result.errors, 0, "cwd: {cwd}");
+            assert_eq!(result.entries.len(), 1, "cwd: {cwd}");
+            let entry = &result.entries[0];
+            assert_eq!(entry.project_path, cwd);
+            assert_eq!(entry.session_id, "path-test-session");
+            assert_eq!(entry.model, "gpt-6-astra");
+            assert_eq!(entry.to_stats().total_tokens(), 105);
+        }
+    }
+}
+
 fn parse_cache_write_usage(writes: i64) -> ParseOutput {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("usage.jsonl");


### PR DESCRIPTION
## What

Deserialize Codex `cwd` as `Option<String>` and borrow it with `as_deref()` when recording session metadata. Other fields keep their existing borrowed representation.

Add a regression test covering Windows drive paths, UNC paths, Unicode escapes, quoted paths, and ordinary POSIX paths. It exercises both the quota parser and interactive-session parser, asserting that the project path, session identity, model, and token totals are preserved.

## Why

A normal Windows Codex event contains an escaped path such as:

```json
{"type":"turn_context","payload":{"cwd":"C:\\work\\sample","model":"gpt-6-astra"}}
```

Serde cannot deserialize a JSON string requiring unescaping into `&str`. The current `Payload.cwd: Option<&str>` therefore rejects valid `session_meta` and `turn_context` records with `expected a borrowed string`.

Consequently, `ccstats quota --json` returns a null `value_estimate` with a parse-error message, while daily reports can lose the current model and fall back to `gpt-5`, producing incorrect attribution and estimates. `--strict-pricing` does not help when the model itself was lost.

This change fixes decoding at the input boundary without rewriting logs, changing pricing, or suppressing malformed-record errors. Files with parse errors are not cached, so no cache migration is needed.

## Test Plan

- [x] `cargo check --locked`
- [x] `cargo fmt --check` and `git diff --check`
- [x] Regression test fails on the original parser and passes with this fix.
- [x] `cargo test --locked --lib source::codex::` — 54 passed.
- [x] `cargo test --locked --test cli_codex_quota` — 8 passed.
- [x] Tested manually on Windows with real Codex logs: parse errors cleared, actual model attribution restored, and strict-pricing weekly estimates returned successfully. Also verified the release binary and an otherwise identical backslash/forward-slash fixture pair.
- [ ] Full `cargo test --locked` passes on Windows. It currently stops at four pre-existing library-test failures. An unmodified checkout of base `74f30c3` reproduces the same failures (724 passed / 4 failed); this branch has 725 passed / 4 failed:
  - `config::tests::test_config_paths_contain_expected_filenames`
  - `source::dsh::tests::discovery_reuses_one_root_encoding_snapshot_for_all_parses`
  - `source::kimi::parser::tests::parses_turn_usage_records`
  - `source::kimi::parser::tests::sub_agent_wire_files_share_session_identity`

Environment: Windows, Rust/Cargo 1.90.0, ccstats 0.7.1. The unrelated baseline failures are intentionally left outside this parser fix.
