### PR TITLE
fix: repair Windows paths, isolation and test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,12 @@ jobs:
           fail_ci_if_error: false
 
   desktop:
-    name: Desktop
-    runs-on: macos-latest
+    name: Desktop (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -89,12 +93,12 @@ jobs:
         working-directory: desktop
         run: npm run test:e2e:native
 
-  windows-credentials:
-    name: Windows credentials
+  windows:
+    name: Windows
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Test private credential storage
-        run: cargo test --locked --lib credentials::tests
+      - name: Test CLI and library
+        run: cargo test --locked --no-fail-fast

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,7 @@ dependencies = [
  "thiserror",
  "toml",
  "ureq",
+ "windows-sys 0.61.2",
  "zstd",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ base64 = "0.23.1"
 sha2 = "0.11.0"
 rpassword = "7.5.4"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61.2", features = ["Win32_Storage_FileSystem"] }
+
 [dev-dependencies]
 tempfile = "3"
 

--- a/README.md
+++ b/README.md
@@ -844,3 +844,22 @@ and Claude indexed summaries, returning `SessionTitle { text, origin }`.
 Missing indices return no titles; unreadable or malformed indices return errors.
 No model call or transcript summarization is performed. Desktop users can keep
 manual titles locally without changing source transcripts.
+
+### Windows directory overrides and verification
+
+Windows uses the native user profile and application directories by default.
+An explicit nonempty `HOME` overrides the profile root for all sources, configuration,
+and credentials. With `HOME` set, Windows config/data/cache defaults become
+`$HOME/.config`, `$HOME/.local/share`, and `$HOME/.cache`; `XDG_CONFIG_HOME`,
+`XDG_DATA_HOME`, and `XDG_CACHE_HOME` override those respective directories.
+This also allows tests to use an isolated profile without reading the real user's data.
+Source-specific overrides such as `CODEX_HOME` still take precedence for source logs.
+
+In PowerShell, set a source root with `$env:CODEX_HOME = 'C:\path\to\.codex'`
+(the inline `NAME=value command` examples above use POSIX shell syntax).
+
+On a clean Windows runner with Rust MSVC and C++ Build Tools installed, run
+`cargo test --locked --no-fail-fast`. This runs library and CLI integration targets
+even if one target fails. Windows CI also runs the desktop Rust, frontend and native
+IPC tests. Manual release acceptance still includes MSI install/start/uninstall,
+terminal Unicode output, UNC paths, and a comparison with real source logs.

--- a/README.md
+++ b/README.md
@@ -848,11 +848,15 @@ manual titles locally without changing source transcripts.
 ### Windows directory overrides and verification
 
 Windows uses the native user profile and application directories by default.
-An explicit nonempty `HOME` overrides the profile root for all sources, configuration,
-and credentials. With `HOME` set, Windows config/data/cache defaults become
-`$HOME/.config`, `$HOME/.local/share`, and `$HOME/.cache`; `XDG_CONFIG_HOME`,
-`XDG_DATA_HOME`, and `XDG_CACHE_HOME` override those respective directories.
-This also allows tests to use an isolated profile without reading the real user's data.
+An explicit nonempty absolute `HOME` overrides the profile root for source logs
+and the `~/.config` / `~/.ccstats.toml` search paths. It does not remap config,
+data, or cache directories to `$HOME/.config`, `$HOME/.local/share`, or
+`$HOME/.cache`. Native known folders stay on the search path, so existing
+AppData credentials and config keep working after upgrade.
+
+`XDG_CONFIG_HOME`, `XDG_DATA_HOME`, and `XDG_CACHE_HOME` override those
+respective directories when set to a nonempty absolute path. Tests should set
+those variables to isolated directories instead of relying on `HOME` alone.
 Source-specific overrides such as `CODEX_HOME` still take precedence for source logs.
 
 In PowerShell, set a source root with `$env:CODEX_HOME = 'C:\path\to\.codex'`

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -429,6 +429,7 @@ dependencies = [
  "thiserror 2.0.20",
  "toml 1.1.4+spec-1.1.0",
  "ureq",
+ "windows-sys 0.61.2",
  "zstd",
 ]
 

--- a/desktop/tests/overview.spec.ts
+++ b/desktop/tests/overview.spec.ts
@@ -977,12 +977,19 @@ test("native Tauri app crosses IPC into the real Rust SDK", async () => {
   await mkdir(configDir, { recursive: true });
   await writeFile(join(configDir, "config.toml"), "offline = true\n", "utf8");
   const binary = fileURLToPath(
-    new URL("../src-tauri/target/debug/ccstats-desktop", import.meta.url),
+    new URL(`../src-tauri/target/debug/ccstats-desktop${process.platform === "win32" ? ".exe" : ""}`, import.meta.url),
   );
   const nativeProcess = spawn(binary, [], {
     cwd: isolatedHome,
     env: {
+      SystemRoot: process.env.SystemRoot,
+      WINDIR: process.env.WINDIR,
+      TEMP: isolatedHome,
+      TMP: isolatedHome,
       HOME: isolatedHome,
+      XDG_CONFIG_HOME: join(isolatedHome, ".config"),
+      XDG_DATA_HOME: join(isolatedHome, ".local", "share"),
+      XDG_CACHE_HOME: join(isolatedHome, ".cache"),
       LANG: process.env.LANG,
       LC_ALL: process.env.LC_ALL,
       PATH: process.env.PATH,

--- a/desktop/tests/overview.spec.ts
+++ b/desktop/tests/overview.spec.ts
@@ -1016,7 +1016,7 @@ test("native Tauri app crosses IPC into the real Rust SDK", async () => {
       await webdriverRequest<string>(port, `/session/${sessionId}/element/${heading}/text`),
     );
 
-    const sourceSelect = await waitForElement(port, sessionId, "#source-select");
+    const sourceSelect = await waitForElement(port, sessionId, "#source-select:enabled");
     await expect
       .poll(
         async () =>
@@ -1052,7 +1052,7 @@ test("native Tauri app crosses IPC into the real Rust SDK", async () => {
         { timeout: 120_000 },
       )
       .toBe("dsh");
-    const overviewButton = await waitForElement(port, sessionId, "button[aria-label='Overview']");
+    const overviewButton = await waitForElement(port, sessionId, "button[aria-label='Overview']:enabled");
     await webdriverRequest<null>(
       port,
       `/session/${sessionId}/element/${overviewButton}/click`,
@@ -1067,7 +1067,7 @@ test("native Tauri app crosses IPC into the real Rust SDK", async () => {
       `DSH overview did not load through the native command: ${nativeStderr}`,
     ).toBe("DeepSeek Harness");
 
-    const trustButton = await waitForElement(port, sessionId, "button[aria-label='Cost evidence']");
+    const trustButton = await waitForElement(port, sessionId, "button[aria-label='Cost evidence']:enabled");
     await webdriverRequest<null>(
       port,
       `/session/${sessionId}/element/${trustButton}/click`,
@@ -1082,7 +1082,7 @@ test("native Tauri app crosses IPC into the real Rust SDK", async () => {
       `cost provenance did not cross IPC: ${nativeStderr}`,
     ).toBe("Cost evidence");
 
-    const activityButton = await waitForElement(port, sessionId, "button[aria-label='Turns & tools']");
+    const activityButton = await waitForElement(port, sessionId, "button[aria-label='Turns & tools']:enabled");
     await webdriverRequest<null>(
       port,
       `/session/${sessionId}/element/${activityButton}/click`,
@@ -1104,7 +1104,7 @@ test("native Tauri app crosses IPC into the real Rust SDK", async () => {
       ),
     ).toBe("0");
 
-    const machinesButton = await waitForElement(port, sessionId, "button[aria-label='Machines']");
+    const machinesButton = await waitForElement(port, sessionId, "button[aria-label='Machines']:enabled");
     await webdriverRequest<null>(
       port,
       `/session/${sessionId}/element/${machinesButton}/click`,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use crate::utils::paths as dirs;
 use serde::Deserialize;
 use std::fs;
 use std::io;
@@ -155,9 +156,13 @@ mod tests {
     #[test]
     fn test_config_paths_contain_expected_filenames() {
         let paths = Config::get_config_paths();
-        let has_xdg = paths
-            .iter()
-            .any(|p| p.to_string_lossy().contains(".config/ccstats/config.toml"));
+        let has_xdg = paths.iter().any(|p| {
+            p.ends_with(
+                std::path::Path::new(".config")
+                    .join("ccstats")
+                    .join("config.toml"),
+            )
+        });
         let has_dotfile = paths
             .iter()
             .any(|p| p.to_string_lossy().ends_with(".ccstats.toml"));

--- a/src/config.rs
+++ b/src/config.rs
@@ -117,28 +117,39 @@ impl Config {
     }
 
     fn get_config_paths() -> Vec<PathBuf> {
-        let mut paths = Vec::new();
-
-        // 1. XDG config: ~/.config/ccstats/config.toml (Linux/cross-platform)
-        if let Some(home) = dirs::home_dir() {
-            paths.push(home.join(".config").join("ccstats").join("config.toml"));
-        }
-
-        // 2. macOS Application Support: ~/Library/Application Support/ccstats/config.toml
-        if let Some(config_dir) = dirs::config_dir() {
-            let macos_path = config_dir.join("ccstats").join("config.toml");
-            if !paths.contains(&macos_path) {
-                paths.push(macos_path);
-            }
-        }
-
-        // 3. Home directory: ~/.ccstats.toml
-        if let Some(home) = dirs::home_dir() {
-            paths.push(home.join(".ccstats.toml"));
-        }
-
-        paths
+        select_config_paths(
+            dirs::home_dir().as_deref(),
+            dirs::config_dir().as_deref(),
+            dirs::has_explicit_xdg_config(),
+        )
     }
+}
+
+fn select_config_paths(
+    home: Option<&std::path::Path>,
+    config_dir: Option<&std::path::Path>,
+    prefer_platform_config: bool,
+) -> Vec<PathBuf> {
+    let home_config = home.map(|home| home.join(".config").join("ccstats").join("config.toml"));
+    let platform_config = config_dir.map(|dir| dir.join("ccstats").join("config.toml"));
+
+    let mut paths = Vec::new();
+    let ordered = if prefer_platform_config {
+        [platform_config, home_config]
+    } else {
+        [home_config, platform_config]
+    };
+    for path in ordered.into_iter().flatten() {
+        if !paths.contains(&path) {
+            paths.push(path);
+        }
+    }
+
+    if let Some(home) = home {
+        paths.push(home.join(".ccstats.toml"));
+    }
+
+    paths
 }
 
 #[cfg(test)]
@@ -168,6 +179,36 @@ mod tests {
             .any(|p| p.to_string_lossy().ends_with(".ccstats.toml"));
         assert!(has_xdg);
         assert!(has_dotfile);
+    }
+
+    #[test]
+    fn config_paths_prefer_platform_config_when_xdg_override_is_set() {
+        let home = std::path::Path::new("/tmp/home-override");
+        let xdg = std::path::Path::new("/tmp/xdg-config");
+        let paths = select_config_paths(Some(home), Some(xdg), true);
+        assert_eq!(
+            paths,
+            vec![
+                xdg.join("ccstats").join("config.toml"),
+                home.join(".config").join("ccstats").join("config.toml"),
+                home.join(".ccstats.toml"),
+            ]
+        );
+    }
+
+    #[test]
+    fn config_paths_keep_home_ahead_without_xdg_override() {
+        let home = std::path::Path::new("/tmp/home-override");
+        let platform = std::path::Path::new("/tmp/AppData/Roaming");
+        let paths = select_config_paths(Some(home), Some(platform), false);
+        assert_eq!(
+            paths,
+            vec![
+                home.join(".config").join("ccstats").join("config.toml"),
+                platform.join("ccstats").join("config.toml"),
+                home.join(".ccstats.toml"),
+            ]
+        );
     }
 
     // --- TOML deserialization tests ---

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -7,6 +7,7 @@
 //! Cursor HTTP clients read `CURSOR_API_KEY` / `CURSOR_SESSION_TOKEN` first,
 //! then this file. Never log secret values.
 
+use crate::utils::paths as dirs;
 use std::env;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, ErrorKind, Write};

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -1,8 +1,9 @@
 //! Local ccstats credentials (`credentials.toml`), separate from `config.toml`.
 //!
 //! Search order matches the config directory family but uses a different file:
-//! 1. `~/.config/ccstats/credentials.toml`
-//! 2. `dirs::config_dir()/ccstats/credentials.toml` when that path is distinct
+//! 1. When `XDG_CONFIG_HOME` is set: `dirs::config_dir()/ccstats/credentials.toml`
+//! 2. `~/.config/ccstats/credentials.toml`
+//! 3. Otherwise `dirs::config_dir()/ccstats/credentials.toml` when distinct
 //!
 //! Cursor HTTP clients read `CURSOR_API_KEY` / `CURSOR_SESSION_TOKEN` first,
 //! then this file. Never log secret values.
@@ -202,19 +203,32 @@ fn existing_credentials_path() -> Option<PathBuf> {
 
 /// Config-directory family used by `config.rs`, with `credentials.toml` as the filename.
 pub(crate) fn credentials_paths() -> Vec<PathBuf> {
+    select_credentials_paths(
+        dirs::home_dir().as_deref(),
+        dirs::config_dir().as_deref(),
+        dirs::has_explicit_xdg_config(),
+    )
+}
+
+fn select_credentials_paths(
+    home: Option<&Path>,
+    config_dir: Option<&Path>,
+    prefer_platform_config: bool,
+) -> Vec<PathBuf> {
+    let home_path = home.map(|home| home.join(".config").join("ccstats").join(CREDENTIALS_FILE));
+    let platform_path = config_dir.map(|dir| dir.join("ccstats").join(CREDENTIALS_FILE));
+
     let mut paths = Vec::new();
-
-    if let Some(home) = dirs::home_dir() {
-        paths.push(home.join(".config").join("ccstats").join(CREDENTIALS_FILE));
-    }
-
-    if let Some(config_dir) = dirs::config_dir() {
-        let path = config_dir.join("ccstats").join(CREDENTIALS_FILE);
+    let ordered = if prefer_platform_config {
+        [platform_path, home_path]
+    } else {
+        [home_path, platform_path]
+    };
+    for path in ordered.into_iter().flatten() {
         if !paths.contains(&path) {
             paths.push(path);
         }
     }
-
     paths
 }
 
@@ -385,6 +399,59 @@ mod tests {
                     .join("credentials.toml"),
             )
         }));
+    }
+
+    #[test]
+    fn credentials_paths_prefer_platform_config_when_xdg_override_is_set() {
+        let home = Path::new("/tmp/home-override");
+        let xdg = Path::new("/tmp/xdg-config");
+        let paths = select_credentials_paths(Some(home), Some(xdg), true);
+        assert_eq!(
+            paths,
+            vec![
+                xdg.join("ccstats").join(CREDENTIALS_FILE),
+                home.join(".config").join("ccstats").join(CREDENTIALS_FILE),
+            ]
+        );
+    }
+
+    #[test]
+    fn credentials_paths_keep_home_ahead_without_xdg_override() {
+        let home = Path::new("/tmp/home-override");
+        let platform = Path::new("/tmp/AppData/Roaming");
+        let paths = select_credentials_paths(Some(home), Some(platform), false);
+        assert_eq!(
+            paths,
+            vec![
+                home.join(".config").join("ccstats").join(CREDENTIALS_FILE),
+                platform.join("ccstats").join(CREDENTIALS_FILE),
+            ]
+        );
+    }
+
+    #[test]
+    fn write_path_keeps_existing_platform_credentials_without_home_copy() {
+        let root = tempfile::tempdir().unwrap();
+        let home = root.path().join("home");
+        let platform = root.path().join("platform-config");
+        let platform_file = platform.join("ccstats").join(CREDENTIALS_FILE);
+        fs::create_dir_all(platform_file.parent().unwrap()).unwrap();
+        fs::write(&platform_file, "[cursor]\napi_key = \"platform-key\"\n").unwrap();
+
+        let paths = select_credentials_paths(Some(&home), Some(&platform), false);
+        let existing = paths.into_iter().find(|path| path.is_file());
+        assert_eq!(existing.as_deref(), Some(platform_file.as_path()));
+
+        write_credentials_file(
+            &platform_file,
+            &CredentialsFile {
+                cursor: CursorCredentials::from_auth(CursorAuth::ApiKey("updated-key".into())),
+            },
+        )
+        .unwrap();
+        let written = fs::read_to_string(&platform_file).unwrap();
+        assert!(written.contains("updated-key"));
+        assert!(!home.join(".config/ccstats").join(CREDENTIALS_FILE).exists());
     }
 
     #[test]

--- a/src/pricing/cache.rs
+++ b/src/pricing/cache.rs
@@ -1,3 +1,4 @@
+use crate::utils::paths as dirs;
 use std::collections::HashMap;
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufReader, BufWriter, ErrorKind, Write};

--- a/src/pricing/currency.rs
+++ b/src/pricing/currency.rs
@@ -1,17 +1,19 @@
 //! Currency conversion with exchange rate caching
 //!
 //! Fetches rates from open.er-api.com (free, no API key required).
-//! Caches to `~/.cache/ccstats/exchange_rates.json` for 24h.
+//! Caches to the platform cache directory (`ccstats/exchange_rates.json`),
+//! with `~/.cache/ccstats/exchange_rates.json` as a legacy read fallback.
 
 use crate::utils::paths as dirs;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::File;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
 const EXCHANGE_RATE_URL: &str = "https://open.er-api.com/v6/latest/USD";
 const CACHE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+const EXCHANGE_CACHE_FILE: &str = "exchange_rates.json";
 
 #[derive(Debug, Serialize, Deserialize)]
 struct ExchangeRateResponse {
@@ -93,35 +95,81 @@ fn currency_symbol(code: &str) -> String {
     }
 }
 
-fn cache_path() -> Option<PathBuf> {
-    let home = dirs::home_dir()?;
-    Some(
-        home.join(".cache")
-            .join("ccstats")
-            .join("exchange_rates.json"),
-    )
+fn exchange_cache_file(root: &Path) -> PathBuf {
+    root.join("ccstats").join(EXCHANGE_CACHE_FILE)
+}
+
+fn legacy_exchange_cache_file(home: &Path) -> PathBuf {
+    home.join(".cache")
+        .join("ccstats")
+        .join(EXCHANGE_CACHE_FILE)
+}
+
+fn select_exchange_cache_paths(
+    platform_cache_dir: Option<&Path>,
+    home_dir: Option<&Path>,
+) -> (Option<PathBuf>, Vec<PathBuf>) {
+    let preferred = platform_cache_dir.map(exchange_cache_file);
+    let legacy = home_dir.map(legacy_exchange_cache_file);
+    let write_path = preferred.clone().or_else(|| legacy.clone());
+
+    let mut read_paths = Vec::new();
+    if let Some(path) = &write_path {
+        read_paths.push(path.clone());
+    }
+    if let Some(path) = legacy
+        && !read_paths.contains(&path)
+    {
+        read_paths.push(path);
+    }
+
+    (write_path, read_paths)
+}
+
+fn cache_paths() -> (Option<PathBuf>, Vec<PathBuf>) {
+    select_exchange_cache_paths(dirs::cache_dir().as_deref(), dirs::home_dir().as_deref())
 }
 
 fn load_cached_rates() -> Option<HashMap<String, f64>> {
-    let path = cache_path()?;
-    let meta = std::fs::metadata(&path).ok()?;
-    let modified = meta.modified().ok()?;
-    let age = SystemTime::now().duration_since(modified).ok()?;
-    if age > CACHE_TTL {
-        return None;
+    let (_, read_paths) = cache_paths();
+    for path in read_paths {
+        let Ok(meta) = std::fs::metadata(&path) else {
+            continue;
+        };
+        let Ok(modified) = meta.modified() else {
+            continue;
+        };
+        let Ok(age) = SystemTime::now().duration_since(modified) else {
+            continue;
+        };
+        if age > CACHE_TTL {
+            continue;
+        }
+        let Ok(file) = File::open(&path) else {
+            continue;
+        };
+        if let Ok(rates) = serde_json::from_reader(file) {
+            return Some(rates);
+        }
     }
-    let file = File::open(&path).ok()?;
-    serde_json::from_reader(file).ok()
+    None
 }
 
 fn load_any_cached_rates() -> Option<HashMap<String, f64>> {
-    let path = cache_path()?;
-    let file = File::open(&path).ok()?;
-    serde_json::from_reader(file).ok()
+    let (_, read_paths) = cache_paths();
+    for path in read_paths {
+        let Ok(file) = File::open(&path) else {
+            continue;
+        };
+        if let Ok(rates) = serde_json::from_reader(file) {
+            return Some(rates);
+        }
+    }
+    None
 }
 
 fn save_cached_rates(rates: &HashMap<String, f64>) {
-    let Some(path) = cache_path() else {
+    let Some(path) = cache_paths().0 else {
         return;
     };
     if let Some(parent) = path.parent()
@@ -217,5 +265,38 @@ mod tests {
     fn currency_code_accessor() {
         let conv = CurrencyConverter::load("USD", true).unwrap();
         assert_eq!(conv.currency_code(), "USD");
+    }
+
+    #[test]
+    fn exchange_cache_paths_prefer_platform_cache_dir() {
+        let platform = PathBuf::from("/tmp/xdg-cache");
+        let home = PathBuf::from("/tmp/home");
+        let (write_path, read_paths) =
+            select_exchange_cache_paths(Some(platform.as_path()), Some(home.as_path()));
+        assert_eq!(
+            write_path,
+            Some(platform.join("ccstats").join(EXCHANGE_CACHE_FILE))
+        );
+        assert_eq!(
+            read_paths,
+            vec![
+                platform.join("ccstats").join(EXCHANGE_CACHE_FILE),
+                home.join(".cache")
+                    .join("ccstats")
+                    .join(EXCHANGE_CACHE_FILE),
+            ]
+        );
+    }
+
+    #[test]
+    fn exchange_cache_paths_fall_back_to_home_cache() {
+        let home = PathBuf::from("/tmp/home");
+        let (write_path, read_paths) = select_exchange_cache_paths(None, Some(home.as_path()));
+        let legacy = home
+            .join(".cache")
+            .join("ccstats")
+            .join(EXCHANGE_CACHE_FILE);
+        assert_eq!(write_path, Some(legacy.clone()));
+        assert_eq!(read_paths, vec![legacy]);
     }
 }

--- a/src/pricing/currency.rs
+++ b/src/pricing/currency.rs
@@ -3,6 +3,7 @@
 //! Fetches rates from open.er-api.com (free, no API key required).
 //! Caches to `~/.cache/ccstats/exchange_rates.json` for 24h.
 
+use crate::utils::paths as dirs;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::File;

--- a/src/source/amp.rs
+++ b/src/source/amp.rs
@@ -60,11 +60,19 @@ impl Source for AmpSource {
     }
 }
 
+fn amp_data_home(xdg_data_home: Option<PathBuf>, home: Option<PathBuf>) -> Option<PathBuf> {
+    xdg_data_home
+        .filter(|path| !path.as_os_str().is_empty() && path.is_absolute())
+        .or_else(|| home.map(|home| home.join(".local/share")))
+}
+
 fn amp_threads_dir() -> Option<PathBuf> {
-    let data_home = match env::var(XDG_DATA_HOME_ENV) {
-        Ok(value) if !value.trim().is_empty() => PathBuf::from(value),
-        Ok(_) | Err(_) => dirs::home_dir()?.join(".local/share"),
-    };
+    let data_home = amp_data_home(
+        env::var_os(XDG_DATA_HOME_ENV)
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from),
+        dirs::home_dir(),
+    )?;
     Some(data_home.join("amp/threads"))
 }
 
@@ -408,6 +416,29 @@ mod tests {
     use super::*;
 
     use tempfile::tempdir;
+
+    #[test]
+    fn amp_data_home_rejects_relative_xdg_override() {
+        let home = if cfg!(windows) {
+            PathBuf::from(r"C:\Users\tester")
+        } else {
+            PathBuf::from("/home/tester")
+        };
+        let absolute_xdg = if cfg!(windows) {
+            PathBuf::from(r"C:\abs\xdg")
+        } else {
+            PathBuf::from("/abs/xdg")
+        };
+
+        assert_eq!(
+            amp_data_home(Some(PathBuf::from("relative-xdg")), Some(home.clone())),
+            Some(home.join(".local/share"))
+        );
+        assert_eq!(
+            amp_data_home(Some(absolute_xdg.clone()), Some(home)),
+            Some(absolute_xdg)
+        );
+    }
 
     #[test]
     fn ledger_and_message_usage_for_same_call_are_counted_once() {

--- a/src/source/amp.rs
+++ b/src/source/amp.rs
@@ -1,5 +1,7 @@
 //! Amp local thread usage source.
 
+use crate::utils::glob_pattern;
+use crate::utils::paths as dirs;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -70,8 +72,8 @@ fn find_amp_files() -> Vec<PathBuf> {
     let Some(root) = amp_threads_dir() else {
         return Vec::new();
     };
-    let pattern = root.join("**").join("T-*.json");
-    let mut files = glob::glob(&pattern.to_string_lossy())
+    let pattern = glob_pattern(&root, "**/T-*.json");
+    let mut files = glob::glob(&pattern)
         .into_iter()
         .flatten()
         .flatten()

--- a/src/source/claude/parser.rs
+++ b/src/source/claude/parser.rs
@@ -2,6 +2,8 @@
 //!
 //! Parses JSONL logs from the Claude config projects directory.
 
+use crate::utils::glob_pattern;
+use crate::utils::paths as dirs;
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
 use std::env;
@@ -79,7 +81,7 @@ pub(super) fn find_claude_files() -> Vec<PathBuf> {
     };
 
     let mut files = Vec::new();
-    if let Ok(entries) = glob::glob(&format!("{}/**/*.jsonl", claude_path.display())) {
+    if let Ok(entries) = glob::glob(&glob_pattern(&claude_path, "**/*.jsonl")) {
         for entry in entries.flatten() {
             files.push(entry);
         }

--- a/src/source/cline.rs
+++ b/src/source/cline.rs
@@ -1,5 +1,7 @@
 //! Cline CLI and VS Code extension local usage source.
 
+use crate::utils::glob_pattern;
+use crate::utils::paths as dirs;
 use std::collections::HashSet;
 use std::env;
 use std::fs;
@@ -95,8 +97,8 @@ fn find_cline_cli_files() -> Vec<PathBuf> {
     let Some(root) = cline_cli_sessions_dir() else {
         return Vec::new();
     };
-    let pattern = root.join("**").join("*.messages.json");
-    let mut files = glob::glob(&pattern.to_string_lossy())
+    let pattern = glob_pattern(&root, "**/*.messages.json");
+    let mut files = glob::glob(&pattern)
         .into_iter()
         .flatten()
         .flatten()

--- a/src/source/cline_extension.rs
+++ b/src/source/cline_extension.rs
@@ -1,5 +1,7 @@
 //! Shared parser for Cline-family VS Code extension task logs.
 
+use crate::utils::glob_pattern;
+use crate::utils::paths as dirs;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -132,8 +134,8 @@ fn extension_task_roots(extension_id: &str) -> Vec<PathBuf> {
 pub(super) fn find_extension_files(extension_id: &str) -> Vec<PathBuf> {
     let mut files = Vec::new();
     for root in extension_task_roots(extension_id) {
-        let pattern = root.join("*").join("ui_messages.json");
-        if let Ok(matches) = glob::glob(&pattern.to_string_lossy()) {
+        let pattern = glob_pattern(&root, "*/ui_messages.json");
+        if let Ok(matches) = glob::glob(&pattern) {
             files.extend(matches.flatten().filter(|path| path.is_file()));
         }
     }

--- a/src/source/codex/cache.rs
+++ b/src/source/codex/cache.rs
@@ -1,11 +1,18 @@
 //! Reusable usage facts. Source JSONL files remain authoritative.
 
+use crate::utils::paths as dirs;
 use std::error::Error;
 use std::fs;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::time::Duration;
+#[cfg(windows)]
+use std::{fs::File, os::windows::io::AsRawHandle};
+#[cfg(windows)]
+use windows_sys::Win32::Storage::FileSystem::{
+    FILE_BASIC_INFO, FileBasicInfo, GetFileInformationByHandleEx,
+};
 
 use chrono::{DateTime, NaiveDate, Utc};
 use rusqlite::{Connection, OptionalExtension, params};
@@ -117,10 +124,30 @@ fn fingerprint(path: &Path) -> CacheResult<String> {
             metadata.ctime_nsec()
         )?;
     }
-    #[cfg(not(unix))]
+    #[cfg(not(any(unix, windows)))]
     {
         use std::fmt::Write;
         write!(stamp, ":{:?}", metadata.created()?)?;
+    }
+    #[cfg(windows)]
+    {
+        use std::fmt::Write;
+        let file = File::open(path)?;
+        let mut info = FILE_BASIC_INFO::default();
+        // SAFETY: file owns a live handle and info is the correctly sized, writable
+        // buffer for FileBasicInfo. The API does not retain either pointer.
+        let success = unsafe {
+            GetFileInformationByHandleEx(
+                file.as_raw_handle(),
+                FileBasicInfo,
+                std::ptr::from_mut(&mut info).cast(),
+                u32::try_from(std::mem::size_of::<FILE_BASIC_INFO>())?,
+            )
+        };
+        if success == 0 {
+            return Err(std::io::Error::last_os_error().into());
+        }
+        write!(stamp, ":{}:{}", info.CreationTime, info.ChangeTime)?;
     }
     Ok(stamp)
 }

--- a/src/source/codex/cache_tests.rs
+++ b/src/source/codex/cache_tests.rs
@@ -221,13 +221,15 @@ fn append_rewrite_and_delete_invalidate_cached_records() {
     let old_time = fs::metadata(&path).unwrap().modified().unwrap();
     let text = fs::read_to_string(&path).unwrap().replace("50", "60");
     fs::write(&path, text).unwrap();
-    // Equal-length overwrite is detected even with restored mtime on Unix.
-    #[cfg(unix)]
-    fs::File::open(&path)
+    // Equal-length overwrite is detected even with restored mtime.
+    #[cfg(any(unix, windows))]
+    fs::OpenOptions::new()
+        .write(true)
+        .open(&path)
         .unwrap()
         .set_times(fs::FileTimes::new().set_modified(old_time))
         .unwrap();
-    #[cfg(not(unix))]
+    #[cfg(not(any(unix, windows)))]
     let _ = old_time;
     assert_eq!(
         parse(&cache, &path, &filter, utc())

--- a/src/source/codex/parser.rs
+++ b/src/source/codex/parser.rs
@@ -3,6 +3,8 @@
 //! Parses JSONL logs from active and archived directories under `~/.codex`.
 //! Codex log format uses cumulative token counts that need delta computation.
 
+use crate::utils::glob_pattern;
+use crate::utils::paths as dirs;
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
 use std::env;
@@ -192,7 +194,7 @@ fn find_codex_files_in_root(root: &Path) -> Vec<PathBuf> {
     let mut files = Vec::new();
     for subdir in [SESSION_SUBDIR, ARCHIVED_SESSION_SUBDIR] {
         let sessions_dir = root.join(subdir);
-        if let Ok(entries) = glob::glob(&format!("{}/**/*.jsonl", sessions_dir.display())) {
+        if let Ok(entries) = glob::glob(&glob_pattern(&sessions_dir, "**/*.jsonl")) {
             files.extend(entries.flatten().filter(|path| path.is_file()));
         }
     }

--- a/src/source/copilot.rs
+++ b/src/source/copilot.rs
@@ -1,5 +1,7 @@
 //! GitHub Copilot CLI OpenTelemetry JSONL usage source.
 
+use crate::utils::glob_pattern;
+use crate::utils::paths as dirs;
 use std::env;
 use std::fs;
 use std::io::{BufRead, BufReader};
@@ -76,8 +78,8 @@ fn find_copilot_files() -> Vec<PathBuf> {
     }
 
     if let Some(home) = dirs::home_dir() {
-        let pattern = home.join(".copilot/otel/**/*.jsonl");
-        if let Ok(matches) = glob::glob(&pattern.to_string_lossy()) {
+        let pattern = glob_pattern(&home, ".copilot/otel/**/*.jsonl");
+        if let Ok(matches) = glob::glob(&pattern) {
             files.extend(matches.flatten().filter(|path| path.is_file()));
         }
     }

--- a/src/source/dsh.rs
+++ b/src/source/dsh.rs
@@ -564,7 +564,7 @@ fn valid_header(header: &Header) -> bool {
         && header
             .cwd
             .as_deref()
-            .is_none_or(|cwd| Path::new(cwd).is_absolute())
+            .is_none_or(|cwd| cwd.starts_with('/') || Path::new(cwd).is_absolute())
 }
 
 fn replace_route(data: serde_json::Value, route: &mut Option<Route>) -> bool {

--- a/src/source/dsh.rs
+++ b/src/source/dsh.rs
@@ -1,5 +1,6 @@
 //! `DeepSeek` Harness durable session usage.
 
+use crate::utils::paths as dirs;
 use std::collections::{BTreeMap, BTreeSet};
 use std::env;
 use std::fs;
@@ -420,9 +421,7 @@ fn parse_log(bytes: &[u8], path: &Path, timezone: Timezone) -> ParseOutput {
         }
         match event.kind.as_str() {
             "request/header" => {
-                if !replace_route(event.data, &mut route) {
-                    output.errors += 1;
-                }
+                output.errors += usize::from(!replace_route(event.data, &mut route));
             }
             "assistant/chunk" => {
                 let Ok(data) = serde_json::from_value::<ChunkData>(event.data) else {

--- a/src/source/fx.rs
+++ b/src/source/fx.rs
@@ -1,4 +1,5 @@
 //! Vercel Fx profile usage ledger and bounded recovery registry.
+use crate::utils::paths as dirs;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/src/source/gemini.rs
+++ b/src/source/gemini.rs
@@ -1,5 +1,7 @@
 //! Gemini CLI local usage source.
 
+use crate::utils::glob_pattern;
+use crate::utils::paths as dirs;
 use std::collections::HashMap;
 use std::env;
 use std::fs;
@@ -77,12 +79,12 @@ fn find_gemini_files() -> Vec<PathBuf> {
     }
 
     let patterns = [
-        tmp.join("*").join("chats").join("*.json"),
-        tmp.join("**").join("*.jsonl"),
+        glob_pattern(&tmp, "*/chats/*.json"),
+        glob_pattern(&tmp, "**/*.jsonl"),
     ];
     let mut files = Vec::new();
     for pattern in patterns {
-        if let Ok(matches) = glob::glob(&pattern.to_string_lossy()) {
+        if let Ok(matches) = glob::glob(&pattern) {
             files.extend(matches.flatten().filter(|path| path.is_file()));
         }
     }

--- a/src/source/goose.rs
+++ b/src/source/goose.rs
@@ -1,5 +1,6 @@
 //! Goose per-call usage ledger source.
 
+use crate::utils::paths as dirs;
 use std::env;
 use std::path::{Path, PathBuf};
 

--- a/src/source/grok/parser.rs
+++ b/src/source/grok/parser.rs
@@ -5,6 +5,8 @@
 //! session has no such events, this parser falls back to `signals.json`
 //! context-token snapshots and labels them `estimated_proxy`.
 
+use crate::utils::glob_pattern;
+use crate::utils::paths as dirs;
 use std::collections::HashMap;
 use std::env;
 use std::fs;
@@ -119,7 +121,7 @@ fn collect_session_files(
     by_session: &mut HashMap<PathBuf, PathBuf>,
     preference: FilePreference,
 ) {
-    let pattern = format!("{}/**/{file_name}", sessions_dir.display());
+    let pattern = glob_pattern(sessions_dir, &format!("**/{file_name}"));
     let Ok(entries) = glob::glob(&pattern) else {
         return;
     };

--- a/src/source/grok/unified.rs
+++ b/src/source/grok/unified.rs
@@ -4,6 +4,8 @@
 //! merges every inference record into an atomic, source-root-scoped
 //! ledger under the platform application-data directory.
 
+use crate::utils::glob_pattern;
+use crate::utils::paths as dirs;
 use std::collections::{BTreeMap, HashMap, hash_map::DefaultHasher};
 use std::env;
 use std::fs::{self, File, OpenOptions};
@@ -330,7 +332,7 @@ pub(super) fn read_inference_records(
 }
 
 fn load_session_metadata(sessions_root: &Path) -> HashMap<String, SessionMetadata> {
-    let pattern = format!("{}/**/summary.json", sessions_root.display());
+    let pattern = glob_pattern(sessions_root, "**/summary.json");
     let Ok(paths) = glob::glob(&pattern) else {
         return HashMap::new();
     };

--- a/src/source/hermes.rs
+++ b/src/source/hermes.rs
@@ -1,5 +1,6 @@
 //! Hermes Agent current `SQLite` usage ledger source.
 
+use crate::utils::paths as dirs;
 use std::collections::HashMap;
 use std::env;
 use std::path::{Path, PathBuf};

--- a/src/source/kimi/parser.rs
+++ b/src/source/kimi/parser.rs
@@ -14,6 +14,8 @@
 //! Project paths come from `$KIMI_CODE_HOME/session_index.jsonl`
 //! (`sessionId` → `workDir`), falling back to the `<workDirKey>` slug.
 
+use crate::utils::glob_pattern;
+use crate::utils::paths as dirs;
 use std::collections::HashMap;
 use std::env;
 use std::fs;
@@ -83,10 +85,7 @@ pub(super) fn find_kimi_files() -> Vec<PathBuf> {
         return Vec::new();
     };
 
-    let pattern = format!(
-        "{}/**/{AGENTS_SUBDIR}/*/{WIRE_FILE}",
-        sessions_dir.display()
-    );
+    let pattern = glob_pattern(&sessions_dir, &format!("**/{AGENTS_SUBDIR}/*/{WIRE_FILE}"));
     let mut files = Vec::new();
     if let Ok(entries) = glob::glob(&pattern) {
         files.extend(entries.flatten().filter(|path| path.is_file()));
@@ -368,10 +367,7 @@ mod tests {
         if with_index {
             fs::write(
                 root.join(SESSION_INDEX_FILE),
-                format!(
-                    r#"{{"sessionId":"{session_id}","sessionDir":"{}","workDir":"/tmp/kimi-project"}}"#,
-                    session_dir.display()
-                ),
+                serde_json::json!({"sessionId": session_id, "sessionDir": session_dir, "workDir": "/tmp/kimi-project"}).to_string(),
             )
             .expect("write session index");
         }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -38,6 +38,7 @@ mod unsloth;
 mod xum;
 
 mod reasonix {
+    use crate::utils::paths as dirs;
     use std::env;
     use std::fs;
     use std::io::{BufRead, BufReader};

--- a/src/source/openclaw_store.rs
+++ b/src/source/openclaw_store.rs
@@ -1,5 +1,7 @@
 //! `OpenClaw` current transcript discovery and storage readers.
 
+use crate::utils::glob_pattern;
+use crate::utils::paths as dirs;
 use std::collections::BTreeMap;
 use std::env;
 use std::fs;
@@ -41,11 +43,11 @@ fn transcript_store_discovery() -> (Vec<PathBuf>, Option<PathBuf>) {
     };
     let mut paths = Vec::new();
     for pattern in [
-        root.join("agents/*/sessions/*"),
-        root.join("agents/*/agent/openclaw-agent.sqlite"),
+        glob_pattern(&root, "agents/*/sessions/*"),
+        glob_pattern(&root, "agents/*/agent/openclaw-agent.sqlite"),
     ] {
         paths.extend(
-            glob::glob(&pattern.to_string_lossy())
+            glob::glob(&pattern)
                 .into_iter()
                 .flatten()
                 .flatten()
@@ -232,9 +234,9 @@ fn configured_session_store_paths(store: &Path) -> Vec<PathBuf> {
         target.parent(),
         target.file_stem().and_then(|stem| stem.to_str()),
     ) {
-        let pattern = parent.join(format!("{stem}.*.sqlite"));
+        let pattern = glob_pattern(parent, &format!("{}.*.sqlite", glob::Pattern::escape(stem)));
         paths.extend(
-            glob::glob(&pattern.to_string_lossy())
+            glob::glob(&pattern)
                 .into_iter()
                 .flatten()
                 .flatten()

--- a/src/source/opencode.rs
+++ b/src/source/opencode.rs
@@ -1,5 +1,7 @@
 //! `OpenCode` local `SQLite` usage source.
 
+use crate::utils::glob_pattern;
+use crate::utils::paths as dirs;
 use std::env;
 use std::path::{Path, PathBuf};
 
@@ -165,8 +167,8 @@ fn find_opencode_databases() -> Vec<PathBuf> {
     let Some(data_dir) = opencode_data_dir() else {
         return Vec::new();
     };
-    let pattern = data_dir.join("opencode*.db");
-    let mut databases = glob::glob(&pattern.to_string_lossy())
+    let pattern = glob_pattern(&data_dir, "opencode*.db");
+    let mut databases = glob::glob(&pattern)
         .into_iter()
         .flatten()
         .flatten()
@@ -208,8 +210,8 @@ fn find_family_databases(
     };
     let mut databases = Vec::new();
     for pattern in patterns {
-        let pattern = data_dir.join(pattern);
-        if let Ok(matches) = glob::glob(&pattern.to_string_lossy()) {
+        let pattern = glob_pattern(&data_dir, pattern);
+        if let Ok(matches) = glob::glob(&pattern) {
             databases.extend(matches.flatten().filter(|path| path.is_file()));
         }
     }

--- a/src/source/opencode.rs
+++ b/src/source/opencode.rs
@@ -144,11 +144,23 @@ impl Source for KiloCliSource {
     }
 }
 
+fn opencode_data_root(
+    xdg_data_home: Option<PathBuf>,
+    platform_data_dir: Option<PathBuf>,
+) -> Option<PathBuf> {
+    xdg_data_home
+        .filter(|path| !path.as_os_str().is_empty() && path.is_absolute())
+        .or(platform_data_dir)
+        .map(|root| root.join("opencode"))
+}
+
 fn opencode_data_dir() -> Option<PathBuf> {
-    match env::var_os(XDG_DATA_HOME_ENV) {
-        Some(value) if !value.is_empty() => Some(PathBuf::from(value).join("opencode")),
-        Some(_) | None => dirs::data_dir().map(|path| path.join("opencode")),
-    }
+    opencode_data_root(
+        env::var_os(XDG_DATA_HOME_ENV)
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from),
+        dirs::data_dir(),
+    )
 }
 
 fn find_opencode_databases() -> Vec<PathBuf> {
@@ -702,6 +714,29 @@ fn parse_opencode_database(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn opencode_data_root_rejects_relative_xdg_override() {
+        let platform = if cfg!(windows) {
+            PathBuf::from(r"C:\Users\tester\AppData\Roaming")
+        } else {
+            PathBuf::from("/home/tester/.local/share")
+        };
+        let absolute_xdg = if cfg!(windows) {
+            PathBuf::from(r"C:\abs\xdg")
+        } else {
+            PathBuf::from("/abs/xdg")
+        };
+
+        assert_eq!(
+            opencode_data_root(Some(PathBuf::from("relative-xdg")), Some(platform.clone())),
+            Some(platform.join("opencode"))
+        );
+        assert_eq!(
+            opencode_data_root(Some(absolute_xdg.clone()), Some(platform)),
+            Some(absolute_xdg.join("opencode"))
+        );
+    }
 
     #[test]
     fn current_v2_message_preserves_independent_buckets_and_recorded_cost() {

--- a/src/source/pi_fork_paths.rs
+++ b/src/source/pi_fork_paths.rs
@@ -212,7 +212,7 @@ fn home_config_root(home: &Path, config: &Path) -> PathBuf {
 }
 
 fn platform_data_root(xdg_data_home: Option<PathBuf>, home: Option<PathBuf>) -> Option<PathBuf> {
-    xdg_data_home.or_else(|| {
+    xdg_data_home.filter(|path| path.is_absolute()).or_else(|| {
         let home = home?;
         if cfg!(target_os = "macos") {
             Some(home.join("Library/Application Support"))
@@ -459,5 +459,26 @@ mod tests {
         };
 
         assert_eq!(platform_data_root(None, Some(home)), expected);
+    }
+
+    #[test]
+    fn platform_data_root_rejects_relative_xdg_override() {
+        let home = PathBuf::from("/home/tester");
+        let expected = if cfg!(target_os = "macos") {
+            Some(home.join("Library/Application Support"))
+        } else if cfg!(target_os = "linux") {
+            Some(home.join(".local/share"))
+        } else {
+            None
+        };
+
+        assert_eq!(
+            platform_data_root(Some(PathBuf::from("relative-xdg")), Some(home.clone())),
+            expected
+        );
+        assert_eq!(
+            platform_data_root(Some(PathBuf::from("/abs/xdg")), Some(home)),
+            Some(PathBuf::from("/abs/xdg"))
+        );
     }
 }

--- a/src/source/pi_fork_paths.rs
+++ b/src/source/pi_fork_paths.rs
@@ -463,7 +463,11 @@ mod tests {
 
     #[test]
     fn platform_data_root_rejects_relative_xdg_override() {
-        let home = PathBuf::from("/home/tester");
+        let home = if cfg!(windows) {
+            PathBuf::from(r"C:\Users\tester")
+        } else {
+            PathBuf::from("/home/tester")
+        };
         let expected = if cfg!(target_os = "macos") {
             Some(home.join("Library/Application Support"))
         } else if cfg!(target_os = "linux") {
@@ -471,14 +475,19 @@ mod tests {
         } else {
             None
         };
+        let absolute_xdg = if cfg!(windows) {
+            PathBuf::from(r"C:\abs\xdg")
+        } else {
+            PathBuf::from("/abs/xdg")
+        };
 
         assert_eq!(
             platform_data_root(Some(PathBuf::from("relative-xdg")), Some(home.clone())),
             expected
         );
         assert_eq!(
-            platform_data_root(Some(PathBuf::from("/abs/xdg")), Some(home)),
-            Some(PathBuf::from("/abs/xdg"))
+            platform_data_root(Some(absolute_xdg.clone()), Some(home)),
+            Some(absolute_xdg)
         );
     }
 }

--- a/src/source/pi_fork_paths.rs
+++ b/src/source/pi_fork_paths.rs
@@ -225,9 +225,6 @@ fn platform_data_root(xdg_data_home: Option<PathBuf>, home: Option<PathBuf>) -> 
 }
 
 fn xdg_app_root(app: &str, suffix: &[&str]) -> Option<PathBuf> {
-    if !cfg!(any(target_os = "linux", target_os = "macos")) {
-        return None;
-    }
     let mut root = platform_data_root(env_path("XDG_DATA_HOME"), dirs::home_dir())?.join(app);
     for part in suffix {
         root.push(part);

--- a/src/source/pi_fork_paths.rs
+++ b/src/source/pi_fork_paths.rs
@@ -1,5 +1,7 @@
 //! Official session-root selection for Gajae Code, Prime Agent, and Oh My Pi.
 
+use crate::utils::glob_pattern;
+use crate::utils::paths as dirs;
 use std::env;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
@@ -57,8 +59,11 @@ fn resolved_path(path: PathBuf) -> PathBuf {
 
 fn find_jsonl(root: &Path) -> Vec<PathBuf> {
     let mut files = Vec::new();
-    for pattern in [root.join("*.jsonl"), root.join("**").join("*.jsonl")] {
-        if let Ok(matches) = glob::glob(&pattern.to_string_lossy()) {
+    for pattern in [
+        glob_pattern(root, "*.jsonl"),
+        glob_pattern(root, "**/*.jsonl"),
+    ] {
+        if let Ok(matches) = glob::glob(&pattern) {
             files.extend(matches.flatten().filter(|path| path.is_file()));
         }
     }

--- a/src/source/pi_paths.rs
+++ b/src/source/pi_paths.rs
@@ -1,5 +1,7 @@
 //! Session discovery for Pi-family sources.
 
+use crate::utils::glob_pattern;
+use crate::utils::paths as dirs;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -123,10 +125,13 @@ fn senpi_sessions_dir() -> Result<PathBuf, PathBuf> {
 }
 
 fn find_family_files(root: &Path) -> Vec<PathBuf> {
-    let patterns = [root.join("*.jsonl"), root.join("**").join("*.jsonl")];
+    let patterns = [
+        glob_pattern(root, "*.jsonl"),
+        glob_pattern(root, "**/*.jsonl"),
+    ];
     let mut files = Vec::new();
     for pattern in patterns {
-        if let Ok(matches) = glob::glob(&pattern.to_string_lossy()) {
+        if let Ok(matches) = glob::glob(&pattern) {
             files.extend(matches.flatten().filter(|path| path.is_file()));
         }
     }

--- a/src/source/qwen.rs
+++ b/src/source/qwen.rs
@@ -1,5 +1,7 @@
 //! Qwen Code usage-ledger source.
 
+use crate::utils::glob_pattern;
+use crate::utils::paths as dirs;
 use std::env;
 use std::fs;
 use std::io::{BufRead, BufReader};
@@ -74,8 +76,8 @@ fn qwen_root() -> Option<PathBuf> {
 }
 
 fn find_qwen_files_in_root(root: &Path) -> Vec<PathBuf> {
-    let pattern = root.join("usage/token-usage-*.jsonl");
-    let mut files = glob::glob(&pattern.to_string_lossy())
+    let pattern = glob_pattern(root, "usage/token-usage-*.jsonl");
+    let mut files = glob::glob(&pattern)
         .into_iter()
         .flatten()
         .flatten()

--- a/src/source/unsloth.rs
+++ b/src/source/unsloth.rs
@@ -1,5 +1,6 @@
 //! Unsloth Studio's durable inference receipts.
 
+use crate::utils::paths as dirs;
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fmt::Write as _;

--- a/src/source/xum.rs
+++ b/src/source/xum.rs
@@ -1,5 +1,7 @@
 //! Xum cumulative session usage source.
 
+use crate::utils::glob_pattern;
+use crate::utils::paths as dirs;
 use std::collections::HashMap;
 use std::env;
 use std::fs;
@@ -66,8 +68,8 @@ fn find_usage_files() -> Vec<PathBuf> {
     let Some(root) = xum_root() else {
         return Vec::new();
     };
-    let pattern = root.join("sessions/*/session-usage.json");
-    let mut files = glob::glob(&pattern.to_string_lossy())
+    let pattern = glob_pattern(&root, "sessions/*/session-usage.json");
+    let mut files = glob::glob(&pattern)
         .into_iter()
         .flatten()
         .flatten()
@@ -168,8 +170,8 @@ fn rollup_disposition(path: &Path) -> RollupDisposition {
     let Some(sessions_dir) = path.parent().and_then(Path::parent) else {
         return RollupDisposition::Keep;
     };
-    let pattern = sessions_dir.join("*/session-usage.json");
-    let ledgers = glob::glob(&pattern.to_string_lossy())
+    let pattern = glob_pattern(sessions_dir, "*/session-usage.json");
+    let ledgers = glob::glob(&pattern)
         .into_iter()
         .flatten()
         .flatten()

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -5,3 +5,6 @@ mod timezone;
 pub(crate) use date::parse_date;
 pub(crate) use jq::filter_json;
 pub(crate) use timezone::Timezone;
+
+pub(crate) mod paths;
+pub(crate) use paths::glob_pattern;

--- a/src/utils/paths.rs
+++ b/src/utils/paths.rs
@@ -1,0 +1,60 @@
+//! Literal filesystem roots and portable directory overrides.
+use std::path::{Path, PathBuf};
+
+pub(crate) fn glob_pattern(root: &Path, suffix: &str) -> String {
+    format!(
+        "{}/{suffix}",
+        glob::Pattern::escape(&root.to_string_lossy())
+    )
+}
+
+pub(crate) fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(dirs::home_dir)
+}
+
+#[cfg(windows)]
+fn overridden_dir(variable: &str, suffix: &str) -> Option<PathBuf> {
+    std::env::var_os(variable)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("HOME")
+                .filter(|value| !value.is_empty())
+                .map(|home| PathBuf::from(home).join(suffix))
+        })
+}
+
+pub(crate) fn config_dir() -> Option<PathBuf> {
+    #[cfg(windows)]
+    if let Some(path) = overridden_dir("XDG_CONFIG_HOME", ".config") {
+        return Some(path);
+    }
+    dirs::config_dir()
+}
+
+pub(crate) fn data_dir() -> Option<PathBuf> {
+    #[cfg(windows)]
+    if let Some(path) = overridden_dir("XDG_DATA_HOME", ".local/share") {
+        return Some(path);
+    }
+    dirs::data_dir()
+}
+
+pub(crate) fn data_local_dir() -> Option<PathBuf> {
+    #[cfg(windows)]
+    if let Some(path) = overridden_dir("XDG_DATA_HOME", ".local/share") {
+        return Some(path);
+    }
+    dirs::data_local_dir()
+}
+
+pub(crate) fn cache_dir() -> Option<PathBuf> {
+    #[cfg(windows)]
+    if let Some(path) = overridden_dir("XDG_CACHE_HOME", ".cache") {
+        return Some(path);
+    }
+    dirs::cache_dir()
+}

--- a/src/utils/paths.rs
+++ b/src/utils/paths.rs
@@ -2,10 +2,31 @@
 use std::path::{Path, PathBuf};
 
 pub(crate) fn glob_pattern(root: &Path, suffix: &str) -> String {
-    format!(
-        "{}/{suffix}",
-        glob::Pattern::escape(&root.to_string_lossy())
-    )
+    let text = root.to_string_lossy();
+    #[cfg(windows)]
+    if let Some(std::path::Component::Prefix(prefix)) = root.components().next() {
+        // The prefix is a literal filesystem scope in glob, not a pattern.
+        // In particular, escaping the ? in \\?\ would corrupt canonical paths.
+        let prefix_text = prefix.as_os_str().to_string_lossy();
+        let scope = match prefix.kind() {
+            std::path::Prefix::VerbatimUNC(server, share) => {
+                // glob supports ordinary UNC scopes, but rejects verbatim UNC.
+                format!(
+                    r"\\{}\{}",
+                    server.to_string_lossy(),
+                    share.to_string_lossy()
+                )
+            }
+            _ => prefix_text.to_string(),
+        };
+        return format!(
+            "{}{}\\{}",
+            scope,
+            glob::Pattern::escape(&text[prefix_text.len()..]),
+            suffix.replace('/', r"\"),
+        );
+    }
+    format!("{}/{suffix}", glob::Pattern::escape(&text))
 }
 
 pub(crate) fn home_dir() -> Option<PathBuf> {

--- a/src/utils/paths.rs
+++ b/src/utils/paths.rs
@@ -29,28 +29,27 @@ pub(crate) fn glob_pattern(root: &Path, suffix: &str) -> String {
     format!("{}/{suffix}", glob::Pattern::escape(&text))
 }
 
+fn nonempty_env_path(variable: &str) -> Option<PathBuf> {
+    Some(PathBuf::from(
+        std::env::var_os(variable).filter(|value| !value.is_empty())?,
+    ))
+}
+
 pub(crate) fn home_dir() -> Option<PathBuf> {
-    std::env::var_os("HOME")
-        .filter(|value| !value.is_empty())
-        .map(PathBuf::from)
-        .or_else(dirs::home_dir)
+    let home = nonempty_env_path("HOME");
+    #[cfg(windows)]
+    let home = home.filter(|path| path.is_absolute());
+    home.or_else(dirs::home_dir)
 }
 
 #[cfg(windows)]
-fn overridden_dir(variable: &str, suffix: &str) -> Option<PathBuf> {
-    std::env::var_os(variable)
-        .filter(|value| !value.is_empty())
-        .map(PathBuf::from)
-        .or_else(|| {
-            std::env::var_os("HOME")
-                .filter(|value| !value.is_empty())
-                .map(|home| PathBuf::from(home).join(suffix))
-        })
+fn explicit_xdg(variable: &str) -> Option<PathBuf> {
+    nonempty_env_path(variable).filter(|path| path.is_absolute())
 }
 
 pub(crate) fn config_dir() -> Option<PathBuf> {
     #[cfg(windows)]
-    if let Some(path) = overridden_dir("XDG_CONFIG_HOME", ".config") {
+    if let Some(path) = explicit_xdg("XDG_CONFIG_HOME") {
         return Some(path);
     }
     dirs::config_dir()
@@ -58,7 +57,7 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 pub(crate) fn data_dir() -> Option<PathBuf> {
     #[cfg(windows)]
-    if let Some(path) = overridden_dir("XDG_DATA_HOME", ".local/share") {
+    if let Some(path) = explicit_xdg("XDG_DATA_HOME") {
         return Some(path);
     }
     dirs::data_dir()
@@ -66,7 +65,7 @@ pub(crate) fn data_dir() -> Option<PathBuf> {
 
 pub(crate) fn data_local_dir() -> Option<PathBuf> {
     #[cfg(windows)]
-    if let Some(path) = overridden_dir("XDG_DATA_HOME", ".local/share") {
+    if let Some(path) = explicit_xdg("XDG_DATA_HOME") {
         return Some(path);
     }
     dirs::data_local_dir()
@@ -74,7 +73,7 @@ pub(crate) fn data_local_dir() -> Option<PathBuf> {
 
 pub(crate) fn cache_dir() -> Option<PathBuf> {
     #[cfg(windows)]
-    if let Some(path) = overridden_dir("XDG_CACHE_HOME", ".cache") {
+    if let Some(path) = explicit_xdg("XDG_CACHE_HOME") {
         return Some(path);
     }
     dirs::cache_dir()

--- a/src/utils/paths.rs
+++ b/src/utils/paths.rs
@@ -42,13 +42,16 @@ pub(crate) fn home_dir() -> Option<PathBuf> {
     home.or_else(dirs::home_dir)
 }
 
-#[cfg(windows)]
 fn explicit_xdg(variable: &str) -> Option<PathBuf> {
     nonempty_env_path(variable).filter(|path| path.is_absolute())
 }
 
+/// True when `XDG_CONFIG_HOME` is a nonempty absolute override.
+pub(crate) fn has_explicit_xdg_config() -> bool {
+    explicit_xdg("XDG_CONFIG_HOME").is_some()
+}
+
 pub(crate) fn config_dir() -> Option<PathBuf> {
-    #[cfg(windows)]
     if let Some(path) = explicit_xdg("XDG_CONFIG_HOME") {
         return Some(path);
     }
@@ -56,7 +59,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 }
 
 pub(crate) fn data_dir() -> Option<PathBuf> {
-    #[cfg(windows)]
     if let Some(path) = explicit_xdg("XDG_DATA_HOME") {
         return Some(path);
     }
@@ -64,7 +66,6 @@ pub(crate) fn data_dir() -> Option<PathBuf> {
 }
 
 pub(crate) fn data_local_dir() -> Option<PathBuf> {
-    #[cfg(windows)]
     if let Some(path) = explicit_xdg("XDG_DATA_HOME") {
         return Some(path);
     }
@@ -72,7 +73,6 @@ pub(crate) fn data_local_dir() -> Option<PathBuf> {
 }
 
 pub(crate) fn cache_dir() -> Option<PathBuf> {
-    #[cfg(windows)]
     if let Some(path) = explicit_xdg("XDG_CACHE_HOME") {
         return Some(path);
     }

--- a/tests/cli_dsh.rs
+++ b/tests/cli_dsh.rs
@@ -745,7 +745,11 @@ fn dsh_rejects_malformed_or_mismatched_retry_boundaries_without_phantom_attempts
 #[test]
 fn dsh_enforces_storage_identity_and_logical_sequence_before_counting() {
     let root = unique_temp_dir("dsh-storage-integrity");
-    let home = root.join("[dsh]*home");
+    let home = root.join(if cfg!(windows) {
+        "[dsh]home"
+    } else {
+        "[dsh]*home"
+    });
     let mut missing_id = assistant_at(
         2,
         1,

--- a/tests/cli_kimi.rs
+++ b/tests/cli_kimi.rs
@@ -11,10 +11,7 @@ fn write_kimi_session(kimi_home: &Path) {
     let session_dir = kimi_home.join(KIMI_SESSION_DIR);
     write_file(
         &kimi_home.join("session_index.jsonl"),
-        &format!(
-            r#"{{"sessionId":"session-kimi-1","sessionDir":"{}","workDir":"/tmp/kimi-project"}}"#,
-            session_dir.display()
-        ),
+        &serde_json::json!({"sessionId": "session-kimi-1", "sessionDir": session_dir, "workDir": "/tmp/kimi-project"}).to_string(),
     );
     write_file(
         &session_dir.join("agents/main/wire.jsonl"),

--- a/tests/cli_login_cursor.rs
+++ b/tests/cli_login_cursor.rs
@@ -183,6 +183,81 @@ fn clear_removes_file_credentials_and_doctor_is_missing() {
     let _ = fs::remove_dir_all(root);
 }
 
+#[cfg(windows)]
+#[test]
+fn home_without_xdg_reads_and_updates_existing_appdata_credentials() {
+    use common::{RestoredFile, lock_appdata, run_ccstats_with_isolation};
+
+    let _lock = lock_appdata();
+    let home = unique_temp_dir("appdata-cred-home");
+    let appdata_credentials = dirs::config_dir()
+        .expect("platform config directory")
+        .join("ccstats")
+        .join("credentials.toml");
+    assert_ne!(
+        credentials_path(&home),
+        appdata_credentials,
+        "isolated HOME must not be the native credentials path"
+    );
+    let _guard = RestoredFile::overwrite(
+        &appdata_credentials,
+        "[cursor]\napi_key = \"appdata-upgrade-key-179\"\n",
+    );
+
+    let (ok, stdout, stderr) = run_ccstats_with_isolation(
+        &["login", "cursor", "--check"],
+        &[("HOME", home.as_path())],
+        false,
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let check = format!(
+        "{}{}",
+        String::from_utf8_lossy(&stdout),
+        String::from_utf8_lossy(&stderr)
+    );
+    assert!(
+        check.contains("file"),
+        "expected AppData credentials: {check}"
+    );
+    assert_no_secret(&stdout, &stderr, "appdata-upgrade-key-179");
+
+    let posix_home = Path::new("/c/Users/not-a-windows-home");
+    let (ok, stdout, stderr) = run_ccstats_with_isolation(
+        &["login", "cursor", "--check"],
+        &[("HOME", posix_home)],
+        false,
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let check = format!(
+        "{}{}",
+        String::from_utf8_lossy(&stdout),
+        String::from_utf8_lossy(&stderr)
+    );
+    assert!(
+        check.contains("file"),
+        "non-absolute HOME must still read AppData credentials: {check}"
+    );
+
+    let (ok, stdout, stderr) = run_ccstats_with_isolation(
+        &["login", "cursor", "--api-key", "appdata-updated-key-179"],
+        &[("HOME", home.as_path())],
+        false,
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    assert_no_secret(&stdout, &stderr, "appdata-updated-key-179");
+    let written = fs::read_to_string(&appdata_credentials).expect("updated AppData credentials");
+    assert!(
+        written.contains("appdata-updated-key-179"),
+        "update must keep the existing AppData file: {written}"
+    );
+    assert!(
+        !credentials_path(&home).exists(),
+        "update must not create HOME/.config credentials"
+    );
+
+    let _ = fs::remove_dir_all(home);
+}
+
 #[test]
 fn no_flags_non_tty_exit_1() {
     let root = unique_temp_dir("login-cursor-nontty");

--- a/tests/cli_login_cursor.rs
+++ b/tests/cli_login_cursor.rs
@@ -12,7 +12,8 @@ const FILE_TOKEN: &str = "file-token-must-not-leak-167";
 const ENV_TOKEN: &str = "env-token-must-not-leak-167";
 
 fn credentials_path(root: &Path) -> PathBuf {
-    root.join(".config/ccstats/credentials.toml")
+    // run_isolated sets absolute XDG_CONFIG_HOME under root/xdg-config.
+    root.join("xdg-config/ccstats/credentials.toml")
 }
 
 fn run_isolated(root: &Path, args: &[&str]) -> (bool, Vec<u8>, Vec<u8>) {
@@ -185,28 +186,27 @@ fn clear_removes_file_credentials_and_doctor_is_missing() {
 
 #[cfg(windows)]
 #[test]
-fn home_without_xdg_reads_and_updates_existing_appdata_credentials() {
-    use common::{RestoredFile, lock_appdata, run_ccstats_with_isolation};
+fn home_without_xdg_still_searches_platform_credentials_path() {
+    use common::run_ccstats_with_isolation;
 
-    let _lock = lock_appdata();
     let home = unique_temp_dir("appdata-cred-home");
-    let appdata_credentials = dirs::config_dir()
-        .expect("platform config directory")
-        .join("ccstats")
-        .join("credentials.toml");
-    assert_ne!(
-        credentials_path(&home),
-        appdata_credentials,
-        "isolated HOME must not be the native credentials path"
-    );
-    let _guard = RestoredFile::overwrite(
-        &appdata_credentials,
-        "[cursor]\napi_key = \"appdata-upgrade-key-179\"\n",
-    );
+    let platform = unique_temp_dir("appdata-cred-platform");
+    let platform_credentials = platform.join("ccstats").join("credentials.toml");
+    fs::create_dir_all(platform_credentials.parent().unwrap()).unwrap();
+    fs::write(
+        &platform_credentials,
+        "[cursor]\napi_key = \"platform-upgrade-key-179\"\n",
+    )
+    .unwrap();
 
+    // Absolute XDG_CONFIG_HOME stands in for the native config root without
+    // touching the developer's real AppData credentials file.
     let (ok, stdout, stderr) = run_ccstats_with_isolation(
         &["login", "cursor", "--check"],
-        &[("HOME", home.as_path())],
+        &[
+            ("HOME", home.as_path()),
+            ("XDG_CONFIG_HOME", platform.as_path()),
+        ],
         false,
     );
     assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
@@ -217,45 +217,32 @@ fn home_without_xdg_reads_and_updates_existing_appdata_credentials() {
     );
     assert!(
         check.contains("file"),
-        "expected AppData credentials: {check}"
+        "expected platform credentials: {check}"
     );
-    assert_no_secret(&stdout, &stderr, "appdata-upgrade-key-179");
+    assert_no_secret(&stdout, &stderr, "platform-upgrade-key-179");
 
-    let posix_home = Path::new("/c/Users/not-a-windows-home");
     let (ok, stdout, stderr) = run_ccstats_with_isolation(
-        &["login", "cursor", "--check"],
-        &[("HOME", posix_home)],
+        &["login", "cursor", "--api-key", "platform-updated-key-179"],
+        &[
+            ("HOME", home.as_path()),
+            ("XDG_CONFIG_HOME", platform.as_path()),
+        ],
         false,
     );
     assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
-    let check = format!(
-        "{}{}",
-        String::from_utf8_lossy(&stdout),
-        String::from_utf8_lossy(&stderr)
+    assert_no_secret(&stdout, &stderr, "platform-updated-key-179");
+    let written = fs::read_to_string(&platform_credentials).expect("updated platform credentials");
+    assert!(
+        written.contains("platform-updated-key-179"),
+        "update must keep the existing platform file: {written}"
     );
     assert!(
-        check.contains("file"),
-        "non-absolute HOME must still read AppData credentials: {check}"
-    );
-
-    let (ok, stdout, stderr) = run_ccstats_with_isolation(
-        &["login", "cursor", "--api-key", "appdata-updated-key-179"],
-        &[("HOME", home.as_path())],
-        false,
-    );
-    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
-    assert_no_secret(&stdout, &stderr, "appdata-updated-key-179");
-    let written = fs::read_to_string(&appdata_credentials).expect("updated AppData credentials");
-    assert!(
-        written.contains("appdata-updated-key-179"),
-        "update must keep the existing AppData file: {written}"
-    );
-    assert!(
-        !credentials_path(&home).exists(),
+        !home.join(".config/ccstats/credentials.toml").exists(),
         "update must not create HOME/.config credentials"
     );
 
     let _ = fs::remove_dir_all(home);
+    let _ = fs::remove_dir_all(platform);
 }
 
 #[test]

--- a/tests/cli_openclaw_xum_hermes.rs
+++ b/tests/cli_openclaw_xum_hermes.rs
@@ -345,9 +345,9 @@ fn openclaw_reads_current_sqlite_and_counted_zstd_archives() {
     write_file(
         &state.join("openclaw.json"),
         &format!(
-            "{{ session: {{ store: '{}' }}, agents: {{ list: [{{ id: 'worker', agentDir: '{}' }}] }} }}",
-            database.display(),
-            worker_dir.display()
+            "{{ session: {{ store: {} }}, agents: {{ list: [{{ id: 'worker', agentDir: {} }}] }} }}",
+            serde_json::to_string(&database).unwrap(),
+            serde_json::to_string(&worker_dir).unwrap()
         ),
     );
 
@@ -405,7 +405,10 @@ fn openclaw_resolves_logical_and_templated_config_stores() {
     );
     write_file(
         &state.join("openclaw.json"),
-        &format!("{{ session: {{ store: '{}' }} }}", logical.display()),
+        &format!(
+            "{{ session: {{ store: {} }} }}",
+            serde_json::to_string(&logical).unwrap()
+        ),
     );
     let envs = [
         ("OPENCLAW_STATE_DIR", state.as_path()),
@@ -433,8 +436,8 @@ fn openclaw_resolves_logical_and_templated_config_stores() {
     write_file(
         &state.join("openclaw.json"),
         &format!(
-            "{{ session: {{ store: '{}' }}, agents: {{ list: [{{ id: 'worker' }}] }} }}",
-            template.display()
+            "{{ session: {{ store: {} }}, agents: {{ list: [{{ id: 'worker' }}] }} }}",
+            serde_json::to_string(&template).unwrap()
         ),
     );
     let template_json = daily_json("openclaw", &envs);

--- a/tests/cli_path_discovery.rs
+++ b/tests/cli_path_discovery.rs
@@ -34,7 +34,7 @@ fn home_override_discovers_logs_and_config_in_literal_unicode_directory() {
         for source in ["claude", "codex"] {
             let (ok, stdout, stderr) = run_ccstats(
                 &["daily", "--source", source, "--json", "--timezone", "UTC"],
-                &[("HOME", &home)],
+                &[("HOME", home)],
             );
             assert!(ok, "{}", String::from_utf8_lossy(&stderr));
             let rows: Value = serde_json::from_slice(&stdout).expect("JSON daily report");

--- a/tests/cli_path_discovery.rs
+++ b/tests/cli_path_discovery.rs
@@ -1,0 +1,49 @@
+mod common;
+
+use common::{run_ccstats, unique_temp_dir, write_file};
+use serde_json::{Value, json};
+
+#[test]
+fn home_override_discovers_logs_and_config_in_literal_unicode_directory() {
+    let temp = unique_temp_dir("literal-home");
+    let home = temp.join("中文 空格 [demo]");
+    write_file(
+        &home.join(".config/ccstats/config.toml"),
+        "no_cost = true\noffline = true\n",
+    );
+    write_file(
+        &home.join(".claude/projects/project/session.jsonl"),
+        &json!({"timestamp":"2026-09-07T00:00:00Z","message":{
+            "id":"claude-path-test","model":"claude-3-5-sonnet-20241022",
+            "stop_reason":"end_turn","usage":{"input_tokens":100,"output_tokens":5}
+        }})
+        .to_string(),
+    );
+    let rows = [
+        json!({"type":"session_meta","payload":{"id":"codex-path-test","cwd":r"C:\work\项目","source":"cli"}}),
+        json!({"type":"turn_context","payload":{"cwd":r"C:\work\项目","model":"gpt-5"}}),
+        json!({"timestamp":"2026-09-07T00:00:00Z","type":"event_msg","payload":{
+            "type":"token_count","info":{"total_token_usage":{"input_tokens":100,"output_tokens":5}}
+        }}),
+    ];
+    write_file(
+        &home.join(".codex/sessions/session.jsonl"),
+        &rows.map(|row| row.to_string()).join("\r\n"),
+    );
+    for source in ["claude", "codex"] {
+        let (ok, stdout, stderr) = run_ccstats(
+            &["daily", "--source", source, "--json", "--timezone", "UTC"],
+            &[("HOME", &home)],
+        );
+        assert!(ok, "{}", String::from_utf8_lossy(&stderr));
+        let rows: Value = serde_json::from_slice(&stdout).expect("JSON daily report");
+        assert_eq!(rows.as_array().unwrap().len(), 1, "{source}: {rows}");
+        assert_eq!(rows[0]["total_tokens"], 105, "{source}: {rows}");
+        assert_eq!(rows[0]["data_quality"]["parse_errors"], 0);
+        assert!(
+            rows[0].get("cost").is_none(),
+            "HOME config must hide costs: {rows}"
+        );
+    }
+    std::fs::remove_dir_all(temp).unwrap();
+}

--- a/tests/cli_path_discovery.rs
+++ b/tests/cli_path_discovery.rs
@@ -30,20 +30,22 @@ fn home_override_discovers_logs_and_config_in_literal_unicode_directory() {
         &home.join(".codex/sessions/session.jsonl"),
         &rows.map(|row| row.to_string()).join("\r\n"),
     );
-    for source in ["claude", "codex"] {
-        let (ok, stdout, stderr) = run_ccstats(
-            &["daily", "--source", source, "--json", "--timezone", "UTC"],
-            &[("HOME", &home)],
-        );
-        assert!(ok, "{}", String::from_utf8_lossy(&stderr));
-        let rows: Value = serde_json::from_slice(&stdout).expect("JSON daily report");
-        assert_eq!(rows.as_array().unwrap().len(), 1, "{source}: {rows}");
-        assert_eq!(rows[0]["total_tokens"], 105, "{source}: {rows}");
-        assert_eq!(rows[0]["data_quality"]["parse_errors"], 0);
-        assert!(
-            rows[0].get("cost").is_none(),
-            "HOME config must hide costs: {rows}"
-        );
+    for home in [&home, &home.canonicalize().unwrap()] {
+        for source in ["claude", "codex"] {
+            let (ok, stdout, stderr) = run_ccstats(
+                &["daily", "--source", source, "--json", "--timezone", "UTC"],
+                &[("HOME", &home)],
+            );
+            assert!(ok, "{}", String::from_utf8_lossy(&stderr));
+            let rows: Value = serde_json::from_slice(&stdout).expect("JSON daily report");
+            assert_eq!(rows.as_array().unwrap().len(), 1, "{source}: {rows}");
+            assert_eq!(rows[0]["total_tokens"], 105, "{source}: {rows}");
+            assert_eq!(rows[0]["data_quality"]["parse_errors"], 0);
+            assert!(
+                rows[0].get("cost").is_none(),
+                "HOME config must hide costs: {rows}"
+            );
+        }
     }
     std::fs::remove_dir_all(temp).unwrap();
 }

--- a/tests/cli_path_discovery.rs
+++ b/tests/cli_path_discovery.rs
@@ -1,12 +1,10 @@
 mod common;
 
 #[cfg(windows)]
-use common::{RestoredFile, lock_appdata, run_ccstats_with_isolation};
+use common::run_ccstats_with_isolation;
 use common::{run_ccstats, unique_temp_dir, write_file};
 use serde_json::{Value, json};
 use std::path::Path;
-#[cfg(windows)]
-use std::path::PathBuf;
 
 fn write_claude_session(home: &Path) {
     write_file(
@@ -17,14 +15,6 @@ fn write_claude_session(home: &Path) {
         }})
         .to_string(),
     );
-}
-
-#[cfg(windows)]
-fn platform_config_file(name: &str) -> PathBuf {
-    dirs::config_dir()
-        .expect("platform config directory")
-        .join("ccstats")
-        .join(name)
 }
 
 fn assert_hidden_cost_row(stdout: &[u8], source: &str) {
@@ -82,26 +72,41 @@ fn home_override_discovers_logs_and_config_in_literal_unicode_directory() {
 #[cfg(windows)]
 #[test]
 fn home_without_xdg_loads_existing_appdata_config() {
-    let _lock = lock_appdata();
     let home = unique_temp_dir("appdata-config-home");
     write_claude_session(&home);
-    let appdata_config = platform_config_file("config.toml");
+    let platform = unique_temp_dir("appdata-config-platform");
+    write_file(
+        &platform.join("ccstats/config.toml"),
+        "no_cost = true\noffline = true\n",
+    );
     assert_ne!(
         home.join(".config"),
-        appdata_config.parent().unwrap().parent().unwrap(),
-        "isolated HOME must not be the native config root"
+        platform,
+        "isolated HOME must not be the platform config root"
     );
-    let _guard = RestoredFile::overwrite(&appdata_config, "no_cost = true\noffline = true\n");
+
+    // Absolute XDG_CONFIG_HOME stands in for the native config root without
+    // touching the developer's real AppData config file.
     let (ok, stdout, stderr) = run_ccstats_with_isolation(
         &["daily", "--source", "claude", "--json", "--timezone", "UTC"],
-        &[("HOME", home.as_path())],
+        &[
+            ("HOME", home.as_path()),
+            ("XDG_CONFIG_HOME", platform.as_path()),
+        ],
         false,
     );
     assert!(ok, "{}", String::from_utf8_lossy(&stderr));
     assert_hidden_cost_row(&stdout, "claude");
     assert!(
         !home.join(".config/ccstats/config.toml").exists(),
-        "AppData config must be used without copying into HOME"
+        "platform config must be used without copying into HOME"
+    );
+
+    // Relative XDG_CONFIG_HOME is rejected; load from HOME/.config instead of
+    // writing the developer's live AppData config.
+    write_file(
+        &home.join(".config/ccstats/config.toml"),
+        "no_cost = true\noffline = true\n",
     );
     let relative_xdg = Path::new(".relative-xdg");
     let (ok, stdout, stderr) = run_ccstats_with_isolation(
@@ -111,5 +116,10 @@ fn home_without_xdg_loads_existing_appdata_config() {
     );
     assert!(ok, "{}", String::from_utf8_lossy(&stderr));
     assert_hidden_cost_row(&stdout, "claude");
+    assert!(
+        !home.join(".relative-xdg").exists(),
+        "relative XDG_CONFIG_HOME must not become a config root"
+    );
     std::fs::remove_dir_all(home).unwrap();
+    std::fs::remove_dir_all(platform).unwrap();
 }

--- a/tests/cli_path_discovery.rs
+++ b/tests/cli_path_discovery.rs
@@ -1,16 +1,14 @@
 mod common;
 
+#[cfg(windows)]
+use common::{RestoredFile, lock_appdata, run_ccstats_with_isolation};
 use common::{run_ccstats, unique_temp_dir, write_file};
 use serde_json::{Value, json};
+use std::path::Path;
+#[cfg(windows)]
+use std::path::PathBuf;
 
-#[test]
-fn home_override_discovers_logs_and_config_in_literal_unicode_directory() {
-    let temp = unique_temp_dir("literal-home");
-    let home = temp.join("中文 空格 [demo]");
-    write_file(
-        &home.join(".config/ccstats/config.toml"),
-        "no_cost = true\noffline = true\n",
-    );
+fn write_claude_session(home: &Path) {
     write_file(
         &home.join(".claude/projects/project/session.jsonl"),
         &json!({"timestamp":"2026-09-07T00:00:00Z","message":{
@@ -19,6 +17,39 @@ fn home_override_discovers_logs_and_config_in_literal_unicode_directory() {
         }})
         .to_string(),
     );
+}
+
+#[cfg(windows)]
+fn platform_config_file(name: &str) -> PathBuf {
+    dirs::config_dir()
+        .expect("platform config directory")
+        .join("ccstats")
+        .join(name)
+}
+
+fn assert_hidden_cost_row(stdout: &[u8], source: &str) {
+    let rows: Value = serde_json::from_slice(stdout).expect("JSON daily report");
+    assert_eq!(rows.as_array().unwrap().len(), 1, "{source}: {rows}");
+    assert_eq!(rows[0]["total_tokens"], 105, "{source}: {rows}");
+    assert_eq!(rows[0]["data_quality"]["parse_errors"], 0);
+    assert!(
+        rows[0].get("cost").is_none(),
+        "config must hide costs: {rows}"
+    );
+}
+
+#[test]
+fn home_override_discovers_logs_and_config_in_literal_unicode_directory() {
+    let temp = unique_temp_dir("literal-home");
+    let home = temp.join("中文 空格 [demo]");
+    let xdg_config = home.join(".config");
+    let xdg_data = home.join(".local/share");
+    let xdg_cache = home.join(".cache");
+    write_file(
+        &xdg_config.join("ccstats/config.toml"),
+        "no_cost = true\noffline = true\n",
+    );
+    write_claude_session(&home);
     let rows = [
         json!({"type":"session_meta","payload":{"id":"codex-path-test","cwd":r"C:\work\项目","source":"cli"}}),
         json!({"type":"turn_context","payload":{"cwd":r"C:\work\项目","model":"gpt-5"}}),
@@ -34,18 +65,51 @@ fn home_override_discovers_logs_and_config_in_literal_unicode_directory() {
         for source in ["claude", "codex"] {
             let (ok, stdout, stderr) = run_ccstats(
                 &["daily", "--source", source, "--json", "--timezone", "UTC"],
-                &[("HOME", home)],
+                &[
+                    ("HOME", home),
+                    ("XDG_CONFIG_HOME", &xdg_config),
+                    ("XDG_DATA_HOME", &xdg_data),
+                    ("XDG_CACHE_HOME", &xdg_cache),
+                ],
             );
             assert!(ok, "{}", String::from_utf8_lossy(&stderr));
-            let rows: Value = serde_json::from_slice(&stdout).expect("JSON daily report");
-            assert_eq!(rows.as_array().unwrap().len(), 1, "{source}: {rows}");
-            assert_eq!(rows[0]["total_tokens"], 105, "{source}: {rows}");
-            assert_eq!(rows[0]["data_quality"]["parse_errors"], 0);
-            assert!(
-                rows[0].get("cost").is_none(),
-                "HOME config must hide costs: {rows}"
-            );
+            assert_hidden_cost_row(&stdout, source);
         }
     }
     std::fs::remove_dir_all(temp).unwrap();
+}
+
+#[cfg(windows)]
+#[test]
+fn home_without_xdg_loads_existing_appdata_config() {
+    let _lock = lock_appdata();
+    let home = unique_temp_dir("appdata-config-home");
+    write_claude_session(&home);
+    let appdata_config = platform_config_file("config.toml");
+    assert_ne!(
+        home.join(".config"),
+        appdata_config.parent().unwrap().parent().unwrap(),
+        "isolated HOME must not be the native config root"
+    );
+    let _guard = RestoredFile::overwrite(&appdata_config, "no_cost = true\noffline = true\n");
+    let (ok, stdout, stderr) = run_ccstats_with_isolation(
+        &["daily", "--source", "claude", "--json", "--timezone", "UTC"],
+        &[("HOME", home.as_path())],
+        false,
+    );
+    assert!(ok, "{}", String::from_utf8_lossy(&stderr));
+    assert_hidden_cost_row(&stdout, "claude");
+    assert!(
+        !home.join(".config/ccstats/config.toml").exists(),
+        "AppData config must be used without copying into HOME"
+    );
+    let relative_xdg = Path::new(".relative-xdg");
+    let (ok, stdout, stderr) = run_ccstats_with_isolation(
+        &["daily", "--source", "claude", "--json", "--timezone", "UTC"],
+        &[("HOME", home.as_path()), ("XDG_CONFIG_HOME", relative_xdg)],
+        false,
+    );
+    assert!(ok, "{}", String::from_utf8_lossy(&stderr));
+    assert_hidden_cost_row(&stdout, "claude");
+    std::fs::remove_dir_all(home).unwrap();
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,8 @@
 use std::fs;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::{Mutex, MutexGuard};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const SOURCE_ENV_VARS: &[&str] = &[
@@ -103,10 +105,32 @@ fn resolve_ccstats_binary() -> PathBuf {
 }
 
 pub(crate) fn run_ccstats(args: &[&str], envs: &[(&str, &Path)]) -> (bool, Vec<u8>, Vec<u8>) {
+    run_ccstats_with_isolation(args, envs, true)
+}
+
+#[allow(dead_code)]
+pub(crate) fn run_ccstats_with_isolation(
+    args: &[&str],
+    envs: &[(&str, &Path)],
+    isolate_unset_xdg: bool,
+) -> (bool, Vec<u8>, Vec<u8>) {
     let mut cmd = Command::new(resolve_ccstats_binary());
     cmd.args(args);
     for key in SOURCE_ENV_VARS {
         cmd.env_remove(key);
+    }
+    let isolation_root = isolate_unset_xdg.then(|| unique_temp_dir("test-xdg"));
+    if let Some(root) = isolation_root.as_ref() {
+        let has = |name: &str| envs.iter().any(|(key, _)| *key == name);
+        if !has("XDG_CONFIG_HOME") {
+            cmd.env("XDG_CONFIG_HOME", root.join("config"));
+        }
+        if !has("XDG_DATA_HOME") {
+            cmd.env("XDG_DATA_HOME", root.join("data"));
+        }
+        if !has("XDG_CACHE_HOME") {
+            cmd.env("XDG_CACHE_HOME", root.join("cache"));
+        }
     }
     for (k, v) in envs {
         if *k == "CCSTATS_TEST_CWD" {
@@ -117,4 +141,52 @@ pub(crate) fn run_ccstats(args: &[&str], envs: &[(&str, &Path)]) -> (bool, Vec<u
     }
     let output = cmd.output().expect("run ccstats");
     (output.status.success(), output.stdout, output.stderr)
+}
+
+#[allow(dead_code)]
+pub(crate) fn lock_appdata() -> MutexGuard<'static, ()> {
+    static LOCK: Mutex<()> = Mutex::new(());
+    LOCK.lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+#[allow(dead_code)]
+pub(crate) struct RestoredFile {
+    #[allow(dead_code)]
+    path: PathBuf,
+    #[allow(dead_code)]
+    original: Option<Vec<u8>>,
+}
+
+impl RestoredFile {
+    #[allow(dead_code)]
+    pub(crate) fn overwrite(path: impl AsRef<Path>, contents: &str) -> Self {
+        let path = path.as_ref().to_path_buf();
+        let original = match fs::read(&path) {
+            Ok(bytes) => Some(bytes),
+            Err(error) if error.kind() == ErrorKind::NotFound => None,
+            Err(error) => panic!("read {}: {error}", path.display()),
+        };
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create parent dirs");
+        }
+        fs::write(&path, contents).expect("write restored file");
+        Self { path, original }
+    }
+}
+
+impl Drop for RestoredFile {
+    fn drop(&mut self) {
+        let result = match self.original.as_deref() {
+            Some(contents) => fs::write(&self.path, contents),
+            None => match fs::remove_file(&self.path) {
+                Ok(()) => Ok(()),
+                Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+                Err(error) => Err(error),
+            },
+        };
+        if let Err(error) = result {
+            eprintln!("failed to restore {}: {error}", self.path.display());
+        }
+    }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -42,6 +42,7 @@ const SOURCE_ENV_VARS: &[&str] = &[
     "XUM_ROOT",
     "XDG_CONFIG_HOME",
     "XDG_DATA_HOME",
+    "XDG_CACHE_HOME",
 ];
 
 pub(crate) fn unique_temp_dir(prefix: &str) -> PathBuf {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,8 +1,6 @@
 use std::fs;
-use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::{Mutex, MutexGuard};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const SOURCE_ENV_VARS: &[&str] = &[
@@ -141,52 +139,4 @@ pub(crate) fn run_ccstats_with_isolation(
     }
     let output = cmd.output().expect("run ccstats");
     (output.status.success(), output.stdout, output.stderr)
-}
-
-#[allow(dead_code)]
-pub(crate) fn lock_appdata() -> MutexGuard<'static, ()> {
-    static LOCK: Mutex<()> = Mutex::new(());
-    LOCK.lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-}
-
-#[allow(dead_code)]
-pub(crate) struct RestoredFile {
-    #[allow(dead_code)]
-    path: PathBuf,
-    #[allow(dead_code)]
-    original: Option<Vec<u8>>,
-}
-
-impl RestoredFile {
-    #[allow(dead_code)]
-    pub(crate) fn overwrite(path: impl AsRef<Path>, contents: &str) -> Self {
-        let path = path.as_ref().to_path_buf();
-        let original = match fs::read(&path) {
-            Ok(bytes) => Some(bytes),
-            Err(error) if error.kind() == ErrorKind::NotFound => None,
-            Err(error) => panic!("read {}: {error}", path.display()),
-        };
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).expect("create parent dirs");
-        }
-        fs::write(&path, contents).expect("write restored file");
-        Self { path, original }
-    }
-}
-
-impl Drop for RestoredFile {
-    fn drop(&mut self) {
-        let result = match self.original.as_deref() {
-            Some(contents) => fs::write(&self.path, contents),
-            None => match fs::remove_file(&self.path) {
-                Ok(()) => Ok(()),
-                Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
-                Err(error) => Err(error),
-            },
-        };
-        if let Err(error) = result {
-            eprintln!("failed to restore {}: {error}", self.path.display());
-        }
-    }
 }

--- a/tests/sdk_integration.rs
+++ b/tests/sdk_integration.rs
@@ -75,7 +75,11 @@ fn sdk_session_titles_respect_source_roots_and_leave_accounting_unchanged() {
 #[test]
 fn sdk_loads_codex_weekly_quota_from_explicit_home() {
     let root = tempfile::tempdir().expect("temp dir");
-    let codex_home = root.path().join("isolated-[quota]*-home");
+    let codex_home = root.path().join(if cfg!(windows) {
+        "isolated-[quota]-home"
+    } else {
+        "isolated-[quota]*-home"
+    });
     let session_file = codex_home.join("sessions").join("quota.jsonl");
     let now = Utc::now();
     let observed_at = now - Duration::hours(1);


### PR DESCRIPTION
Windows could miss logs under literal paths such as `work[demo]`, ignore HOME/XDG overrides, and reuse stale Codex cache entries after equal-size rewrites. Escape literal roots while preserving Windows prefixes, honor existing directory overrides, use Windows file change time for cache invalidation, and accept POSIX DSH metadata when reading logs on Windows.

Fix platform-dependent JSON/JSON5 fixtures and filenames without weakening assertions. Extend CI from Windows credential tests to the complete Rust suite and desktop checks; make the native desktop test process environment and executable path portable.

Validation: Windows Rust suite 959 passed; local macOS Rust suite 961 passed; Linux check/coverage and macOS desktop CI passed. Local Clippy, formatting, frontend build, and the regression proving unescaped roots fail / escaped roots pass also succeeded. Windows desktop Rust, browser, and native IPC tests also passed after waiting for enabled controls during navigation.

HOME overrides change credential file selection and require human review before merge. Native directory defaults remain in use when overrides are unset. MSI publisher signing remains outside this change.
