### PR TITLE
fix: skip Error sources in auto-detect ready-set (#180)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,10 +227,7 @@ fn resolve_source_name<'a>(
         }
         (Some(hint), None) => Some(hint),
         (None, Some(name)) => Some(name),
-        (None, None) => auto_detected_source_name(&ready_source_names().unwrap_or_else(|error| {
-            eprintln!("Error: {error}");
-            std::process::exit(1);
-        })),
+        (None, None) => auto_detected_source_name(&ready_source_names()),
     }
 }
 

--- a/src/source/registry.rs
+++ b/src/source/registry.rs
@@ -20,20 +20,20 @@ pub(crate) fn all_sources() -> impl Iterator<Item = &'static dyn Source> {
 
 /// Ready sources: `diagnose()` is Detected or Configured, in registry order.
 ///
+/// Missing and Error statuses are skipped (not ready). A credential or I/O
+/// error on one source must not abort auto-detect for other healthy sources.
+///
 /// This inspects local files and credentials only. It does not parse logs or
 /// contact remote APIs.
-pub(crate) fn ready_source_names() -> Result<Vec<&'static str>, String> {
+pub(crate) fn ready_source_names() -> Vec<&'static str> {
     let mut ready = Vec::new();
     for source in all_sources() {
         let diagnostic = source.diagnose();
-        if diagnostic.status == super::DiagnosticStatus::Error {
-            return Err(format!("{}: {}", source.display_name(), diagnostic.detail));
-        }
         if diagnostic.status.is_ready() {
             ready.push(source.name());
         }
     }
-    Ok(ready)
+    ready
 }
 
 pub(crate) fn auto_detected_source_name(ready: &[&'static str]) -> Option<&'static str> {
@@ -356,5 +356,6 @@ mod tests {
         assert!(DiagnosticStatus::Detected.is_ready());
         assert!(DiagnosticStatus::Configured.is_ready());
         assert!(!DiagnosticStatus::Missing.is_ready());
+        assert!(!DiagnosticStatus::Error.is_ready());
     }
 }

--- a/tests/cli_auto_detect.rs
+++ b/tests/cli_auto_detect.rs
@@ -292,6 +292,82 @@ fn config_source_pins_codex_on_a_multi_source_machine() {
 }
 
 #[test]
+fn corrupt_cursor_credentials_do_not_abort_claude_auto_detect() {
+    let root = unique_temp_dir("auto-detect-corrupt-cursor-creds");
+    write_claude_session(&root, "2026-02-06T10:00:00Z");
+    write_file(
+        &root.join(".config/ccstats/credentials.toml"),
+        "[cursor]\napi_key = \"unterminated",
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &[
+            "daily",
+            "-j",
+            "-O",
+            "--no-cost",
+            "--timezone",
+            "UTC",
+            "--since",
+            "2026-02-06",
+            "--until",
+            "2026-02-06",
+        ],
+        &[("HOME", &root)],
+    );
+    assert!(
+        ok,
+        "corrupt Cursor credentials must not abort auto-detect: {}",
+        String::from_utf8_lossy(&stderr)
+    );
+    assert_eq!(json_total_tokens(&stdout), 150);
+
+    let (doctor_ok, doctor_stdout, doctor_stderr) =
+        run_ccstats(&["doctor", "--json"], &[("HOME", &root)]);
+    assert!(
+        !doctor_ok,
+        "doctor must exit non-zero when Cursor reports Error"
+    );
+    let doctor: Value = serde_json::from_slice(&doctor_stdout).expect("doctor json");
+    let cursor = doctor
+        .as_array()
+        .expect("doctor array")
+        .iter()
+        .find(|row| row["name"] == "cursor")
+        .expect("cursor diagnostic");
+    assert_eq!(
+        cursor["status"].as_str(),
+        Some("error"),
+        "doctor must still surface Cursor credential Error: {cursor}"
+    );
+    let doctor_output = format!(
+        "{}{}",
+        String::from_utf8_lossy(&doctor_stdout),
+        String::from_utf8_lossy(&doctor_stderr)
+    );
+    assert!(
+        doctor_output.contains("failed to parse credentials"),
+        "expected parse failure detail, got: {doctor_output}"
+    );
+
+    let (ok, stdout, stderr) = run_ccstats(
+        &["daily", "--source", "cursor", "-O", "--no-cost"],
+        &[("HOME", &root)],
+    );
+    let cursor_output = format!(
+        "{}{}",
+        String::from_utf8_lossy(&stdout),
+        String::from_utf8_lossy(&stderr)
+    );
+    assert!(
+        cursor_output.contains("failed to parse credentials"),
+        "explicit --source cursor must still surface credential failure (ok={ok}): {cursor_output}"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn explicit_source_all_uses_all_path_with_one_ready_source() {
     let root = unique_temp_dir("auto-detect-explicit-all");
     let codex_home = root.join("codex-home");


### PR DESCRIPTION
## Summary
- `ready_source_names()` no longer aborts on `DiagnosticStatus::Error`; Error sources are skipped like Missing so Detected/Configured sources still drive auto-detect.
- Doctor still projects Cursor credential failures as `error` and exits non-zero; explicit `--source cursor` still surfaces the parse failure.
- Adds CLI regression: corrupt `credentials.toml` + valid Claude logs → default `daily` succeeds.

Closes #180

## Test plan
- [x] `cargo test --test cli_auto_detect`
- [x] `cargo test --test cli_limits limits_empty_home_keeps_its_schema_and_ignores_unrelated_credentials`
- [x] `cargo test --test cli_login_cursor corrupt_credentials`
- [x] `cargo test --lib diagnostic_status_ready`
- [ ] Manual: corrupt `~/.config/ccstats/credentials.toml` + Claude logs → `ccstats daily -O --no-cost` exits 0; `ccstats doctor` still reports Cursor error


Made with [Cursor](https://cursor.com)