### PR TITLE
fix(login): stop accepting Cursor secrets on argv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Security
+- Stop accepting Cursor secrets on `ccstats login cursor --api-key` / `--session-token` argv. Non-interactive login imports from `CURSOR_API_KEY` / `CURSOR_SESSION_TOKEN`, or from `--api-key-file` / `--session-token-file`.
+
 ## [0.7.1] - 2026-09-06
 
 ### Fixed

--- a/specs/first-run-ux/F4-cursor-login/product.md
+++ b/specs/first-run-ux/F4-cursor-login/product.md
@@ -28,11 +28,12 @@ Cursor 用量来自官方 API，必须提供 `CURSOR_API_KEY` 或 `CURSOR_SESSIO
 ## Behavior Invariants
 
 1. 命令：`ccstats login cursor`。
-   - `--api-key <value>` 非交互写入 API key。
-   - `--session-token <value>` 非交互写入 session token。
-   - 两者同时提供：报错退出 1（一次只存一种）。
+   - `--api-key` 从环境变量 `CURSOR_API_KEY` 导入 API key（secret 不得出现在 argv）。
+   - `--session-token` 从环境变量 `CURSOR_SESSION_TOKEN` 导入 session token（secret 不得出现在 argv）。
+   - `--api-key-file <path>` / `--session-token-file <path>` 从文件读取对应 secret。
+   - 以上四种输入同时只能选一种：否则报错退出 1。
    - 皆无且 stdin 是 TTY：打印说明 + URL，提示选择 1/2，隐藏回显读入一行。
-   - 皆无且 stdin 非 TTY：报错，要求 flag（测试走这条）。
+   - 皆无且 stdin 非 TTY：报错，要求上述 flag / env / file（测试走这条）。
 2. 存储路径：与 config 搜索同根的 credentials 文件，例如 `~/.config/ccstats/credentials.toml`（若本次运行已有权威 config 目录，用同一目录）。不把 secret 写进 `config.toml`。
 3. 文件权限：Unix 0600；写时先写 temp 再 rename。
 4. 读取顺序：环境变量 `CURSOR_API_KEY` / `CURSOR_SESSION_TOKEN` > credentials 文件 > 无。`CURSOR_USAGE_FILE` 仍独立。
@@ -44,7 +45,7 @@ Cursor 用量来自官方 API，必须提供 `CURSOR_API_KEY` 或 `CURSOR_SESSIO
 
 ## 验收标准
 
-- [ ] 非交互 `--session-token` 写入后，去掉 env，`doctor --json` 中 cursor status 为 `configured`。
+- [ ] 非交互 `CURSOR_SESSION_TOKEN=… ccstats login cursor --session-token` 写入后，去掉 env，`doctor --json` 中 cursor status 为 `configured`。
 - [ ] 同一 doctor JSON 字符串不包含该 token。
 - [ ] env 已设置时覆盖文件，`--check` 报告 `env`。
 - [ ] `--api-key` 与 `--session-token` 同时给出 → exit 1。

--- a/specs/first-run-ux/F4-cursor-login/tech.md
+++ b/specs/first-run-ux/F4-cursor-login/tech.md
@@ -29,8 +29,12 @@ https://github.com/majiayu000/ccstats/issues/167
 4. CLI:
 
    ```text
-   ccstats login cursor [--api-key] [--session-token] [--check] [--clear] [--no-browser]
+   ccstats login cursor [--api-key | --session-token | --api-key-file PATH | --session-token-file PATH]
+                        [--check] [--clear] [--no-browser]
    ```
+
+   `--api-key` / `--session-token` are value-less flags that import from
+   `CURSOR_API_KEY` / `CURSOR_SESSION_TOKEN`. Secrets must never appear on argv.
 
    Nested: `Commands::Login { target: LoginTarget::Cursor, ... }` so we do not invent `ccstats cursor` 源子命令（与「不再为新源加子命令」一致）。
 5. Browser: `open` crate is extra dependency — prefer `std::process::Command` with `open` / `xdg-open` / `cmd /c start` and ignore failure. Or print URL only if adding a dep is undesirable; **prefer zero new deps**.
@@ -40,7 +44,7 @@ https://github.com/majiayu000/ccstats/issues/167
 
 | Invariant | Test |
 | --- | --- |
-| File write | temp HOME, login --session-token, file mode 0600 on unix |
+| File write | temp HOME, `CURSOR_SESSION_TOKEN=… login --session-token`, file mode 0600 on unix |
 | Doctor configured | after login, doctor json status configured, token not in stdout/stderr |
 | Env precedence | file + env, --check says env |
 | Mutual exclusion | both flags → exit 1 |

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -568,7 +568,6 @@ mod tests {
             "login",
             "cursor",
             "--session-token",
-            "abc",
             "--no-browser",
         ]);
         match cli.command {
@@ -577,16 +576,52 @@ mod tests {
                     crate::cli::LoginTarget::Cursor {
                         api_key,
                         session_token,
+                        api_key_file,
+                        session_token_file,
                         check,
                         clear,
                         no_browser,
                     },
             }) => {
-                assert!(api_key.is_none());
-                assert_eq!(session_token.as_deref(), Some("abc"));
+                assert!(!api_key);
+                assert!(session_token);
+                assert!(api_key_file.is_none());
+                assert!(session_token_file.is_none());
                 assert!(!check);
                 assert!(!clear);
                 assert!(no_browser);
+            }
+            _ => panic!("expected login cursor"),
+        }
+    }
+
+    #[test]
+    fn login_cursor_parses_secret_file_flags() {
+        let cli = Cli::parse_from([
+            "ccstats",
+            "login",
+            "cursor",
+            "--api-key-file",
+            "/tmp/cursor.key",
+        ]);
+        match cli.command {
+            Some(crate::cli::Commands::Login {
+                target:
+                    crate::cli::LoginTarget::Cursor {
+                        api_key,
+                        session_token,
+                        api_key_file,
+                        session_token_file,
+                        ..
+                    },
+            }) => {
+                assert!(!api_key);
+                assert!(!session_token);
+                assert_eq!(
+                    api_key_file.as_deref(),
+                    Some(std::path::Path::new("/tmp/cursor.key"))
+                );
+                assert!(session_token_file.is_none());
             }
             _ => panic!("expected login cursor"),
         }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -2,6 +2,8 @@
 //!
 //! Defines the available commands for each data source.
 
+use std::path::PathBuf;
+
 use clap::{Subcommand, ValueEnum};
 
 /// Dimension to rank in the `top` command
@@ -90,12 +92,18 @@ pub(crate) enum Commands {
 pub(crate) enum LoginTarget {
     /// Store a Cursor API key or dashboard session token
     Cursor {
-        /// Cursor Admin API key (enterprise)
-        #[arg(long, value_name = "KEY")]
-        api_key: Option<String>,
-        /// Dashboard `WorkosCursorSessionToken` cookie
-        #[arg(long, value_name = "TOKEN")]
-        session_token: Option<String>,
+        /// Import API key from `CURSOR_API_KEY` (never pass the secret on argv)
+        #[arg(long)]
+        api_key: bool,
+        /// Import session token from `CURSOR_SESSION_TOKEN` (never pass the secret on argv)
+        #[arg(long)]
+        session_token: bool,
+        /// Read API key from a file (contents trimmed; never pass the secret on argv)
+        #[arg(long, value_name = "PATH")]
+        api_key_file: Option<PathBuf>,
+        /// Read session token from a file (contents trimmed; never pass the secret on argv)
+        #[arg(long, value_name = "PATH")]
+        session_token_file: Option<PathBuf>,
         /// Report whether credentials are configured without printing secrets
         #[arg(long)]
         check: bool,

--- a/src/login_cmd.rs
+++ b/src/login_cmd.rs
@@ -1,11 +1,15 @@
 //! `ccstats login` — store local provider credentials without printing secrets.
 
+use std::env;
+use std::fs;
 use std::io::{self, IsTerminal, Write};
+use std::path::Path;
 use std::process::Command;
 
 use crate::cli::LoginTarget;
 use crate::credentials::{
-    CursorAuth, clear_cursor_credentials, resolve_cursor_credentials, save_cursor_auth,
+    API_KEY_ENV, SESSION_TOKEN_ENV, CursorAuth, clear_cursor_credentials,
+    resolve_cursor_credentials, save_cursor_auth,
 };
 
 const CURSOR_API_KEY_URL: &str = "https://cursor.com/dashboard/api";
@@ -16,12 +20,16 @@ pub(crate) fn handle_login(target: &LoginTarget) {
         LoginTarget::Cursor {
             api_key,
             session_token,
+            api_key_file,
+            session_token_file,
             check,
             clear,
             no_browser,
         } => handle_cursor_login(
-            api_key.as_deref(),
-            session_token.as_deref(),
+            *api_key,
+            *session_token,
+            api_key_file.as_deref(),
+            session_token_file.as_deref(),
             *check,
             *clear,
             *no_browser,
@@ -33,17 +41,34 @@ pub(crate) fn handle_login(target: &LoginTarget) {
 }
 
 fn handle_cursor_login(
-    api_key: Option<&str>,
-    session_token: Option<&str>,
+    api_key: bool,
+    session_token: bool,
+    api_key_file: Option<&Path>,
+    session_token_file: Option<&Path>,
     check: bool,
     clear: bool,
     no_browser: bool,
 ) -> Result<(), String> {
-    if api_key.is_some() && session_token.is_some() {
-        return Err("provide only one of --api-key or --session-token".to_string());
+    let selected = [
+        ("--api-key", api_key),
+        ("--session-token", session_token),
+        ("--api-key-file", api_key_file.is_some()),
+        ("--session-token-file", session_token_file.is_some()),
+    ]
+    .into_iter()
+    .filter_map(|(name, on)| on.then_some(name))
+    .collect::<Vec<_>>();
+
+    if selected.len() > 1 {
+        return Err(
+            "provide only one of --api-key, --session-token, --api-key-file, or --session-token-file"
+                .to_string(),
+        );
     }
-    if clear && (api_key.is_some() || session_token.is_some()) {
-        return Err("--clear cannot be combined with --api-key or --session-token".to_string());
+    if clear && !selected.is_empty() {
+        return Err(
+            "--clear cannot be combined with --api-key, --session-token, or --*-file".to_string(),
+        );
     }
 
     if clear {
@@ -53,8 +78,8 @@ fn handle_cursor_login(
         return Ok(());
     }
 
-    if let Some(api_key) = api_key {
-        save_cursor_auth(CursorAuth::ApiKey(parse_secret(api_key)?))
+    if api_key {
+        save_cursor_auth(CursorAuth::ApiKey(secret_from_env(API_KEY_ENV)?))
             .map_err(|error| error.to_string())?;
         println!("Saved Cursor credentials locally.");
         if check {
@@ -63,8 +88,28 @@ fn handle_cursor_login(
         return Ok(());
     }
 
-    if let Some(session_token) = session_token {
-        save_cursor_auth(CursorAuth::SessionToken(parse_secret(session_token)?))
+    if session_token {
+        save_cursor_auth(CursorAuth::SessionToken(secret_from_env(SESSION_TOKEN_ENV)?))
+            .map_err(|error| error.to_string())?;
+        println!("Saved Cursor credentials locally.");
+        if check {
+            print_cursor_check()?;
+        }
+        return Ok(());
+    }
+
+    if let Some(path) = api_key_file {
+        save_cursor_auth(CursorAuth::ApiKey(secret_from_file(path)?))
+            .map_err(|error| error.to_string())?;
+        println!("Saved Cursor credentials locally.");
+        if check {
+            print_cursor_check()?;
+        }
+        return Ok(());
+    }
+
+    if let Some(path) = session_token_file {
+        save_cursor_auth(CursorAuth::SessionToken(secret_from_file(path)?))
             .map_err(|error| error.to_string())?;
         println!("Saved Cursor credentials locally.");
         if check {
@@ -79,7 +124,9 @@ fn handle_cursor_login(
     }
 
     if !io::stdin().is_terminal() {
-        return Err("non-interactive login requires --api-key or --session-token".to_string());
+        return Err(format!(
+            "non-interactive login requires --api-key (from {API_KEY_ENV}), --session-token (from {SESSION_TOKEN_ENV}), --api-key-file, or --session-token-file"
+        ));
     }
 
     interactive_cursor_login(no_browser)
@@ -142,6 +189,20 @@ fn interactive_cursor_login(no_browser: bool) -> Result<(), String> {
     save_cursor_auth(auth).map_err(|error| error.to_string())?;
     println!("Saved Cursor credentials locally.");
     Ok(())
+}
+
+fn secret_from_env(var: &str) -> Result<String, String> {
+    match env::var(var) {
+        Ok(value) => parse_secret(&value),
+        Err(env::VarError::NotPresent) => Err(format!("{var} is not set")),
+        Err(env::VarError::NotUnicode(_)) => Err(format!("{var} must be valid UTF-8")),
+    }
+}
+
+fn secret_from_file(path: &Path) -> Result<String, String> {
+    let raw = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    parse_secret(&raw)
 }
 
 fn parse_secret(raw: &str) -> Result<String, String> {

--- a/tests/cli_login_cursor.rs
+++ b/tests/cli_login_cursor.rs
@@ -4,7 +4,7 @@ mod common;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use common::{run_ccstats, unique_temp_dir};
+use common::{run_ccstats, unique_temp_dir, write_file};
 use serde_json::Value;
 
 const SESSION_TOKEN: &str = "login-cursor-session-secret-167";
@@ -32,6 +32,14 @@ fn run_isolated_with(
     run_ccstats(args, &envs)
 }
 
+fn login_session_from_env(root: &Path, token: &str) -> (bool, Vec<u8>, Vec<u8>) {
+    run_isolated_with(
+        root,
+        &["login", "cursor", "--session-token"],
+        &[("CURSOR_SESSION_TOKEN", Path::new(token))],
+    )
+}
+
 fn cursor_row(stdout: &[u8]) -> Value {
     let rows: Value = serde_json::from_slice(stdout).expect("doctor json");
     rows.as_array()
@@ -52,10 +60,7 @@ fn assert_no_secret(stdout: &[u8], stderr: &[u8], secret: &str) {
 #[test]
 fn login_session_token_configures_doctor_without_leaking_secret() {
     let root = unique_temp_dir("login-cursor-session");
-    let (ok, stdout, stderr) = run_isolated(
-        &root,
-        &["login", "cursor", "--session-token", SESSION_TOKEN],
-    );
+    let (ok, stdout, stderr) = login_session_from_env(&root, SESSION_TOKEN);
     assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
     assert_no_secret(&stdout, &stderr, SESSION_TOKEN);
 
@@ -75,10 +80,7 @@ fn login_session_token_configures_doctor_without_leaking_secret() {
 #[test]
 fn login_writes_unix_0600_credentials_file() {
     let root = unique_temp_dir("login-cursor-mode");
-    let (ok, stdout, stderr) = run_isolated(
-        &root,
-        &["login", "cursor", "--session-token", SESSION_TOKEN],
-    );
+    let (ok, stdout, stderr) = login_session_from_env(&root, SESSION_TOKEN);
     assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
     assert_no_secret(&stdout, &stderr, SESSION_TOKEN);
 
@@ -97,9 +99,34 @@ fn login_writes_unix_0600_credentials_file() {
 }
 
 #[test]
+fn login_session_token_file_configures_without_argv_secret() {
+    let root = unique_temp_dir("login-cursor-file");
+    let secret_path = root.join("session.token");
+    write_file(&secret_path, &format!("{FILE_TOKEN}\n"));
+
+    let (ok, stdout, stderr) = run_isolated(
+        &root,
+        &[
+            "login",
+            "cursor",
+            "--session-token-file",
+            secret_path.to_str().expect("utf-8 path"),
+        ],
+    );
+    assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
+    assert_no_secret(&stdout, &stderr, FILE_TOKEN);
+
+    let written = fs::read_to_string(credentials_path(&root)).expect("credentials file");
+    assert!(written.contains(FILE_TOKEN));
+    assert!(written.contains("session_token"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn env_overrides_file_and_check_reports_env() {
     let root = unique_temp_dir("login-cursor-env");
-    let (ok, _, stderr) = run_isolated(&root, &["login", "cursor", "--session-token", FILE_TOKEN]);
+    let (ok, _, stderr) = login_session_from_env(&root, FILE_TOKEN);
     assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
 
     let (ok, stdout, stderr) = run_isolated(&root, &["login", "cursor", "--check"]);
@@ -138,15 +165,12 @@ fn env_overrides_file_and_check_reports_env() {
 #[test]
 fn both_credential_flags_exit_1() {
     let root = unique_temp_dir("login-cursor-both");
-    let (ok, stdout, stderr) = run_isolated(
+    let (ok, stdout, stderr) = run_isolated_with(
         &root,
+        &["login", "cursor", "--api-key", "--session-token"],
         &[
-            "login",
-            "cursor",
-            "--api-key",
-            "api-secret",
-            "--session-token",
-            "session-secret",
+            ("CURSOR_API_KEY", Path::new("api-secret")),
+            ("CURSOR_SESSION_TOKEN", Path::new("session-secret")),
         ],
     );
     assert!(!ok);
@@ -164,10 +188,7 @@ fn both_credential_flags_exit_1() {
 #[test]
 fn clear_removes_file_credentials_and_doctor_is_missing() {
     let root = unique_temp_dir("login-cursor-clear");
-    let (ok, _, stderr) = run_isolated(
-        &root,
-        &["login", "cursor", "--session-token", SESSION_TOKEN],
-    );
+    let (ok, _, stderr) = login_session_from_env(&root, SESSION_TOKEN);
     assert!(ok, "stderr: {}", String::from_utf8_lossy(&stderr));
 
     let (ok, stdout, stderr) = run_isolated(&root, &["login", "cursor", "--clear"]);
@@ -222,10 +243,11 @@ fn home_without_xdg_still_searches_platform_credentials_path() {
     assert_no_secret(&stdout, &stderr, "platform-upgrade-key-179");
 
     let (ok, stdout, stderr) = run_ccstats_with_isolation(
-        &["login", "cursor", "--api-key", "platform-updated-key-179"],
+        &["login", "cursor", "--api-key"],
         &[
             ("HOME", home.as_path()),
             ("XDG_CONFIG_HOME", platform.as_path()),
+            ("CURSOR_API_KEY", Path::new("platform-updated-key-179")),
         ],
         false,
     );
@@ -258,6 +280,10 @@ fn no_flags_non_tty_exit_1() {
     assert!(
         output.contains("--api-key") || output.contains("--session-token"),
         "expected flag guidance: {output}"
+    );
+    assert!(
+        output.contains("CURSOR_API_KEY") || output.contains("CURSOR_SESSION_TOKEN"),
+        "expected env guidance: {output}"
     );
     assert!(!credentials_path(&root).exists());
 


### PR DESCRIPTION
## Summary
- Make `ccstats login cursor --api-key` / `--session-token` value-less flags that import from `CURSOR_API_KEY` / `CURSOR_SESSION_TOKEN` (never argv).
- Add `--api-key-file` / `--session-token-file` for file-based non-interactive login; keep interactive `rpassword` as the human default.
- Update F4 specs, CHANGELOG, and login CLI tests accordingly.

Closes #181

## Test plan
- [x] `cargo test --test cli_login_cursor`
- [x] `cargo test login_cursor`
- [x] `cargo check`
- [ ] Confirm `ccstats login cursor --api-key secret` fails clap parsing (unexpected argument) and does not store the secret


Made with [Cursor](https://cursor.com)